### PR TITLE
Remove unused analytics store

### DIFF
--- a/pages/deep_analytics/layout.py
+++ b/pages/deep_analytics/layout.py
@@ -159,7 +159,6 @@ def layout():
 
         # Hidden stores
         stores = [
-            dcc.Store(id="analytics-results-store", data={}),
             dcc.Store(id="service-health-store", data={}),
             html.Div(id="hidden-trigger", style={"display": "none"})
         ]


### PR DESCRIPTION
## Summary
- clean up unused `analytics-results-store`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68626fb5b5b48320aa90577bac5cb9ed