### PR TITLE
Improve file decoding robustness

### DIFF
--- a/tests/test_surrogate_handling.py
+++ b/tests/test_surrogate_handling.py
@@ -1,0 +1,25 @@
+import json
+import pandas as pd
+from utils.file_validator import process_dataframe
+
+
+def test_process_dataframe_csv_with_surrogate(tmp_path):
+    csv_path = tmp_path / "bad.csv"
+    text = "col1,col2\nvalue1,\ud83d\nvalue2,ok\n"
+    csv_path.write_text(text, encoding="utf-8", errors="surrogatepass")
+    data = csv_path.read_bytes()
+    df, err = process_dataframe(data, "bad.csv")
+    assert err is None
+    assert isinstance(df, pd.DataFrame)
+    assert df.loc[0, "col2"] == "\ud83d"
+
+
+def test_process_dataframe_json_with_surrogate(tmp_path):
+    json_path = tmp_path / "bad.json"
+    content = json.dumps({"value": "\ud83d"})
+    json_path.write_text(content, encoding="utf-8", errors="surrogatepass")
+    data = json_path.read_bytes()
+    df, err = process_dataframe(data, "bad.json")
+    assert err is None
+    assert isinstance(df, pd.DataFrame)
+    assert df.loc[0, "value"] == "\ud83d"


### PR DESCRIPTION
## Summary
- add a `decode_bytes` helper for surrogate-friendly decoding
- use it in `process_dataframe`
- handle surrogates in `FileProcessorService` CSV/JSON helpers
- test decoding of files that contain unpaired surrogates

## Testing
- `pytest tests/test_surrogate_handling.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f70583c708320a8d2398170c85e2c