### PR TITLE
Document container usage

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -1,14 +1,19 @@
 class Container:
-    """Simple dependency injection container."""
+    """Registry for application services used to resolve dependencies."""
+
     def __init__(self):
+        # Stores registered services keyed by name
         self._services = {}
 
     def register(self, name: str, service):
+        """Register a service instance under the given ``name``."""
         self._services[name] = service
 
     def get(self, name: str):
+        """Retrieve a previously registered service by name."""
         return self._services.get(name)
 
     def has(self, name: str) -> bool:
+        """Check if a service with the given name exists."""
         return name in self._services
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,3 +37,19 @@ Represents a single access control event.
 - `person_id: str`: Person attempting access
 - `door_id: str`: Door being accessed
 - `access_result: AccessResult`: Success/failure of access
+
+## Service Container
+
+`Container` provides a simple registry for services that can be resolved by
+name. It is typically configured during application startup.
+
+```python
+from core.container import Container
+
+container = Container()
+container.register("db", DatabaseManager())
+
+# Later in the code
+if container.has("db"):
+    db = container.get("db")
+```


### PR DESCRIPTION
## Summary
- expand `core.container.Container` docs
- add example of using the service container to `docs/api.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f55c025a08320b97a0beef128f5e8