### PR TITLE
Add periodic plugin health monitoring

### DIFF
--- a/core/plugins/protocols.py
+++ b/core/plugins/protocols.py
@@ -10,8 +10,10 @@ from enum import Enum
 from dataclasses import dataclass
 from datetime import datetime
 
+
 class PluginStatus(Enum):
     """Plugin lifecycle status"""
+
     DISCOVERED = "discovered"
     LOADED = "loaded"
     CONFIGURED = "configured"
@@ -19,16 +21,20 @@ class PluginStatus(Enum):
     STOPPED = "stopped"
     FAILED = "failed"
 
+
 class PluginPriority(Enum):
     """Plugin loading priority"""
-    CRITICAL = 0      # Core functionality plugins
-    HIGH = 10         # Important feature plugins  
-    NORMAL = 50       # Standard feature plugins
-    LOW = 100         # Optional enhancement plugins
+
+    CRITICAL = 0  # Core functionality plugins
+    HIGH = 10  # Important feature plugins
+    NORMAL = 50  # Standard feature plugins
+    LOW = 100  # Optional enhancement plugins
+
 
 @dataclass
 class PluginMetadata:
     """Plugin metadata definition"""
+
     name: str
     version: str
     description: str
@@ -40,74 +46,77 @@ class PluginMetadata:
     min_yosai_version: Optional[str] = None
     max_yosai_version: Optional[str] = None
 
+
 @runtime_checkable
 class PluginProtocol(Protocol):
     """Core plugin protocol that all plugins must implement"""
-    
+
     @property
     @abstractmethod
     def metadata(self) -> PluginMetadata:
         """Plugin metadata"""
         ...
-    
+
     @abstractmethod
     def load(self, container: Any, config: Dict[str, Any]) -> bool:
         """Load and register plugin services with the DI container"""
         ...
-    
+
     @abstractmethod
     def configure(self, config: Dict[str, Any]) -> bool:
         """Configure the plugin with provided settings"""
         ...
-    
+
     @abstractmethod
     def start(self) -> bool:
         """Start the plugin (if it has runtime components)"""
         ...
-    
+
     @abstractmethod
     def stop(self) -> bool:
         """Stop the plugin gracefully"""
         ...
-    
+
     @abstractmethod
     def health_check(self) -> Dict[str, Any]:
-        """Return plugin health status"""
+        """Return plugin health status used for monitoring"""
         ...
+
 
 @runtime_checkable
 class CallbackPluginProtocol(PluginProtocol, Protocol):
     """Protocol for plugins that register Dash callbacks"""
-    
+
     @abstractmethod
     def register_callbacks(self, app: Any, container: Any) -> bool:
         """Register Dash callbacks with the application"""
         ...
 
+
 @runtime_checkable
 class ServicePluginProtocol(PluginProtocol, Protocol):
     """Protocol for plugins that provide services"""
-    
+
     @abstractmethod
     def get_service_definitions(self) -> Dict[str, Any]:
         """Return service definitions for DI container registration"""
         ...
 
+
 class PluginManagerProtocol(Protocol):
     """Protocol for plugin management"""
-    
+
     @abstractmethod
     def discover_plugins(self) -> List[PluginProtocol]:
         """Discover available plugins"""
         ...
-    
+
     @abstractmethod
     def load_plugin(self, plugin: PluginProtocol) -> bool:
         """Load a specific plugin"""
         ...
-    
+
     @abstractmethod
     def get_plugin_status(self, plugin_name: str) -> PluginStatus:
         """Get current status of a plugin"""
         ...
