### PR TITLE
Add learned mapping support

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -125,23 +125,14 @@ class AnalyticsDataAccessor:
 
     def _apply_column_mappings(self, df: pd.DataFrame, filename: str,
                               mappings_data: Dict[str, Any]) -> pd.DataFrame:
-        """Apply learned column mappings"""
-        for fingerprint, mapping_info in mappings_data.items():
+        """Apply learned column mappings and standard cleaning."""
+        column_mappings = {}
+        for mapping_info in mappings_data.values():
             if mapping_info.get('filename') == filename:
                 column_mappings = mapping_info.get('column_mappings', {})
-                if column_mappings:
-                    return df.rename(columns=column_mappings)
+                break
 
-        # Fallback to standard mapping patterns
-        standard_mappings = {
-            'Timestamp': 'timestamp',
-            'Person ID': 'person_id',
-            'Token ID': 'token_id',
-            'Device name': 'door_id',
-            'Access result': 'access_result'
-        }
-
-        return df.rename(columns=standard_mappings)
+        return map_and_clean(df, column_mappings)
 
     def _apply_device_mappings(self, df: pd.DataFrame, filename: str,
                               mappings_data: Dict[str, Any]) -> pd.DataFrame:

--- a/tests/test_mapping_helpers.py
+++ b/tests/test_mapping_helpers.py
@@ -31,3 +31,23 @@ def test_map_and_clean_missing_columns():
     cleaned = map_and_clean(df)
     assert "token_id" not in cleaned.columns
     assert "door_id" not in cleaned.columns
+
+
+def test_map_and_clean_with_learned_mappings():
+    df = pd.DataFrame({
+        "Time": ["2024-01-01 12:00:00"],
+        "User": [" u2 "],
+        "Door": ["d2"],
+        "Token ID": ["t2"],
+    })
+
+    learned = {"Time": "timestamp", "User": "person_id", "Door": "door_id"}
+    cleaned = map_and_clean(df, learned)
+
+    assert list(cleaned.columns) == [
+        "timestamp",
+        "person_id",
+        "door_id",
+        "token_id",
+    ]
+    assert cleaned.loc[0, "person_id"] == "u2"

--- a/utils/mapping_helpers.py
+++ b/utils/mapping_helpers.py
@@ -1,6 +1,6 @@
 """Utility functions for mapping uploaded data columns."""
 
-from typing import Dict
+from typing import Dict, Optional
 import pandas as pd
 
 # Standard column mapping used across the project
@@ -13,9 +13,25 @@ STANDARD_COLUMN_MAPPING: Dict[str, str] = {
 }
 
 
-def map_and_clean(df: pd.DataFrame) -> pd.DataFrame:
-    """Rename columns using :data:`STANDARD_COLUMN_MAPPING` and clean fields."""
-    df = df.rename(columns=STANDARD_COLUMN_MAPPING)
+def map_and_clean(
+    df: pd.DataFrame, learned_mappings: Optional[Dict[str, str]] = None
+) -> pd.DataFrame:
+    """Rename columns using provided mappings and clean fields.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to clean.
+    learned_mappings:
+        Optional user or AI learned column mappings. These take precedence over
+        :data:`STANDARD_COLUMN_MAPPING`.
+    """
+
+    mappings = STANDARD_COLUMN_MAPPING.copy()
+    if learned_mappings:
+        mappings.update(learned_mappings)
+
+    df = df.rename(columns=mappings)
 
     if "timestamp" in df.columns:
         df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")


### PR DESCRIPTION
## Summary
- expand `map_and_clean` helper to merge optional learned mappings
- use `map_and_clean` for column mapping logic in `AnalyticsDataAccessor`
- test learned mapping rename and cleaning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861be0b88e8832094caf1ffc33f9def