### PR TITLE
Load secrets via SecretManager in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ SECRET_KEY=your-key  # Change for production
 
 The secret key is not included in the default YAML files. Define
 `SECRET_KEY` in your environment or a `.env` file before starting the
-application.
+application. The example scripts under `examples/` also rely on this
+variable through the `SecretManager` helper.
 
 When `YOSAI_ENV=production` the application will refuse to start unless both
 `DB_PASSWORD` and `SECRET_KEY` are provided via environment variables or Docker
@@ -312,6 +313,9 @@ See the [data model diagram](docs/data_model.md) for an overview of key entities
 4. Add tests for new functionality and update documentation when applicable
 5. Optional debug helpers live in `examples/`. Run the upload helper with
    `python examples/debug_upload.py` to validate environment setup
+6. The example CSRF scripts in `examples/` read `SECRET_KEY` from the
+   environment using the `SecretManager`. Set this variable in your shell or
+   `.env` file before running them.
 
 ## 📦 Versioning
 

--- a/examples/advanced_usage.py
+++ b/examples/advanced_usage.py
@@ -1,18 +1,19 @@
+import os
 import dash
 from dash import html
 from dash_csrf_plugin import DashCSRFPlugin, CSRFConfig, CSRFMode
+from core.secret_manager import SecretManager
 
-config = CSRFConfig.for_production('super-secret-key', exempt_routes=['/health'])
+manager = SecretManager()
+secret_key = manager.get("SECRET_KEY", os.getenv("SECRET_KEY", "super-secret-key"))
+config = CSRFConfig.for_production(secret_key, exempt_routes=["/health"])
 
 app = dash.Dash(__name__)
-app.server.config['SECRET_KEY'] = config.secret_key
+app.server.config["SECRET_KEY"] = secret_key
 
 csrf = DashCSRFPlugin(app, config=config, mode=CSRFMode.ENABLED)
 
-app.layout = html.Div([
-    csrf.create_csrf_component(),
-    html.H1('Advanced CSRF Example')
-])
+app.layout = html.Div([csrf.create_csrf_component(), html.H1("Advanced CSRF Example")])
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run()

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,16 +1,18 @@
+import os
 import dash
 from dash import html
 from dash_csrf_plugin import DashCSRFPlugin
+from core.secret_manager import SecretManager
 
 app = dash.Dash(__name__)
-app.server.config['SECRET_KEY'] = 'change-me'
+manager = SecretManager()
+app.server.config["SECRET_KEY"] = manager.get(
+    "SECRET_KEY", os.getenv("SECRET_KEY", "change-me")
+)
 
 csrf = DashCSRFPlugin(app)
 
-app.layout = html.Div([
-    csrf.create_csrf_component(),
-    html.H1('Basic CSRF Example')
-])
+app.layout = html.Div([csrf.create_csrf_component(), html.H1("Basic CSRF Example")])
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/production_setup.py
+++ b/examples/production_setup.py
@@ -1,18 +1,21 @@
 """Example production configuration using the CSRF plugin"""
 
+import os
 import dash
 from dash_csrf_plugin import DashCSRFPlugin, CSRFConfig, CSRFMode
+from core.secret_manager import SecretManager
 
 app = dash.Dash(__name__)
-app.server.config['SECRET_KEY'] = 'prod-secret-key'
+manager = SecretManager()
+secret_key = manager.get("SECRET_KEY", os.getenv("SECRET_KEY", "prod-secret-key"))
+app.server.config["SECRET_KEY"] = secret_key
 
-config = CSRFConfig.for_production('prod-secret-key')
+config = CSRFConfig.for_production(secret_key)
 csrf = DashCSRFPlugin(app, config=config, mode=CSRFMode.PRODUCTION)
 
-app.layout = dash.html.Div([
-    csrf.create_csrf_component(),
-    dash.html.H1('Production Setup')
-])
+app.layout = dash.html.Div(
+    [csrf.create_csrf_component(), dash.html.H1("Production Setup")]
+)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=False)

--- a/examples/testing_setup.py
+++ b/examples/testing_setup.py
@@ -1,17 +1,21 @@
 """Example testing configuration with CSRF disabled"""
 
+import os
 import dash
 from dash_csrf_plugin import DashCSRFPlugin, CSRFMode
+from core.secret_manager import SecretManager
 
 app = dash.Dash(__name__)
-app.server.config['SECRET_KEY'] = 'test-secret-key'
+manager = SecretManager()
+app.server.config["SECRET_KEY"] = manager.get(
+    "SECRET_KEY", os.getenv("SECRET_KEY", "test-secret-key")
+)
 
 csrf = DashCSRFPlugin(app, mode=CSRFMode.TESTING)
 
-app.layout = dash.html.Div([
-    csrf.create_csrf_component(),
-    dash.html.H1('Testing Setup')
-])
+app.layout = dash.html.Div(
+    [csrf.create_csrf_component(), dash.html.H1("Testing Setup")]
+)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- update example scripts to read `SECRET_KEY` from environment using `SecretManager`
- document required env vars for running examples

## Testing
- `black --check examples/basic_usage.py examples/advanced_usage.py examples/production_setup.py examples/testing_setup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861ad36919883209c5d403f9f312638