### PR TITLE
Add offline setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ yosai_intel_dashboard/
 
 3. **Install dependencies:**
    ```bash
-   pip install -r requirements.txt
+   ./scripts/setup.sh
    ```
-   Make sure all dependencies are installed **before** running Pyright or using
+   The script installs requirements from PyPI or a local `packages/` directory if
+   present. Ensure dependencies are installed **before** running Pyright or using
    the Pylance extension. Missing packages will otherwise appear as unresolved
    imports.
 
@@ -83,7 +84,7 @@ following steps:
 
 2. Install dependencies:
    ```bash
-   pip install -r requirements.txt
+   ./scripts/setup.sh
    ```
    If you encounter errors like `module 'flask' has no attribute 'helpers'`,
    ensure there are no local directories named `flask`, `pandas`, or `yaml`

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+if [ -d "$ROOT_DIR/packages" ]; then
+    pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements.txt"
+else
+    pip install -r "$ROOT_DIR/requirements.txt"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` for installing dependencies offline
- document the new setup script in the README

## Testing
- `./scripts/setup.sh` *(fails: Could not find a version that satisfies the requirement dash-leaflet==1.1.3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861aea8b8c083209f542e6fd15e7d91