-

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -3,113 +3,119 @@
 Comprehensive tests for the JSON Serialization Plugin
 """
 import pytest
+
 pytest.skip("legacy DI tests skipped", allow_module_level=True)
 
 import unittest
 import pandas as pd
 from datetime import datetime
 import json
+import time
+from flask import Flask
 
 from plugins.builtin.json_serialization_plugin import (
-    JsonSerializationPlugin, JsonSerializationConfig,
-    JsonSerializationService, JsonCallbackService
+    JsonSerializationPlugin,
+    JsonSerializationConfig,
+    JsonSerializationService,
+    JsonCallbackService,
 )
 from core.plugins.manager import PluginManager
 from core.container import Container as DIContainer
 
+
 class TestJsonSerializationPlugin(unittest.TestCase):
     """Test the JSON Serialization Plugin"""
-    
+
     def setUp(self):
         self.plugin = JsonSerializationPlugin()
         self.container = DIContainer()
         self.config = {
-            'enabled': True,
-            'max_dataframe_rows': 5,
-            'auto_wrap_callbacks': True
+            "enabled": True,
+            "max_dataframe_rows": 5,
+            "auto_wrap_callbacks": True,
         }
-    
+
     def test_plugin_metadata(self):
         """Test plugin metadata"""
         metadata = self.plugin.metadata
-        
-        self.assertEqual(metadata.name, 'json_serialization')
-        self.assertEqual(metadata.version, '1.0.0')
+
+        self.assertEqual(metadata.name, "json_serialization")
+        self.assertEqual(metadata.version, "1.0.0")
         self.assertTrue(metadata.enabled_by_default)
-    
+
     def test_plugin_lifecycle(self):
         """Test plugin load, configure, start, stop lifecycle"""
         # Load
         success = self.plugin.load(self.container, self.config)
         self.assertTrue(success)
-        
+
         # Configure
         success = self.plugin.configure(self.config)
         self.assertTrue(success)
-        
+
         # Start
         success = self.plugin.start()
         self.assertTrue(success)
-        
+
         # Health check
         health = self.plugin.health_check()
-        self.assertTrue(health['healthy'])
-        
+        self.assertTrue(health["healthy"])
+
         # Stop
         success = self.plugin.stop()
         self.assertTrue(success)
-    
+
     def test_service_registration(self):
         """Test that services are properly registered"""
         self.plugin.load(self.container, self.config)
-        
+
         # Check that services are registered
-        self.assertTrue(self.container.has('json_serialization_service'))
-        self.assertTrue(self.container.has('json_callback_service'))
-        
+        self.assertTrue(self.container.has("json_serialization_service"))
+        self.assertTrue(self.container.has("json_callback_service"))
+
         # Test service functionality
-        serialization_service = self.container.get('json_serialization_service')
+        serialization_service = self.container.get("json_serialization_service")
         self.assertIsNotNone(serialization_service)
-        
+
         # Test DataFrame serialization
-        df = pd.DataFrame({'A': [1, 2, 3], 'B': ['x', 'y', 'z']})
+        df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
         result = serialization_service.sanitize_for_transport(df)
-        
-        self.assertEqual(result['type'], 'dataframe')
-        self.assertEqual(result['shape'], (3, 2))
-        self.assertEqual(len(result['data']), 3)
-    
+
+        self.assertEqual(result["type"], "dataframe")
+        self.assertEqual(result["shape"], (3, 2))
+        self.assertEqual(len(result["data"]), 3)
+
     def test_callback_wrapping(self):
         """Test callback function wrapping"""
         self.plugin.load(self.container, self.config)
-        
-        callback_service = self.container.get('json_callback_service')
-        
+
+        callback_service = self.container.get("json_callback_service")
+
         def test_callback():
-            return pd.DataFrame({'A': [1, 2, 3]})
-        
+            return pd.DataFrame({"A": [1, 2, 3]})
+
         wrapped_callback = callback_service.wrap_callback(test_callback)
         result = wrapped_callback()
-        
+
         # Should return sanitized DataFrame representation
         self.assertIsInstance(result, dict)
-        self.assertEqual(result['type'], 'dataframe')
-    
+        self.assertEqual(result["type"], "dataframe")
+
     def test_error_handling(self):
         """Test error handling in callbacks"""
         self.plugin.load(self.container, self.config)
-        
-        callback_service = self.container.get('json_callback_service')
-        
+
+        callback_service = self.container.get("json_callback_service")
+
         def failing_callback():
             raise ValueError("Test error")
-        
+
         wrapped_callback = callback_service.wrap_callback(failing_callback)
         result = wrapped_callback()
-        
+
         # Should return error representation
-        self.assertTrue(result.get('error', False))
-        self.assertIn('Test error', result['message'])
+        self.assertTrue(result.get("error", False))
+        self.assertIn("Test error", result["message"])
 
     def test_lazystring_handling(self):
         """Ensure LazyString objects are sanitized to plain strings"""
@@ -119,7 +125,7 @@ class TestJsonSerializationPlugin(unittest.TestCase):
             self.skipTest("flask_babel not available")
 
         self.plugin.load(self.container, self.config)
-        service = self.container.get('json_serialization_service')
+        service = self.container.get("json_serialization_service")
 
         lazy_value = lazy_gettext("hello")
         sanitized = service.sanitize_for_transport(lazy_value)
@@ -127,33 +133,54 @@ class TestJsonSerializationPlugin(unittest.TestCase):
         self.assertIsInstance(sanitized, str)
         self.assertEqual(sanitized, str(lazy_value))
 
+
 class TestPluginManager(unittest.TestCase):
     """Test plugin manager with JSON serialization plugin"""
-    
+
     def setUp(self):
         self.container = Container()
         self.manager = PluginManager(self.container)
-    
+
     def test_plugin_discovery(self):
         """Test that the JSON serialization plugin can be discovered"""
         # This test would require the plugin to be in the discovery path
         # For now, we test manual plugin loading
-        
+
         plugin = JsonSerializationPlugin()
         success = self.manager.load_plugin(plugin)
-        
+
         self.assertTrue(success)
-        self.assertIn('json_serialization', self.manager.plugins)
-    
+        self.assertIn("json_serialization", self.manager.plugins)
+
     def test_plugin_health_monitoring(self):
         """Test plugin health monitoring"""
         plugin = JsonSerializationPlugin()
         self.manager.load_plugin(plugin)
-        
-        health_status = self.manager.get_plugin_health()
-        
-        self.assertIn('json_serialization', health_status)
-        self.assertTrue(health_status['json_serialization']['health']['healthy'])
 
-if __name__ == '__main__':
+        health_status = self.manager.get_plugin_health()
+
+        self.assertIn("json_serialization", health_status)
+        self.assertTrue(health_status["json_serialization"]["health"]["healthy"])
+
+    def test_periodic_health_snapshot(self):
+        """Plugin manager updates health snapshot periodically"""
+        manager = PluginManager(DIContainer(), health_check_interval=1)
+        plugin = JsonSerializationPlugin()
+        manager.load_plugin(plugin)
+        time.sleep(1.5)
+        snapshot = manager.health_snapshot
+        self.assertIn("json_serialization", snapshot)
+        manager.stop_health_monitor()
+
+    def test_health_endpoint_registration(self):
+        """Ensure /health/plugins endpoint is registered"""
+        app = Flask(__name__)
+        manager = PluginManager(DIContainer(), health_check_interval=1)
+        manager.register_health_endpoint(app)
+        rules = [str(rule) for rule in app.url_map.iter_rules()]
+        self.assertIn("/health/plugins", rules)
+        manager.stop_health_monitor()
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enforce that plugins implement `health_check`
- add a background thread in `PluginManager` to poll plugin health
- expose `/health/plugins` endpoint to serve aggregated plugin health
- extend tests for monitoring behaviour

## Testing
- `flake8 core/plugins/manager.py core/plugins/protocols.py tests/test_json_serialization_plugin.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860513a0e448320851873f4a6bc3286