### PR TITLE
Implement settings persistence and UI

### DIFF
--- a/assets/css/03-components/_settings.css
+++ b/assets/css/03-components/_settings.css
@@ -1,0 +1,29 @@
+/* Settings Modal Styles */
+.settings-modal {
+  /* wrapper styles if needed */
+}
+
+.settings-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-modal-title {
+  font-size: 1.125rem;
+  font-weight: bold;
+  margin: 0;
+}
+
+.settings-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.settings-modal-body {
+  padding: 1.5rem;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -22,6 +22,7 @@
 @import './03-components/_forms.css';
 @import './03-components/_navigation.css';
 @import './03-components/_modals.css';
+@import './03-components/_settings.css';
 
 /* Dashboard Panels */
 @import './04-panels/_panel-base.css';

--- a/components/ui_settings.py
+++ b/components/ui_settings.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Optional
+import dash_bootstrap_components as dbc
+from dash import html, dcc
+
+from services.settings_service import (
+    SettingsManager,
+    UserSettings,
+    AdminSettings,
+)
+
+
+class SettingsUIBuilder:
+    """Builds the settings modal UI"""
+
+    def __init__(self, manager: Optional[SettingsManager] = None) -> None:
+        self.manager = manager or SettingsManager()
+
+    # ------------------------------------------------------------------
+    def create_settings_modal(self) -> dbc.Modal:
+        user = self.manager.load_user_settings()
+        admin = self.manager.load_admin_settings()
+
+        return dbc.Modal(
+            [
+                dbc.ModalHeader(
+                    [
+                        dbc.ModalTitle("Settings"),
+                        dbc.Button(
+                            "×",
+                            id="settings-modal-close",
+                            n_clicks=0,
+                            className="btn-close",
+                        ),
+                    ]
+                ),
+                dbc.ModalBody(
+                    [
+                        dbc.Form(
+                            [
+                                dbc.Label("Site Name"),
+                                dbc.Input(
+                                    id="admin-site-name",
+                                    value=admin.site_name,
+                                    type="text",
+                                ),
+                                dbc.Label("DB Retries", className="mt-2"),
+                                dbc.Input(
+                                    id="admin-db-retry",
+                                    value=admin.db_retry,
+                                    type="number",
+                                ),
+                                dbc.Label("Redis Connections", className="mt-2"),
+                                dbc.Input(
+                                    id="admin-redis-connections",
+                                    value=admin.redis_connections,
+                                    type="number",
+                                ),
+                                html.Hr(),
+                                dbc.Label("Theme"),
+                                dcc.Dropdown(
+                                    id="user-theme",
+                                    options=[
+                                        {"label": "Light", "value": "light"},
+                                        {"label": "Dark", "value": "dark"},
+                                    ],
+                                    value=user.theme,
+                                ),
+                                dbc.Label("Language", className="mt-2"),
+                                dcc.Dropdown(
+                                    id="user-language",
+                                    options=[
+                                        {"label": "English", "value": "en"},
+                                        {"label": "Japanese", "value": "jp"},
+                                    ],
+                                    value=user.language,
+                                ),
+                                html.Div(id="settings-save-status", className="mt-2"),
+                            ]
+                        )
+                    ]
+                ),
+                dbc.ModalFooter(
+                    dbc.Button(
+                        "Save",
+                        id="settings-modal-save",
+                        color="primary",
+                    )
+                ),
+            ],
+            id="settings-modal",
+            is_open=False,
+            className="settings-modal",
+        )
+
+
+# Convenience wrapper for callbacks
+from services.settings_service import settings_manager as settings_ui_manager

--- a/components/unified_settings_callbacks.py
+++ b/components/unified_settings_callbacks.py
@@ -1,0 +1,72 @@
+import dash
+from dash import callback_context
+from dash.dependencies import Input, Output, State
+
+from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from services.settings_service import AdminSettings
+from .ui_settings import settings_ui_manager
+
+
+def toggle_settings_modal(open_clicks, close_clicks, save_clicks, is_open):
+    ctx = callback_context
+    if not ctx.triggered:
+        return is_open
+    trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+    if trigger == "open-settings-btn":
+        return True
+    if trigger in {"settings-modal-close", "settings-modal-save"}:
+        return False
+    return is_open
+
+
+def save_admin_settings_callback(n_clicks, site_name, db_retry, redis_connections):
+    if not n_clicks:
+        raise dash.exceptions.PreventUpdate
+
+    try:
+        retry = int(db_retry) if db_retry is not None else 0
+    except ValueError:
+        retry = 0
+    try:
+        redis_conns = int(redis_connections) if redis_connections is not None else 0
+    except ValueError:
+        redis_conns = 0
+
+    settings = AdminSettings(
+        site_name=site_name or "",
+        db_retry=retry,
+        redis_connections=redis_conns,
+    )
+    settings_ui_manager.save_admin_settings(settings)
+    return "Settings saved"
+
+
+def register_settings_callbacks(manager: UnifiedCallbackCoordinator) -> None:
+    manager.register_callback(
+        Output("settings-modal", "is_open"),
+        [
+            Input("open-settings-btn", "n_clicks"),
+            Input("settings-modal-close", "n_clicks"),
+            Input("settings-modal-save", "n_clicks"),
+        ],
+        [State("settings-modal", "is_open")],
+        prevent_initial_call=True,
+        callback_id="toggle_settings_modal",
+        component_name="settings",
+    )(toggle_settings_modal)
+
+    manager.register_callback(
+        Output("settings-save-status", "children"),
+        Input("settings-modal-save", "n_clicks"),
+        [
+            State("admin-site-name", "value"),
+            State("admin-db-retry", "value"),
+            State("admin-redis-connections", "value"),
+        ],
+        prevent_initial_call=True,
+        callback_id="save_admin_settings",
+        component_name="settings",
+    )(save_admin_settings_callback)
+
+
+__all__ = ["register_settings_callbacks"]

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -8,7 +8,10 @@ import os
 from typing import Optional, Any
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Input, Output, callback
+from components.ui_settings import SettingsUIBuilder, settings_ui_manager
+from components.unified_settings_callbacks import register_settings_callbacks
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from dashboard.layout.navbar import create_navbar_layout
 import pandas as pd
 
 # ✅ FIXED IMPORTS - Use correct config system
@@ -82,6 +85,7 @@ def _create_full_app() -> dash.Dash:
             register_device_verification(coordinator)
             register_deep_callbacks(coordinator)
             register_navbar_callbacks(coordinator)
+            register_settings_callbacks(coordinator)
 
             if config_manager.get_app_config().environment == "development":
                 coordinator.print_callback_summary()
@@ -202,61 +206,22 @@ def _create_json_safe_app() -> dash.Dash:
 
 def _create_main_layout() -> html.Div:
     """Create main application layout with complete integration"""
+    builder = SettingsUIBuilder(settings_ui_manager)
+    settings_modal = builder.create_settings_modal()
+
     return html.Div(
         [
-            # URL routing component
             dcc.Location(id="url", refresh=False),
-            # Navigation bar
-            _create_navbar(),
-            # Main content area (dynamically populated)
+            create_navbar_layout(),
             html.Div(id="page-content", className="main-content p-4"),
-            # Global data stores
             dcc.Store(id="global-store", data={}),
             dcc.Store(id="session-store", data={}),
             dcc.Store(id="app-state-store", data={"initial": True}),
+            settings_modal,
         ]
     )
 
 
-def _create_navbar() -> dbc.Navbar:
-    """Create navigation bar"""
-    return dbc.Navbar(
-        [
-            dbc.Container(
-                [
-                    # Brand
-                    dbc.NavbarBrand(
-                        [
-                            html.I(className="fas fa-shield-alt me-2"),
-                            "Yōsai Intel Dashboard",
-                        ],
-                        href="/",
-                    ),
-                    # Navigation links
-                    dbc.Nav(
-                        [
-                            dbc.NavItem(dbc.NavLink("📊 Analytics", href="/analytics")),
-                            dbc.NavItem(dbc.NavLink("📁 Upload", href="/upload")),
-                            dbc.NavItem(
-                                [
-                                    dbc.Button(
-                                        "🔄 Clear Cache",
-                                        id="clear-cache-btn",
-                                        color="outline-secondary",
-                                        size="sm",
-                                    )
-                                ]
-                            ),
-                        ],
-                        navbar=True,
-                    ),
-                ]
-            )
-        ],
-        color="dark",
-        dark=True,
-        className="mb-4",
-    )
 
 
 def _create_placeholder_page(title: str, subtitle: str, message: str) -> html.Div:

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -149,22 +149,6 @@ def create_navbar_layout() -> Optional[Any]:
                                                             className="navbar-nav-link",
                                                             title="Export"
                                                         ),
