### PR TITLE
Use config for sample dataset paths

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -59,11 +59,19 @@ class SecurityConfig:
 
 
 @dataclass
+class SampleFilesConfig:
+    """File paths for bundled sample datasets"""
+    csv_path: str = "data/sample_data.csv"
+    json_path: str = "data/sample_data.json"
+
+
+@dataclass
 class Config:
     """Main configuration object"""
     app: AppConfig = field(default_factory=AppConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
+    sample_files: SampleFilesConfig = field(default_factory=SampleFilesConfig)
     environment: str = "development"
 
 
@@ -176,6 +184,11 @@ class ConfigManager:
                 self.config.security.csrf_enabled = bool(sec_data.get("csrf_enabled"))
             if "max_failed_attempts" in sec_data:
                 self.config.security.max_failed_attempts = int(sec_data.get("max_failed_attempts"))
+
+        if "sample_files" in yaml_config:
+            sample_data = yaml_config["sample_files"]
+            self.config.sample_files.csv_path = sample_data.get("csv_path", self.config.sample_files.csv_path)
+            self.config.sample_files.json_path = sample_data.get("json_path", self.config.sample_files.json_path)
     
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides"""
@@ -228,6 +241,14 @@ class ConfigManager:
         max_failed = os.getenv("MAX_FAILED_ATTEMPTS")
         if max_failed is not None:
             self.config.security.max_failed_attempts = int(max_failed)
+
+        # Sample file overrides
+        sample_csv = os.getenv("SAMPLE_CSV_PATH")
+        if sample_csv is not None:
+            self.config.sample_files.csv_path = sample_csv
+        sample_json = os.getenv("SAMPLE_JSON_PATH")
+        if sample_json is not None:
+            self.config.sample_files.json_path = sample_json
     
     def _validate_config(self) -> None:
         """Validate configuration and log warnings"""
@@ -265,6 +286,10 @@ class ConfigManager:
         """Get security configuration"""
         return self.config.security
 
+    def get_sample_files_config(self) -> SampleFilesConfig:
+        """Get sample file path configuration"""
+        return self.config.sample_files
+
 
 # Global configuration instance
 _config_manager: Optional[ConfigManager] = None
@@ -301,9 +326,15 @@ def get_security_config() -> SecurityConfig:
     return get_config().get_security_config()
 
 
+def get_sample_files_config() -> SampleFilesConfig:
+    """Get sample file configuration"""
+    return get_config().get_sample_files_config()
+
+
 # Export main classes and functions
 __all__ = [
     'Config', 'AppConfig', 'DatabaseConfig', 'SecurityConfig',
-    'ConfigManager', 'get_config', 'reload_config',
-    'get_app_config', 'get_database_config', 'get_security_config'
+    'SampleFilesConfig', 'ConfigManager', 'get_config', 'reload_config',
+    'get_app_config', 'get_database_config', 'get_security_config',
+    'get_sample_files_config'
 ]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,10 @@ security:
   session_timeout: 3600
   csrf_enabled: false
 
+sample_files:
+  csv_path: "data/sample_data.csv"
+  json_path: "data/sample_data.json"
+
 logging:
   level: "INFO"
   format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -17,6 +17,10 @@ security:
   secret_key: "${SECRET_KEY}"
   session_timeout: 3600
 
+sample_files:
+  csv_path: "data/sample_data.csv"
+  json_path: "data/sample_data.json"
+
 analytics:
   enabled: true
   batch_size: 100

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -17,6 +17,10 @@ security:
   secret_key: "change-me"
   session_timeout: 3600
 
+sample_files:
+  csv_path: "data/sample_data.csv"
+  json_path: "data/sample_data.json"
+
 analytics:
   enabled: true
   batch_size: 100

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -591,8 +591,11 @@ class AnalyticsService:
     def _get_analytics_with_fixed_processor(self) -> Dict[str, Any]:
         """Get analytics using the FIXED file processor"""
 
-        csv_file = "/Users/tombrayman/Library/CloudStorage/Dropbox/1. YOSAI CODING/03_Data/Datasets/Demo3_data.csv"
-        json_file = "/Users/tombrayman/Library/CloudStorage/Dropbox/1. YOSAI CODING/03_Data/Datasets/key_fob_access_log_sample.json"
+        from config.config import get_sample_files_config
+
+        sample_cfg = get_sample_files_config()
+        csv_file = os.getenv("SAMPLE_CSV_PATH", sample_cfg.csv_path)
+        json_file = os.getenv("SAMPLE_JSON_PATH", sample_cfg.json_path)
 
         try:
             from services.file_processor import FileProcessor

--- a/tests/test_sample_paths.py
+++ b/tests/test_sample_paths.py
@@ -1,0 +1,51 @@
+import os
+
+from services.analytics_service import AnalyticsService
+from config.config import get_config, reload_config
+
+
+def test_fixed_processor_paths_from_env(monkeypatch):
+    """Paths should come from environment variables when set."""
+
+    monkeypatch.setenv("SAMPLE_CSV_PATH", "/tmp/env_sample.csv")
+    monkeypatch.setenv("SAMPLE_JSON_PATH", "/tmp/env_sample.json")
+
+    calls = []
+
+    def fake_exists(path):
+        calls.append(path)
+        return False
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+
+    service = AnalyticsService()
+    service._get_analytics_with_fixed_processor()
+
+    assert "/tmp/env_sample.csv" in calls
+    assert "/tmp/env_sample.json" in calls
+
+
+def test_fixed_processor_paths_from_config(monkeypatch):
+    """Service should fallback to config when env vars are absent."""
+
+    monkeypatch.delenv("SAMPLE_CSV_PATH", raising=False)
+    monkeypatch.delenv("SAMPLE_JSON_PATH", raising=False)
+
+    cfg = reload_config()  # fresh config
+    cfg.config.sample_files.csv_path = "/tmp/config_sample.csv"
+    cfg.config.sample_files.json_path = "/tmp/config_sample.json"
+
+    calls = []
+
+    def fake_exists(path):
+        calls.append(path)
+        return False
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+
+    service = AnalyticsService()
+    service._get_analytics_with_fixed_processor()
+
+    assert "/tmp/config_sample.csv" in calls
+    assert "/tmp/config_sample.json" in calls
+


### PR DESCRIPTION
## Summary
- configure sample file paths in `config`
- read sample paths in `AnalyticsService` from config or environment
- document sample file paths in YAML configs
- test that analytics service uses configured paths

## Testing
- `pytest tests/test_sample_paths.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860b72ac6888320a5d3b4a0aa1d3906