### PR TITLE
Fix RetryConfig NameError with postponed annotations

### DIFF
--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """
 Database Manager - Fixed imports for streamlined architecture
 """


### PR DESCRIPTION
## Summary
- fix `RetryConfig` NameError by deferring annotation evaluation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861ca124534832087dc0af2cbd51a7e