### PR TITLE
Sanitize unicode inputs before security checks

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -15,6 +15,8 @@ import logging
 from pathlib import Path
 import mimetypes
 
+from utils.unicode_handler import sanitize_unicode_input
+
 class SecurityLevel(Enum):
     """Security threat levels"""
     LOW = "low"
@@ -86,6 +88,7 @@ class InputValidator:
         """Comprehensive input validation"""
         if not isinstance(input_data, str):
             input_data = str(input_data)
+        input_data = sanitize_unicode_input(input_data)
         
         result = {
             'field': field_name,
@@ -147,6 +150,7 @@ class InputValidator:
     
     def _sanitize_input(self, data: str) -> str:
         """Sanitize input data"""
+        data = sanitize_unicode_input(data)
         # Remove null bytes
         sanitized = data.replace('\x00', '')
         
@@ -240,7 +244,8 @@ class InputValidator:
         """Check file content for security issues"""
         # Convert to string for pattern matching (first 1KB)
         try:
-            text_content = content[:1024].decode('utf-8', errors='ignore').lower()
+            text_content = content[:1024].decode('utf-8', errors='ignore')
+            text_content = sanitize_unicode_input(text_content).lower()
         except:
             return False
         

--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -7,6 +7,8 @@ import os
 import hashlib
 import secrets
 from typing import Dict, Any, List
+
+from utils.unicode_handler import sanitize_unicode_input
 from dataclasses import dataclass
 from enum import Enum
 
@@ -55,6 +57,7 @@ class SecurityValidator:
 
     def validate_input(self, value: str, field_name: str = "input") -> Dict[str, Any]:
         """Comprehensive input validation"""
+        value = sanitize_unicode_input(value)
         issues: List[SecurityIssue] = []
 
         # Check SQL injection
@@ -102,6 +105,7 @@ class SecurityValidator:
 
     def _sanitize_input(self, value: str) -> str:
         """Sanitize input by encoding dangerous characters"""
+        value = sanitize_unicode_input(value)
         # HTML entity encoding
         replacements = {
             '&': '&amp;',

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .base import BaseService
 from .protocols import FileProcessorProtocol
 from utils.file_validator import safe_decode_with_unicode_handling
+from utils.unicode_handler import sanitize_unicode_input
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ class FileProcessorService(BaseService):
     
     def validate_file(self, filename: str, content: bytes) -> Dict[str, Any]:
         """Validate uploaded file"""
+        filename = sanitize_unicode_input(filename)
         issues = []
         
         # Check file extension
@@ -54,6 +56,7 @@ class FileProcessorService(BaseService):
     def process_file(self, file_content: bytes, filename: str) -> pd.DataFrame:
         """Process uploaded file and return DataFrame"""
         try:
+            filename = sanitize_unicode_input(filename)
             file_ext = Path(filename).suffix.lower()
             
             if file_ext == '.csv':
@@ -76,6 +79,7 @@ class FileProcessorService(BaseService):
             for encoding in ['utf-8', 'latin-1', 'cp1252']:
                 try:
                     text = safe_decode_with_unicode_handling(content, encoding)
+                    text = sanitize_unicode_input(text)
                     return pd.read_csv(io.StringIO(text))
                 except UnicodeDecodeError:
                     continue
@@ -89,6 +93,7 @@ class FileProcessorService(BaseService):
             for encoding in ['utf-8', 'latin-1', 'cp1252']:
                 try:
                     text = safe_decode_with_unicode_handling(content, encoding)
+                    text = sanitize_unicode_input(text)
                     return pd.read_json(io.StringIO(text))
                 except UnicodeDecodeError:
                     continue

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,5 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
-__all__: list[str] = []
+from .unicode_handler import sanitize_unicode_input
+
+__all__: list[str] = ["sanitize_unicode_input"]

--- a/utils/file_validator.py
+++ b/utils/file_validator.py
@@ -6,6 +6,8 @@ import io
 import base64
 from typing import Dict, Any, Optional, Tuple
 
+from .unicode_handler import sanitize_unicode_input
+
 
 def decode_bytes(data: bytes, enc: str) -> str:
     """Decode bytes using specified encoding with surrogatepass."""
@@ -19,6 +21,7 @@ def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
     except UnicodeDecodeError:
         text = data.decode(enc, errors="replace")
 
+    text = sanitize_unicode_input(text)
     # Re-encode to UTF-8 ignoring any invalid surrogates/characters
     cleaned = text.encode("utf-8", errors="ignore")
     return cleaned.decode("utf-8", errors="ignore")

--- a/utils/unicode_handler.py
+++ b/utils/unicode_handler.py
@@ -1,0 +1,20 @@
+"""Unicode sanitization utilities."""
+
+
+def sanitize_unicode_input(input_str: str) -> str:
+    """Remove invalid surrogate/control characters and normalize Unicode."""
+    try:
+        cleaned = input_str.encode("utf-8", errors="ignore").decode("utf-8")
+        import unicodedata
+        normalized = unicodedata.normalize("NFKC", cleaned)
+        allowed = []
+        for ch in normalized:
+            cat = unicodedata.category(ch)
+            if cat.startswith("C") and ch not in "\t\n\r ":
+                continue
+            allowed.append(ch)
+        return "".join(allowed)
+    except UnicodeError:
+        return input_str.encode("ascii", errors="replace").decode("ascii")
+
+__all__ = ["sanitize_unicode_input"]


### PR DESCRIPTION
## Summary
- add `utils/unicode_handler.py` with `sanitize_unicode_input`
- export sanitizer in `utils.__init__`
- clean input values at the start of security validation
- sanitize uploaded filenames and decoded text
- ensure decode helper removes invalid surrogates

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: Found 1 error in 1 file)*
- `python test_modular_system.py` *(fails: file not found)*
- `python tests/test_dashboard.py` *(fails: file not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686054247374832094ae38df44f13387