### PR TITLE
Improve file validation error handling

### DIFF
--- a/tests/test_file_validator_errors.py
+++ b/tests/test_file_validator_errors.py
@@ -1,0 +1,21 @@
+from utils.file_validator import safe_decode_file, process_dataframe
+
+
+def test_safe_decode_file_invalid_base64():
+    malformed = "data:text/csv;base64,@@@"
+    assert safe_decode_file(malformed) is None
+
+
+def test_process_dataframe_unsupported_type(tmp_path):
+    data = b"col1,col2\n1,2"
+    df, err = process_dataframe(data, "data.txt")
+    assert df is None
+    assert "Unsupported file type" in err
+
+
+def test_process_dataframe_invalid_json():
+    bad_json = b"{invalid"  # not valid JSON
+    df, err = process_dataframe(bad_json, "file.json")
+    assert df is None
+    assert err is not None
+    assert "Error processing file" in err

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -123,7 +123,7 @@ class TestJsonSerializationPlugin(unittest.TestCase):
         """Ensure LazyString objects are sanitized to plain strings"""
         try:
             from flask_babel import lazy_gettext
-        except Exception:
+        except ImportError:
             self.skipTest("flask_babel not available")
 
         self.plugin.load(self.container, self.config)


### PR DESCRIPTION
## Summary
- catch specific decoding and parsing errors in `file_validator`
- log unexpected errors and re-raise them
- tweak a test to use ImportError for optional module
- add tests for invalid file handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6861a778bf7c83208d7889169fd6b42f