### PR TITLE
Update numpy requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dash-bootstrap-components==1.6.0
 dash==3.0.0
 plotly==5.15.0
 pandas==2.1.1
-numpy==2.1.0
+numpy>=1.23.2,<1.28
 Flask-Babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1

--- a/requirements_ui.txt
+++ b/requirements_ui.txt
@@ -2,4 +2,4 @@ dash==3.0.0
 dash-bootstrap-components==1.6.0
 plotly==5.15.0
 pandas==2.1.1
-numpy==2.1.0
+numpy>=1.23.2,<1.28


### PR DESCRIPTION
## Summary
- loosen numpy bounds to prevent conflicts

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861b1a747048320b3849e731fd75dbd