-                                                        html.Button(
-                                                            html.Img(
-                                                                src="/assets/navbar_icons/settings.png",
-                                                                className="navbar-icon",
-                                                                alt="Settings"
-                                                            ),
-                                                            id="navbar-settings-btn",
-                                                            className="navbar-nav-link",
-                                                            title="Settings",
-                                                            style={
-                                                                "background": "none",
-                                                                "border": "none",
-                                                                "padding": "0",
-                                                                "cursor": "pointer",
-                                                            },
-                                                        ),
                                                         html.A(
                                                             html.Img(
                                                                 src="/assets/navbar_icons/logout.png",
@@ -177,7 +161,15 @@ def create_navbar_layout() -> Optional[Any]:
                                                         ),
                                                     ],
                                                     className="d-flex align-items-center",
+
                                                     style={"gap": "1rem"}  # Increased from 0.75rem
+                                                ),
+                                                dbc.Button(
+                                                    "Clear Cache",
+                                                    id="clear-cache-btn",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    className="ms-3",
                                                 ),
 
                                                 # Language Toggle
@@ -190,6 +182,13 @@ def create_navbar_layout() -> Optional[Any]:
                                                     className="d-flex align-items-center text-sm",
                                                     style={"marginLeft": "2rem"},
                                                     id="language-toggle"
