### PR TITLE
Fix pipeline failure on safety check

### DIFF
--- a/workflow/ci.yml
+++ b/workflow/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: bandit -r .
 
       - name: 📚 Safety (dependency CVE scan)
-        run: safety check --full-report || true  # do not fail build yet, surfaced in summary
+        run: safety check --full-report
 
       # ----- Tests -----
       - name: ✅ Run PyTest


### PR DESCRIPTION
## Summary
- ensure safety alerts fail the pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f557348588320abb59919949ef60f