### PR TITLE
Add service registry and update optional service imports

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -451,7 +451,7 @@ def _initialize_services() -> None:
     """Initialize all application services"""
     try:
         # Initialize analytics service
-        from services.analytics_service import get_analytics_service
+        from services import get_analytics_service
 
         analytics_service = get_analytics_service()
         health = analytics_service.health_check()

--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -22,15 +22,10 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 # Add this import
-from services.analytics_service import AnalyticsService
+from services import AnalyticsService
 
 # Internal service imports with CORRECTED paths
-try:
-    from services.analytics_service import AnalyticsService
-
-    ANALYTICS_SERVICE_AVAILABLE = True
-except ImportError:
-    ANALYTICS_SERVICE_AVAILABLE = False
+ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
 try:
     from components.column_verification import get_ai_suggestions_for_file
@@ -67,12 +62,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_analytics_service_safe():
-    """Safely get analytics service"""
-    try:
-        from services.analytics_service import AnalyticsService
-        return AnalyticsService()
-    except ImportError:
+    """Safely instantiate the analytics service if available."""
+    if AnalyticsService is None:
         return None
+    try:
+        return AnalyticsService()
     except Exception:
         return None
 

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -13,7 +13,7 @@ from .analysis import (
     create_analysis_results_display_safe,
     AI_SUGGESTIONS_AVAILABLE,
 )
-from services.analytics_service import AnalyticsService
+from services import AnalyticsService
 
 
 def run_suggests_analysis(data_source: str):

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,39 +1,29 @@
 #!/usr/bin/env python3
-"""
-Simplified Services Package
-"""
+"""Simplified Services Package"""
 import logging
+
 from .ai_mapping_store import ai_mapping_store
 from .data_loader import DataLoader
+from .registry import get_service
 
 logger = logging.getLogger(__name__)
 
-# Only import existing services
-try:
-    from .file_processor import FileProcessor
-    FILE_PROCESSOR_AVAILABLE = True
-except ImportError:
-    logger.warning("File processor not available")
-    FILE_PROCESSOR_AVAILABLE = False
-    FileProcessor = None
+# Resolve optional services from the registry
+FileProcessor = get_service("FileProcessor")
+FILE_PROCESSOR_AVAILABLE = FileProcessor is not None
 
-try:
-    from .analytics_service import (
-        get_analytics_service,
-        create_analytics_service,
-        AnalyticsService,
-    )
-    ANALYTICS_SERVICE_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Analytics service not available: {e}")
-    get_analytics_service = None
-    create_analytics_service = None
-    AnalyticsService = None
-    ANALYTICS_SERVICE_AVAILABLE = False
+get_analytics_service = get_service("get_analytics_service")
+create_analytics_service = get_service("create_analytics_service")
+AnalyticsService = get_service("AnalyticsService")
+ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
 __all__ = [
-    'FileProcessor', 'FILE_PROCESSOR_AVAILABLE',
-    'get_analytics_service', 'create_analytics_service', 'AnalyticsService',
-    'ANALYTICS_SERVICE_AVAILABLE', 'DataLoader',
-    'ai_mapping_store'
+    "FileProcessor",
+    "FILE_PROCESSOR_AVAILABLE",
+    "get_analytics_service",
+    "create_analytics_service",
+    "AnalyticsService",
+    "ANALYTICS_SERVICE_AVAILABLE",
+    "DataLoader",
+    "ai_mapping_store",
 ]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -418,7 +418,7 @@ class AnalyticsService:
         json_file = os.getenv("SAMPLE_JSON_PATH", sample_cfg.json_path)
 
         try:
-            from services.file_processor import FileProcessor
+            from services import FileProcessor
             import pandas as pd
             import json
 

--- a/services/file_processing_service.py
+++ b/services/file_processing_service.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import List, Tuple
 
-from services.file_processor import FileProcessor
+from services import FileProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/services/registry.py
+++ b/services/registry.py
@@ -1,0 +1,48 @@
+"""Simple registry for optional services."""
+from importlib import import_module
+from typing import Any, Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ServiceRegistry:
+    """Registry mapping service names to import paths."""
+
+    def __init__(self) -> None:
+        self._services: Dict[str, str] = {}
+
+    def register_service(self, name: str, import_path: str) -> None:
+        """Register a service by import path.
+
+        ``import_path`` may include an attribute name using the ``module:attr``
+        syntax.
+        """
+        self._services[name] = import_path
+
+    def get_service(self, name: str) -> Optional[Any]:
+        """Return the resolved service or ``None`` if not available."""
+        path = self._services.get(name)
+        if not path:
+            return None
+        module_path, _, attr = path.partition(":")
+        try:
+            module = import_module(module_path)
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            logger.warning("Optional service '%s' unavailable: %s", name, exc)
+            return None
+        return getattr(module, attr) if attr else module
+
+
+# Global registry instance
+registry = ServiceRegistry()
+
+# Convenience wrappers
+register_service = registry.register_service
+get_service = registry.get_service
+
+
+# Register built-in optional services
+register_service("FileProcessor", "services.file_processor:FileProcessor")
+register_service("get_analytics_service", "services.analytics_service:get_analytics_service")
+register_service("create_analytics_service", "services.analytics_service:create_analytics_service")
+register_service("AnalyticsService", "services.analytics_service:AnalyticsService")

--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -4,7 +4,7 @@ Complete Integration Tests for Analytics System
 """
 import pytest
 import pandas as pd
-from services.analytics_service import get_analytics_service, create_analytics_service
+from services import get_analytics_service, create_analytics_service
 from models.base import ModelFactory
 
 

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from services.file_processor import FileProcessor
+from services import FileProcessor
 
 
 @pytest.mark.parametrize("sep", [";", "\t"])

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import base64
 
-from services.file_processor import FileProcessor
+from services import FileProcessor
 from services.upload_service import process_uploaded_file
 from config.dynamic_config import dynamic_config
 

--- a/tests/test_sample_paths.py
+++ b/tests/test_sample_paths.py
@@ -1,6 +1,6 @@
 import os
 
-from services.analytics_service import AnalyticsService
+from services import AnalyticsService
 from config.config import get_config, reload_config
 
 

--- a/tests/test_uploaded_chunk_processing.py
+++ b/tests/test_uploaded_chunk_processing.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from services.analytics_service import AnalyticsService
+from services import AnalyticsService
 
 
 def test_process_uploaded_data_directly_chunked(tmp_path):

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from services.analytics_service import AnalyticsService
+from services import AnalyticsService
 
 
 def test_load_uploaded_data(monkeypatch):


### PR DESCRIPTION
## Summary
- add `services.registry` to register optional services
- resolve optional services via registry in `services/__init__`
- refactor imports to use the registry across the project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861ed70bd74832090d3f5fcc5a37914