+                                                ),
+                                                dbc.Button(
+                                                    "Settings",
+                                                    id="open-settings-btn",
+                                                    color="secondary",
+                                                    size="sm",
+                                                    className="ms-3",
                                                 ),
                                             ],
                                             className="d-flex align-items-center justify-content-end",

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass, asdict
+from typing import Optional, Dict, Any
+import json
+
+from config.config import get_database_config
+from config.database_manager import DatabaseManager
+
+
+@dataclass
+class UserSettings:
+    """User specific settings"""
+    theme: str = "light"
+    language: str = "en"
+
+
+@dataclass
+class AdminSettings:
+    """Administrative settings"""
+    site_name: str = "Yosai Dashboard"
+    db_retry: int = 0
+    redis_connections: int = 0
+
+
+class SettingsPersistenceService:
+    """Persist settings using the application database"""
+
+    def __init__(self) -> None:
+        self.db_manager = DatabaseManager(get_database_config())
+        self._ensure_table()
+
+    # ------------------------------------------------------------------
+    def _ensure_table(self) -> None:
+        conn = self.db_manager.get_connection()
+        conn.execute_command(
+            "CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT)"
+        )
+
+    # ------------------------------------------------------------------
+    def save_settings(self, key: str, data: Dict[str, Any]) -> None:
+        conn = self.db_manager.get_connection()
+        conn.execute_command(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)",
+            (key, json.dumps(data)),
+        )
+
+    # ------------------------------------------------------------------
+    def load_settings(self, key: str) -> Dict[str, Any]:
+        conn = self.db_manager.get_connection()
+        rows = conn.execute_query(
+            "SELECT value FROM app_settings WHERE key = ?", (key,)
+        )
+        if rows:
+            try:
+                return json.loads(rows[0]["value"])
+            except Exception:
+                return {}
+        return {}
+
+
+class SettingsManager:
+    """High level manager for user and admin settings"""
+
+    def __init__(self, persistence: Optional[SettingsPersistenceService] = None) -> None:
+        self._persistence = persistence or SettingsPersistenceService()
+        self._user_settings = UserSettings()
+        self._admin_settings = AdminSettings()
+        self.load_user_settings()
+        self.load_admin_settings()
+
+    # ------------------------------------------------------------------
+    def save_user_settings(self, settings: UserSettings) -> None:
+        self._user_settings = settings
+        self._persistence.save_settings("user", asdict(settings))
+
+    def load_user_settings(self) -> UserSettings:
+        data = self._persistence.load_settings("user")
+        if data:
+            self._user_settings = UserSettings(**data)
+        return self._user_settings
+
+    # ------------------------------------------------------------------
+    def save_admin_settings(self, settings: AdminSettings) -> None:
+        self._admin_settings = settings
+        self._persistence.save_settings("admin", asdict(settings))
+
+    def load_admin_settings(self) -> AdminSettings:
+        data = self._persistence.load_settings("admin")
+        if data:
+            self._admin_settings = AdminSettings(**data)
+        return self._admin_settings
+
+
+# Global instance
+settings_manager = SettingsManager()
+
+__all__ = [
+    "UserSettings",
+    "AdminSettings",
+    "SettingsPersistenceService",
+    "SettingsManager",
+    "settings_manager",
+]


### PR DESCRIPTION
## Summary
- add a persistence-backed settings service
- implement Settings UI modal and callbacks
- register settings callbacks in the app factory
- add settings modal button to the navbar
- include styling for settings modal
- fix missing import in settings callbacks
- use the advanced navbar layout so the Settings button appears
- add Clear Cache button and remove legacy navbar code

## Testing
- `pytest -k 'nothing' -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68608b833f648320bc4ec3bd3cfe4c2a