### PR TITLE
Improve CSV delimiter detection

### DIFF
--- a/services/file_processor.py
+++ b/services/file_processor.py
@@ -77,33 +77,20 @@ class FileProcessor:
             }
     
     def _parse_csv(self, file_path: str) -> pd.DataFrame:
-        """Parse CSV file with various delimiters"""
-        
-        # Try different delimiters
-        delimiters = [',', ';', '\t', '|']
+        """Parse CSV file using pandas automatic delimiter detection"""
 
-        # Read the header only once to determine date parsing
-        header = pd.read_csv(file_path, nrows=0).columns
-        parse_dates = ['timestamp'] if 'timestamp' in header else False
+        # Detect header with automatic delimiter detection
+        header = pd.read_csv(file_path, nrows=0, sep=None, engine="python").columns
+        parse_dates = ["timestamp"] if "timestamp" in header else False
 
-        for delimiter in delimiters:
-            try:
-                df = pd.read_csv(
-                    file_path,
-                    delimiter=delimiter,
-                    encoding='utf-8',
-                    parse_dates=parse_dates
-                )
-
-                # Check if we got reasonable columns (more than 1 column)
-                if len(df.columns) > 1:
-                    return df
-
-            except Exception:
-                continue
-        
-        # Fallback to default comma delimiter
-        return pd.read_csv(file_path, encoding='utf-8')
+        # Read the entire file once using the detected delimiter
+        return pd.read_csv(
+            file_path,
+            sep=None,
+            engine="python",
+            encoding="utf-8",
+            parse_dates=parse_dates,
+        )
     
     def _parse_json(self, file_path: str) -> pd.DataFrame:
         """Parse JSON file"""

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from services.file_processor import FileProcessor
+
+
+@pytest.mark.parametrize("sep", [";", "\t"])
+def test_parse_csv_with_various_delimiters(tmp_path, sep):
+    data = {
+        "person_id": ["EMP1", "EMP2"],
+        "door_id": ["D1", "D2"],
+        "access_result": ["Granted", "Denied"],
+        "timestamp": ["2024-01-01 10:00:00", "2024-01-01 11:00:00"],
+    }
+    df = pd.DataFrame(data)
+
+    csv_path = tmp_path / "sample.csv"
+    df.to_csv(csv_path, index=False, sep=sep)
+
+    processor = FileProcessor(upload_folder=str(tmp_path), allowed_extensions={"csv"})
+    parsed = processor._parse_csv(str(csv_path))
+
+    expected = df.copy()
+    expected["timestamp"] = pd.to_datetime(expected["timestamp"])
+
+    pd.testing.assert_frame_equal(parsed, expected)
+


### PR DESCRIPTION
## Summary
- use pandas automatic delimiter detection in `_parse_csv`
- test `_parse_csv` with semicolon and tab delimiters

## Testing
- `pytest tests/test_csv_parsing.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f5313edc48320bee06dc8393d6389