### PR TITLE
Add CallbackManager with event system

### DIFF
--- a/analytics/analytics_controller.py
+++ b/analytics/analytics_controller.py
@@ -19,10 +19,14 @@ from .access_trends import AccessTrendsAnalyzer, create_trends_analyzer
 from .user_behavior import UserBehaviorAnalyzer, create_behavior_analyzer
 from .anomaly_detection import AnomalyDetector, create_anomaly_detector
 from .interactive_charts import SecurityChartsGenerator, create_charts_generator
+from core.callback_manager import CallbackManager
+from core.callback_events import CallbackEvent
+
 
 @dataclass
 class AnalyticsConfig:
     """Configuration for analytics processing"""
+
     enable_security_patterns: bool = True
     enable_access_trends: bool = True
     enable_user_behavior: bool = True
@@ -33,9 +37,11 @@ class AnalyticsConfig:
     cache_results: bool = True
     cache_duration_minutes: int = 30
 
+
 @dataclass
 class AnalyticsResult:
     """Complete analytics result structure"""
+
     security_patterns: Dict[str, Any]
     access_trends: Dict[str, Any]
     user_behavior: Dict[str, Any]
@@ -47,119 +53,142 @@ class AnalyticsResult:
     status: str
     errors: List[str]
 
+
 class AnalyticsController:
     """Unified controller for all analytics operations"""
-    
-    def __init__(self, config: Optional[AnalyticsConfig] = None):
+
+    def __init__(
+        self,
+        config: Optional[AnalyticsConfig] = None,
+        callback_manager: Optional[CallbackManager] = None,
+    ):
         self.config = config or AnalyticsConfig()
         self.logger = logging.getLogger(__name__)
-        
+
         # Initialize analyzers
-        self.security_analyzer = create_security_analyzer() if self.config.enable_security_patterns else None
-        self.trends_analyzer = create_trends_analyzer() if self.config.enable_access_trends else None
-        self.behavior_analyzer = create_behavior_analyzer() if self.config.enable_user_behavior else None
-        self.anomaly_detector = create_anomaly_detector() if self.config.enable_anomaly_detection else None
-        self.charts_generator = create_charts_generator() if self.config.enable_interactive_charts else None
-        
+        self.security_analyzer = (
+            create_security_analyzer() if self.config.enable_security_patterns else None
+        )
+        self.trends_analyzer = (
+            create_trends_analyzer() if self.config.enable_access_trends else None
+        )
+        self.behavior_analyzer = (
+            create_behavior_analyzer() if self.config.enable_user_behavior else None
+        )
+        self.anomaly_detector = (
+            create_anomaly_detector() if self.config.enable_anomaly_detection else None
+        )
+        self.charts_generator = (
+            create_charts_generator() if self.config.enable_interactive_charts else None
+        )
+
         # Cache for results
         self._cache = {}
         self._cache_timestamps = {}
-        
-        # Callback registry
-        self._callbacks = {
-            'on_analysis_start': [],
-            'on_analysis_progress': [],
-            'on_analysis_complete': [],
-            'on_analysis_error': [],
-            'on_data_processed': []
-        }
-        
+
+        self._manager = callback_manager or CallbackManager()
+
         # Thread pool for parallel processing
-        self._executor = ThreadPoolExecutor(max_workers=5) if self.config.parallel_processing else None
-    
-    def register_callback(self, event: str, callback: Callable):
+        self._executor = (
+            ThreadPoolExecutor(max_workers=5)
+            if self.config.parallel_processing
+            else None
+        )
+
+    _EVENT_MAP = {
+        "on_analysis_start": CallbackEvent.ANALYSIS_START,
+        "on_analysis_progress": CallbackEvent.ANALYSIS_PROGRESS,
+        "on_analysis_complete": CallbackEvent.ANALYSIS_COMPLETE,
+        "on_analysis_error": CallbackEvent.ANALYSIS_ERROR,
+        "on_data_processed": CallbackEvent.DATA_PROCESSED,
+    }
+
+    def register_callback(self, event: str, callback: Callable) -> None:
         """Register callback for specific events"""
-        if event in self._callbacks:
-            self._callbacks[event].append(callback)
-        else:
+        if event not in self._EVENT_MAP:
             raise ValueError(f"Unknown event type: {event}")
-    
-    def unregister_callback(self, event: str, callback: Callable):
+        self._manager.register_callback(self._EVENT_MAP[event], callback)
+
+    def unregister_callback(self, event: str, callback: Callable) -> None:
         """Unregister callback for specific events"""
-        if event in self._callbacks and callback in self._callbacks[event]:
-            self._callbacks[event].remove(callback)
-    
-    def _trigger_callbacks(self, event: str, *args, **kwargs):
+        # Simple removal by rebuilding list
+        if event not in self._EVENT_MAP:
+            return
+        mapped = self._EVENT_MAP[event]
+        self._manager.unregister_callback(mapped, callback)
+
+    def _trigger_callbacks(self, event: str, *args, **kwargs) -> None:
         """Trigger all callbacks for an event"""
