### PR TITLE
Fix full dataset processing

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,9 +29,10 @@ logging:
 plugins:
   json_serialization:
     enabled: true
-    max_dataframe_rows: 1000
-    max_string_length: 10000
+    max_dataframe_rows: 2000000
+    max_string_length: 50000
     include_type_metadata: true
     compress_large_objects: true
     fallback_to_repr: true
     auto_wrap_callbacks: true
+    force_complete_analysis: true

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -35,15 +35,16 @@ sample_files:
 
 analytics:
   cache_timeout_seconds: 60
-  max_records_per_query: 500000
+  max_records_per_query: 2000000
   enable_real_time: true
   batch_size: 25000
-  chunk_size: 50000
+  chunk_size: 100000
   enable_chunked_analysis: true
   anomaly_detection_enabled: true
   ml_models_path: models/ml
   data_retention_days: 30
-  query_timeout_seconds: 300
+  query_timeout_seconds: 600
+  force_full_dataset_analysis: true
 
 monitoring:
   health_check_interval: 30

--- a/security/dataframe_validator.py
+++ b/security/dataframe_validator.py
@@ -59,15 +59,15 @@ class DataFrameSecurityValidator:
         # Clean the DataFrame first
         df = self._sanitize_dataframe(df)
 
-        # Be more conservative about chunking - only chunk very large files
-        needs_chunking = memory_usage > max_bytes or len(df) > 100000
+        # FIXED: More aggressive threshold for chunking - only chunk truly massive files
+        needs_chunking = memory_usage > max_bytes or len(df) > 500000
 
         if needs_chunking:
             logger.info(
                 f"Large DataFrame detected: {len(df)} rows, {memory_usage/1024/1024:.1f}MB. Chunked processing enabled."
             )
         else:
-            logger.info(f"Regular processing for {len(df)} rows")
+            logger.info(f"Regular processing for {len(df)} rows - FULL DATASET ANALYSIS")
 
         return df, needs_chunking
 

--- a/tests/test_complete_dataset_analysis.py
+++ b/tests/test_complete_dataset_analysis.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Test complete dataset analysis without row limits."""
+
+import pandas as pd
+import pytest
+from services.analytics_service import AnalyticsService
+import tempfile
+import os
+
+
+def test_complete_dataset_analysis():
+    """Test that analytics processes complete dataset, not just samples."""
+
+    # Create test dataset with 2500 rows (more than typical limits)
+    test_data = []
+    for i in range(2500):
+        test_data.append({
+            'person_id': f'USER_{i % 100}',
+            'door_id': f'DOOR_{i % 50}',
+            'access_result': 'Granted' if i % 3 != 0 else 'Denied',
+            'timestamp': f'2024-01-{(i % 30) + 1:02d} {(i % 24):02d}:00:00'
+        })
+
+    df = pd.DataFrame(test_data)
+
+    # Save to temporary CSV
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        df.to_csv(f.name, index=False)
+        temp_path = f.name
+
+    try:
+        service = AnalyticsService()
+
+        uploaded_data = {'test_file.csv': temp_path}
+
+        result = service._process_uploaded_data_directly(uploaded_data)
+
+        assert result['total_events'] == 2500, f"Expected 2500 events, got {result['total_events']}"
+        assert result['active_users'] == 100, f"Expected 100 users, got {result['active_users']}"
+        assert result['active_doors'] == 50, f"Expected 50 doors, got {result['active_doors']}"
+        assert result['status'] == 'success'
+
+    finally:
+        os.unlink(temp_path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- configure analytics to use bigger limits and force full analysis
- relax chunking threshold for analysis validator
- process whole CSV files in analytics service
- read CSVs fully in FileProcessor
- expand plugin serialization limits
- add unicode processing helper
- test processing of entire dataset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68624c4c10408320b530fe367bf6ec7a