### PR TITLE
Use dynamic config for upload limits

### DIFF
--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -9,14 +9,13 @@ from typing import Any, Dict
 
 from utils.unicode_handler import sanitize_unicode_input
 from utils.file_validator import safe_decode_with_unicode_handling
+from config.dynamic_config import dynamic_config
 
 import pandas as pd
 import dash_bootstrap_components as dbc
 from dash import html
 
 logger = logging.getLogger(__name__)
-
-MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
 
 
@@ -32,7 +31,8 @@ def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 
         content_type, content_string = contents.split(",", 1)
         decoded = base64.b64decode(content_string)
-        if len(decoded) > MAX_FILE_SIZE_BYTES:
+        max_size = dynamic_config.security.max_upload_mb * 1024 * 1024
+        if len(decoded) > max_size:
             return {
                 "success": False,
                 "error": "File too large",

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -2,7 +2,8 @@ import pandas as pd
 import base64
 
 from services.file_processor import FileProcessor
-from services.upload_service import process_uploaded_file, MAX_FILE_SIZE_BYTES
+from services.upload_service import process_uploaded_file
+from config.dynamic_config import dynamic_config
 
 
 def test_enhanced_processor(tmp_path):
@@ -38,7 +39,8 @@ def test_malicious_filename_rejected(tmp_path):
 
 
 def test_oversized_file_rejected(tmp_path):
-    data = base64.b64encode(b"A" * (MAX_FILE_SIZE_BYTES + 1)).decode()
+    max_bytes = dynamic_config.security.max_upload_mb * 1024 * 1024
+    data = base64.b64encode(b"A" * (max_bytes + 1)).decode()
     contents = f"data:text/csv;base64,{data}"
     result = process_uploaded_file(contents, "big.csv")
     assert result["success"] is False

--- a/tests/test_upload_service_env.py
+++ b/tests/test_upload_service_env.py
@@ -1,0 +1,21 @@
+import base64
+import importlib
+
+from config import dynamic_config as dyn_module
+from services import upload_service as upload_module
+
+
+def test_env_max_upload_limit(monkeypatch):
+    monkeypatch.setenv("MAX_UPLOAD_MB", "1")
+    importlib.reload(dyn_module)
+    importlib.reload(upload_module)
+
+    max_bytes = dyn_module.dynamic_config.security.max_upload_mb * 1024 * 1024
+    data = base64.b64encode(b"A" * (max_bytes + 1)).decode()
+    contents = f"data:text/csv;base64,{data}"
+    result = upload_module.process_uploaded_file(contents, "big.csv")
+    assert result["success"] is False
+
+    monkeypatch.delenv("MAX_UPLOAD_MB", raising=False)
+    importlib.reload(dyn_module)
+    importlib.reload(upload_module)


### PR DESCRIPTION
## Summary
- read upload limit from dynamic_config
- update tests to reference dynamic_config
- add regression test for environment override

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861b80008748320bac4e22c902c0586