### PR TITLE
Add changelog and release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Initial changelog with standard sections.
+
+### Changed
+- N/A
+
+### Fixed
+- N/A
+

--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 5. Optional debug helpers live in `examples/`. Run the upload helper with
    `python examples/debug_upload.py` to validate environment setup
 
+## 📦 Versioning
+
+This project adheres to [Semantic Versioning](https://semver.org). See
+[docs/release.md](docs/release.md) for details on how releases are managed.
+
 ## 📄 License
 
 MIT License - see LICENSE file for details.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,14 @@
+# Release Process
+
+This project follows [Semantic Versioning](https://semver.org) for all public
+releases. Versions are tagged in the form `vMAJOR.MINOR.PATCH`.
+
+To create a new release:
+
+1. Increment the version number according to the nature of your changes.
+2. Tag the commit with the version (e.g. `git tag v1.2.0`).
+3. Push the tag to GitHub. The CI workflow will automatically generate release
+   notes for the tag.
+
+See the [CHANGELOG](../CHANGELOG.md) for a list of changes.
+

--- a/workflow/ci.yml
+++ b/workflow/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ["*"]
   push:
     branches: ["main"]
+    tags: ['v*.*.*']
 
 jobs:
   build-test:
@@ -88,3 +89,16 @@ jobs:
 
       - name: ✅ Image digest
         run: echo "Image built: ${{ steps.build-and-push.outputs.digest }}"
+
+  release-notes:
+    needs: build-test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📝 Generate release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- create initial `CHANGELOG.md`
- document semantic versioning and release process
- mention versioning approach in README
- generate GitHub release notes when a tag is pushed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861a79bcfe88320aadf395db3bfbca7