### PR TITLE
Switch ConsolidatedLearningService storage to JSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,11 +38,11 @@ def check_learning_status():
 
     # Check if storage file exists
     import os
-    storage_exists = os.path.exists("data/learned_mappings.pkl")
+    storage_exists = os.path.exists("data/learned_mappings.json")
     print(f"\n💾 Storage file exists: {storage_exists}")
 
     if storage_exists:
-        file_size = os.path.getsize("data/learned_mappings.pkl")
+        file_size = os.path.getsize("data/learned_mappings.json")
         print(f"   File size: {file_size} bytes")
 
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -4,7 +4,6 @@ Analytics Service - Enhanced with Unique Patterns Analysis
 """
 import pandas as pd
 import numpy as np
-import pickle
 import json
 import logging
 from pathlib import Path
@@ -22,7 +21,7 @@ class AnalyticsDataAccessor:
 
     def __init__(self, base_data_path: str = "data"):
         self.base_path = Path(base_data_path)
-        self.mappings_file = self.base_path / "learned_mappings.pkl"
+        self.mappings_file = self.base_path / "learned_mappings.json"
         self.session_storage = self.base_path.parent / "session_storage"
 
     def get_processed_database(self) -> Tuple[pd.DataFrame, Dict[str, Any]]:
@@ -37,11 +36,11 @@ class AnalyticsDataAccessor:
         return combined_df, metadata
 
     def _load_consolidated_mappings(self) -> Dict[str, Any]:
-        """Load consolidated mappings from learned_mappings.pkl"""
+        """Load consolidated mappings from learned_mappings.json"""
         try:
             if self.mappings_file.exists():
-                with open(self.mappings_file, 'rb') as f:
-                    return pickle.load(f)
+                with open(self.mappings_file, "r") as f:
+                    return json.load(f)
             return {}
         except Exception as e:
             logger.error(f"Error loading mappings: {e}")

--- a/tests/test_consolidated_learning_service.py
+++ b/tests/test_consolidated_learning_service.py
@@ -10,7 +10,7 @@ class TestConsolidatedLearningService:
 
     def setup_method(self):
         self.temp_dir = tempfile.mkdtemp()
-        self.storage_path = Path(self.temp_dir) / "test_mappings.pkl"
+        self.storage_path = Path(self.temp_dir) / "test_mappings.json"
         self.service = ConsolidatedLearningService(str(self.storage_path))
 
     def test_save_and_retrieve_exact_match(self):


### PR DESCRIPTION
## Summary
- store consolidated learning data as JSON instead of pickle
- migrate legacy pickle files on load
- update analytics service to read JSON mappings
- adjust path checks in the app
- adapt tests for JSON storage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860bc0b261083208fdf32a303ef629e