### PR TITLE
Add dynamic config manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ YOSAI_CONFIG_FILE=/path/to/custom.yaml python app.py
 YOSAI_APP_MODE=simple python app.py
 ```
 
+#### Dynamic Constants
+
+The new `DynamicConfigManager` reads several optional environment variables to
+override security and performance defaults:
+
+- `PBKDF2_ITERATIONS` – password hashing iterations
+- `RATE_LIMIT_API` – number of requests allowed per window
+- `RATE_LIMIT_WINDOW` – rate limit window in minutes
+- `MAX_UPLOAD_MB` – maximum allowed upload size
+- `DB_POOL_SIZE` – database connection pool size
+
 ### Plugins
 
 Plugins live in the `plugins/` package and are loaded by the `PluginManager` when enabled in `config/config.yaml`.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -6,7 +6,7 @@ Simplified configuration package - Fixed imports
 # Import the main configuration system
 from .config import (
     Config,
-    AppConfig, 
+    AppConfig,
     DatabaseConfig,
     SecurityConfig,
     ConfigManager,
@@ -16,6 +16,10 @@ from .config import (
     get_database_config, 
     get_security_config
 )
+
+# Import dynamic configuration helpers
+from .dynamic_config import dynamic_config, DynamicConfigManager
+from .constants import SecurityConstants, PerformanceConstants, CSSConstants
 
 # Try to import database manager safely
 try:
@@ -42,5 +46,10 @@ __all__ = [
     'DatabaseManager',
     'DatabaseConnection',
     'MockConnection',
-    'DATABASE_MANAGER_AVAILABLE'
+    'DATABASE_MANAGER_AVAILABLE',
+    'dynamic_config',
+    'DynamicConfigManager',
+    'SecurityConstants',
+    'PerformanceConstants',
+    'CSSConstants'
 ]

--- a/config/config.py
+++ b/config/config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List
 
+from .dynamic_config import dynamic_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +35,7 @@ class DatabaseConfig:
     name: str = "yosai.db"
     user: str = "user"
     password: str = ""
-    connection_pool_size: int = 10
+    connection_pool_size: int = dynamic_config.get_db_pool_size()
     connection_timeout: int = 30
     
     def get_connection_string(self) -> str:
@@ -203,8 +205,8 @@ class ConfigManager:
             self.config.database.user = os.getenv("DB_USER")
         if os.getenv("DB_PASSWORD"):
             self.config.database.password = os.getenv("DB_PASSWORD")
-        if os.getenv("DB_POOL_SIZE"):
-            self.config.database.connection_pool_size = int(os.getenv("DB_POOL_SIZE"))
+        # Pool size is loaded from DynamicConfigManager
+        self.config.database.connection_pool_size = dynamic_config.get_db_pool_size()
         if os.getenv("DB_TIMEOUT"):
             self.config.database.connection_timeout = int(os.getenv("DB_TIMEOUT"))
 

--- a/config/constants.py
+++ b/config/constants.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+@dataclass
+class SecurityConstants:
+    """Security related default values"""
+    pbkdf2_iterations: int = 100000
+    salt_bytes: int = 32
+    rate_limit_requests: int = 100
+    rate_limit_window_minutes: int = 1
+    max_upload_mb: int = 100
+
+@dataclass
+class PerformanceConstants:
+    """Performance tuning defaults"""
+    db_pool_size: int = 10
+    ai_confidence_threshold: int = 75
+
+@dataclass
+class CSSConstants:
+    """Thresholds for CSS quality metrics"""
+    bundle_excellent_kb: int = 50
+    bundle_good_kb: int = 100
+    bundle_warning_kb: int = 200
+    bundle_threshold_kb: int = 100
+    specificity_high: int = 30

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,0 +1,58 @@
+import os
+from typing import Dict, Any
+from .constants import SecurityConstants, PerformanceConstants, CSSConstants
+
+class DynamicConfigManager:
+    """Loads constants and applies environment overrides."""
+
+    def __init__(self) -> None:
+        self.security = SecurityConstants()
+        self.performance = PerformanceConstants()
+        self.css = CSSConstants()
+        self._apply_env_overrides()
+
+    def _apply_env_overrides(self) -> None:
+        """Override defaults from environment variables."""
+        if os.getenv("PBKDF2_ITERATIONS"):
+            self.security.pbkdf2_iterations = int(os.getenv("PBKDF2_ITERATIONS"))
+        if os.getenv("RATE_LIMIT_API"):
+            self.security.rate_limit_requests = int(os.getenv("RATE_LIMIT_API"))
+        if os.getenv("RATE_LIMIT_WINDOW"):
+            self.security.rate_limit_window_minutes = int(os.getenv("RATE_LIMIT_WINDOW"))
+        if os.getenv("MAX_UPLOAD_MB"):
+            self.security.max_upload_mb = int(os.getenv("MAX_UPLOAD_MB"))
+        if os.getenv("DB_POOL_SIZE"):
+            self.performance.db_pool_size = int(os.getenv("DB_POOL_SIZE"))
+        if os.getenv("AI_CONFIDENCE_THRESHOLD"):
+            self.performance.ai_confidence_threshold = int(os.getenv("AI_CONFIDENCE_THRESHOLD"))
+        if os.getenv("CSS_BUNDLE_THRESHOLD"):
+            self.css.bundle_threshold_kb = int(os.getenv("CSS_BUNDLE_THRESHOLD"))
+        if os.getenv("CSS_SPECIFICITY_HIGH"):
+            self.css.specificity_high = int(os.getenv("CSS_SPECIFICITY_HIGH"))
+
+    def get_rate_limit(self) -> Dict[str, int]:
+        return {
+            "requests": self.security.rate_limit_requests,
+            "window_minutes": self.security.rate_limit_window_minutes,
+        }
+
+    def get_security_level(self) -> int:
+        return self.security.pbkdf2_iterations
+
+    def get_max_upload_size(self) -> int:
+        return self.security.max_upload_mb
+
+    def get_db_pool_size(self) -> int:
+        return self.performance.db_pool_size
+
+    def get_css_thresholds(self) -> Dict[str, Any]:
+        return {
+            "bundle_threshold_kb": self.css.bundle_threshold_kb,
+            "specificity_high": self.css.specificity_high,
+        }
+
+    def get_ai_confidence_threshold(self) -> int:
+        return self.performance.ai_confidence_threshold
+
+# Global instance
+dynamic_config = DynamicConfigManager()

--- a/models/css_build_optimizer.py
+++ b/models/css_build_optimizer.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Tuple, Any, Optional
 from dataclasses import dataclass
+from config.dynamic_config import dynamic_config
 import logging
 
 # FIXED: Configure CSS utils logging with proper error handling
@@ -56,7 +57,7 @@ class CSSQualityAnalyzer:
         main_css = self.css_dir / "main.css"
         
         if not main_css.exists():
-            return CSSMetric("bundle_size", 0, "KB", "error", 100, "Main CSS file not found")
+            return CSSMetric("bundle_size", 0, "KB", "error", dynamic_config.css.bundle_threshold_kb, "Main CSS file not found")
         
         # Calculate total size including imports
         total_size = 0
@@ -87,11 +88,11 @@ class CSSQualityAnalyzer:
         size_kb = total_size / 1024
         
         # Determine status
-        if size_kb <= 50:
+        if size_kb <= dynamic_config.css.bundle_excellent_kb:
             status = "excellent"
-        elif size_kb <= 100:
+        elif size_kb <= dynamic_config.css.bundle_good_kb:
             status = "good"
-        elif size_kb <= 200:
+        elif size_kb <= dynamic_config.css.bundle_warning_kb:
             status = "warning"
         else:
             status = "critical"
@@ -101,7 +102,7 @@ class CSSQualityAnalyzer:
             round(size_kb, 2), 
             "KB", 
             status, 
-            100, 
+            dynamic_config.css.bundle_threshold_kb, 
             f"Total CSS bundle size including all imports"
         )
     
@@ -185,7 +186,7 @@ class CSSQualityAnalyzer:
                                 
                                 specificity = (id_count * 100) + (class_count * 10) + element_count
                                 
-                                if specificity > 30:  # High specificity threshold
+                                if specificity > dynamic_config.css.specificity_high:  # High specificity threshold
                                     high_specificity_selectors.append((selector_text, specificity))
                     except Exception as e:
                         logging.warning(f"Error parsing CSS in {css_file}: {e}")

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 # ADD after existing imports
 from services.ai_device_generator import AIDeviceGenerator
 from services.consolidated_learning_service import get_learning_service
+from config.dynamic_config import dynamic_config
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class DoorMappingService:
     
     def __init__(self):
         self.ai_model_version = "v2.3"
-        self.confidence_threshold = 75
+        self.confidence_threshold = dynamic_config.get_ai_confidence_threshold()
         
     def process_uploaded_data(self, df: pd.DataFrame, client_profile: str = "auto") -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- centralize security & performance constants
- implement `DynamicConfigManager` for env overrides
- use dynamic config in core modules
- document env vars for configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68607940a67083209228cdc39a6069f5