### PR TITLE
Enhance validation middleware

### DIFF
--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -3,6 +3,8 @@
 from flask import request, Response
 from typing import Callable
 
+from config.dynamic_config import dynamic_config
+
 from .validation_exceptions import ValidationError
 from .input_validator import InputValidator, Validator
 
@@ -22,11 +24,26 @@ class ValidationMiddleware:
 
     def __init__(self) -> None:
         self.orchestrator = ValidationOrchestrator([InputValidator()])
+        self.max_body_size = dynamic_config.security.max_upload_mb * 1024 * 1024
 
     def validate_request(self) -> None:
+        # Enforce maximum request body size
+        if request.content_length and request.content_length > self.max_body_size:
+            return Response("Request Entity Too Large", status=413)
+
+        # Validate query string parameters
+        for value in request.args.values():
+            try:
+                self.orchestrator.validate(value)
+            except ValidationError:
+                return Response("Bad Request", status=400)
+
+        # Validate body content
         if request.data:
             try:
-                request._cached_data = self.orchestrator.validate(request.data.decode("utf-8", errors="ignore")).encode("utf-8")
+                request._cached_data = self.orchestrator.validate(
+                    request.data.decode("utf-8", errors="ignore")
+                ).encode("utf-8")
             except ValidationError:
                 return Response("Bad Request", status=400)
         return None


### PR DESCRIPTION
## Summary
- extend ValidationMiddleware to check query strings and enforce request body size
- test oversized uploads and malicious query params

## Testing
- `pytest -q tests/security/test_validators.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861e2908890832090504c22b0d44c71