### PR TITLE
Standardize door mapping attribute keys

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -70,9 +70,9 @@ def create_device_verification_modal(
                                     {"label": "Exit", "value": "is_exit"},
                                 ],
                                 value=[
-                                    k
-                                    for k, v in attributes.items()
-                                    if k in ["is_entry", "is_exit"] and v
+                                    key
+                                    for key in ["is_entry", "is_exit"]
+                                    if attributes.get(key, attributes.get(key.replace("is_", "")))
                                 ],
                                 inline=True,
                             )
@@ -86,11 +86,14 @@ def create_device_verification_modal(
                                 id={"type": "device-special", "index": i},
                                 options=special_areas_options,
                                 value=[
-                                    k
-                                    for k, v in attributes.items()
-                                    if k
-                                    in ["is_elevator", "is_stairwell", "is_fire_escape"]
-                                    and v
+                                    key
+                                    for key in [
+                                        "is_elevator",
+                                        "is_stairwell",
+                                        "is_fire_escape",
+                                        "is_restricted",
+                                    ]
+                                    if attributes.get(key, attributes.get(key.replace("is_", "")))
                                 ],
                                 inline=False,
                                 className="small",

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -92,10 +92,20 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
         default_floor = ai_data.get("floor_number")
         default_security = ai_data.get("security_level", 5)
         default_access = []
-        if ai_data.get("is_entry"):
+        if ai_data.get("is_entry", ai_data.get("entry")):
             default_access.append("entry")
-        if ai_data.get("is_exit"):
+        if ai_data.get("is_exit", ai_data.get("exit")):
             default_access.append("exit")
+
+        default_special = []
+        if ai_data.get("is_elevator", ai_data.get("elevator")):
+            default_special.append("is_elevator")
+        if ai_data.get("is_stairwell", ai_data.get("stairwell")):
+            default_special.append("is_stairwell")
+        if ai_data.get("is_fire_escape", ai_data.get("fire_escape")):
+            default_special.append("is_fire_escape")
+        if ai_data.get("is_restricted", ai_data.get("restricted")):
+            default_special.append("is_restricted")
 
         device_rows.append(
             dbc.Row(
@@ -147,12 +157,8 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
                         [
                             dbc.Checklist(
                                 id={"type": "device-special", "index": i},
-                                options=[
-                                    {"label": "Elevator", "value": "is_elevator"},
-                                    {"label": "Stairwell", "value": "is_stairwell"},
-                                    {"label": "Fire Exit", "value": "is_fire_escape"},
-                                ],
-                                value=[],
+                                options=special_areas_options,
+                                value=default_special,
                                 inline=True,
                             )
                         ],

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -717,19 +717,19 @@ def populate_device_modal_with_learning(is_open, file_info):
                                     {"label": "Elevator", "value": "is_elevator"},
                                     {"label": "Stairwell", "value": "is_stairwell"},
                                     {"label": "Fire Exit", "value": "is_fire_escape"},
+                                    {"label": "Restricted", "value": "is_restricted"},
                                 ],
                                 value=[
-                                    k
-                                    for k, v in ai_attributes.items()
-                                    if k
-                                    in [
+                                    key
+                                    for key in [
                                         "is_entry",
                                         "is_exit",
                                         "is_elevator",
                                         "is_stairwell",
                                         "is_fire_escape",
+                                        "is_restricted",
                                     ]
-                                    and v
+                                    if ai_attributes.get(key, ai_attributes.get(key.replace("is_", "")))
                                 ],
                                 inline=False,
                             ),

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -22,11 +22,12 @@ class DeviceAttributeData:
     """Device attribute data structure"""
     door_id: str
     name: str
-    entry: bool = False
-    exit: bool = False
-    elevator: bool = False
-    stairwell: bool = False
-    fire_escape: bool = False
+    is_entry: bool = False
+    is_exit: bool = False
+    is_elevator: bool = False
+    is_stairwell: bool = False
+    is_fire_escape: bool = False
+    is_restricted: bool = False
     other: bool = False
     security_level: int = 50
     confidence: Optional[int] = None
@@ -111,15 +112,16 @@ class DoorMappingService:
         # Convert confidence from 0.0-1.0 scale to 0-100 scale
         confidence_percentage = int(ai_attributes.confidence * 100)
 
-        # Convert to existing DeviceAttributeData format
+        # Convert to DeviceAttributeData with standardized keys
         return DeviceAttributeData(
             door_id=ai_attributes.device_id,
             name=ai_attributes.device_name,
-            entry=ai_attributes.is_entry,
-            exit=ai_attributes.is_exit,
-            elevator=ai_attributes.is_elevator,
-            stairwell=ai_attributes.is_stairwell,
-            fire_escape=ai_attributes.is_fire_escape,
+            is_entry=ai_attributes.is_entry,
+            is_exit=ai_attributes.is_exit,
+            is_elevator=ai_attributes.is_elevator,
+            is_stairwell=ai_attributes.is_stairwell,
+            is_fire_escape=ai_attributes.is_fire_escape,
+            is_restricted=getattr(ai_attributes, "is_restricted", False),
             other=not any(
                 [
                     ai_attributes.is_entry,
@@ -349,9 +351,9 @@ class DoorMappingService:
                     "confidence": ai_attrs.confidence,
                     "reasoning": ai_attrs.ai_reasoning,
                     "access_types": {
-                        "entry": ai_attrs.is_entry,
-                        "exit": ai_attrs.is_exit,
-                        "elevator": ai_attrs.is_elevator,
+                        "is_entry": ai_attrs.is_entry,
+                        "is_exit": ai_attrs.is_exit,
+                        "is_elevator": ai_attrs.is_elevator,
                     },
                 }
             except Exception as e:
@@ -375,11 +377,12 @@ class DoorMappingService:
                         "device_name": device.get("name", ""),
                         "floor_number": device.get("floor_number", 1),
                         "security_level": device.get("security_level", 50),
-                        "is_entry": device.get("entry", False),
-                        "is_exit": device.get("exit", False),
-                        "is_elevator": device.get("elevator", False),
-                        "is_stairwell": device.get("stairwell", False),
-                        "is_fire_escape": device.get("fire_escape", False),
+                        "is_entry": device.get("is_entry", device.get("entry", False)),
+                        "is_exit": device.get("is_exit", device.get("exit", False)),
+                        "is_elevator": device.get("is_elevator", device.get("elevator", False)),
+                        "is_stairwell": device.get("is_stairwell", device.get("stairwell", False)),
+                        "is_fire_escape": device.get("is_fire_escape", device.get("fire_escape", False)),
+                        "is_restricted": device.get("is_restricted", device.get("restricted", False)),
                     }
 
             learning_service = get_learning_service()

--- a/tests/test_door_mapping_service.py
+++ b/tests/test_door_mapping_service.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from services.door_mapping_service import DoorMappingService
+from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+
+def test_standardized_output(monkeypatch):
+    dummy = DeviceAttributes(
+        device_id="d1",
+        device_name="Door 1",
+        floor_number=1,
+        security_level=5,
+        is_entry=True,
+        is_exit=False,
+        is_elevator=False,
+        is_stairwell=False,
+        is_fire_escape=False,
+        confidence=0.9,
+        ai_reasoning="test",
+    )
+
+    def fake_generate(self, device_id, *args, **kwargs):
+        return dummy
+
+    monkeypatch.setattr(AIDeviceGenerator, "generate_device_attributes", fake_generate)
+    service = DoorMappingService()
+    df = pd.DataFrame({"door_id": ["d1"]})
+    result = service.process_uploaded_data(df)
+    device = result["devices"][0]
+    assert device["is_entry"] is True
+    assert "entry" not in device
+


### PR DESCRIPTION
## Summary
- unify `DoorMappingService` output under `is_*` keys and add `is_restricted`
- update simple device mapping modal to read both new and legacy keys
- show "Restricted" in device verification and include `is_restricted` defaults
- expand access options in upload page
- add regression test covering the new service output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68620622a2b88320b10ccbec95075701