### PR TITLE
Fix JSON file encoding

### DIFF
--- a/services/data_loader.py
+++ b/services/data_loader.py
@@ -28,7 +28,12 @@ class DataLoader:
     def _load_consolidated_mappings(self) -> Dict[str, Any]:
         try:
             if self.mappings_file.exists():
-                with open(self.mappings_file, "r") as fh:
+                with open(
+                    self.mappings_file,
+                    "r",
+                    encoding="utf-8",
+                    errors="replace",
+                ) as fh:
                     return json.load(fh)
             return {}
         except Exception as exc:  # pragma: no cover - best effort

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -57,7 +57,12 @@ class DeviceLearningService:
         try:
             for mapping_file in self.storage_dir.glob("mapping_*.json"):
                 try:
-                    with open(mapping_file, "r") as f:
+                    with open(
+                        mapping_file,
+                        "r",
+                        encoding="utf-8",
+                        errors="replace",
+                    ) as f:
                         data = json.load(f)
                         fingerprint = mapping_file.stem.replace("mapping_", "")
                         self.learned_mappings[fingerprint] = data
@@ -72,7 +77,7 @@ class DeviceLearningService:
         try:
             for fingerprint, data in self.learned_mappings.items():
                 mapping_file = self.storage_dir / f"mapping_{fingerprint}.json"
-                with open(mapping_file, "w") as f:
+                with open(mapping_file, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2)
         except Exception as e:
             logger.error(f"Failed to persist learned mappings: {e}")
@@ -104,7 +109,7 @@ class DeviceLearningService:
 
             # Save to file immediately
             mapping_file = self.storage_dir / f"mapping_{fingerprint}.json"
-            with open(mapping_file, "w") as f:
+            with open(mapping_file, "w", encoding="utf-8") as f:
                 json.dump(learning_data, f, indent=2)
 
             # Update in-memory cache

--- a/services/file_processing_service.py
+++ b/services/file_processing_service.py
@@ -23,7 +23,12 @@ class FileProcessingService:
         if path.endswith(".csv"):
             return pd.read_csv(path)
         if path.endswith(".json"):
-            with open(path, "r") as f:
+            with open(
+                path,
+                "r",
+                encoding="utf-8",
+                errors="replace",
+            ) as f:
                 data = json.load(f)
             return pd.DataFrame(data)
         if path.endswith(('.xlsx', '.xls')):

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -39,7 +39,12 @@ class UploadedDataStore:
     def _load_from_disk(self) -> None:
         try:
             if self._info_path().exists():
-                with open(self._info_path(), "r") as f:
+                with open(
+                    self._info_path(),
+                    "r",
+                    encoding="utf-8",
+                    errors="replace",
+                ) as f:
                     self._file_info_store = json.load(f)
             for fname in self._file_info_store.keys():
                 fpath = self._get_file_path(fname)
@@ -61,7 +66,7 @@ class UploadedDataStore:
                     "upload_time": datetime.now().isoformat(),
                     "size_mb": round(df.memory_usage(deep=True).sum() / 1024 / 1024, 2),
                 }
-                with open(self._info_path(), "w") as f:
+                with open(self._info_path(), "w", encoding="utf-8") as f:
                     json.dump(self._file_info_store, f, indent=2)
             except Exception as e:  # pragma: no cover - best effort
                 logger.error(f"Error saving uploaded data: {e}")


### PR DESCRIPTION
## Summary
- open mappings file and JSON data using UTF-8 encoding with replace errors
- preserve encoding for JSON reads in FileProcessingService
- ensure device learning service reads/writes JSON with UTF-8
- persist UploadedDataStore info file using UTF-8

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861ed6fd6348320889148426c0b153f