### PR TITLE
Organize debug helpers and ignore temp data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ data/uploads/*
 *.json
 logs/
 
+# Temporary uploaded files
+temp/
+
 # Database
 *.db
 *.sqlite3

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 2. Format code with `black` and run `flake8`
 3. Follow type safety guidelines and maintain the modular architecture
 4. Add tests for new functionality and update documentation when applicable
+5. Optional debug helpers live in `examples/`. Run the upload helper with
+   `python examples/debug_upload.py` to validate environment setup
 
 ## 📄 License
 

--- a/examples/debug_upload.py
+++ b/examples/debug_upload.py
@@ -7,7 +7,8 @@ import logging
 from pathlib import Path
 
 # Add project root to path
-project_root = Path(__file__).parent
+# When run from the examples directory, include the repository root
+project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(project_root))
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- move `debug_upload.py` into `examples/`
- ignore `temp/` data directory
- document running `debug_upload.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f5c69b52c8320b08bf10fef1acad8