### PR TITLE
Refactor analytics helpers

### DIFF
--- a/tests/test_fixed_processor_helpers.py
+++ b/tests/test_fixed_processor_helpers.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import json
+from services.analytics_service import AnalyticsService
+from services.file_processor import FileProcessor
+
+
+def test_load_fixed_file_csv(tmp_path):
+    csv = tmp_path / "data.csv"
+    pd.DataFrame({"person_id": ["u1"], "door_id": ["d1"], "access_result": ["Granted"], "timestamp": ["2024-01-01"]}).to_csv(csv, index=False)
+    processor = FileProcessor(upload_folder=str(tmp_path), allowed_extensions={"csv"})
+    service = AnalyticsService()
+    df = service._load_fixed_file(str(csv), processor)
+    assert df is not None
+    assert list(df.columns) == ["person_id", "door_id", "access_result", "timestamp"]
+
+
+def test_load_fixed_file_json(tmp_path):
+    json_path = tmp_path / "data.json"
+    data = [{"person_id": "u1", "door_id": "d1", "access_result": "Granted", "timestamp": "2024-01-01"}]
+    json_path.write_text(json.dumps(data))
+    processor = FileProcessor(upload_folder=str(tmp_path), allowed_extensions={"json"})
+    service = AnalyticsService()
+    df = service._load_fixed_file(str(json_path), processor)
+    assert df is not None
+    assert "person_id" in df.columns
+
+
+def test_summarize_fixed_data():
+    service = AnalyticsService()
+    df1 = pd.DataFrame({"person_id": ["u1"], "door_id": ["d1"], "timestamp": pd.to_datetime(["2024-01-01"]), "access_result": ["Granted"]})
+    df2 = pd.DataFrame({"person_id": ["u2"], "door_id": ["d2"], "timestamp": pd.to_datetime(["2024-01-02"]), "access_result": ["Denied"]})
+    summary = service._summarize_fixed_data([df1, df2])
+    assert summary["status"] == "success"
+    assert summary["total_events"] == 2

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -39,3 +39,27 @@ def test_summarize_dataframe():
     assert summary["active_doors"] == 2
     assert summary["date_range"]["start"] == "2024-01-01"
     assert summary["date_range"]["end"] == "2024-01-02"
+
+
+def test_combine_uploaded_data():
+    service = AnalyticsService()
+    data = {
+        "a.csv": pd.DataFrame({"Person ID": ["u1"], "Device name": ["d1"], "Access result": ["Granted"], "Timestamp": ["2024-01-01"]}),
+        "b.csv": pd.DataFrame({"Person ID": ["u2"], "Device name": ["d2"], "Access result": ["Denied"], "Timestamp": ["2024-01-02"]}),
+    }
+    combined = service._combine_uploaded_data(data)
+    assert len(combined) == 2
+    assert list(combined.columns) == ["timestamp", "person_id", "access_result", "door_id"] or list(combined.columns) == ["timestamp", "person_id", "door_id", "access_result"]
+
+
+def test_summarize_direct_processing():
+    service = AnalyticsService()
+    df = pd.DataFrame({
+        "person_id": ["u1", "u2"],
+        "door_id": ["d1", "d2"],
+        "timestamp": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+        "access_result": ["Granted", "Denied"],
+    })
+    summary = service._summarize_direct_processing(df)
+    assert summary["status"] == "success"
+    assert summary["total_events"] == 2


### PR DESCRIPTION
## Summary
- split direct file processing into helper functions
- split fixed processor analytics into helper functions
- test new helper utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860b73658588320b27b3b78c08d3b74