### PR TITLE
Implement SecurityService validation and tests

### DIFF
--- a/security/auth_service.py
+++ b/security/auth_service.py
@@ -1,6 +1,18 @@
 """Minimal security service used for dependency injection."""
 
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
 from typing import Any, Dict
+
+from config.dynamic_config import dynamic_config
+from utils.unicode_handler import sanitize_unicode_input
+from core.security import RateLimiter
+
+SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
+ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 
 
 class SecurityService:
@@ -8,24 +20,67 @@ class SecurityService:
 
     def __init__(self, config: Any) -> None:
         self.config = config
+        self.logger = logging.getLogger(__name__)
+        self.input_validation_enabled = False
+        self.rate_limiter: RateLimiter | None = None
+        self.file_validation_enabled = False
+        self.events: list[Dict[str, Any]] = []
 
     def enable_input_validation(self) -> None:
-        pass
+        self.input_validation_enabled = True
+        self.logger.info("Input validation enabled")
 
     def enable_rate_limiting(self) -> None:
-        pass
+        self.rate_limiter = RateLimiter(
+            dynamic_config.security.rate_limit_requests,
+            dynamic_config.security.rate_limit_window_minutes,
+        )
+        self.logger.info(
+            "Rate limiting enabled: %s req / %s min",
+            dynamic_config.security.rate_limit_requests,
+            dynamic_config.security.rate_limit_window_minutes,
+        )
 
     def enable_file_validation(self) -> None:
-        pass
+        self.file_validation_enabled = True
+        self.logger.info("File validation enabled")
 
     def validate_file(self, filename: str, size: int) -> Dict[str, Any]:
-        return {"valid": True}
+        filename = sanitize_unicode_input(filename)
+        issues: list[str] = []
+
+        max_size_bytes = dynamic_config.security.max_upload_mb * 1024 * 1024
+        if size > max_size_bytes:
+            issues.append("File too large")
+
+        if not SAFE_FILENAME_RE.fullmatch(filename):
+            issues.append("Invalid filename")
+
+        ext = Path(filename).suffix.lower()
+        if ext not in ALLOWED_EXTENSIONS:
+            issues.append(f"Unsupported file type: {ext}")
+
+        valid = len(issues) == 0
+        return {"valid": valid, "issues": issues}
 
     def log_file_processing_event(self, filename: str, success: bool, error: str | None = None) -> None:
-        pass
+        event = {
+            "filename": filename,
+            "success": success,
+            "error": error,
+        }
+        self.events.append(event)
+        if success:
+            self.logger.info("Processed file %s", filename)
+        else:
+            self.logger.warning("File processing failed for %s: %s", filename, error)
 
     def get_security_status(self) -> Dict[str, Any]:
-        return {"overall": "basic"}
+        return {
+            "input_validation": self.input_validation_enabled,
+            "rate_limiting": self.rate_limiter is not None,
+            "file_validation": self.file_validation_enabled,
+        }
 
 
 __all__ = ["SecurityService"]

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -1,0 +1,21 @@
+import pytest
+
+from security.auth_service import SecurityService
+from config.dynamic_config import dynamic_config
+
+
+def test_malicious_filename_is_invalid():
+    service = SecurityService(None)
+    service.enable_file_validation()
+    result = service.validate_file("../../evil.csv", 10)
+    assert result["valid"] is False
+    assert any("Invalid filename" in issue for issue in result["issues"])
+
+
+def test_oversized_upload_is_invalid():
+    service = SecurityService(None)
+    service.enable_file_validation()
+    too_big = dynamic_config.security.max_upload_mb * 1024 * 1024 + 1
+    result = service.validate_file("big.csv", too_big)
+    assert result["valid"] is False
+    assert any("File too large" in issue for issue in result["issues"])


### PR DESCRIPTION
## Summary
- flesh out SecurityService with basic validation and logging
- use configuration constants for limits
- add unit tests for malicious filenames and oversized uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860b72d24e88320acf0c370914d91d9