### PR TITLE
Use thread-safe AI mapping store

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -9,7 +9,8 @@ import dash_bootstrap_components as dbc
 from typing import Dict, List, Any, Union
 import logging
 from datetime import datetime
-from components.simple_device_mapping import _device_ai_mappings, special_areas_options
+from components.simple_device_mapping import special_areas_options
+from services.ai_mapping_store import ai_mapping_store
 
 logger = logging.getLogger(__name__)
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -33,11 +33,11 @@ learning_service = DeviceLearningService()
 def analyze_device_name_with_ai(device_name):
     """User mappings ALWAYS override AI - FIXED"""
     try:
-        from components.simple_device_mapping import _device_ai_mappings
+        from services.ai_mapping_store import ai_mapping_store
 
         # Check for user-confirmed mapping first
-        if device_name in _device_ai_mappings:
-            mapping = _device_ai_mappings[device_name]
+        mapping = ai_mapping_store.get(device_name)
+        if mapping:
             if mapping.get("source") == "user_confirmed":
                 print(f"\U0001f512 Using USER CONFIRMED mapping for '{device_name}'")
                 return mapping
@@ -504,20 +504,20 @@ def process_uploaded_files(
                 try:
                     user_mappings = learning_service.get_user_device_mappings(filename)
                     if user_mappings:
-                        from components.simple_device_mapping import _device_ai_mappings
+                        from services.ai_mapping_store import ai_mapping_store
 
-                        _device_ai_mappings.clear()
+                        ai_mapping_store.clear()
                         for device, mapping in user_mappings.items():
                             mapping["source"] = "user_confirmed"
-                            _device_ai_mappings[device] = mapping
+                            ai_mapping_store.set(device, mapping)
                         print(
                             f"✅ Loaded {len(user_mappings)} saved mappings - AI SKIPPED"
                         )
                     else:
                         print("🆕 First upload - AI will be used")
-                        from components.simple_device_mapping import _device_ai_mappings
+                        from services.ai_mapping_store import ai_mapping_store
 
-                        _device_ai_mappings.clear()
+                        ai_mapping_store.clear()
                 except Exception as e:  # pragma: no cover - best effort
                     print(f"⚠️ Error: {e}")
 
@@ -1085,9 +1085,9 @@ def save_confirmed_device_mappings(
         learning_service.save_user_device_mappings(filename, user_mappings)
 
         # Update global mappings
-        from components.simple_device_mapping import _device_ai_mappings
+        from services.ai_mapping_store import ai_mapping_store
 
-        _device_ai_mappings.update(user_mappings)
+        ai_mapping_store.update(user_mappings)
 
         print(
             f"\u2705 Saved {len(user_mappings)} confirmed device mappings to database"

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -3,6 +3,7 @@
 Simplified Services Package
 """
 import logging
+from .ai_mapping_store import ai_mapping_store
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,11 @@ except ImportError:
     FileProcessor = None
 
 try:
-    from .analytics_service import get_analytics_service, create_analytics_service, AnalyticsService
+    from .analytics_service import (
+        get_analytics_service,
+        create_analytics_service,
+        AnalyticsService,
+    )
     ANALYTICS_SERVICE_AVAILABLE = True
 except ImportError as e:
     logger.warning(f"Analytics service not available: {e}")
@@ -28,5 +33,6 @@ except ImportError as e:
 __all__ = [
     'FileProcessor', 'FILE_PROCESSOR_AVAILABLE',
     'get_analytics_service', 'create_analytics_service', 'AnalyticsService',
-    'ANALYTICS_SERVICE_AVAILABLE'
+    'ANALYTICS_SERVICE_AVAILABLE',
+    'ai_mapping_store'
 ]

--- a/services/ai_mapping_store.py
+++ b/services/ai_mapping_store.py
@@ -1,0 +1,37 @@
+import threading
+from typing import Dict, Any
+
+class AIMappingStore:
+    """Thread-safe store for device AI mappings."""
+
+    def __init__(self):
+        self._mappings: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, device: str) -> Dict[str, Any]:
+        with self._lock:
+            return self._mappings.get(device, {})
+
+    def set(self, device: str, mapping: Dict[str, Any]) -> None:
+        with self._lock:
+            self._mappings[device] = mapping
+
+    def update(self, mappings: Dict[str, Dict[str, Any]]) -> None:
+        with self._lock:
+            self._mappings.update(mappings)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._mappings.clear()
+
+    def all(self) -> Dict[str, Dict[str, Any]]:
+        with self._lock:
+            return dict(self._mappings)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._mappings)
+
+ai_mapping_store = AIMappingStore()
+
+__all__ = ["AIMappingStore", "ai_mapping_store"]

--- a/services/consolidated_learning_service.py
+++ b/services/consolidated_learning_service.py
@@ -82,15 +82,15 @@ class ConsolidatedLearningService:
     def apply_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
         """Apply learned mappings to global device mapping store."""
         try:
-            from components.simple_device_mapping import _device_ai_mappings
+            from services.ai_mapping_store import ai_mapping_store
         except ImportError:
             self.logger.warning("Could not import global device mappings store")
             return False
 
         learned = self.get_learned_mappings(df, filename)
         if learned['match_type'] != 'none' and learned['device_mappings']:
-            _device_ai_mappings.clear()
-            _device_ai_mappings.update(learned['device_mappings'])
+            ai_mapping_store.clear()
+            ai_mapping_store.update(learned['device_mappings'])
             self.logger.info(
                 f"Applied {len(learned['device_mappings'])} learned device mappings"
             )

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -138,16 +138,16 @@ class DeviceLearningService:
 
     def apply_learned_mappings_to_global_store(self, df: pd.DataFrame, filename: str):
         """Apply learned mappings to the global AI mappings store - NEW METHOD"""
-        from components.simple_device_mapping import _device_ai_mappings
+        from services.ai_mapping_store import ai_mapping_store
 
         learned_mappings = self.get_learned_mappings(df, filename)
 
         if learned_mappings:
             # Clear existing AI mappings
-            _device_ai_mappings.clear()
+            ai_mapping_store.clear()
 
             # Apply learned mappings
-            _device_ai_mappings.update(learned_mappings)
+            ai_mapping_store.update(learned_mappings)
 
             logger.info(
                 f"🤖 Applied {len(learned_mappings)} learned mappings to AI store"

--- a/tests/test_learning_priority.py
+++ b/tests/test_learning_priority.py
@@ -1,6 +1,6 @@
 import pytest
 from pages.file_upload import analyze_device_name_with_ai
-from components.simple_device_mapping import _device_ai_mappings
+from services.ai_mapping_store import ai_mapping_store
 from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
 
 class DummyAttrs:
@@ -18,14 +18,14 @@ class DummyAttrs:
 
 def test_learned_mapping_priority(monkeypatch):
     """Ensure learned mappings are used before invoking AI"""
-    _device_ai_mappings.clear()
-    _device_ai_mappings['door_1'] = {
+    ai_mapping_store.clear()
+    ai_mapping_store.set('door_1', {
         'floor_number': 2,
         'security_level': 7,
         'confidence': 0.95,
         'is_entry': True,
         'device_name': 'Door 1'
-    }
+    })
 
     def fail_generate(self, *args, **kwargs):
         raise AssertionError('AI should not be called')
@@ -40,7 +40,7 @@ def test_learned_mapping_priority(monkeypatch):
 
 def test_fallback_to_ai(monkeypatch):
     """If no learned mapping exists, AI generator should be used"""
-    _device_ai_mappings.clear()
+    ai_mapping_store.clear()
 
     def fake_generate(self, name):
         return DummyAttrs()


### PR DESCRIPTION
## Summary
- centralize device AI mappings in a new `AIMappingStore`
- update services and components to use the new mapping store
- replace tests and file upload logic with service usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860b732c8108320b954b15701c3a387