### PR TITLE
Refactor column mapping into utility

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -8,6 +8,8 @@ import json
 import logging
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
+
+from utils.mapping_helpers import map_and_clean
 from datetime import datetime, timedelta
 import os
 
@@ -302,16 +304,8 @@ class AnalyticsService:
                 print(f"   📄 {filename}: {len(df):,} rows")
                 print(f"      Original columns: {list(df.columns)}")
 
-                # YOUR SPECIFIC COLUMN MAPPING
-                df_processed = df.copy()
-                if 'Person ID' in df_processed.columns:
-                    df_processed = df_processed.rename(columns={
-                        'Timestamp': 'timestamp',
-                        'Person ID': 'person_id',
-                        'Device name': 'door_id',
-                        'Access result': 'access_result'
-                    })
-                    print(f"      ✅ Columns mapped: {list(df_processed.columns)}")
+                df_processed = map_and_clean(df.copy())
+                print(f"      ✅ Columns mapped: {list(df_processed.columns)}")
 
                 all_dataframes.append(df_processed)
 
@@ -384,24 +378,7 @@ class AnalyticsService:
 
     def clean_uploaded_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Apply standard column mappings and basic cleaning."""
-        column_mapping = {
-            'Timestamp': 'timestamp',
-            'Person ID': 'person_id',
-            'Token ID': 'token_id',
-            'Device name': 'door_id',
-            'Access result': 'access_result',
-        }
-
-        df = df.rename(columns=column_mapping)
-
-        if 'timestamp' in df.columns:
-            df['timestamp'] = pd.to_datetime(df['timestamp'], errors='coerce')
-
-        for col in ['person_id', 'door_id', 'access_result']:
-            if col in df.columns:
-                df[col] = df[col].astype(str).str.strip()
-
-        return df
+        return map_and_clean(df)
 
     def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Create a summary dictionary from a combined DataFrame."""
@@ -632,15 +609,7 @@ class AnalyticsService:
                 # Process the first available file
                 filename, df = next(iter(uploaded_data.items()))
 
-                # Apply basic column mapping
-                column_mapping = {
-                    'Timestamp': 'timestamp',
-                    'Person ID': 'person_id',
-                    'Token ID': 'token_id',
-                    'Device name': 'door_id',
-                    'Access result': 'access_result'
-                }
-                df = df.rename(columns=column_mapping)
+                df = map_and_clean(df)
 
                 # Calculate real statistics
                 total_records = len(df)

--- a/tests/test_mapping_helpers.py
+++ b/tests/test_mapping_helpers.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from utils.mapping_helpers import map_and_clean
+
+
+def test_map_and_clean_basic():
+    df = pd.DataFrame({
+        "Timestamp": ["2024-01-01 00:00:00"],
+        "Person ID": [" u1 "],
+        "Token ID": ["t1"],
+        "Device name": ["d1"],
+        "Access result": ["Granted"],
+    })
+
+    cleaned = map_and_clean(df)
+    assert list(cleaned.columns) == [
+        "timestamp",
+        "person_id",
+        "token_id",
+        "door_id",
+        "access_result",
+    ]
+    assert pd.api.types.is_datetime64_any_dtype(cleaned["timestamp"])
+    assert cleaned.loc[0, "person_id"] == "u1"
+
+
+def test_map_and_clean_missing_columns():
+    df = pd.DataFrame({
+        "Timestamp": ["2024-01-01"],
+        "Person ID": ["u1"],
+    })
+    cleaned = map_and_clean(df)
+    assert "token_id" not in cleaned.columns
+    assert "door_id" not in cleaned.columns

--- a/utils/mapping_helpers.py
+++ b/utils/mapping_helpers.py
@@ -1,0 +1,30 @@
+"""Utility functions for mapping uploaded data columns."""
+
+from typing import Dict
+import pandas as pd
+
+# Standard column mapping used across the project
+STANDARD_COLUMN_MAPPING: Dict[str, str] = {
+    "Timestamp": "timestamp",
+    "Person ID": "person_id",
+    "Token ID": "token_id",
+    "Device name": "door_id",
+    "Access result": "access_result",
+}
+
+
+def map_and_clean(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename columns using :data:`STANDARD_COLUMN_MAPPING` and clean fields."""
+    df = df.rename(columns=STANDARD_COLUMN_MAPPING)
+
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+
+    for col in ("person_id", "door_id", "access_result"):
+        if col in df.columns:
+            df[col] = df[col].astype(str).str.strip()
+
+    return df
+
+
+__all__ = ["STANDARD_COLUMN_MAPPING", "map_and_clean"]


### PR DESCRIPTION
## Summary
- add `map_and_clean` helper under `utils`
- use new helper throughout `AnalyticsService`
- test helper functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f55bb0a9083208c956a55ad34b046