### PR TITLE
Refactor file upload modules

### DIFF
--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -1,0 +1,125 @@
+"""Utilities for processing uploaded files and creating previews."""
+import base64
+import io
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict
+
+import pandas as pd
+import dash_bootstrap_components as dbc
+from dash import html
+
+logger = logging.getLogger(__name__)
+
+
+def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
+    """Process uploaded file content into a DataFrame."""
+    try:
+        content_type, content_string = contents.split(",")
+        decoded = base64.b64decode(content_string)
+
+        if filename.endswith(".csv"):
+            df = pd.read_csv(io.StringIO(decoded.decode("utf-8")))
+        elif filename.endswith((".xlsx", ".xls")):
+            df = pd.read_excel(io.BytesIO(decoded))
+        elif filename.endswith(".json"):
+            try:
+                json_data = json.loads(decoded.decode("utf-8"))
+                if isinstance(json_data, list):
+                    df = pd.DataFrame(json_data)
+                elif isinstance(json_data, dict):
+                    if "data" in json_data:
+                        df = pd.DataFrame(json_data["data"])
+                    else:
+                        df = pd.DataFrame([json_data])
+                else:
+                    return {"success": False, "error": f"Unsupported JSON structure: {type(json_data)}"}
+            except json.JSONDecodeError as e:
+                return {"success": False, "error": f"Invalid JSON format: {str(e)}"}
+        else:
+            return {
+                "success": False,
+                "error": "Unsupported file type. Supported: .csv, .json, .xlsx, .xls",
+            }
+
+        if not isinstance(df, pd.DataFrame):
+            return {"success": False, "error": f"Processing resulted in {type(df)} instead of DataFrame"}
+
+        if df.empty:
+            return {"success": False, "error": "File contains no data"}
+
+        return {
+            "success": True,
+            "data": df,
+            "rows": len(df),
+            "columns": list(df.columns),
+            "upload_time": datetime.now(),
+        }
+    except Exception as e:  # pragma: no cover - best effort
+        return {"success": False, "error": f"Error processing file: {str(e)}"}
+
+
+def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert:
+    """Create a preview card for an uploaded DataFrame."""
+    try:
+        num_rows, num_cols = df.shape
+
+        column_info = []
+        for col in df.columns[:10]:
+            dtype = str(df[col].dtype)
+            null_count = df[col].isnull().sum()
+            column_info.append(f"{col} ({dtype}) - {null_count} nulls")
+
+        return dbc.Card(
+            [
+                dbc.CardHeader([html.H6(f"\U0001F4C4 {filename}", className="mb-0")]),
+                dbc.CardBody(
+                    [
+                        dbc.Row(
+                            [
+                                dbc.Col(
+                                    [
+                                        html.H6("File Statistics:", className="text-primary"),
+                                        html.Ul(
+                                            [
+                                                html.Li(f"Rows: {num_rows:,}"),
+                                                html.Li(f"Columns: {num_cols}"),
+                                                html.Li(
+                                                    f"Memory usage: {df.memory_usage(deep=True).sum() / 1024:.1f} KB"
+                                                ),
+                                            ]
+                                        ),
+                                    ],
+                                    width=6,
+                                ),
+                                dbc.Col(
+                                    [
+                                        html.H6("Columns:", className="text-primary"),
+                                        html.Ul([html.Li(info) for info in column_info]),
+                                    ],
+                                    width=6,
+                                ),
+                            ]
+                        ),
+                        html.Hr(),
+                        html.H6("Sample Data:", className="text-primary mt-3"),
+                        dbc.Table.from_dataframe(
+                            df.head(5),
+                            striped=True,
+                            bordered=True,
+                            hover=True,
+                            responsive=True,
+                            size="sm",
+                        ),
+                    ]
+                ),
+            ],
+            className="mb-3",
+        )
+    except Exception as e:  # pragma: no cover - best effort
+        logger.error(f"Error creating preview for {filename}: {e}")
+        return dbc.Alert(f"Error creating preview: {str(e)}", color="warning")
+
+
+__all__ = ["process_uploaded_file", "create_file_preview"]

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -1,0 +1,89 @@
+"""Persistent uploaded data store module."""
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, List
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class UploadedDataStore:
+    """Persistent uploaded data store with file system backup."""
+
+    def __init__(self) -> None:
+        self._data_store: Dict[str, pd.DataFrame] = {}
+        self._file_info_store: Dict[str, Dict[str, Any]] = {}
+        self.storage_dir = Path("temp/uploaded_data")
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._load_from_disk()
+
+    # -- Internal helpers ---------------------------------------------------
+    def _get_file_path(self, filename: str) -> Path:
+        safe_name = filename.replace(" ", "_").replace("/", "_")
+        return self.storage_dir / f"{safe_name}.pkl"
+
+    def _info_path(self) -> Path:
+        return self.storage_dir / "file_info.json"
+
+    def _load_from_disk(self) -> None:
+        try:
+            if self._info_path().exists():
+                with open(self._info_path(), "r") as f:
+                    self._file_info_store = json.load(f)
+            for fname in self._file_info_store.keys():
+                fpath = self._get_file_path(fname)
+                if fpath.exists():
+                    df = pd.read_pickle(fpath)
+                    self._data_store[fname] = df
+                    logger.info(f"Loaded {fname} from disk")
+        except Exception as e:  # pragma: no cover - best effort
+            logger.error(f"Error loading uploaded data: {e}")
+
+    def _save_to_disk(self, filename: str, df: pd.DataFrame) -> None:
+        try:
+            df.to_pickle(self._get_file_path(filename))
+            self._file_info_store[filename] = {
+                "rows": len(df),
+                "columns": len(df.columns),
+                "column_names": list(df.columns),
+                "upload_time": datetime.now().isoformat(),
+                "size_mb": round(df.memory_usage(deep=True).sum() / 1024 / 1024, 2),
+            }
+            with open(self._info_path(), "w") as f:
+                json.dump(self._file_info_store, f, indent=2)
+        except Exception as e:  # pragma: no cover - best effort
+            logger.error(f"Error saving uploaded data: {e}")
+
+    # -- Public API ---------------------------------------------------------
+    def add_file(self, filename: str, df: pd.DataFrame) -> None:
+        self._data_store[filename] = df
+        self._save_to_disk(filename, df)
+
+    def get_all_data(self) -> Dict[str, pd.DataFrame]:
+        return self._data_store.copy()
+
+    def get_filenames(self) -> List[str]:
+        return list(self._data_store.keys())
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
+        return self._file_info_store.copy()
+
+    def clear_all(self) -> None:
+        self._data_store.clear()
+        self._file_info_store.clear()
+        try:
+            for pkl in self.storage_dir.glob("*.pkl"):
+                pkl.unlink()
+            if self._info_path().exists():
+                self._info_path().unlink()
+        except Exception as e:  # pragma: no cover - best effort
+            logger.error(f"Error clearing uploaded data: {e}")
+
+
+# Global persistent storage instance
+uploaded_data_store = UploadedDataStore()
+
+__all__ = ["UploadedDataStore", "uploaded_data_store"]


### PR DESCRIPTION
## Summary
- extract `UploadedDataStore` into **utils/upload_store.py**
- extract file processing helpers into **services/upload_service.py**
- update `pages/file_upload.py` to use new helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68604c6eb69883209105267c7590ebba