### PR TITLE
Restore Unicode tools and update analytics

### DIFF
--- a/test_import_fix.py
+++ b/test_import_fix.py
@@ -1,0 +1,19 @@
+"""Simple import check for utils package."""
+
+from utils import (
+    safe_unicode_encode,
+    sanitize_data_frame,
+    clean_unicode_surrogates,
+    sanitize_unicode_input,
+    process_large_csv_content,
+)
+
+if __name__ == "__main__":
+    print(
+        safe_unicode_encode,
+        sanitize_data_frame,
+        clean_unicode_surrogates,
+        sanitize_unicode_input,
+        process_large_csv_content,
+    )
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,10 +1,22 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
-from .unicode_handler import sanitize_unicode_input
-from .unicode_processor import safe_unicode_encode, sanitize_data_frame
+try:
+    from .unicode_processor import (
+        safe_unicode_encode,
+        sanitize_data_frame,
+        clean_unicode_surrogates,
+        sanitize_unicode_input,
+        process_large_csv_content,
+    )
+except Exception:  # pragma: no cover - fallback when processor unavailable
+    from .unicode_handler import sanitize_unicode_input
+    from .unicode_processor import safe_unicode_encode, sanitize_data_frame, clean_unicode_surrogates, process_large_csv_content  # type: ignore
 
 __all__: list[str] = [
     "sanitize_unicode_input",
     "safe_unicode_encode",
     "sanitize_data_frame",
+    "clean_unicode_surrogates",
+    "process_large_csv_content",
 ]
+

--- a/utils/unicode_processor.py
+++ b/utils/unicode_processor.py
@@ -1,49 +1,77 @@
 #!/usr/bin/env python3
-"""Unicode processor with surrogate character handling."""
+"""Unicode processing helpers with surrogate cleanup and large CSV handling."""
 
-import pandas as pd
+from __future__ import annotations
+
 import logging
 import re
-from typing import Any, Union
+from typing import Any
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 
+def safe_unicode_encode(value: Any) -> str:
+    """Return a valid UTF-8 string removing invalid surrogates."""
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8", "surrogatepass")
+        except Exception:
+            value = value.decode("latin-1", "surrogatepass")
+    else:
+        value = str(value)
+
+    value = re.sub(r"[\ud800-\udfff]", "", value)
+    return value.encode("utf-8", "ignore").decode("utf-8", "ignore")
+
+
+def clean_unicode_surrogates(text: Any) -> str:
+    """Remove Unicode surrogate characters from text."""
+    if text is None or (isinstance(text, float) and pd.isna(text)):
+        return ""
+    text = str(text)
+    text = re.sub(r"[\ud800-\udfff]", "", text)
+    text = text.replace("\ufffe", "").replace("\uffff", "")
+    return text
+
+
 def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
-    """Sanitize DataFrame handling Unicode surrogates that can't be encoded in UTF-8."""
+    """Sanitize DataFrame column names and string values."""
     df_clean = df.copy()
 
-    # Process string columns for Unicode issues
-    for col in df_clean.select_dtypes(include=['object']).columns:
-        df_clean[col] = df_clean[col].apply(clean_unicode_surrogates)
+    new_columns = []
+    for col in df_clean.columns:
+        safe_col = clean_unicode_surrogates(col)
+        safe_col = re.sub(r"^[=+\-@]+", "", safe_col)
+        new_columns.append(safe_col)
+    df_clean.columns = new_columns
+
+    for col in df_clean.select_dtypes(include=["object"]).columns:
+        df_clean[col] = df_clean[col].map(clean_unicode_surrogates)
 
     return df_clean
 
 
-def clean_unicode_surrogates(text: Any) -> str:
-    """Clean Unicode surrogate characters that can't be encoded in UTF-8."""
-    if pd.isna(text):
-        return ""
-
-    text_str = str(text)
-
-    # Remove Unicode surrogates (U+D800-U+DFFF)
-    text_str = re.sub(r'[\uD800-\uDFFF]', '', text_str)
-
-    # Remove other problematic Unicode ranges
-    text_str = re.sub(r'[\uFFFE\uFFFF]', '', text_str)
-
-    # Encode to UTF-8 and decode to ensure clean text
-    try:
-        text_str = text_str.encode('utf-8', errors='ignore').decode('utf-8')
-    except UnicodeError:
-        logger.warning(f"Unicode encoding issue with text: {text_str[:50]}...")
-        text_str = text_str.encode('ascii', errors='ignore').decode('ascii')
-
-    return text_str
-
-
-def sanitize_unicode_input(value: Union[str, Any]) -> str:
-    """Sanitize single Unicode input value."""
+def sanitize_unicode_input(value: Any) -> str:
+    """Sanitize a single input value containing possible surrogates."""
     return clean_unicode_surrogates(value)
 
+
+def process_large_csv_content(content: bytes, encoding: str = "utf-8", *, chunk_size: int = 1024 * 1024) -> str:
+    """Decode potentially large CSV content in chunks and sanitize."""
+    pieces: list[str] = []
+    mv = memoryview(content)
+    for start in range(0, len(mv), chunk_size):
+        chunk = mv[start : start + chunk_size].tobytes()
+        text = chunk.decode(encoding, errors="surrogatepass")
+        pieces.append(clean_unicode_surrogates(text))
+    return "".join(pieces)
+
+__all__ = [
+    "safe_unicode_encode",
+    "sanitize_data_frame",
+    "clean_unicode_surrogates",
+    "sanitize_unicode_input",
+    "process_large_csv_content",
+]


### PR DESCRIPTION
## Summary
- overhaul `unicode_processor` with full surrogate and CSV utilities
- export Unicode helpers from `utils` with a fallback
- add full CSV decoding for uploads
- include per-file info when processing uploaded data
- provide import check script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862521210f0832096fc0b3054f7237c