### PR TITLE
Implement LazyString sanitization plugin

### DIFF
--- a/plugins/builtin/lazystring_fix_plugin.py
+++ b/plugins/builtin/lazystring_fix_plugin.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 # Import the application factory
 from core.app_factory import create_app
 
-# Import the LazyString fix plugin (save the first artifact as this file)
+# Import the LazyString fix implementation
 from plugins.lazystring_fix_plugin import (
-    initialize_lazystring_fix, 
-    LazyStringFixConfig
+    initialize_lazystring_fix,
+    LazyStringFixConfig,
 )
 
 

--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -1,0 +1,101 @@
+"""LazyString sanitization and Flask integration plugin."""
+
+from __future__ import annotations
+import logging
+import unicodedata
+from dataclasses import dataclass
+from typing import Any
+
+from utils.unicode_handler import handle_surrogate_characters
+
+# Optional Babel import
+try:
+    from flask_babel import LazyString
+    BABEL_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    LazyString = None  # type: ignore
+    BABEL_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LazyStringFixConfig:
+    """Configuration options for ``LazyString`` sanitization."""
+
+    enabled: bool = True
+    auto_wrap_callbacks: bool = True
+    deep_sanitize: bool = True
+    log_conversions: bool = False
+    fallback_locale: str = "en"
+
+
+class LazyStringFixPlugin:
+    """Minimal plugin object returned by :func:`initialize_lazystring_fix`."""
+
+    def __init__(self, config: LazyStringFixConfig) -> None:
+        self.config = config
+        self.conversion_count = 0
+
+    def get_stats(self) -> dict[str, Any]:
+        return {"conversions": self.conversion_count}
+
+
+# Global plugin instance used by sanitize_lazystring
+_plugin: LazyStringFixPlugin | None = None
+
+
+def _is_lazy_string(obj: Any) -> bool:
+    if BABEL_AVAILABLE and isinstance(obj, LazyString):
+        return True
+    return hasattr(obj, "__class__") and "LazyString" in str(obj.__class__)
+
+
+def _sanitize_text(text: str) -> str:
+    text = unicodedata.normalize("NFKC", text)
+    text = handle_surrogate_characters(text)
+    return text
+
+
+def sanitize_lazystring(obj: Any) -> Any:
+    """Recursively sanitize LazyString objects inside ``obj``."""
+    global _plugin
+    config = _plugin.config if _plugin else LazyStringFixConfig()
+
+    try:
+        if _is_lazy_string(obj):
+            result = _sanitize_text(str(obj))
+            if _plugin:
+                _plugin.conversion_count += 1
+            if config.log_conversions:
+                logger.debug("Converted LazyString %r -> %r", obj, result)
+            return result
+
+        if config.deep_sanitize and isinstance(obj, dict):
+            return {k: sanitize_lazystring(v) for k, v in obj.items()}
+        if config.deep_sanitize and isinstance(obj, list):
+            return [sanitize_lazystring(v) for v in obj]
+        if config.deep_sanitize and isinstance(obj, tuple):
+            return tuple(sanitize_lazystring(v) for v in obj)
+    except Exception as exc:  # pragma: no cover - defensive
+        if config.log_conversions:
+            logger.error("LazyString sanitization failed: %s", exc)
+
+    return obj
+
+
+def initialize_lazystring_fix(app, config: LazyStringFixConfig) -> LazyStringFixPlugin:
+    """Patch Flask JSON handling to sanitize ``LazyString`` objects."""
+
+    global _plugin
+    _plugin = LazyStringFixPlugin(config)
+
+    class SanitizingJSONProvider(app.json_provider_class):
+        def dumps(self, obj, **kwargs):
+            obj = sanitize_lazystring(obj)
+            return super().dumps(obj, **kwargs)
+
+    app.json_provider_class = SanitizingJSONProvider
+    app.json = SanitizingJSONProvider(app)
+    app.extensions["lazystring_fix"] = _plugin
+    return _plugin

--- a/tests/test_lazystring_fix.py
+++ b/tests/test_lazystring_fix.py
@@ -1,0 +1,50 @@
+import pytest
+
+from plugins.lazystring_fix_plugin import sanitize_lazystring
+
+
+def _contains_surrogate(text: str) -> bool:
+    return any(0xD800 <= ord(ch) <= 0xDFFF for ch in text)
+
+
+def test_surrogate_pair_removed():
+    text = "\ud800\udc00test"
+    result = sanitize_lazystring(text)
+    assert not _contains_surrogate(result)
+    assert "test" in result
+
+
+def test_lone_surrogate_removed():
+    text = "start\ud800end"
+    result = sanitize_lazystring(text)
+    assert not _contains_surrogate(result)
+
+
+def test_unicode_normalization():
+    # Angstrom sign -> Latin capital A with ring above
+    text = "\u212B"
+    result = sanitize_lazystring(text)
+    assert result == "\u00C5"
+
+
+def test_nested_structures_and_types():
+    try:
+        from flask_babel import lazy_gettext
+    except Exception:
+        pytest.skip("flask_babel not available")
+
+    data = {
+        "msg": lazy_gettext("hello"),
+        "items": [1, lazy_gettext("bye"), {"again": lazy_gettext("again")}],
+    }
+    sanitized = sanitize_lazystring(data)
+    assert sanitized["msg"] == "hello"
+    assert sanitized["items"][1] == "bye"
+    assert sanitized["items"][2]["again"] == "again"
+    assert sanitized["items"][0] == 1
+
+
+def test_long_string_performance():
+    text = "a" * 50000
+    result = sanitize_lazystring(text)
+    assert result == text


### PR DESCRIPTION
## Summary
- add a new `LazyString` sanitization plugin with unicode handling
- update builtin entry point to use the new plugin
- test sanitization of surrogates and nested structures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68621632e92883209afe210b84101efb