### PR TITLE
Refactor optional imports to use service registry

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -25,19 +25,16 @@ from .database_exceptions import DatabaseError, ConnectionRetryExhausted, Connec
 from .dynamic_config import dynamic_config, DynamicConfigManager
 from .constants import SecurityConstants, PerformanceConstants, CSSConstants
 import logging
+from services.registry import get_service
 
 logger = logging.getLogger(__name__)
 
-# Try to import database manager safely
-try:
-    from .database_manager import DatabaseManager, DatabaseConnection, MockConnection, EnhancedPostgreSQLManager
-    DATABASE_MANAGER_AVAILABLE = True
-except ImportError as e:
-    logger.info(f"Warning: Database manager not available: {e}")
-    DatabaseManager = None
-    DatabaseConnection = None 
-    MockConnection = None
-    DATABASE_MANAGER_AVAILABLE = False
+# Resolve optional database manager via registry
+DatabaseManager = get_service("DatabaseManager")
+DatabaseConnection = get_service("DatabaseConnection")
+MockConnection = get_service("MockConnection")
+EnhancedPostgreSQLManager = get_service("EnhancedPostgreSQLManager")
+DATABASE_MANAGER_AVAILABLE = DatabaseManager is not None
 
 __all__ = [
     'Config',

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -11,16 +11,13 @@ from .enums import (
 
 from .entities import Person, Door, Facility
 from .events import AccessEvent, AnomalyDetection, IncidentTicket
+from services.registry import get_service
 
-try:
-    from .base import BaseModel, AccessEventModel, AnomalyDetectionModel, ModelFactory
-    BASE_MODELS_AVAILABLE = True
-except ImportError:
-    BASE_MODELS_AVAILABLE = False
-    BaseModel = None
-    AccessEventModel = None
-    AnomalyDetectionModel = None
-    ModelFactory = None
+BaseModel = get_service("BaseModel")
+AccessEventModel = get_service("AccessEventModel")
+AnomalyDetectionModel = get_service("AnomalyDetectionModel")
+ModelFactory = get_service("ModelFactory")
+BASE_MODELS_AVAILABLE = BaseModel is not None
 
 __all__ = [
     'AnomalyType', 'AccessResult', 'BadgeStatus', 'SeverityLevel',

--- a/services/registry.py
+++ b/services/registry.py
@@ -46,3 +46,13 @@ register_service("FileProcessor", "services.file_processor:FileProcessor")
 register_service("get_analytics_service", "services.analytics_service:get_analytics_service")
 register_service("create_analytics_service", "services.analytics_service:create_analytics_service")
 register_service("AnalyticsService", "services.analytics_service:AnalyticsService")
+
+# Optional model and database classes
+register_service("BaseModel", "models.base:BaseModel")
+register_service("AccessEventModel", "models.base:AccessEventModel")
+register_service("AnomalyDetectionModel", "models.base:AnomalyDetectionModel")
+register_service("ModelFactory", "models.base:ModelFactory")
+register_service("DatabaseManager", "config.database_manager:DatabaseManager")
+register_service("DatabaseConnection", "config.database_manager:DatabaseConnection")
+register_service("MockConnection", "config.database_manager:MockConnection")
+register_service("EnhancedPostgreSQLManager", "config.database_manager:EnhancedPostgreSQLManager")


### PR DESCRIPTION
## Summary
- register optional models and database managers in the service registry
- resolve optional classes via the registry in `models` and `config`
- update analytics integration tests for registry usage and add missing-service check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68620c2d6ccc83209ee23758c50bc9ae