### PR TITLE
Fix security patterns import

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -19,7 +19,9 @@ import mimetypes
 # These constants live in ``core/security_patterns.py`` and are reused in
 # ``core/security_validator.py``. Importing them here ensures ``InputValidator``
 # has access to the pre-defined patterns without duplicating definitions.
-from .security_patterns import (
+# Use an absolute import so this module can run standalone without relying on
+# the package context. This prevents NameError when executed directly.
+from core.security_patterns import (
     SQL_INJECTION_PATTERNS,
     XSS_PATTERNS,
     PATH_TRAVERSAL_PATTERNS,


### PR DESCRIPTION
## Summary
- resolve NameError when running `core/security.py` directly by using absolute import

## Testing
- `black core/security.py --check` *(fails: would reformat)*
- `flake8 core/security.py` *(fails: command not found)*
- `mypy core/security.py` *(fails: many missing stubs and typing errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686225c28804832089d122ac4280b51c