### PR TITLE
Ensure large upload limit

### DIFF
--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -46,3 +46,8 @@ def test_oversized_file_rejected(tmp_path):
     assert result["success"] is False
 
 
+def test_upload_limit_allows_large_files():
+    """Default upload size should permit files of at least 50MB."""
+    assert dynamic_config.security.max_upload_mb >= 50
+
+


### PR DESCRIPTION
## Summary
- add unit test verifying default upload limit allows files of at least 50MB

## Testing
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: missing type stubs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862296cf9a08320a4e7e3310d19df08