### PR TITLE
Convert manual upload and callback checks to pytest

### DIFF
--- a/test_callbacks.py
+++ b/test_callbacks.py
@@ -1,128 +1,29 @@
-#!/usr/bin/env python3
-"""
-Test to verify callback registration is working
-"""
-import sys
-import logging
-from pathlib import Path
+"""Tests for callback registration."""
 
-# Add project root to path
-project_root = Path(__file__).parent
-sys.path.insert(0, str(project_root))
+import importlib
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from core.app_factory import create_app
 
-# Ensure new deep_analytics package can be imported
-import pages.deep_analytics.layout as deep_layout
 
-def test_callback_registration():
-    """Test that callbacks are properly registered"""
-    
-    try:
-        # Import the app factory
-        from core.app_factory import create_app
-        
-        logger.info("Creating app...")
-        app = create_app()
-        
-        # Check if app has callbacks
-        if hasattr(app, 'callback_map'):
-            callback_count = len(app.callback_map)
-            logger.info(f"✅ App created with {callback_count} callbacks registered")
-            
-            # List callback IDs for debugging
-            for callback_id in app.callback_map.keys():
-                logger.info(f"  - Callback: {callback_id}")
-                
-            # Check specifically for upload callback
-            upload_callbacks = [cid for cid in app.callback_map.keys() 
-                              if 'upload' in cid.lower()]
-            
-            if upload_callbacks:
-                logger.info(f"✅ Found {len(upload_callbacks)} upload-related callbacks")
-                for ucb in upload_callbacks:
-                    logger.info(f"  - Upload callback: {ucb}")
-            else:
-                logger.warning("❌ No upload callbacks found!")
-                
-            # Test for specific callback outputs we expect
-            expected_outputs = [
-                'upload-results.children',
-                'file-preview.children', 
-                'upload-nav.children'
-            ]
-            
-            found_outputs = []
-            for expected in expected_outputs:
-                for callback_id in app.callback_map.keys():
-                    if expected in callback_id:
-                        found_outputs.append(expected)
-                        break
-            
-            logger.info(f"Expected outputs found: {found_outputs}")
-            missing_outputs = set(expected_outputs) - set(found_outputs)
-            if missing_outputs:
-                logger.warning(f"Missing expected outputs: {missing_outputs}")
-            else:
-                logger.info("✅ All expected upload outputs found!")
-                
-        else:
-            logger.error("❌ App has no callback_map attribute")
-            
-        return app
-        
-    except Exception as e:
-        logger.error(f"❌ Failed to create app: {e}")
-        import traceback
-        traceback.print_exc()
-        return None
+def test_upload_module_import() -> None:
+    """Ensure the upload module exposes expected helpers."""
 
-def test_upload_module():
-    """Test that upload module can be imported and has callbacks"""
-    
-    try:
-        logger.info("Testing upload module import...")
-        import pages.file_upload
-        
-        # Check if module has the callback registration function
-        if hasattr(pages.file_upload, 'register_upload_callbacks'):
-            logger.info("✅ Upload module has register_upload_callbacks function")
-        else:
-            logger.warning("❌ Upload module missing register_upload_callbacks")
-            
-        # Check if module has the callback function
-        if hasattr(pages.file_upload, 'consolidated_upload_callback'):
-            logger.info("✅ Upload module has consolidated_upload_callback function")
-        else:
-            logger.warning("❌ Upload module missing consolidated_upload_callback")
-            
-        # List all attributes for debugging
-        attrs = [attr for attr in dir(pages.file_upload) if not attr.startswith('_')]
-        logger.info(f"Upload module attributes: {attrs}")
-        
-    except Exception as e:
-        logger.error(f"❌ Failed to import upload module: {e}")
-        import traceback
-        traceback.print_exc()
+    mod = importlib.import_module("pages.file_upload")
 
