### PR TITLE
Remove unused unique patterns card

### DIFF
--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -341,34 +341,6 @@ def update_status_alert(trigger):
 # Add these helper functions for non-suggests analysis types
 # =============================================================================
 
-def analyze_unique_patterns(n_clicks):
-    """Run unique patterns analysis with proper number formatting"""
-    try:
-        analytics_service = AnalyticsService()
-        results = analytics_service.get_unique_patterns_analysis()
-
-        if results['status'] == 'success':
-            data_summary = results['data_summary']
-            user_patterns = results['user_patterns']
-            device_patterns = results['device_patterns']
-
-            return html.Div([
-                html.H4("📊 Analysis Results"),
-                html.P(f"Total Records: {data_summary.get('total_records', 0):,}"),
-                html.P(f"Unique Users: {data_summary.get('unique_entities', {}).get('users', 0):,}"),
-                html.P(f"Unique Devices: {data_summary.get('unique_entities', {}).get('devices', 0):,}"),
-                html.P(f"Power Users: {len(user_patterns.get('user_classifications', {}).get('power_users', [])):,}"),
-                html.P(
-                    f"High Traffic Devices: {len(device_patterns.get('device_classifications', {}).get('high_traffic_devices', [])):,}"
-                ),
-                html.P(f"Success Rate: {results.get('access_patterns', {}).get('overall_success_rate', 0):.1%}")
-            ])
-        else:
-            return html.P(f"Error: {results.get('message', 'Analysis failed')}")
-    except Exception as e:
-        return html.P(f"Error: {str(e)}")
-
-
 def register_callbacks(manager: CallbackManager) -> None:
     """Register page callbacks using the provided manager."""
 
@@ -402,12 +374,6 @@ def register_callbacks(manager: CallbackManager) -> None:
         callback_id="update_status_alert",
     )(update_status_alert)
 
-    manager.callback(
-        Output("unique-patterns-output", "children"),
-        Input("unique-patterns-card-btn", "n_clicks"),
-        prevent_initial_call=True,
-        callback_id="analyze_unique_patterns",
-    )(analyze_unique_patterns)
 
 
 __all__ = ["register_callbacks"]

--- a/pages/deep_analytics/layout.py
+++ b/pages/deep_analytics/layout.py
@@ -134,19 +134,6 @@ def layout():
             ])
         ], className="mb-4")
 
-
-        simple_unique_patterns_card = dbc.Card([
-            dbc.CardHeader("Unique Patterns Analysis"),
-            dbc.CardBody([
-                dbc.Button(
-                    "Analyze Patterns",
-                    id="unique-patterns-card-btn",
-                    color="primary"
-                ),
-                html.Div(id="unique-patterns-output", className="mt-3")
-            ])
-        ])
-
         # Results display area
         results_area = html.Div(
             id="analytics-display-area",
@@ -167,7 +154,7 @@ def layout():
             html.Div(id="hidden-trigger", style={"display": "none"})
         ]
 
-        return dbc.Container([header, config_card, simple_unique_patterns_card, results_area] + stores, fluid=True)
+        return dbc.Container([header, config_card, results_area] + stores, fluid=True)
 
     except Exception as e:
         logger.error(f"Layout creation error: {e}")


### PR DESCRIPTION
## Summary
- drop unused card from deep analytics layout
- remove callback and helper for deleted card

## Testing
- `black pages/deep_analytics/layout.py pages/deep_analytics/callbacks.py --check` *(fails: would reformat)*
- `mypy pages/deep_analytics/layout.py pages/deep_analytics/callbacks.py` *(fails: missing stubs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f730b707c8320ac423b8315dc5b72