### PR TITLE
Add service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ files while maintaining backwards compatible helper functions like
 - Full type annotations and validation
 
 ### Services Layer (`services/`)
-- **analytics_service.py**: Business logic for analytics
+- **analytics_service.py**: Business logic for analytics ([docs](docs/analytics_service.md))
+- **device_learning_service.py**: Persists learned device mappings ([docs](docs/device_learning_service.md))
 - Caching and performance optimization
 - Modular and testable
 

--- a/docs/analytics_service.md
+++ b/docs/analytics_service.md
@@ -1,0 +1,35 @@
+# Analytics Service
+
+The Analytics Service powers most data insights in the dashboard.
+It processes raw uploads or database records, applies learned mappings,
+and generates summaries for the UI.
+
+## Responsibilities
+
+- Load uploaded files and consolidate them with existing mappings
+- Clean and map columns and device identifiers
+- Produce analytics such as event counts and top users/doors
+- Provide sample or database based summaries when needed
+
+## Major Classes and Methods
+
+### `AnalyticsDataAccessor`
+
+- `get_processed_database()` – return combined dataframe and metadata
+- `_load_consolidated_mappings()` – read saved mapping information
+- `_get_uploaded_data()` – retrieve uploaded files from the UI layer
+- `_apply_mappings_and_combine()` – apply mappings and merge files
+
+### `AnalyticsService`
+
+- `get_analytics_from_uploaded_data()` – process files directly
+- `get_analytics_by_source(source)` – dispatch to uploaded, sample or database data
+- `_process_uploaded_data_directly()` – internal helper for uploaded datasets
+- `summarize_dataframe(df)` – build counts and distributions from a dataframe
+
+## Data Flow
+
+1. User uploads files or selects a data source.
+2. `AnalyticsDataAccessor` loads mappings and cleans each file.
+3. Cleaned data is combined and handed to `AnalyticsService`.
+4. Analytics are computed and returned to the dashboard.

--- a/docs/device_learning_service.md
+++ b/docs/device_learning_service.md
@@ -1,0 +1,31 @@
+# Device Learning Service
+
+This service manages persistent device mappings learned from uploaded files.
+It stores mapping data on disk and can apply the mappings automatically
+when similar files are uploaded again.
+
+## Responsibilities
+
+- Create fingerprints for uploaded data to uniquely identify a file format
+- Persist learned device mapping information as JSON
+- Reload mappings on startup and expose them to other services
+- Allow user-confirmed mappings to be saved for future use
+
+## Major Methods
+
+- `_get_file_fingerprint(df, filename)` – build a stable identifier
+- `_load_all_learned_mappings()` – initialize in-memory cache from disk
+- `save_device_mappings(df, filename, device_mappings)` – store mappings
+- `get_learned_mappings(df, filename)` – fetch mappings by fingerprint
+- `apply_learned_mappings_to_global_store(df, filename)` – update the
+  global mapping store used by the UI components
+- `save_user_device_mappings(filename, user_mappings)` – persist manual
+  corrections provided by users
+
+## Data Flow
+
+1. A user uploads a file and confirms device mappings.
+2. The service generates a fingerprint and saves mappings to
+   `data/device_learning/`.
+3. When a matching file is processed later, mappings are loaded and
+   applied automatically.


### PR DESCRIPTION
## Summary
- document the Analytics Service
- document the Device Learning Service
- link the new docs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860a35ae7208320b1c909604796f25e