### PR TITLE
Add placeholder dashboard, graphs, and settings pages

### DIFF
--- a/assets/css/05-pages/_graphs.css
+++ b/assets/css/05-pages/_graphs.css
@@ -1,0 +1,8 @@
+/* =================================================================== */
+/* 05-pages/_graphs.css - Graphs Page Styles */
+/* =================================================================== */
+
+.graphs-placeholder {
+  min-height: 300px;
+  background-color: var(--surface-section);
+}

--- a/assets/css/05-pages/_settings.css
+++ b/assets/css/05-pages/_settings.css
@@ -1,0 +1,8 @@
+/* =================================================================== */
+/* 05-pages/_settings.css - Settings Page Styles */
+/* =================================================================== */
+
+.settings-section {
+  min-height: 200px;
+  background-color: var(--surface-section);
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -33,6 +33,8 @@
 
 /* Page-Specific Styles */
 @import './05-pages/_dashboard.css';
+@import './05-pages/_graphs.css';
+@import './05-pages/_settings.css';
 @import './_analytics.css';
 
 /* Theme System */

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -245,8 +245,36 @@ def _create_navbar() -> dbc.Navbar:
                     # Navigation links
                     dbc.Nav(
                         [
-                            dbc.NavItem(dbc.NavLink("📊 Analytics", href="/analytics")),
-                            dbc.NavItem(dbc.NavLink("📁 Upload", href="/upload")),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    [html.I(className="fas fa-tachometer-alt me-1"), "Dashboard"],
+                                    href="/",
+                                )
+                            ),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    [html.I(className="fas fa-chart-line me-1"), "Analytics"],
+                                    href="/analytics",
+                                )
+                            ),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    [html.I(className="fas fa-chart-area me-1"), "Graphs"],
+                                    href="/graphs",
+                                )
+                            ),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    [html.I(className="fas fa-file-upload me-1"), "Upload"],
+                                    href="/upload",
+                                )
+                            ),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    [html.I(className="fas fa-cog me-1"), "Settings"],
+                                    href="/settings",
+                                )
+                            ),
                             dbc.NavItem(
                                 [
                                     dbc.Button(
@@ -290,12 +318,16 @@ def _create_placeholder_page(title: str, subtitle: str, message: str) -> html.Di
 
 @callback(Output("page-content", "children"), Input("url", "pathname"))
 def display_page(pathname):
-    """Route pages based on URL"""
+    """Route pages based on URL."""
     if pathname == "/analytics":
         return _get_analytics_page()
+    elif pathname == "/graphs":
+        return _get_graphs_page()
+    elif pathname == "/settings":
+        return _get_settings_page()
     elif pathname == "/upload" or pathname == "/file-upload":  # Handle both paths
         return _get_upload_page()
-    elif pathname == "/":
+    elif pathname in {"/", "/dashboard"}:
         return _get_home_page()
     else:
         return html.Div(
@@ -312,84 +344,24 @@ def display_page(pathname):
         )
 
 
-def _get_home_page() -> Any:
-    """Get home page"""
-    return dbc.Container(
-        [
-            dbc.Row(
-                [
-                    dbc.Col(
-                        [
-                            html.H1(
-                                "🏯 Welcome to Yōsai Intel Dashboard",
-                                className="text-center mb-4",
-                            ),
-                            html.P(
-                                "Advanced security analytics and monitoring platform",
-                                className="text-center text-muted mb-5",
-                            ),
-                            # Feature cards
-                            dbc.Row(
-                                [
-                                    dbc.Col(
-                                        [
-                                            dbc.Card(
-                                                [
-                                                    dbc.CardBody(
-                                                        [
-                                                            html.H4(
-                                                                "📊 Analytics",
-                                                                className="card-title",
-                                                            ),
-                                                            html.P(
-                                                                "Deep dive into security data and patterns"
-                                                            ),
-                                                            dbc.Button(
-                                                                "Go to Analytics",
-                                                                href="/analytics",
-                                                                color="primary",
-                                                            ),
-                                                        ]
-                                                    )
-                                                ]
-                                            )
-                                        ],
-                                        md=6,
-                                    ),
-                                    dbc.Col(
-                                        [
-                                            dbc.Card(
-                                                [
-                                                    dbc.CardBody(
-                                                        [
-                                                            html.H4(
-                                                                "📁 File Upload",
-                                                                className="card-title",
-                                                            ),
-                                                            html.P(
-                                                                "Upload and analyze security data files"
-                                                            ),
-                                                            dbc.Button(
-                                                                "Upload Files",
-                                                                href="/upload",
-                                                                color="secondary",
-                                                            ),
-                                                        ]
-                                                    )
-                                                ]
-                                            )
-                                        ],
-                                        md=6,
-                                    ),
-                                ]
-                            ),
-                        ]
-                    )
-                ]
-            )
-        ]
-    )
 
+def _get_home_page() -> Any:
+    """Get home page (dashboard)."""
+    return _get_dashboard_page()
+
+
+def _get_dashboard_page() -> Any:
+    """Get dashboard page with overview metrics."""
+    try:
+        from pages.dashboard import layout
+        return layout()
+    except ImportError as e:
+        logger.error(f"Dashboard page import failed: {e}")
+        return _create_placeholder_page(
+            "Dashboard",
+            "Dashboard page is being loaded...",
+            "The dashboard module is not available. Please check the installation.",
+        )
 
 def _get_analytics_page() -> Any:
     """Get analytics page with complete integration"""
@@ -405,6 +377,33 @@ def _get_analytics_page() -> Any:
             "The analytics module is not available. Please check the installation.",
         )
 
+
+def _get_graphs_page() -> Any:
+    """Get graphs page with placeholder content."""
+    try:
+        from pages.graphs import layout
+        return layout()
+    except ImportError as e:
+        logger.error(f"Graphs page import failed: {e}")
+        return _create_placeholder_page(
+            "Graphs",
+            "Graphs page is being loaded...",
+            "The graphs module is not available. Please check the installation.",
+        )
+
+
+def _get_settings_page() -> Any:
+    """Get settings page with placeholder content."""
+    try:
+        from pages.settings import layout
+        return layout()
+    except ImportError as e:
+        logger.error(f"Settings page import failed: {e}")
+        return _create_placeholder_page(
+            "Settings",
+            "Settings page is being loaded...",
+            "The settings module is not available. Please check the installation.",
+        )
 
 def _get_upload_page() -> Any:
     """Get upload page with complete integration"""

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -12,17 +12,38 @@ _pages = {}
 
 try:
     from . import deep_analytics
-    _pages['deep_analytics'] = deep_analytics
+    _pages["deep_analytics"] = deep_analytics
 except ImportError as e:
     logger.warning(f"Deep analytics page not available: {e}")
-    _pages['deep_analytics'] = None
+    _pages["deep_analytics"] = None
 
 try:
     from . import file_upload
-    _pages['file_upload'] = file_upload
+    _pages["file_upload"] = file_upload
 except ImportError as e:
     logger.warning(f"File upload page not available: {e}")
-    _pages['file_upload'] = None
+    _pages["file_upload"] = None
+
+try:
+    from . import dashboard
+    _pages["dashboard"] = dashboard
+except ImportError as e:
+    logger.warning(f"Dashboard page not available: {e}")
+    _pages["dashboard"] = None
+
+try:
+    from . import graphs
+    _pages["graphs"] = graphs
+except ImportError as e:
+    logger.warning(f"Graphs page not available: {e}")
+    _pages["graphs"] = None
+
+try:
+    from . import settings
+    _pages["settings"] = settings
+except ImportError as e:
+    logger.warning(f"Settings page not available: {e}")
+    _pages["settings"] = None
 
 def get_page_layout(page_name: str) -> Optional[Callable]:
     """Get page layout function safely"""

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Dashboard overview page with placeholder metrics."""
+
+from dash import html
+import dash_bootstrap_components as dbc
+from utils import sanitize_unicode_input
+
+
+def _metric_card(title: str, value: str) -> dbc.Col:
+    """Return a simple metric card."""
+    title = sanitize_unicode_input(title)
+    value = sanitize_unicode_input(value)
+    return dbc.Col(
+        dbc.Card(
+            dbc.CardBody(
+                [
+                    html.H5(title, className="card-title"),
+                    html.H2(value, className="card-text"),
+                ]
+            ),
+            className="mb-4",
+        ),
+        md=4,
+    )
+
+
+def layout() -> dbc.Container:
+    """Dashboard page layout."""
+    header = dbc.Row(
+        dbc.Col(
+            [
+                html.H1("Security Dashboard", className="text-primary mb-4"),
+                html.P(
+                    "Real-time security metrics will appear here.",
+                    className="text-muted",
+                ),
+            ]
+        )
+    )
+
+    metrics = dbc.Row(
+        [
+            _metric_card("Active Alerts", "0"),
+            _metric_card("Devices Online", "0"),
+            _metric_card("Last Update", "N/A"),
+        ],
+        className="gy-4",
+    )
+
+    return dbc.Container([header, metrics], fluid=True)
+
+
+__all__ = ["layout"]

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Graphs visualization page with placeholder content."""
+
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+from utils import sanitize_unicode_input
+
+
+def layout() -> dbc.Container:
+    """Graphs page layout."""
+    header = dbc.Row(
+        dbc.Col(
+            [
+                html.H1("Graphs", className="text-primary mb-4"),
+                html.P(
+                    "Interactive charts will be integrated here.",
+                    className="text-muted",
+                ),
+            ]
+        )
+    )
+
+    tabs = dbc.Tabs(
+        [
+            dbc.Tab(label=sanitize_unicode_input("Line Charts"), tab_id="line"),
+            dbc.Tab(label=sanitize_unicode_input("Bar Charts"), tab_id="bar"),
+            dbc.Tab(label=sanitize_unicode_input("Other"), tab_id="other"),
+        ],
+        id="graphs-tabs",
+        active_tab="line",
+        className="mb-3",
+    )
+
+    placeholder = html.Div("Chart placeholders", className="graphs-placeholder")
+
+    return dbc.Container([header, tabs, placeholder], fluid=True)
+
+
+__all__ = ["layout"]

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Settings management page with placeholders."""
+
+from dash import html
+import dash_bootstrap_components as dbc
+from utils import sanitize_unicode_input
+
+
+def _settings_section(title: str) -> dbc.Card:
+    """Return a placeholder settings section."""
+    title = sanitize_unicode_input(title)
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H5(title, className="card-title"),
+                html.P("Configuration options coming soon.", className="card-text"),
+            ]
+        ),
+        className="mb-4 settings-section",
+    )
+
+
+def layout() -> dbc.Container:
+    """Settings page layout."""
+    header = dbc.Row(
+        dbc.Col(
+            [
+                html.H1("Settings", className="text-primary mb-4"),
+                html.P(
+                    "Manage dashboard configuration.",
+                    className="text-muted",
+                ),
+            ]
+        )
+    )
+
+    sections = dbc.Row(
+        [
+            dbc.Col(_settings_section("User Preferences"), md=6),
+            dbc.Col(_settings_section("System Configuration"), md=6),
+        ]
+    )
+
+    return dbc.Container([header, sections], fluid=True)
+
+
+__all__ = ["layout"]


### PR DESCRIPTION
## Summary
- create placeholder page modules for Dashboard, Graphs, and Settings
- register new pages and update navigation
- route new endpoints and make dashboard the home page
- import new CSS files and styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862131f95a88320948aa62f549a2270