### PR TITLE
Fix config values and cleanup imports

### DIFF
--- a/analytics/chunked_analytics_controller.py
+++ b/analytics/chunked_analytics_controller.py
@@ -3,7 +3,6 @@
 import pandas as pd
 import logging
 from typing import Dict, Any, List, Iterator
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import numpy as np
 
 logger = logging.getLogger(__name__)

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -35,14 +35,15 @@ sample_files:
 
 analytics:
   cache_timeout_seconds: 60
-  max_records_per_query: 50000
+  max_records_per_query: 500000
   enable_real_time: true
-  batch_size: 5000
-  chunk_size: 10000
+  batch_size: 25000
+  chunk_size: 50000
   enable_chunked_analysis: true
   anomaly_detection_enabled: true
   ml_models_path: models/ml
   data_retention_days: 30
+  query_timeout_seconds: 300
 
 monitoring:
   health_check_interval: 30

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -23,7 +23,10 @@ sample_files:
 
 analytics:
   enabled: true
-  batch_size: 100
+  batch_size: 25000
+  max_records_per_query: 500000
+  chunk_size: 50000
+  query_timeout_seconds: 300
 
 monitoring:
   health_check_interval: 30

--- a/security/dataframe_validator.py
+++ b/security/dataframe_validator.py
@@ -14,7 +14,6 @@ class DataFrameSecurityValidator:
 
     def __init__(self):
         try:
-            from config.dynamic_config import dynamic_config
             self.max_upload_mb = getattr(dynamic_config.security, "max_upload_mb", 500)
             self.max_analysis_mb = getattr(dynamic_config.security, "max_analysis_mb", 1000)
             if hasattr(dynamic_config, 'analytics'):

--- a/tests/test_analyze_with_chunking.py
+++ b/tests/test_analyze_with_chunking.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from services.analytics_service import AnalyticsService
+
+
+def test_analyze_with_chunking_large_df():
+    df = pd.DataFrame({
+        "person_id": [f"user_{i}" for i in range(120000)],
+        "door_id": [f"door_{i % 100}" for i in range(120000)],
+        "access_result": ["Granted" if i % 2 == 0 else "Denied" for i in range(120000)],
+        "timestamp": pd.date_range("2024-01-01", periods=120000, freq="min"),
+    })
+
+    service = AnalyticsService()
+    result = service.analyze_with_chunking(
+        df, ["security", "trends", "anomaly", "behavior"]
+    )
+
+    summary = result.get("processing_summary", {})
+    assert summary.get("rows_processed") == len(df)
+    assert summary.get("chunking_used") is True


### PR DESCRIPTION
## Summary
- drop redundant import from `DataFrameSecurityValidator`
- remove unused `ThreadPoolExecutor` import
- align config defaults with new `AnalyticsConstants`
- test chunked analysis on large dataframes

## Testing
- `pytest -q tests/test_analyze_with_chunking.py -vv` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686245a822388320b5928e7ee625a63f