### PR TITLE
Unify file processor modules

### DIFF
--- a/examples/debug_upload.py
+++ b/examples/debug_upload.py
@@ -161,8 +161,7 @@ def debug_file_processor():
     logger.info("\n🔍 Testing file processor...")
     
     try:
-        from services.file_processor_service import FileProcessorService
-        from services.upload_utils import parse_uploaded_file
+        from services.upload_service import process_uploaded_file
         
         # Create a simple test CSV content
         test_csv = "name,value\ntest1,123\ntest2,456"
@@ -170,8 +169,8 @@ def debug_file_processor():
         encoded = base64.b64encode(test_csv.encode('utf-8')).decode('utf-8')
         data_url = f"data:text/csv;base64,{encoded}"
         
-        # Test parsing
-        result = parse_uploaded_file(data_url, "test.csv")
+        # Test parsing using the main upload service
+        result = process_uploaded_file(data_url, "test.csv")
         
         if result.get('success'):
             logger.info("✅ File processing works")

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -1,109 +1,57 @@
-"""
-File Processing Service for Yōsai Intel Dashboard
-"""
-import pandas as pd
-import io
-import logging
-from typing import Dict, Any, List
-from pathlib import Path
+"""Compatibility wrapper around :class:`FileProcessor`.
 
-from .base import BaseService
-from .protocols import FileProcessorProtocol
-from utils.file_validator import safe_decode_with_unicode_handling
-from utils.unicode_handler import sanitize_unicode_input
+This module exists for backward compatibility. It exposes
+``FileProcessorService`` which delegates all logic to
+:class:`~services.file_processor.FileProcessor`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+from .file_processor import FileProcessor
 
 logger = logging.getLogger(__name__)
 
-class FileProcessorService(BaseService):
-    """File processing service implementation"""
-    
-    ALLOWED_EXTENSIONS = {'.csv', '.json', '.xlsx', '.xls'}
+
+class FileProcessorService(FileProcessor):
+    """Thin wrapper for the :class:`FileProcessor` class."""
+
+    ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
     MAX_FILE_SIZE_MB = 100
-    
-    def __init__(self):
-        super().__init__("file_processor")
-    
-    def _do_initialize(self) -> None:
-        """Initialize file processor"""
-        pass  # No special initialization needed
-    
+
+    def __init__(self, upload_folder: str = "temp", allowed_extensions: set | None = None) -> None:
+        exts = allowed_extensions or {ext.lstrip(".") for ext in self.ALLOWED_EXTENSIONS}
+        super().__init__(upload_folder=upload_folder, allowed_extensions=exts)
+
     def validate_file(self, filename: str, content: bytes) -> Dict[str, Any]:
-        """Validate uploaded file"""
-        filename = sanitize_unicode_input(filename)
-        issues = []
-        
-        # Check file extension
+        """Validate an uploaded file.
+
+        Parameters
+        ----------
+        filename:
+            Name of the uploaded file.
+        content:
+            Raw file bytes.
+        """
         file_ext = Path(filename).suffix.lower()
-        if file_ext not in self.ALLOWED_EXTENSIONS:
-            issues.append(f"File type {file_ext} not allowed. Allowed: {self.ALLOWED_EXTENSIONS}")
-        
-        # Check file size
         size_mb = len(content) / (1024 * 1024)
+        issues = []
+
+        if file_ext not in self.ALLOWED_EXTENSIONS:
+            issues.append(
+                f"File type {file_ext} not allowed. Allowed: {self.ALLOWED_EXTENSIONS}"
+            )
         if size_mb > self.MAX_FILE_SIZE_MB:
             issues.append(f"File too large: {size_mb:.1f}MB > {self.MAX_FILE_SIZE_MB}MB")
-        
-        # Check for empty file
-        if len(content) == 0:
+        if not content:
             issues.append("File is empty")
-        
+
         return {
-            'valid': len(issues) == 0,
-            'issues': issues,
-            'size_mb': size_mb,
-            'extension': file_ext
+            "valid": not issues,
+            "issues": issues,
+            "size_mb": size_mb,
+            "extension": file_ext,
         }
-    
-    def process_file(self, file_content: bytes, filename: str) -> pd.DataFrame:
-        """Process uploaded file and return DataFrame"""
-        try:
-            filename = sanitize_unicode_input(filename)
-            file_ext = Path(filename).suffix.lower()
-            
-            if file_ext == '.csv':
-                return self._process_csv(file_content)
-            elif file_ext == '.json':
-                return self._process_json(file_content)
-            elif file_ext in ['.xlsx', '.xls']:
-                return self._process_excel(file_content)
-            else:
-                raise ValueError(f"Unsupported file type: {file_ext}")
-                
-        except Exception as e:
-            logger.error(f"Error processing file {filename}: {e}")
-            raise
-    
-    def _process_csv(self, content: bytes) -> pd.DataFrame:
-        """Process CSV file"""
-        try:
-            # Try different encodings with surrogate handling
-            for encoding in ['utf-8', 'latin-1', 'cp1252']:
-                try:
-                    text = safe_decode_with_unicode_handling(content, encoding)
-                    text = sanitize_unicode_input(text)
-                    return pd.read_csv(io.StringIO(text))
-                except UnicodeDecodeError:
-                    continue
-            raise ValueError("Could not decode CSV file with any standard encoding")
-        except Exception as e:
-            raise ValueError(f"Error reading CSV: {e}")
-    
-    def _process_json(self, content: bytes) -> pd.DataFrame:
-        """Process JSON file"""
-        try:
-            for encoding in ['utf-8', 'latin-1', 'cp1252']:
-                try:
-                    text = safe_decode_with_unicode_handling(content, encoding)
-                    text = sanitize_unicode_input(text)
-                    return pd.read_json(io.StringIO(text))
-                except UnicodeDecodeError:
-                    continue
-            raise ValueError("Could not decode JSON with any standard encoding")
-        except Exception as e:
-            raise ValueError(f"Error reading JSON: {e}")
-    
-    def _process_excel(self, content: bytes) -> pd.DataFrame:
-        """Process Excel file"""
-        try:
-            return pd.read_excel(io.BytesIO(content))
-        except Exception as e:
-            raise ValueError(f"Error reading Excel file: {e}")


### PR DESCRIPTION
## Summary
- replace old `FileProcessorService` with lightweight wrapper around `FileProcessor`
- update `debug_upload.py` example to use `process_uploaded_file`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6861ed71583483208a8867758e82847e