### PR TITLE
Add automatic dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ yosai_intel_dashboard/
    imports.
 
 4. **Set up environment:**
-   ```bash
+```bash
    cp .env.example .env
    # Edit .env with your configuration (e.g. set HOST and database info)
-   ```
+```
+
+   Environment variables from `.env` are automatically loaded when running `app.py`.
 
 5. **Run the application:**
    ```bash

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ Fixed Main Application - No import issues
 import logging
 import os
 import sys
+from dotenv import load_dotenv
 
 # Configure logging first
 logging.basicConfig(
@@ -66,6 +67,7 @@ def print_startup_info(app_config):
 
 def main():
     """Main application entry point"""
+    load_dotenv()
     try:
         # Import configuration
         try:

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,29 @@
+import app
+
+class DummyApp:
+    def run_server(self, **kwargs):
+        pass
+
+class DummyAppConfig:
+    debug = False
+    host = "127.0.0.1"
+    port = 8050
+    environment = "test"
+
+class DummyConfig:
+    def get_app_config(self):
+        return DummyAppConfig
+
+def test_load_dotenv_invoked(monkeypatch):
+    called = {"flag": False}
+
+    def fake_load():
+        called["flag"] = True
+
+    monkeypatch.setattr(app, "load_dotenv", fake_load)
+    monkeypatch.setattr("core.app_factory.create_app", lambda: DummyApp())
+    monkeypatch.setattr("config.config.get_config", lambda: DummyConfig())
+    monkeypatch.setattr(app, "print_startup_info", lambda cfg: None)
+
+    app.main()
+    assert called["flag"] is True


### PR DESCRIPTION
## Summary
- load environment variables using `python-dotenv`
- note automatic `.env` loading in README
- test that `load_dotenv()` executes without error

## Testing
- `pytest tests/test_env_loading.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686099fa6158832086e5c401049a3556