### PR TITLE
Handle UTF-8 encodings for file IO

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -572,7 +572,10 @@ def save_ai_training_data(filename: str, mappings: Dict[str, str], file_info: Di
 
         os.makedirs("data/training", exist_ok=True)
         with open(
-            f"data/training/mappings_{datetime.now().strftime('%Y%m%d')}.jsonl", "a"
+            f"data/training/mappings_{datetime.now().strftime('%Y%m%d')}.jsonl",
+            "a",
+            encoding="utf-8",
+            errors="replace",
         ) as f:
             f.write(json.dumps(training_data) + "\n")
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -48,7 +48,7 @@ class AnalyticsDataAccessor:
         """Load consolidated mappings from learned_mappings.json"""
         try:
             if self.mappings_file.exists():
-                with open(self.mappings_file, "r") as f:
+                with open(self.mappings_file, "r", encoding="utf-8", errors="replace") as f:
                     return json.load(f)
             return {}
         except Exception as e:
@@ -436,7 +436,7 @@ class AnalyticsService:
 
             # Process JSON with FIXED processor
             if os.path.exists(json_file):
-                with open(json_file, 'r') as f:
+                with open(json_file, 'r', encoding='utf-8', errors='replace') as f:
                     json_data = json.load(f)
                 df_json = pd.DataFrame(json_data)
                 result = processor._validate_data(df_json)

--- a/services/consolidated_learning_service.py
+++ b/services/consolidated_learning_service.py
@@ -173,7 +173,7 @@ class ConsolidatedLearningService:
         """Load learned data from storage. Migrate legacy pickle data if needed."""
         if self.storage_path.exists():
             try:
-                with open(self.storage_path, "r") as f:
+                with open(self.storage_path, "r", encoding="utf-8", errors="replace") as f:
                     self.learned_data = json.load(f)
                 self.logger.info(
                     f"Loaded {len(self.learned_data)} learned mappings")
@@ -204,7 +204,7 @@ class ConsolidatedLearningService:
     def _persist_learned_data(self):
         """Persist learned data to storage using JSON."""
         try:
-            with open(self.storage_path, "w") as f:
+            with open(self.storage_path, "w", encoding="utf-8", errors="replace") as f:
                 json.dump(self.learned_data, f, indent=2)
         except Exception as e:
             self.logger.error(f"Could not persist learned data: {e}")

--- a/tests/test_unicode_file_handling.py
+++ b/tests/test_unicode_file_handling.py
@@ -1,0 +1,78 @@
+import builtins
+from datetime import datetime
+
+import pandas as pd
+
+from services.consolidated_learning_service import ConsolidatedLearningService
+from services.analytics_service import AnalyticsDataAccessor
+from pages import file_upload
+
+
+def test_consolidated_learning_unicode(tmp_path):
+    storage = tmp_path / "mäppings.json"
+    service = ConsolidatedLearningService(str(storage))
+
+    df = pd.DataFrame({
+        "door_id": ["дверь"],
+        "timestamp": ["2024-01-01"],
+        "user": ["пользователь"],
+    })
+    mappings = {"дверь": {"floor": 1}}
+
+    service.save_complete_mapping(df, "файл.csv", mappings)
+
+    reloaded = ConsolidatedLearningService(str(storage))
+    learned = reloaded.get_learned_mappings(df, "файл.csv")
+    assert learned["device_mappings"] == mappings
+
+
+def test_accessor_load_unicode(tmp_path):
+    base = tmp_path
+    data = {"kéy": "välue"}
+    f = base / "learned_mappings.json"
+    # write some invalid UTF-8 bytes to ensure errors="replace" works
+    with open(f, "wb") as fh:
+        fh.write(b'{"k\xe9y": "v\xe4lue"}')
+
+    accessor = AnalyticsDataAccessor(str(base))
+    loaded = accessor._load_consolidated_mappings()
+    assert loaded
+    assert list(loaded.keys())[0].startswith("k")
+
+
+def test_save_ai_training_data_unicode(tmp_path, monkeypatch):
+    training_dir = tmp_path / "training"
+    training_dir.mkdir()
+
+    target = training_dir / "out.jsonl"
+
+    def fake_makedirs(path, exist_ok=False):
+        training_dir.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(file_upload.os, "makedirs", fake_makedirs)
+
+    open_orig = builtins.open
+
+    def fake_open(path, mode="r", encoding=None, errors=None):
+        if path.startswith("data/training"):
+            return open_orig(target, mode, encoding=encoding, errors=errors)
+        return open_orig(path, mode, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(file_upload, "open", fake_open)
+
+    class DummyDT:
+        @classmethod
+        def now(cls):
+            return datetime(2024, 1, 1, 0, 0, 0)
+
+    monkeypatch.setattr(file_upload, "datetime", DummyDT)
+
+    file_upload.save_ai_training_data(
+        "файл.csv",
+        {"дверь": "timestamp"},
+        {"columns": ["a"], "ai_suggestions": {}},
+    )
+
+    content = target.read_text(encoding="utf-8")
+    assert "файл.csv" in content
+    assert "дверь" in content


### PR DESCRIPTION
## Summary
- specify `encoding='utf-8'` and `errors='replace'` for file operations
- write a new unit test covering Unicode filenames and data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68620c46ac9c8320af5116c8b0ba9fba