### PR TITLE
Add gunicorn-ready wsgi entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Docker Compose reads variables from a `.env` file in this directory. Set
 `DB_PASSWORD` **and** `SECRET_KEY` there (or export them in your shell) before
 starting the services.
 
+Alternatively you can launch the app with Gunicorn:
+```bash
+gunicorn wsgi:server
+```
+
 ## 🧪 Testing
 
 Run the complete test suite:

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+from core.app_factory import create_app
+
+app = create_app()
+server = app.server
+
+if __name__ == "__main__":
+    app.run_server()


### PR DESCRIPTION
## Summary
- add `wsgi.py` entry point for production
- document running `gunicorn wsgi:server` in README

## Testing
- `python -m py_compile wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_685f6e9953ac8320b02d164d28b25ac5