### PR TITLE
Allow quotes in InputValidator

### DIFF
--- a/security/input_validator.py
+++ b/security/input_validator.py
@@ -19,7 +19,7 @@ class Validator(Protocol):
 class InputValidator:
     """Simple input validator using unicode sanitization and basic patterns."""
 
-    _dangerous_pattern = re.compile(r"[<>\"']")
+    _dangerous_pattern = re.compile(r"[<>]")
 
     def validate(self, data: str) -> str:
         cleaned = sanitize_unicode_input(data)

--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -14,6 +14,12 @@ def test_unicode_normalization():
         validator.validate("<bad>")
 
 
+def test_json_input_allowed():
+    validator = InputValidator()
+    # Should not raise ValidationError for quotes within JSON structures
+    validator.validate('{"key":"val"}')
+
+
 def test_sql_injection_detection():
     with pytest.raises(ValidationError):
         SQLInjectionPrevention.validate_query_parameter("1; DROP TABLE users")


### PR DESCRIPTION
## Summary
- loosen InputValidator to permit quotes
- add regression test for JSON input

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861e4adcb3083209c4ce7c10c79ed7b