### PR TITLE
Refactor analytics helpers

### DIFF
--- a/docs/analytics_service.md
+++ b/docs/analytics_service.md
@@ -13,7 +13,7 @@ and generates summaries for the UI.
 
 ## Major Classes and Methods
 
-### `AnalyticsDataAccessor`
+### `DataLoader`
 
 - `get_processed_database()` – return combined dataframe and metadata
 - `_load_consolidated_mappings()` – read saved mapping information
@@ -31,7 +31,7 @@ and generates summaries for the UI.
 ## Data Flow
 
 1. User uploads files or selects a data source.
-2. `AnalyticsDataAccessor` loads mappings and cleans each file.
+2. `DataLoader` loads mappings and cleans each file.
 3. Cleaned data is combined and handed to `AnalyticsService`.
 4. Analytics are computed and returned to the dashboard.
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -4,6 +4,7 @@ Simplified Services Package
 """
 import logging
 from .ai_mapping_store import ai_mapping_store
+from .data_loader import DataLoader
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,6 @@ except ImportError as e:
 __all__ = [
     'FileProcessor', 'FILE_PROCESSOR_AVAILABLE',
     'get_analytics_service', 'create_analytics_service', 'AnalyticsService',
-    'ANALYTICS_SERVICE_AVAILABLE',
+    'ANALYTICS_SERVICE_AVAILABLE', 'DataLoader',
     'ai_mapping_store'
 ]

--- a/services/analytics_summary.py
+++ b/services/analytics_summary.py
@@ -1,0 +1,167 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def summarize_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
+    """Return a basic summary for an uploaded dataframe."""
+    total_events = len(df)
+    active_users = df["person_id"].nunique() if "person_id" in df.columns else 0
+    active_doors = df["door_id"].nunique() if "door_id" in df.columns else 0
+
+    date_range = {"start": "Unknown", "end": "Unknown"}
+    if "timestamp" in df.columns:
+        valid_ts = df["timestamp"].dropna()
+        if not valid_ts.empty:
+            date_range = {
+                "start": str(valid_ts.min().date()),
+                "end": str(valid_ts.max().date()),
+            }
+
+    access_patterns = {}
+    if "access_result" in df.columns:
+        access_patterns = df["access_result"].value_counts().to_dict()
+
+    top_users = []
+    if "person_id" in df.columns:
+        user_counts = df["person_id"].value_counts().head(10)
+        top_users = [
+            {"user_id": uid, "count": int(cnt)} for uid, cnt in user_counts.items()
+        ]
+
+    top_doors = []
+    if "door_id" in df.columns:
+        door_counts = df["door_id"].value_counts().head(10)
+        top_doors = [
+            {"door_id": did, "count": int(cnt)} for did, cnt in door_counts.items()
+        ]
+
+    return {
+        "total_events": total_events,
+        "active_users": active_users,
+        "active_doors": active_doors,
+        "unique_users": active_users,
+        "unique_doors": active_doors,
+        "data_source": "uploaded",
+        "date_range": date_range,
+        "access_patterns": access_patterns,
+        "top_users": top_users,
+        "top_doors": top_doors,
+    }
+
+
+def create_sample_data(n_events: int = 1000) -> pd.DataFrame:
+    np.random.seed(42)
+    end_date = datetime.now()
+    start_date = end_date - timedelta(days=30)
+    timestamps = [
+        start_date
+        + timedelta(
+            days=np.random.randint(0, 30),
+            hours=np.random.randint(0, 24),
+            minutes=np.random.randint(0, 60),
+        )
+        for _ in range(n_events)
+    ]
+    users = [f"USER{i:04d}" for i in range(1, 51)]
+    doors = [f"DOOR{i:03d}" for i in range(1, 6)]
+    data = {
+        "event_id": [f"EVT{i:06d}" for i in range(n_events)],
+        "timestamp": timestamps,
+        "person_id": np.random.choice(users, n_events),
+        "door_id": np.random.choice(doors, n_events),
+        "access_result": np.random.choice(["Granted", "Denied"], n_events, p=[0.85, 0.15]),
+        "badge_status": np.random.choice(["Valid", "Invalid", "Expired"], n_events, p=[0.9, 0.08, 0.02]),
+        "device_status": np.random.choice(["normal", "maintenance"], n_events, p=[0.95, 0.05]),
+    }
+    df = pd.DataFrame(data).sort_values("timestamp").reset_index(drop=True)
+    return df
+
+
+def analyze_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
+    if df.empty:
+        return {"total_events": 0}
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    total_events = len(df)
+    unique_users = df["person_id"].nunique()
+    unique_doors = df["door_id"].nunique()
+
+    access_counts = df["access_result"].value_counts()
+    granted = access_counts.get("Granted", 0)
+    denied = access_counts.get("Denied", 0)
+    success_rate = (granted / total_events) * 100 if total_events else 0
+
+    date_range = {
+        "start": df["timestamp"].min().isoformat(),
+        "end": df["timestamp"].max().isoformat(),
+        "days": (df["timestamp"].max() - df["timestamp"].min()).days + 1,
+    }
+    hourly_dist = df["timestamp"].dt.hour.value_counts().sort_index().to_dict()
+    daily_dist = df["timestamp"].dt.day_name().value_counts().to_dict()
+
+    return {
+        "total_events": total_events,
+        "unique_users": unique_users,
+        "unique_doors": unique_doors,
+        "success_rate": round(success_rate, 2),
+        "granted_events": int(granted),
+        "denied_events": int(denied),
+        "date_range": date_range,
+        "hourly_distribution": hourly_dist,
+        "daily_distribution": daily_dist,
+    }
+
+
+def generate_basic_analytics(df: pd.DataFrame) -> Dict[str, Any]:
+    try:
+        analytics: Dict[str, Any] = {
+            "status": "success",
+            "total_events": len(df),
+            "total_rows": len(df),
+            "total_columns": len(df.columns),
+            "summary": {},
+            "timestamp": datetime.now().isoformat(),
+        }
+        for col in df.columns:
+            if pd.api.types.is_numeric_dtype(df[col]):
+                analytics["summary"][col] = {
+                    "type": "numeric",
+                    "mean": float(df[col].mean()),
+                    "min": float(df[col].min()),
+                    "max": float(df[col].max()),
+                    "null_count": int(df[col].isnull().sum()),
+                }
+            else:
+                counts = df[col].value_counts().head(10)
+                analytics["summary"][col] = {
+                    "type": "categorical",
+                    "unique_values": int(df[col].nunique()),
+                    "top_values": {str(k): int(v) for k, v in counts.items()},
+                    "null_count": int(df[col].isnull().sum()),
+                }
+        return analytics
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Error generating basic analytics: %s", exc)
+        return {"status": "error", "message": str(exc)}
+
+
+def generate_sample_analytics() -> Dict[str, Any]:
+    df = create_sample_data()
+    basic = generate_basic_analytics(df)
+    basic.update(analyze_dataframe(df))
+    return basic
+
+
+__all__ = [
+    "summarize_dataframe",
+    "create_sample_data",
+    "analyze_dataframe",
+    "generate_basic_analytics",
+    "generate_sample_analytics",
+]

--- a/services/data_loader.py
+++ b/services/data_loader.py
@@ -1,0 +1,153 @@
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class DataLoader:
+    """Load uploaded datasets and apply learned mappings."""
+
+    def __init__(self, base_data_path: str = "data"):
+        self.base_path = Path(base_data_path)
+        self.mappings_file = self.base_path / "learned_mappings.json"
+        self.session_storage = self.base_path.parent / "session_storage"
+
+    def get_processed_database(self) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+        """Return uploaded data combined with mapping metadata."""
+        mappings = self._load_consolidated_mappings()
+        uploaded = self._get_uploaded_data()
+        if not uploaded:
+            return pd.DataFrame(), {}
+        return self._apply_mappings_and_combine(uploaded, mappings)
+
+    def _load_consolidated_mappings(self) -> Dict[str, Any]:
+        try:
+            if self.mappings_file.exists():
+                with open(self.mappings_file, "r") as fh:
+                    return json.load(fh)
+            return {}
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error(f"Error loading mappings: {exc}")
+            return {}
+
+    def _get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        try:
+            from pages.file_upload import get_uploaded_data
+
+            data = get_uploaded_data()
+            if not data:
+                logger.info("No uploaded data found")
+                return {}
+
+            logger.info("Found %d uploaded files", len(data))
+            for name, df in data.items():
+                logger.info("%s: %d rows", name, len(df))
+            return data
+        except ImportError:
+            logger.error("Could not import uploaded data from file_upload")
+            return {}
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Error getting uploaded data: %s", exc)
+            return {}
+
+    def _apply_mappings_and_combine(
+        self, uploaded: Dict[str, pd.DataFrame], mappings: Dict[str, Any]
+    ) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+        combined: list[pd.DataFrame] = []
+        meta = {
+            "total_files": len(uploaded),
+            "processed_files": 0,
+            "total_records": 0,
+            "unique_users": set(),
+            "unique_devices": set(),
+            "date_range": {"start": None, "end": None},
+        }
+
+        for filename, df in uploaded.items():
+            try:
+                mapped = self._apply_column_mappings(df, filename, mappings)
+                enriched = self._apply_device_mappings(mapped, filename, mappings)
+                enriched["source_file"] = filename
+                enriched["processed_at"] = datetime.now()
+
+                combined.append(enriched)
+                meta["processed_files"] += 1
+                meta["total_records"] += len(enriched)
+
+                if "person_id" in enriched.columns:
+                    meta["unique_users"].update(
+                        enriched["person_id"].dropna().unique()
+                    )
+                if "door_id" in enriched.columns:
+                    meta["unique_devices"].update(
+                        enriched["door_id"].dropna().unique()
+                    )
+
+                if "timestamp" in enriched.columns:
+                    dates = pd.to_datetime(enriched["timestamp"], errors="coerce").dropna()
+                    if not dates.empty:
+                        if meta["date_range"]["start"] is None:
+                            meta["date_range"]["start"] = dates.min()
+                            meta["date_range"]["end"] = dates.max()
+                        else:
+                            meta["date_range"]["start"] = min(
+                                meta["date_range"]["start"], dates.min()
+                            )
+                            meta["date_range"]["end"] = max(
+                                meta["date_range"]["end"], dates.max()
+                            )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.error("Error processing %s: %s", filename, exc)
+
+        if combined:
+            final_df = pd.concat(combined, ignore_index=True)
+            meta["unique_users"] = len(meta["unique_users"])
+            meta["unique_devices"] = len(meta["unique_devices"])
+            return final_df, meta
+
+        return pd.DataFrame(), meta
+
+    def _apply_column_mappings(
+        self, df: pd.DataFrame, filename: str, mappings: Dict[str, Any]
+    ) -> pd.DataFrame:
+        for mapping in mappings.values():
+            if mapping.get("filename") == filename:
+                cols = mapping.get("column_mappings", {})
+                if cols:
+                    return df.rename(columns=cols)
+
+        standard = {
+            "Timestamp": "timestamp",
+            "Person ID": "person_id",
+            "Token ID": "token_id",
+            "Device name": "door_id",
+            "Access result": "access_result",
+        }
+        return df.rename(columns=standard)
+
+    def _apply_device_mappings(
+        self, df: pd.DataFrame, filename: str, mappings: Dict[str, Any]
+    ) -> pd.DataFrame:
+        if "door_id" not in df.columns:
+            return df
+
+        device_mappings = {}
+        for mapping in mappings.values():
+            if mapping.get("filename") == filename:
+                device_mappings = mapping.get("device_mappings", {})
+                break
+        if not device_mappings:
+            return df
+
+        attrs_df = pd.DataFrame.from_dict(device_mappings, orient="index")
+        attrs_df.index.name = "door_id"
+        attrs_df.reset_index(inplace=True)
+        return df.merge(attrs_df, on="door_id", how="left")
+
+
+__all__ = ["DataLoader"]

--- a/tests/test_analytics_summary.py
+++ b/tests/test_analytics_summary.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from services.analytics_summary import generate_basic_analytics, generate_sample_analytics
+
+
+def test_generate_basic_analytics():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
+    result = generate_basic_analytics(df)
+    assert result["total_events"] == 3
+    assert result["summary"]["a"]["mean"] == 2.0
+    assert result["summary"]["b"]["type"] == "categorical"
+
+
+def test_generate_sample_analytics():
+    result = generate_sample_analytics()
+    assert result["status"] == "success"
+    assert result["total_events"] > 0

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from services.data_loader import DataLoader
+
+
+def test_get_processed_database_basic(monkeypatch):
+    loader = DataLoader()
+    uploaded = {
+        "sample.csv": pd.DataFrame({
+            "ts": ["2024-01-01"],
+            "door_id": ["d1"],
+            "person_id": ["u1"],
+        })
+    }
+    mappings = {
+        "fp": {
+            "filename": "sample.csv",
+            "column_mappings": {"ts": "timestamp"},
+            "device_mappings": {"d1": {"location": "HQ"}},
+        }
+    }
+    monkeypatch.setattr(loader, "_get_uploaded_data", lambda: uploaded)
+    monkeypatch.setattr(loader, "_load_consolidated_mappings", lambda: mappings)
+
+    df, meta = loader.get_processed_database()
+    assert "timestamp" in df.columns
+    assert "location" in df.columns
+    assert meta["processed_files"] == 1
+    assert meta["total_records"] == 1


### PR DESCRIPTION
## Summary
- extract uploaded data handling into `DataLoader`
- move summarization routines to `analytics_summary`
- update `AnalyticsService` to use the new helpers
- document class rename and expose `DataLoader` package-wide
- test `DataLoader` and `analytics_summary`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861be323a048320961dda4d28bad850