-        for callback in self._callbacks.get(event, []):
-            try:
-                callback(*args, **kwargs)
-            except Exception as e:
-                self.logger.error(f"Callback error for {event}: {e}")
-    
-    def analyze_all(self, df: pd.DataFrame, 
-                    analysis_id: Optional[str] = None) -> AnalyticsResult:
+        if event not in self._EVENT_MAP:
+            return
+        self._manager.trigger(self._EVENT_MAP[event], *args, **kwargs)
+
+    def analyze_all(
+        self, df: pd.DataFrame, analysis_id: Optional[str] = None
+    ) -> AnalyticsResult:
         """Run complete analytics analysis"""
-        
+
         start_time = datetime.now()
         analysis_id = analysis_id or f"analysis_{int(start_time.timestamp())}"
         errors = []
-        
+
         try:
             # Trigger start callbacks
-            self._trigger_callbacks('on_analysis_start', analysis_id, df)
-            
+            self._trigger_callbacks("on_analysis_start", analysis_id, df)
+
             # Check cache first
             if self.config.cache_results:
                 cached_result = self._get_cached_result(df)
                 if cached_result:
                     self.logger.info("Returning cached analytics result")
                     return cached_result
-            
+
             # Validate and prepare data
             df_processed = self._prepare_data(df)
             data_summary = self._generate_data_summary(df_processed)
-            
-            self._trigger_callbacks('on_data_processed', analysis_id, data_summary)
-            
+
+            self._trigger_callbacks("on_data_processed", analysis_id, data_summary)
+
             # Run analytics
             if self.config.parallel_processing and self._executor:
                 results = self._run_parallel_analysis(df_processed, analysis_id)
             else:
                 results = self._run_sequential_analysis(df_processed, analysis_id)
-            
+
             # Create final result
             processing_time = (datetime.now() - start_time).total_seconds()
-            
+
             analytics_result = AnalyticsResult(
-                security_patterns=results.get('security_patterns', {}),
-                access_trends=results.get('access_trends', {}),
-                user_behavior=results.get('user_behavior', {}),
-                anomaly_detection=results.get('anomaly_detection', {}),
-                interactive_charts=results.get('interactive_charts', {}),
+                security_patterns=results.get("security_patterns", {}),
+                access_trends=results.get("access_trends", {}),
+                user_behavior=results.get("user_behavior", {}),
+                anomaly_detection=results.get("anomaly_detection", {}),
+                interactive_charts=results.get("interactive_charts", {}),
                 processing_time=processing_time,
                 data_summary=data_summary,
                 generated_at=start_time,
-                status='success',
-                errors=errors
+                status="success",
+                errors=errors,
             )
-            
+
             # Cache result
             if self.config.cache_results:
                 self._cache_result(df, analytics_result)
-            
+
             # Trigger completion callbacks
-            self._trigger_callbacks('on_analysis_complete', analysis_id, analytics_result)
-            
+            self._trigger_callbacks(
+                "on_analysis_complete", analysis_id, analytics_result
+            )
+
             return analytics_result
-            
+
         except Exception as e:
             self.logger.error(f"Analytics analysis failed: {e}")
             errors.append(str(e))
-            
+
             # Trigger error callbacks
-            self._trigger_callbacks('on_analysis_error', analysis_id, e)
-            
+            self._trigger_callbacks("on_analysis_error", analysis_id, e)
+
             # Return error result
             return AnalyticsResult(
                 security_patterns={},
@@ -170,243 +199,300 @@ class AnalyticsController:
                 processing_time=(datetime.now() - start_time).total_seconds(),
                 data_summary=self._generate_data_summary(df),
                 generated_at=start_time,
-                status='error',
-                errors=errors
+                status="error",
+                errors=errors,
             )
