### PR TITLE
Add callback manager for centralized registration

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -2,8 +2,8 @@
 
 import pandas as pd
 from dash import html, dcc
-from dash._callback import callback
 from dash.dependencies import Input, Output, State, ALL, MATCH
+from core.callback_manager import CallbackManager
 import dash
 import dash_bootstrap_components as dbc
 from typing import Dict, List, Any, Union
@@ -237,19 +237,25 @@ def create_device_verification_modal(
     )
 
 
-@callback(
-    Output({"type": "device-edited", "index": MATCH}, "data"),
-    [
-        Input({"type": "device-floor", "index": MATCH}, "value"),
-        Input({"type": "device-access", "index": MATCH}, "value"),
-        Input({"type": "device-special", "index": MATCH}, "value"),
-        Input({"type": "device-security", "index": MATCH}, "value"),
-    ],
-    prevent_initial_call=True,
-)
 def mark_device_as_edited(floor, access, special, security):
     """Mark device as manually edited when user makes changes"""
     return True  # Simplified - any change marks as edited
 
 
-__all__ = ["create_device_verification_modal"]
+def register_callbacks(manager: CallbackManager) -> None:
+    """Register component callbacks using the provided manager."""
+
+    manager.callback(
+        Output({"type": "device-edited", "index": MATCH}, "data"),
+        [
+            Input({"type": "device-floor", "index": MATCH}, "value"),
+            Input({"type": "device-access", "index": MATCH}, "value"),
+            Input({"type": "device-special", "index": MATCH}, "value"),
+            Input({"type": "device-security", "index": MATCH}, "value"),
+        ],
+        prevent_initial_call=True,
+        callback_id="mark_device_as_edited",
+    )(mark_device_as_edited)
+
+
+__all__ = ["create_device_verification_modal", "register_callbacks"]

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -1,8 +1,8 @@
 """Simple manual device mapping component"""
 
 from dash import html, dcc
-from dash._callback import callback
 from dash._callback_context import callback_context
+from core.callback_manager import CallbackManager
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any
@@ -364,16 +364,6 @@ def create_simple_device_modal(devices: List[str]) -> dbc.Modal:
     )
 
 
-@callback(
-    Output("simple-device-modal", "is_open"),
-    [
-        Input("open-device-mapping", "n_clicks"),
-        Input("device-modal-cancel", "n_clicks"),
-        Input("device-modal-save", "n_clicks"),
-    ],
-    [State("simple-device-modal", "is_open")],
-    prevent_initial_call=True,
-)
 def toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open):
     """Control the simple device modal open/close state"""
     ctx = callback_context
@@ -394,16 +384,6 @@ def toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open)
     return is_open
 
 
-@callback(
-    Output("device-save-status", "children"),
-    [
-        Input({"type": "device-floor", "index": ALL}, "value"),
-        Input({"type": "device-security", "index": ALL}, "value"),
-        Input({"type": "device-access", "index": ALL}, "value"),
-    ],
-    [State("current-devices-list", "data")],
-    prevent_initial_call=True,
-)
 def save_user_inputs(floors, security, access, devices):
     """Save user inputs immediately when they change"""
     global _device_ai_mappings
@@ -429,3 +409,34 @@ def save_user_inputs(floors, security, access, devices):
         }
 
     return ""
+
+
+def register_callbacks(manager: CallbackManager) -> None:
+    """Register component callbacks using the provided manager."""
+
+    manager.callback(
+        Output("simple-device-modal", "is_open"),
+        [
+            Input("open-device-mapping", "n_clicks"),
+            Input("device-modal-cancel", "n_clicks"),
+            Input("device-modal-save", "n_clicks"),
+        ],
+        [State("simple-device-modal", "is_open")],
+        prevent_initial_call=True,
+        callback_id="toggle_simple_device_modal",
+    )(toggle_simple_device_modal)
+
+    manager.callback(
+        Output("device-save-status", "children"),
+        [
+            Input({"type": "device-floor", "index": ALL}, "value"),
+            Input({"type": "device-security", "index": ALL}, "value"),
+            Input({"type": "device-access", "index": ALL}, "value"),
+        ],
+        [State("current-devices-list", "data")],
+        prevent_initial_call=True,
+        callback_id="save_user_inputs",
+    )(save_user_inputs)
+
+
+__all__ = ["register_callbacks"]

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -8,6 +8,7 @@ import os
 from typing import Optional, Any
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Input, Output, callback
+from core.callback_manager import CallbackManager
 import pandas as pd
 
 # ✅ FIXED IMPORTS - Use correct config system
