### PR TITLE
Increase file upload limits and add diagnostics

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -2,12 +2,14 @@ from dataclasses import dataclass
 
 @dataclass
 class SecurityConstants:
-    """Security related default values"""
+    """Security related default values with large file support"""
     pbkdf2_iterations: int = 100000
     salt_bytes: int = 32
     rate_limit_requests: int = 100
     rate_limit_window_minutes: int = 1
-    max_upload_mb: int = 100
+    max_upload_mb: int = 500  # Changed from 100 to 500
+    max_file_size_mb: int = 500  # Added for consistency
+    max_analysis_mb: int = 1000  # Added for large file processing
 
 @dataclass
 class PerformanceConstants:

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -191,7 +191,7 @@ def layout():
                                         [
                                             dcc.Upload(
                                                 id="upload-data",
-                                                max_size=dynamic_config.security.max_upload_mb * 1024 * 1024,
+                                                max_size=dynamic_config.get_max_upload_size_bytes(),  # Updated to use new method
                                                 children=html.Div(
                                                     [
                                                         html.I(


### PR DESCRIPTION
## Summary
- support larger file uploads via config constants
- add env var validation and helper methods
- improve upload service error messages
- update file processor service with better defaults and CSV decoding
- expose upload size helper in file upload page
- add diagnostic output for upload configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python - <<'EOF'
try:
    from config.dynamic_config import diagnose_upload_config
except Exception as e:
    print('error', e)
EOF
` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686232da5f58832085cfd6546424d691