### PR TITLE
Refactor service and session manager instantiation

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -801,9 +801,15 @@ class AnalyticsService:
 # Global service instance
 _analytics_service: Optional[AnalyticsService] = None
 
-def get_analytics_service() -> AnalyticsService:
-    """Get global analytics service instance"""
+def get_analytics_service(service: Optional[AnalyticsService] = None) -> AnalyticsService:
+    """Return a global analytics service instance.
+
+    If ``service`` is provided, it becomes the global instance.  Otherwise an
+    instance is created on first access.
+    """
     global _analytics_service
+    if service is not None:
+        _analytics_service = service
     if _analytics_service is None:
         _analytics_service = AnalyticsService()
     return _analytics_service

--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -4,20 +4,20 @@ Complete Integration Tests for Analytics System
 """
 import pytest
 import pandas as pd
-from services.analytics_service import get_analytics_service
+from services.analytics_service import get_analytics_service, create_analytics_service
 from models.base import ModelFactory
 
 
 def test_analytics_service_creation():
     """Test analytics service can be created"""
-    service = get_analytics_service()
+    service = get_analytics_service(create_analytics_service())
     assert service is not None
     assert hasattr(service, 'health_check')
 
 
 def test_analytics_with_sample_data():
     """Test analytics generation with sample data"""
-    service = get_analytics_service()
+    service = get_analytics_service(create_analytics_service())
     result = service.get_analytics_by_source("sample")
 
     assert result['status'] == 'success'
@@ -40,7 +40,7 @@ def test_model_factory():
 
 def test_health_check():
     """Test service health check"""
-    service = get_analytics_service()
+    service = get_analytics_service(create_analytics_service())
     health = service.health_check()
 
     assert 'service' in health

--- a/utils/session_manager.py
+++ b/utils/session_manager.py
@@ -77,4 +77,30 @@ class SessionManager:
 
 
 # Global session manager instance
-session_manager = SessionManager()
+_session_manager: Optional[SessionManager] = None
+
+
+def get_session_manager(manager: Optional[SessionManager] = None) -> SessionManager:
+    """Return a global session manager instance.
+
+    If ``manager`` is provided, it becomes the global instance. Otherwise an
+    instance is created on first access.
+    """
+    global _session_manager
+    if manager is not None:
+        _session_manager = manager
+    if _session_manager is None:
+        _session_manager = SessionManager()
+    return _session_manager
+
+
+def create_session_manager() -> SessionManager:
+    """Create a new session manager instance."""
+    return SessionManager()
+
+
+__all__ = [
+    "SessionManager",
+    "get_session_manager",
+    "create_session_manager",
+]


### PR DESCRIPTION
## Summary
- allow passing an instance to `get_analytics_service`
- make `SessionManager` injectable via `get_session_manager`
- update analytics integration tests for the new API

## Testing
- `pytest tests/test_analytics_integration.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861be64c58c832084622313d59c6974