@@ -64,8 +65,23 @@ def _create_full_app() -> dash.Dash:
         # Set main layout
         app.layout = _create_main_layout()
 
-        # Register all callbacks
-        _register_global_callbacks(app)
+        # Register all callbacks using CallbackManager
+        callback_manager = CallbackManager(app)
+        _register_global_callbacks(callback_manager)
+
+        # Register page/component callbacks
+        try:
+            from pages.file_upload import register_callbacks as register_upload_callbacks
+            from components.simple_device_mapping import register_callbacks as register_simple_mapping
+            from components.device_verification import register_callbacks as register_device_verification
+            from pages.deep_analytics.callbacks import register_callbacks as register_deep_callbacks
+
+            register_upload_callbacks(callback_manager)
+            register_simple_mapping(callback_manager)
+            register_device_verification(callback_manager)
+            register_deep_callbacks(callback_manager)
+        except Exception as e:
+            logger.warning(f"Failed to register module callbacks: {e}")
 
         # Initialize services
         _initialize_services()
@@ -369,13 +385,14 @@ def _get_upload_page() -> Any:
         )
 
 
-def _register_global_callbacks(app: dash.Dash) -> None:
+def _register_global_callbacks(manager: CallbackManager) -> None:
     """Register global application callbacks"""
 
-    @app.callback(
+    @manager.callback(
         Output("global-store", "data"),
         Input("clear-cache-btn", "n_clicks"),
         prevent_initial_call=True,
+        callback_id="clear_cache",
     )
     def clear_cache(n_clicks):
         """Clear application cache"""

--- a/core/callback_manager.py
+++ b/core/callback_manager.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Simple Callback Manager for Dash applications."""
+from __future__ import annotations
+
+from dash import Dash
+from typing import Callable, Any
+
+class CallbackManager:
+    """Register Dash callbacks and prevent duplicate IDs."""
+
+    def __init__(self, app: Dash) -> None:
+        self.app = app
+        self._registered_ids: set[str] = set()
+
+    @property
+    def registered_ids(self) -> set[str]:
+        """Return a copy of registered callback IDs."""
+        return set(self._registered_ids)
+
+    def callback(
+        self,
+        *args: Any,
+        callback_id: str,
+        **kwargs: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Wrap ``Dash.callback`` and track callback IDs.
+
+        Parameters
+        ----------
+        callback_id:
+            Unique identifier for the callback. Attempting to register a
+            duplicate ID will raise ``ValueError``.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            if callback_id in self._registered_ids:
+                raise ValueError(f"Callback ID '{callback_id}' already registered")
+            wrapped = self.app.callback(*args, **kwargs)(func)
+            self._registered_ids.add(callback_id)
+            return wrapped
+
+        return decorator
+

--- a/pages/deep_analytics/__init__.py
+++ b/pages/deep_analytics/__init__.py
@@ -1,5 +1,5 @@
 from .layout import layout
-from .callbacks import *  # noqa: F401,F403
+from .callbacks import register_callbacks  # noqa: F401
 from .analysis import *  # noqa: F401,F403
 
-__all__ = ["layout"]
+__all__ = ["layout", "register_callbacks"]

--- a/tests/test_callback_manager.py
+++ b/tests/test_callback_manager.py
@@ -1,0 +1,30 @@
+import pytest
+from dash import Dash, Input, Output, html
+
+from core.callback_manager import CallbackManager
+
+
+def test_duplicate_callback_registration():
+    app = Dash(__name__)
+    manager = CallbackManager(app)
+
+    @manager.callback(Output('out', 'children'), Input('in', 'value'), callback_id='dup')
+    def _cb(value):
+        return value
+
+    with pytest.raises(ValueError):
+        @manager.callback(Output('out2', 'children'), Input('in2', 'value'), callback_id='dup')
+        def _cb2(value):  # pragma: no cover - should not run
+            return value
+
+
+def test_callback_registration_to_app():
+    app = Dash(__name__)
+    manager = CallbackManager(app)
+
+    @manager.callback(Output('out', 'children'), Input('in', 'value'), callback_id='reg')
+    def _cb(value):
+        return value
+
+    assert 'out.children' in app.callback_map
+    assert 'reg' in manager.registered_ids


### PR DESCRIPTION
## Summary
- implement `CallbackManager` to track registered callbacks
- register callbacks from several modules through the manager
- initialize manager in app factory and pass to modules
- add tests covering duplicate IDs and registration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f7059a0b08320a0879a441b7487b1