### PR TITLE
Handle invalid surrogate pairs safely

### DIFF
--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .base import BaseService
 from .protocols import FileProcessorProtocol
-from utils.file_validator import decode_bytes
+from utils.file_validator import safe_decode_with_unicode_handling
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class FileProcessorService(BaseService):
             # Try different encodings with surrogate handling
             for encoding in ['utf-8', 'latin-1', 'cp1252']:
                 try:
-                    text = decode_bytes(content, encoding)
+                    text = safe_decode_with_unicode_handling(content, encoding)
                     return pd.read_csv(io.StringIO(text))
                 except UnicodeDecodeError:
                     continue
@@ -88,7 +88,7 @@ class FileProcessorService(BaseService):
         try:
             for encoding in ['utf-8', 'latin-1', 'cp1252']:
                 try:
-                    text = decode_bytes(content, encoding)
+                    text = safe_decode_with_unicode_handling(content, encoding)
                     return pd.read_json(io.StringIO(text))
                 except UnicodeDecodeError:
                     continue

--- a/tests/test_surrogate_handling.py
+++ b/tests/test_surrogate_handling.py
@@ -11,7 +11,7 @@ def test_process_dataframe_csv_with_surrogate(tmp_path):
     df, err = process_dataframe(data, "bad.csv")
     assert err is None
     assert isinstance(df, pd.DataFrame)
-    assert df.loc[0, "col2"] == "\ud83d"
+    assert df.loc[0, "col2"] == ""
 
 
 def test_process_dataframe_json_with_surrogate(tmp_path):
@@ -22,4 +22,29 @@ def test_process_dataframe_json_with_surrogate(tmp_path):
     df, err = process_dataframe(data, "bad.json")
     assert err is None
     assert isinstance(df, pd.DataFrame)
-    assert df.loc[0, "value"] == "\ud83d"
+    assert df.loc[0, "value"] == ""
+
+
+def test_process_dataframe_csv_with_malformed_pairs(tmp_path):
+    csv_path = tmp_path / "mal.csv"
+    # High surrogate followed by normal char and lone low surrogate
+    text = "col\n\ud83dX\ude0a"
+    csv_path.write_text(text, encoding="utf-8", errors="surrogatepass")
+    data = csv_path.read_bytes()
+    df, err = process_dataframe(data, "mal.csv")
+    assert err is None
+    assert isinstance(df, pd.DataFrame)
+    # Both invalid sequences should be dropped
+    assert df.loc[0, "col"] == "X"
+
+
+def test_process_dataframe_json_with_malformed_pairs(tmp_path):
+    json_path = tmp_path / "mal.json"
+    obj = {"v": "\ud83dX\ude0a"}
+    content = json.dumps(obj)
+    json_path.write_text(content, encoding="utf-8", errors="surrogatepass")
+    data = json_path.read_bytes()
+    df, err = process_dataframe(data, "mal.json")
+    assert err is None
+    assert isinstance(df, pd.DataFrame)
+    assert df.loc[0, "v"] == "X"


### PR DESCRIPTION
## Summary
- add `safe_decode_with_unicode_handling` helper
- use the new decoder in `process_dataframe`
- switch `FileProcessorService` to the new strategy
- extend surrogate-handling tests for malformed pairs

## Testing
- `pytest -q tests/test_surrogate_handling.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f7d9a3a408320bb84a41f8956d900