### PR TITLE
Add plugin usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,14 @@ override security and performance defaults:
 
 ### Plugins
 
-Plugins live in the `plugins/` package and are loaded by the `PluginManager` when enabled in `config/config.yaml`.
-To enable a plugin, add it under the `plugins:` section and set `enabled: true`.
-After creating the `PluginManager` in your app factory, call `load_all_plugins()` and `register_plugin_callbacks(app)` to activate them.
+Plugins live in the `plugins/` directory. Place any custom plugin package inside
+this folder, for example `plugins/my_plugin/plugin.py` defining a
+`create_plugin()` function. Enable the plugin by adding a section under
+`plugins:` in `config/config.yaml` and setting `enabled: true` plus any plugin
+options. In your app factory create a `PluginManager`, call
+`load_all_plugins()` and then `register_plugin_callbacks(app)` to activate all
+enabled plugins. See [docs/plugins.md](docs/plugins.md) for a detailed overview
+of discovery, configuration and the plugin lifecycle.
 
 ### Migration Notes
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,30 @@
+# Plugins
+
+This document explains how plugins are discovered, configured, and managed at runtime.
+
+## Discovery
+
+Plugins live in the `plugins/` directory by default. The `PluginManager` scans this package with `pkgutil.iter_modules` and imports every submodule. A plugin module should expose a `create_plugin()` function, a `plugin` instance, or an `init_plugin(container, config)` function that returns an object implementing `PluginProtocol`.
+
+You can change the search location by passing a different package name to `PluginManager(package="myplugins")` when constructing it.
+
+## Configuration
+
+Application settings include a top level `plugins:` section in `config/config.yaml`. Each plugin has its own subsection named after its metadata name. Set `enabled: true` to load a plugin and supply any plugin specific options under that key. These options are provided to `configure()` after the plugin is loaded.
+
+```yaml
+plugins:
+  json_serialization:
+    enabled: true
+    max_dataframe_rows: 1000
+```
+
+## Lifecycle
+
+For each enabled plugin the manager calls these methods:
+
+1. `load(container, config)` – register services with the DI container.
+2. `configure(config)` – apply configuration values.
+3. `start()` – perform any runtime initialization.
+
+After all plugins are loaded call `register_plugin_callbacks(app)` so callback plugins can hook into Dash. Plugins implement `health_check()` and `stop()`. The manager periodically gathers health data and exposes it via `/health/plugins`.


### PR DESCRIPTION
## Summary
- document plugin discovery and lifecycle in `docs/plugins.md`
- explain where to place plugins and how to enable them in `README.md`
- link the new docs from README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: duplicate module error)*
- `black . --check` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861be0f1f0c8320af4b61dcfcca5185