-    
-    def analyze_specific(self, df: pd.DataFrame, 
-                         analysis_types: List[str],
-                         analysis_id: Optional[str] = None) -> Dict[str, Any]:
+
+    def analyze_specific(
+        self,
+        df: pd.DataFrame,
+        analysis_types: List[str],
+        analysis_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Run specific analytics only"""
-        
+
         start_time = datetime.now()
         analysis_id = analysis_id or f"specific_{int(start_time.timestamp())}"
         results = {}
-        
+
         try:
-            self._trigger_callbacks('on_analysis_start', analysis_id, df)
-            
+            self._trigger_callbacks("on_analysis_start", analysis_id, df)
+
             df_processed = self._prepare_data(df)
-            
+
             # Run only requested analytics
             for analysis_type in analysis_types:
                 try:
-                    self._trigger_callbacks('on_analysis_progress', analysis_id, analysis_type, 0)
-                    
-                    if analysis_type == 'security_patterns' and self.security_analyzer:
-                        results[analysis_type] = self.security_analyzer.analyze_patterns(df_processed)
-                    elif analysis_type == 'access_trends' and self.trends_analyzer:
-                        results[analysis_type] = self.trends_analyzer.analyze_trends(df_processed)
-                    elif analysis_type == 'user_behavior' and self.behavior_analyzer:
-                        results[analysis_type] = self.behavior_analyzer.analyze_behavior(df_processed)
-                    elif analysis_type == 'anomaly_detection' and self.anomaly_detector:
+                    self._trigger_callbacks(
+                        "on_analysis_progress", analysis_id, analysis_type, 0
+                    )
+
+                    if analysis_type == "security_patterns" and self.security_analyzer:
+                        results[analysis_type] = (
+                            self.security_analyzer.analyze_patterns(df_processed)
+                        )
+                    elif analysis_type == "access_trends" and self.trends_analyzer:
+                        results[analysis_type] = self.trends_analyzer.analyze_trends(
+                            df_processed
+                        )
+                    elif analysis_type == "user_behavior" and self.behavior_analyzer:
+                        results[analysis_type] = (
+                            self.behavior_analyzer.analyze_behavior(df_processed)
+                        )
+                    elif analysis_type == "anomaly_detection" and self.anomaly_detector:
                         results[analysis_type] = self.anomaly_detector.detect_anomalies(
                             df_processed, self.config.anomaly_sensitivity
                         )
-                    elif analysis_type == 'interactive_charts' and self.charts_generator:
-                        results[analysis_type] = self.charts_generator.generate_all_charts(df_processed)
+                    elif (
+                        analysis_type == "interactive_charts" and self.charts_generator
+                    ):
+                        results[analysis_type] = (
+                            self.charts_generator.generate_all_charts(df_processed)
+                        )
                     else:
                         results[analysis_type] = {}
-                    
-                    self._trigger_callbacks('on_analysis_progress', analysis_id, analysis_type, 100)
-                    
+
+                    self._trigger_callbacks(
+                        "on_analysis_progress", analysis_id, analysis_type, 100
+                    )
+
                 except Exception as e:
                     self.logger.error(f"Analysis {analysis_type} failed: {e}")
                     results[analysis_type] = {}
-            
-            self._trigger_callbacks('on_analysis_complete', analysis_id, results)
+
+            self._trigger_callbacks("on_analysis_complete", analysis_id, results)
             return results
-            
+
         except Exception as e:
             self.logger.error(f"Specific analysis failed: {e}")
-            self._trigger_callbacks('on_analysis_error', analysis_id, e)
+            self._trigger_callbacks("on_analysis_error", analysis_id, e)
             return {}
-    
-    def _run_parallel_analysis(self, df: pd.DataFrame, 
-                               analysis_id: str) -> Dict[str, Any]:
+
+    def _run_parallel_analysis(
+        self, df: pd.DataFrame, analysis_id: str
+    ) -> Dict[str, Any]:
         """Run analytics in parallel using thread pool"""
-        
+
         futures = {}
         results = {}
-        
+
         # Submit all enabled analytics to thread pool
         if self.security_analyzer:
-            futures['security_patterns'] = self._executor.submit(
+            futures["security_patterns"] = self._executor.submit(
                 self.security_analyzer.analyze_patterns, df
             )
-        
+
         if self.trends_analyzer:
-            futures['access_trends'] = self._executor.submit(
+            futures["access_trends"] = self._executor.submit(
                 self.trends_analyzer.analyze_trends, df
             )
-        
+
         if self.behavior_analyzer:
-            futures['user_behavior'] = self._executor.submit(
+            futures["user_behavior"] = self._executor.submit(
                 self.behavior_analyzer.analyze_behavior, df
             )
-        
+
         if self.anomaly_detector:
-            futures['anomaly_detection'] = self._executor.submit(
-                self.anomaly_detector.detect_anomalies, df, self.config.anomaly_sensitivity
+            futures["anomaly_detection"] = self._executor.submit(
+                self.anomaly_detector.detect_anomalies,
+                df,
+                self.config.anomaly_sensitivity,
             )
-        
+
         if self.charts_generator:
-            futures['interactive_charts'] = self._executor.submit(
+            futures["interactive_charts"] = self._executor.submit(
                 self.charts_generator.generate_all_charts, df
             )
-        
+
         # Collect results as they complete
         total_tasks = len(futures)
         completed_tasks = 0
-        
+
         for analysis_type, future in futures.items():
             try:
                 results[analysis_type] = future.result(timeout=300)  # 5 minute timeout
                 completed_tasks += 1
                 progress = (completed_tasks / total_tasks) * 100
-                self._trigger_callbacks('on_analysis_progress', analysis_id, analysis_type, progress)
-                
+                self._trigger_callbacks(
+                    "on_analysis_progress", analysis_id, analysis_type, progress
+                )
+
             except Exception as e:
                 self.logger.error(f"Parallel analysis {analysis_type} failed: {e}")
                 results[analysis_type] = {}
-        
+
         return results
-    
-    def _run_sequential_analysis(self, df: pd.DataFrame, 
-                                analysis_id: str) -> Dict[str, Any]:
+
+    def _run_sequential_analysis(
+        self, df: pd.DataFrame, analysis_id: str
+    ) -> Dict[str, Any]:
         """Run analytics sequentially"""
-        
+
         results = {}
         analyses = []
-        
+
         # Build list of enabled analyses
         if self.security_analyzer:
-            analyses.append(('security_patterns', self.security_analyzer.analyze_patterns))
+            analyses.append(
+                ("security_patterns", self.security_analyzer.analyze_patterns)
+            )
         if self.trends_analyzer:
-            analyses.append(('access_trends', self.trends_analyzer.analyze_trends))
+            analyses.append(("access_trends", self.trends_analyzer.analyze_trends))
         if self.behavior_analyzer:
-            analyses.append(('user_behavior', self.behavior_analyzer.analyze_behavior))
+            analyses.append(("user_behavior", self.behavior_analyzer.analyze_behavior))
         if self.anomaly_detector:
-            analyses.append(('anomaly_detection', 
-                            lambda df: self.anomaly_detector.detect_anomalies(df, self.config.anomaly_sensitivity)))
+            analyses.append(
+                (
+                    "anomaly_detection",
+                    lambda df: self.anomaly_detector.detect_anomalies(
+                        df, self.config.anomaly_sensitivity
+                    ),
+                )
+            )
         if self.charts_generator:
-            analyses.append(('interactive_charts', self.charts_generator.generate_all_charts))
-        
+            analyses.append(
+                ("interactive_charts", self.charts_generator.generate_all_charts)
+            )
+
         # Run each analysis sequentially
         total_analyses = len(analyses)
         for i, (analysis_type, analyzer_func) in enumerate(analyses):
             try:
                 progress = (i / total_analyses) * 100
-                self._trigger_callbacks('on_analysis_progress', analysis_id, analysis_type, progress)
-                
+                self._trigger_callbacks(
+                    "on_analysis_progress", analysis_id, analysis_type, progress
+                )
+
                 results[analysis_type] = analyzer_func(df)
-                
+
                 progress = ((i + 1) / total_analyses) * 100
-                self._trigger_callbacks('on_analysis_progress', analysis_id, analysis_type, progress)
-                
+                self._trigger_callbacks(
+                    "on_analysis_progress", analysis_id, analysis_type, progress
+                )
+
             except Exception as e:
                 self.logger.error(f"Sequential analysis {analysis_type} failed: {e}")
                 results[analysis_type] = {}
-        
+
         return results
-    
+
     def _prepare_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Prepare and validate data for analytics"""
-        
+
         if df.empty:
             raise ValueError("DataFrame is empty")
-        
+
         # Required columns check
-        required_columns = ['event_id', 'timestamp', 'person_id', 'door_id', 'access_result']
+        required_columns = [
+            "event_id",
+            "timestamp",
+            "person_id",
+            "door_id",
+            "access_result",
+        ]
         missing_columns = [col for col in required_columns if col not in df.columns]
-        
+
         if missing_columns:
             raise ValueError(f"Missing required columns: {missing_columns}")
-        
+
         # Data type conversions
         df = df.copy()
-        df['timestamp'] = pd.to_datetime(df['timestamp'])
-        
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+
         # Sort by timestamp
-        df = df.sort_values('timestamp').reset_index(drop=True)
-        
+        df = df.sort_values("timestamp").reset_index(drop=True)
+
         # Remove duplicates
-        df = df.drop_duplicates(subset=['event_id'], keep='first')
-        
+        df = df.drop_duplicates(subset=["event_id"], keep="first")
+
         return df
-    
+
     def _generate_data_summary(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Generate summary of data for analytics"""
-        
+
         if df.empty:
             return {
-                'total_events': 0,
-                'date_range': {'start': None, 'end': None},
-                'unique_users': 0,
-                'unique_doors': 0,
-                'data_quality': 'empty'
+                "total_events": 0,
+                "date_range": {"start": None, "end": None},
+                "unique_users": 0,
+                "unique_doors": 0,
+                "data_quality": "empty",
             }
-        
+
         return {
-            'total_events': len(df),
-            'date_range': {
-                'start': df['timestamp'].min().isoformat() if 'timestamp' in df.columns else None,
-                'end': df['timestamp'].max().isoformat() if 'timestamp' in df.columns else None
+            "total_events": len(df),
+            "date_range": {
+                "start": (
+                    df["timestamp"].min().isoformat()
+                    if "timestamp" in df.columns
+                    else None
+                ),
+                "end": (
+                    df["timestamp"].max().isoformat()
+                    if "timestamp" in df.columns
+                    else None
+                ),
             },
-            'unique_users': df['person_id'].nunique(),
-            'unique_doors': df['door_id'].nunique(),
-            'access_success_rate': (df['access_result'] == 'Granted').mean() * 100 if 'access_result' in df.columns else 0,
-            'data_quality': self._assess_data_quality(df)
+            "unique_users": df["person_id"].nunique(),
+            "unique_doors": df["door_id"].nunique(),
+            "access_success_rate": (
+                (df["access_result"] == "Granted").mean() * 100
+                if "access_result" in df.columns
+                else 0
+            ),
+            "data_quality": self._assess_data_quality(df),
         }
-    
+
     def _assess_data_quality(self, df: pd.DataFrame) -> str:
         """Assess quality of data"""
-        
+
         if df.empty:
-            return 'empty'
-        
+            return "empty"
+
         # Check for missing values in critical columns
-        critical_columns = ['timestamp', 'person_id', 'door_id', 'access_result']
+        critical_columns = ["timestamp", "person_id", "door_id", "access_result"]
         missing_rates = []
-        
+
         for col in critical_columns:
             if col in df.columns:
                 missing_rate = df[col].isnull().mean()
                 missing_rates.append(missing_rate)
-        
+
         if not missing_rates:
-            return 'poor'
-        
+            return "poor"
+
         avg_missing_rate = np.mean(missing_rates)
-        
+
         if avg_missing_rate < 0.01:
-            return 'excellent'
+            return "excellent"
         elif avg_missing_rate < 0.05:
-            return 'good'
+            return "good"
         elif avg_missing_rate < 0.1:
-            return 'fair'
+            return "fair"
         else:
-            return 'poor'
-    
+            return "poor"
+
     def _get_cache_key(self, df: pd.DataFrame) -> str:
         """Generate cache key for DataFrame"""
-        
+
         # Create hash based on data shape and content sample
-        data_hash = hash((
-            len(df),
-            df.shape[1],
-            df['timestamp'].min() if 'timestamp' in df.columns else 0,
-            df['timestamp'].max() if 'timestamp' in df.columns else 0,
-            df['person_id'].nunique() if 'person_id' in df.columns else 0
-        ))
-        
+        data_hash = hash(
+            (
+                len(df),
+                df.shape[1],
+                df["timestamp"].min() if "timestamp" in df.columns else 0,
+                df["timestamp"].max() if "timestamp" in df.columns else 0,
+                df["person_id"].nunique() if "person_id" in df.columns else 0,
+            )
+        )
+
         return str(data_hash)
-    
+
     def _get_cached_result(self, df: pd.DataFrame) -> Optional[AnalyticsResult]:
         """Get cached result if available and valid"""
-        
+
         cache_key = self._get_cache_key(df)
-        
+
         if cache_key in self._cache:
             cached_time = self._cache_timestamps.get(cache_key)
             if cached_time:
@@ -417,99 +503,104 @@ class AnalyticsController:
                     # Cache expired, remove it
                     del self._cache[cache_key]
                     del self._cache_timestamps[cache_key]
-        
+
         return None
-    
+
     def _cache_result(self, df: pd.DataFrame, result: AnalyticsResult):
         """Cache analytics result"""
-        
+
         cache_key = self._get_cache_key(df)
         self._cache[cache_key] = result
         self._cache_timestamps[cache_key] = datetime.now()
-        
+
         # Limit cache size
         if len(self._cache) > 100:
             # Remove oldest entries
             oldest_keys = sorted(
-                self._cache_timestamps.keys(),
-                key=lambda k: self._cache_timestamps[k]
+                self._cache_timestamps.keys(), key=lambda k: self._cache_timestamps[k]
             )[:50]
-            
+
             for key in oldest_keys:
                 del self._cache[key]
                 del self._cache_timestamps[key]
-    
+
     def clear_cache(self):
         """Clear analytics cache"""
         self._cache.clear()
         self._cache_timestamps.clear()
-    
+
     def get_analytics_status(self) -> Dict[str, Any]:
         """Get status of analytics modules"""
-        
+
         return {
-            'modules_enabled': {
-                'security_patterns': self.config.enable_security_patterns,
-                'access_trends': self.config.enable_access_trends,
-                'user_behavior': self.config.enable_user_behavior,
-                'anomaly_detection': self.config.enable_anomaly_detection,
-                'interactive_charts': self.config.enable_interactive_charts
+            "modules_enabled": {
+                "security_patterns": self.config.enable_security_patterns,
+                "access_trends": self.config.enable_access_trends,
+                "user_behavior": self.config.enable_user_behavior,
+                "anomaly_detection": self.config.enable_anomaly_detection,
+                "interactive_charts": self.config.enable_interactive_charts,
             },
-            'modules_loaded': {
-                'security_patterns': self.security_analyzer is not None,
-                'access_trends': self.trends_analyzer is not None,
-                'user_behavior': self.behavior_analyzer is not None,
-                'anomaly_detection': self.anomaly_detector is not None,
-                'interactive_charts': self.charts_generator is not None
+            "modules_loaded": {
+                "security_patterns": self.security_analyzer is not None,
+                "access_trends": self.trends_analyzer is not None,
+                "user_behavior": self.behavior_analyzer is not None,
+                "anomaly_detection": self.anomaly_detector is not None,
+                "interactive_charts": self.charts_generator is not None,
             },
-            'configuration': {
-                'parallel_processing': self.config.parallel_processing,
-                'cache_enabled': self.config.cache_results,
-                'cache_duration_minutes': self.config.cache_duration_minutes,
-                'anomaly_sensitivity': self.config.anomaly_sensitivity
+            "configuration": {
+                "parallel_processing": self.config.parallel_processing,
+                "cache_enabled": self.config.cache_results,
+                "cache_duration_minutes": self.config.cache_duration_minutes,
+                "anomaly_sensitivity": self.config.anomaly_sensitivity,
             },
-            'cache_stats': {
-                'cached_results': len(self._cache),
-                'cache_memory_usage': sum(len(str(result)) for result in self._cache.values())
+            "cache_stats": {
+                "cached_results": len(self._cache),
+                "cache_memory_usage": sum(
+                    len(str(result)) for result in self._cache.values()
+                ),
             },
-            'callback_counts': {event: len(callbacks) for event, callbacks in self._callbacks.items()}
+            "callback_counts": {
+                event.name: len(self._manager.get_callbacks(event))
+                for event in CallbackEvent
+            },
         }
-    
-    def export_results(self, result: AnalyticsResult, 
-                       export_format: str = 'json') -> str:
+
+    def export_results(
+        self, result: AnalyticsResult, export_format: str = "json"
+    ) -> str:
         """Export analytics results in specified format"""
-        
-        if export_format.lower() == 'json':
+
+        if export_format.lower() == "json":
             return self._export_to_json(result)
-        elif export_format.lower() == 'summary':
+        elif export_format.lower() == "summary":
             return self._export_to_summary(result)
         else:
             raise ValueError(f"Unsupported export format: {export_format}")
-    
+
     def _export_to_json(self, result: AnalyticsResult) -> str:
         """Export results to JSON format"""
-        
+
         # Convert to serializable format
         export_data = {
-            'metadata': {
-                'generated_at': result.generated_at.isoformat(),
-                'processing_time': result.processing_time,
-                'status': result.status,
-                'errors': result.errors
+            "metadata": {
+                "generated_at": result.generated_at.isoformat(),
+                "processing_time": result.processing_time,
+                "status": result.status,
+                "errors": result.errors,
             },
-            'data_summary': result.data_summary,
-            'security_patterns': result.security_patterns,
-            'access_trends': result.access_trends,
-            'user_behavior': result.user_behavior,
-            'anomaly_detection': result.anomaly_detection
+            "data_summary": result.data_summary,
+            "security_patterns": result.security_patterns,
+            "access_trends": result.access_trends,
+            "user_behavior": result.user_behavior,
+            "anomaly_detection": result.anomaly_detection,
             # Note: interactive_charts excluded due to Plotly figures not being JSON serializable
         }
-        
+
         return json.dumps(export_data, indent=2, default=str)
-    
+
     def _export_to_summary(self, result: AnalyticsResult) -> str:
         """Export results to human-readable summary"""
-        
+
         summary_lines = [
             f"Analytics Report Generated: {result.generated_at}",
             f"Processing Time: {result.processing_time:.2f} seconds",
@@ -523,58 +614,62 @@ class AnalyticsController:
             f"Data Quality: {result.data_summary.get('data_quality', 'unknown')}",
             "",
         ]
-        
+
         # Add security patterns summary
         if result.security_patterns:
-            security_score = result.security_patterns.get('security_score', 0)
-            summary_lines.extend([
-                "=== SECURITY PATTERNS ===",
-                f"Security Score: {security_score}/100",
-                f"Failed Access Events: {result.security_patterns.get('failed_access_patterns', {}).get('total', 0)}",
-                ""
-            ])
-        
+            security_score = result.security_patterns.get("security_score", 0)
+            summary_lines.extend(
+                [
+                    "=== SECURITY PATTERNS ===",
+                    f"Security Score: {security_score}/100",
+                    f"Failed Access Events: {result.security_patterns.get('failed_access_patterns', {}).get('total', 0)}",
+                    "",
+                ]
+            )
+
         # Add anomaly detection summary
         if result.anomaly_detection:
-            anomaly_summary = result.anomaly_detection.get('anomaly_summary', {})
-            summary_lines.extend([
-                "=== ANOMALY DETECTION ===",
-                f"Total Anomalies: {anomaly_summary.get('total_anomalies', 0)}",
-                f"Risk Level: {result.anomaly_detection.get('risk_assessment', {}).get('risk_level', 'unknown')}",
-                ""
-            ])
-        
+            anomaly_summary = result.anomaly_detection.get("anomaly_summary", {})
+            summary_lines.extend(
+                [
+                    "=== ANOMALY DETECTION ===",
+                    f"Total Anomalies: {anomaly_summary.get('total_anomalies', 0)}",
+                    f"Risk Level: {result.anomaly_detection.get('risk_assessment', {}).get('risk_level', 'unknown')}",
+                    "",
+                ]
+            )
+
         if result.errors:
-            summary_lines.extend([
-                "=== ERRORS ===",
-                *result.errors,
-                ""
-            ])
-        
+            summary_lines.extend(["=== ERRORS ===", *result.errors, ""])
+
         return "\n".join(summary_lines)
-    
+
     def __del__(self):
         """Cleanup resources"""
         if self._executor:
             self._executor.shutdown(wait=True)
 
+
 # Convenience factory functions
-def create_analytics_controller(config: Optional[AnalyticsConfig] = None) -> AnalyticsController:
+def create_analytics_controller(
+    config: Optional[AnalyticsConfig] = None,
+) -> AnalyticsController:
     """Create analytics controller with default or custom configuration"""
     return AnalyticsController(config)
+
 
 def create_default_controller() -> AnalyticsController:
     """Create analytics controller with default settings"""
     return AnalyticsController()
 
+
 def create_performance_controller() -> AnalyticsController:
     """Create analytics controller optimized for performance"""
     config = AnalyticsConfig(
-        parallel_processing=True,
-        cache_results=True,
-        cache_duration_minutes=60
+        parallel_processing=True, cache_results=True, cache_duration_minutes=60
     )
     return AnalyticsController(config)
+
 
 def create_minimal_controller() -> AnalyticsController:
     """Create analytics controller with minimal features for testing"""
@@ -585,17 +680,18 @@ def create_minimal_controller() -> AnalyticsController:
         enable_anomaly_detection=False,
         enable_interactive_charts=False,
         parallel_processing=False,
-        cache_results=False
+        cache_results=False,
     )
     return AnalyticsController(config)
 
+
 # Export all classes and functions
 __all__ = [
-    'AnalyticsController',
-    'AnalyticsConfig', 
-    'AnalyticsResult',
-    'create_analytics_controller',
-    'create_default_controller',
-    'create_performance_controller',
-    'create_minimal_controller'
+    "AnalyticsController",
+    "AnalyticsConfig",
+    "AnalyticsResult",
+    "create_analytics_controller",
+    "create_default_controller",
+    "create_performance_controller",
+    "create_minimal_controller",
 ]

--- a/core/callback_events.py
+++ b/core/callback_events.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class CallbackEvent(Enum):
+    """Enumeration of application callback events."""
+
+    BEFORE_REQUEST = auto()
+    AFTER_REQUEST = auto()
+    ANALYSIS_START = auto()
+    ANALYSIS_PROGRESS = auto()
+    ANALYSIS_COMPLETE = auto()
+    ANALYSIS_ERROR = auto()
+    DATA_PROCESSED = auto()

--- a/core/callback_manager.py
+++ b/core/callback_manager.py
@@ -1,43 +1,108 @@
-#!/usr/bin/env python3
-"""Simple Callback Manager for Dash applications."""
 from __future__ import annotations
 
-from dash import Dash
-from typing import Callable, Any
+import asyncio
+import logging
+import threading
+import time
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict, List, Tuple
+
+from .callback_events import CallbackEvent
+
+logger = logging.getLogger(__name__)
+
 
 class CallbackManager:
-    """Register Dash callbacks and prevent duplicate IDs."""
+    """Thread-safe event callback manager."""
 
-    def __init__(self, app: Dash) -> None:
-        self.app = app
-        self._registered_ids: set[str] = set()
+    def __init__(self) -> None:
+        self._callbacks: Dict[CallbackEvent, List[Tuple[int, Callable[..., Any]]]] = (
+            defaultdict(list)
+        )
+        self._metrics: Dict[CallbackEvent, Dict[str, float | int]] = defaultdict(
+            lambda: {"calls": 0, "exceptions": 0, "total_time": 0.0}
+        )
+        self._lock = threading.Lock()
 
-    @property
-    def registered_ids(self) -> set[str]:
-        """Return a copy of registered callback IDs."""
-        return set(self._registered_ids)
+    # ------------------------------------------------------------------
+    def register_callback(
+        self, event: CallbackEvent, func: Callable[..., Any], *, priority: int = 50
+    ) -> None:
+        """Register a callback for an event with optional priority."""
+        with self._lock:
+            self._callbacks[event].append((priority, func))
+            self._callbacks[event].sort(key=lambda x: x[0])
 
-    def callback(
-        self,
-        *args: Any,
-        callback_id: str,
-        **kwargs: Any,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """Wrap ``Dash.callback`` and track callback IDs.
+    # ------------------------------------------------------------------
+    def unregister_callback(
+        self, event: CallbackEvent, func: Callable[..., Any]
+    ) -> None:
+        """Unregister a previously registered callback."""
+        with self._lock:
+            self._callbacks[event] = [
+                (p, f) for p, f in self._callbacks.get(event, []) if f != func
+            ]
 
-        Parameters
-        ----------
-        callback_id:
-            Unique identifier for the callback. Attempting to register a
-            duplicate ID will raise ``ValueError``.
-        """
+    # ------------------------------------------------------------------
+    def _record_metric(
+        self, event: CallbackEvent, start: float, error: bool = False
+    ) -> None:
+        metric = self._metrics[event]
+        metric["calls"] += 1
+        if error:
+            metric["exceptions"] += 1
+        metric["total_time"] += time.perf_counter() - start
 
-        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            if callback_id in self._registered_ids:
-                raise ValueError(f"Callback ID '{callback_id}' already registered")
-            wrapped = self.app.callback(*args, **kwargs)(func)
-            self._registered_ids.add(callback_id)
-            return wrapped
+    # ------------------------------------------------------------------
+    def trigger(self, event: CallbackEvent, *args: Any, **kwargs: Any) -> List[Any]:
+        """Synchronously trigger callbacks for an event."""
+        results = []
+        callbacks = self.get_callbacks(event)
+        for _, func in callbacks:
+            start = time.perf_counter()
+            try:
+                if asyncio.iscoroutinefunction(func):
+                    result = asyncio.run(func(*args, **kwargs))
+                else:
+                    result = func(*args, **kwargs)
+                results.append(result)
+                self._record_metric(event, start)
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.exception("Callback error on %s: %s", event.name, exc)
+                self._record_metric(event, start, error=True)
+                results.append(None)
+        return results
 
-        return decorator
+    # ------------------------------------------------------------------
+    async def trigger_async(
+        self, event: CallbackEvent, *args: Any, **kwargs: Any
+    ) -> List[Any]:
+        """Asynchronously trigger callbacks for an event."""
+        results = []
+        callbacks = self.get_callbacks(event)
+        for _, func in callbacks:
+            start = time.perf_counter()
+            try:
+                if asyncio.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = func(*args, **kwargs)
+                results.append(result)
+                self._record_metric(event, start)
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.exception("Callback error on %s: %s", event.name, exc)
+                self._record_metric(event, start, error=True)
+                results.append(None)
+        return results
 
+    # ------------------------------------------------------------------
+    def get_callbacks(
+        self, event: CallbackEvent
+    ) -> List[Tuple[int, Callable[..., Any]]]:
+        with self._lock:
+            return list(self._callbacks.get(event, []))
+
+    # ------------------------------------------------------------------
+    def get_metrics(self, event: CallbackEvent) -> Dict[str, float | int]:
+        with self._lock:
+            return dict(self._metrics.get(event, {}))

--- a/core/callback_migration.py
+++ b/core/callback_migration.py
@@ -1,0 +1,21 @@
+"""Migration helpers for the new callback system."""
+
+from __future__ import annotations
+
+from dash import Dash
+
+from .callback_manager import CallbackManager
+from .callback_events import CallbackEvent
+from .unified_callback_coordinator import UnifiedCallbackCoordinator
+
+
+class UnifiedCallbackCoordinatorWrapper(UnifiedCallbackCoordinator):
+    """Wrapper exposing a callback manager for backward compatibility."""
+
+    def __init__(self, app: Dash, callback_manager: CallbackManager) -> None:
+        super().__init__(app)
+        self.callback_manager = callback_manager
+
+    def register_event(self, event: CallbackEvent, func, *, priority: int = 50) -> None:
+        """Register an event callback through :class:`CallbackManager`."""
+        self.callback_manager.register_callback(event, func, priority=priority)

--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -101,22 +101,23 @@ class PluginManager:
             )
             return False
 
-    def register_plugin_callbacks(self, app: Any) -> List[Any]:
+    def register_plugin_callbacks(
+        self, app: Any, manager: CallbackManager
+    ) -> List[Any]:
         """Register callbacks for all loaded plugins"""
         results = []
-        # expose health endpoint on first registration
         try:
             self.register_health_endpoint(app)
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - log and continue
             logger.error("Failed to register plugin health endpoint: %s", exc)
         for plugin in self.plugins.values():
             if isinstance(plugin, CallbackPluginProtocol) or hasattr(
                 plugin, "register_callbacks"
             ):
                 try:
-                    result = plugin.register_callbacks(app, self.container)
+                    result = plugin.register_callbacks(manager, self.container)
                     results.append(result)
-                except Exception as exc:
+                except Exception as exc:  # pragma: no cover - log and continue
                     logger.error("Failed to register callbacks for %s: %s", plugin, exc)
                     results.append(False)
         return results

--- a/core/plugins/protocols.py
+++ b/core/plugins/protocols.py
@@ -88,8 +88,8 @@ class CallbackPluginProtocol(PluginProtocol, Protocol):
     """Protocol for plugins that register Dash callbacks"""
 
     @abstractmethod
-    def register_callbacks(self, app: Any, container: Any) -> bool:
-        """Register Dash callbacks with the application"""
+    def register_callbacks(self, manager: Any, container: Any) -> bool:
+        """Register callbacks with the application"""
         ...
 
 

--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -1,0 +1,12 @@
+# Callback System Migration
+
+This release introduces a new `CallbackManager` and `CallbackEvent` API used across the application. Existing modules may still rely on `UnifiedCallbackCoordinator` for Dash callbacks. The helper class `UnifiedCallbackCoordinatorWrapper` bridges both systems and allows registering event callbacks while keeping the old interface intact.
+
+## Migrating
+
+1. Import `CallbackManager` and `CallbackEvent` from `core`.
+2. Register hooks using `CallbackManager.register_callback` with the appropriate `CallbackEvent`.
+3. Trigger callbacks via `CallbackManager.trigger` or `trigger_async`.
+4. For modules expecting `UnifiedCallbackCoordinator`, wrap it with `UnifiedCallbackCoordinatorWrapper` and pass a `CallbackManager` instance.
+
+During migration, both systems can coexist. Once all modules use the new API directly, the wrapper can be removed.

--- a/tests/test_callback_manager_events.py
+++ b/tests/test_callback_manager_events.py
@@ -1,0 +1,22 @@
+from core.callback_manager import CallbackManager
+from core.callback_events import CallbackEvent
+
+
+def test_priority_and_async_trigger():
+    manager = CallbackManager()
+    events = []
+
+    async def async_cb():
+        events.append("async")
+
+    def sync_cb():
+        events.append("sync")
+
+    manager.register_callback(CallbackEvent.BEFORE_REQUEST, sync_cb, priority=10)
+    manager.register_callback(CallbackEvent.BEFORE_REQUEST, async_cb, priority=0)
+
+    manager.trigger(CallbackEvent.BEFORE_REQUEST)
+    assert events == ["async", "sync"]
+
+    metrics = manager.get_metrics(CallbackEvent.BEFORE_REQUEST)
+    assert metrics["calls"] == 2


### PR DESCRIPTION
## Summary
- implement `CallbackEvent` enum and thread-safe `CallbackManager`
- migrate validation middleware and analytics controller to use callbacks
- hook Flask request lifecycle via the new manager
- update plugin manager to register plugin callbacks through the manager
- provide a migration wrapper and documentation
- add tests for callback manager behaviour

## Testing
- `black analytics/analytics_controller.py app.py core/callback_manager.py core/plugins/manager.py core/plugins/protocols.py security/validation_middleware.py core/callback_events.py core/callback_migration.py tests/test_callback_manager_events.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `flake8` *(fails: command not found)*
- `mypy --strict .` *(fails: many missing stubs)*
- `bandit -r .` *(fails: command not found)*
- `safety check --full-report` *(fails: command not found)*
- `pytest -q` *(fails: missing pandas module)*

------
https://chatgpt.com/codex/tasks/task_e_68621647e1cc8320b1f0fda2544bbfec