-if __name__ == "__main__":
-    print("🧪 Testing callback registration...")
-    print("=" * 50)
-    
-    # Test 1: Upload module import
-    test_upload_module()
-    print("-" * 30)
-    
-    # Test 2: App creation and callback registration
-    app = test_callback_registration()
-    
-    if app:
-        print("✅ All tests passed! Upload should work.")
-        print("\n📋 Next steps:")
-        print("1. Run: python3 test_upload.py  (to create test file)")
-        print("2. Run: python3 app.py  (to start the app)")
-        print("3. Go to: http://127.0.0.1:8050/upload")
-        print("4. Test file upload functionality")
-    else:
-        print("❌ Tests failed. Check the errors above.")
+    assert hasattr(mod, "layout")
+    assert hasattr(mod, "register_callbacks")
+
+
+def test_callback_registration(dash_duo) -> None:
+    """Verify callbacks are registered and the upload page renders."""
+
+    app = create_app()
+    assert hasattr(app, "callback_map")
+    assert app.callback_map
+
+    upload_callbacks = [cid for cid in app.callback_map if "upload" in cid.lower()]
+    assert upload_callbacks
+
+    dash_duo.start_server(app)
+    dash_duo.driver.get(dash_duo.server_url + "/upload")
+    dash_duo.find_element("#upload-data")

--- a/test_upload.py
+++ b/test_upload.py
@@ -1,42 +1,51 @@
-#!/usr/bin/env python3
-"""
-Simple upload test - Creates a test CSV file to verify upload functionality
-"""
-import csv
-import tempfile
-import os
-from pathlib import Path
+"""Tests for the upload page."""
 
-def create_test_csv():
-    """Create a simple test CSV file for upload testing"""
-    
-    # Create test data
+from pathlib import Path
+import csv
+
+import pytest
+
+from core.app_factory import create_app
+
+
+@pytest.fixture()
+def sample_csv(tmp_path: Path) -> Path:
+    """Create a temporary CSV file for upload testing."""
+
     test_data = [
-        ['device_name', 'user_name', 'timestamp', 'access_type'],
-        ['Door_A1', 'John_Smith', '2025-06-28 10:00:00', 'entry'],
-        ['Door_B2', 'Jane_Doe', '2025-06-28 10:05:00', 'exit'],
-        ['Door_C3', 'Bob_Wilson', '2025-06-28 10:10:00', 'entry'],
-        ['Door_A1', 'Alice_Brown', '2025-06-28 10:15:00', 'exit'],
-        ['Door_D4', 'Mike_Davis', '2025-06-28 10:20:00', 'entry'],
+        ["device_name", "user_name", "timestamp", "access_type"],
+        ["Door_A1", "John_Smith", "2025-06-28 10:00:00", "entry"],
+        ["Door_B2", "Jane_Doe", "2025-06-28 10:05:00", "exit"],
+        ["Door_C3", "Bob_Wilson", "2025-06-28 10:10:00", "entry"],
+        ["Door_A1", "Alice_Brown", "2025-06-28 10:15:00", "exit"],
+        ["Door_D4", "Mike_Davis", "2025-06-28 10:20:00", "entry"],
     ]
-    
-    # Create test file in current directory
-    test_file = Path("test_upload_data.csv")
-    
-    with open(test_file, 'w', newline='', encoding='utf-8') as csvfile:
+
+    file_path = tmp_path / "test_upload_data.csv"
+    with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerows(test_data)
-    
-    print(f"✅ Created test file: {test_file.absolute()}")
-    print(f"📄 File contains {len(test_data)-1} data rows")
-    print("🔧 Use this file to test the upload functionality")
-    print("\n📋 Next steps:")
-    print("1. Start the app: python3 app.py")
-    print("2. Go to: http://127.0.0.1:8050/upload")
-    print("3. Upload the test_upload_data.csv file")
-    print("4. Check logs for upload processing messages")
-    
-    return test_file
 
-if __name__ == "__main__":
-    create_test_csv()
+    return file_path
+
+
+def test_sample_csv_created(sample_csv: Path) -> None:
+    """Verify the temporary CSV contains the expected rows."""
+
+    with open(sample_csv, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+
+    # header + 5 data rows
+    assert len(rows) == 6
+
+
+def test_upload_page_renders(dash_duo) -> None:
+    """Ensure the upload page renders and the upload component exists."""
+
+    app = create_app()
+    dash_duo.start_server(app)
+
+    dash_duo.driver.get(dash_duo.server_url + "/upload")
+    upload = dash_duo.find_element("#upload-data")
+
+    assert upload is not None


### PR DESCRIPTION
## Summary
- replace script-style upload test with pytest functions
- convert callback registration checks to pytest
- use `dash_duo` fixture to exercise rendering

## Testing
- `pytest -k "test_upload or test_callbacks" -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861a7838c848320982ea70d9146f895