### PR TITLE
Add ER diagram documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 
 ![Language Toggle Demo](docs/i18n_demo.gif)
 
+## 📚 Documentation
+
+See the [data model diagram](docs/data_model.md) for an overview of key entities.
+
 ## 🤝 Contributing
 
 1. Ensure all tests pass: `pytest`

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -1,0 +1,51 @@
+# Data Model
+
+Core entities and relationships in the Yōsai Intel system.
+
+```mermaid
+erDiagram
+    PERSON {
+        string person_id PK
+        string name
+        string employee_id
+        int clearance_level
+    }
+    DOOR {
+        string door_id PK
+        string door_name
+        string facility_id FK
+        int required_clearance
+    }
+    FACILITY {
+        string facility_id PK
+        string facility_name
+        string campus_id
+    }
+    ACCESS_EVENT {
+        string event_id PK
+        datetime timestamp
+        string person_id FK
+        string door_id FK
+        string badge_id
+        string access_result
+    }
+    ANOMALY_DETECTION {
+        string anomaly_id PK
+        string event_id FK
+        string anomaly_type
+        string severity
+    }
+    INCIDENT_TICKET {
+        string ticket_id PK
+        string event_id FK
+        string anomaly_id FK
+        string status
+    }
+
+    PERSON ||--o{ ACCESS_EVENT : "has"
+    DOOR ||--o{ ACCESS_EVENT : "records"
+    FACILITY ||--o{ DOOR : "contains"
+    ACCESS_EVENT ||--o{ ANOMALY_DETECTION : "triggers"
+    ACCESS_EVENT ||--o{ INCIDENT_TICKET : "linked to"
+    ANOMALY_DETECTION ||--o{ INCIDENT_TICKET : "investigated by"
+```


### PR DESCRIPTION
## Summary
- document the core data model with a Mermaid ER diagram
- link the new diagram from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: duplicate module error)*

------
https://chatgpt.com/codex/tasks/task_e_6861a78b26188320893235581078ed6d