### PR TITLE
Update unique patterns to respect data source

### DIFF
--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -44,11 +44,11 @@ def run_service_analysis(data_source: str, analysis_type: str):
     return create_analysis_results_display_safe(results, analysis_type)
 
 
-def run_unique_patterns_analysis():
+def run_unique_patterns_analysis(data_source: str):
     """Run unique patterns analysis using the analytics service."""
     try:
         analytics_service = AnalyticsService()
-        results = analytics_service.get_unique_patterns_analysis()
+        results = analytics_service.get_unique_patterns_analysis(data_source)
 
         if results["status"] == "success":
             data_summary = results["data_summary"]
@@ -406,7 +406,7 @@ def dispatch_analysis(button_id: str, data_source: str):
     dispatch = {
         "suggests": lambda: run_suggests_analysis(data_source),
         "quality": lambda: run_quality_analysis(data_source),
-        "unique_patterns": run_unique_patterns_analysis,
+        "unique_patterns": lambda: run_unique_patterns_analysis(data_source),
         "security": lambda: run_service_analysis(data_source, "security"),
         "trends": lambda: run_service_analysis(data_source, "trends"),
         "behavior": lambda: run_service_analysis(data_source, "behavior"),

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -579,8 +579,8 @@ class AnalyticsService:
             logger.error(f"Dashboard summary failed: {e}")
             return {'status': 'error', 'message': str(e)}
 
-    def get_unique_patterns_analysis(self):
-        """FIXED: Get unique patterns analysis ensuring complete dataset processing"""
+    def get_unique_patterns_analysis(self, data_source: str | None = None):
+        """Get unique patterns analysis for the requested source."""
         import logging
         logger = logging.getLogger(__name__)
 
@@ -588,8 +588,12 @@ class AnalyticsService:
             logger.info("🎯 Starting Unique Patterns Analysis")
 
             # STEP 1: Get uploaded data with verification
-            from pages.file_upload import get_uploaded_data
-            uploaded_data = get_uploaded_data()
+            if data_source == "database":
+                df, _meta = self.data_loader.get_processed_database()
+                uploaded_data = {"database": df} if not df.empty else {}
+            else:
+                from pages.file_upload import get_uploaded_data
+                uploaded_data = get_uploaded_data()
 
             if not uploaded_data:
                 logger.warning("❌ No uploaded data found for unique patterns analysis")

--- a/tests/test_callback_helpers.py
+++ b/tests/test_callback_helpers.py
@@ -34,7 +34,7 @@ def test_run_service_analysis_error(monkeypatch):
 
 def test_run_unique_patterns_analysis(monkeypatch):
     class FakeService:
-        def get_unique_patterns_analysis(self):
+        def get_unique_patterns_analysis(self, data_source):
             return {
                 "status": "success",
                 "data_summary": {
@@ -83,15 +83,15 @@ def test_run_unique_patterns_analysis(monkeypatch):
             }
 
     monkeypatch.setattr(cb, "AnalyticsService", lambda: FakeService())
-    result = cb.run_unique_patterns_analysis()
+    result = cb.run_unique_patterns_analysis("service:test")
     assert isinstance(result, html.Div)
 
 
 def test_run_unique_patterns_analysis_no_data(monkeypatch):
     class FakeService:
-        def get_unique_patterns_analysis(self):
+        def get_unique_patterns_analysis(self, data_source):
             return {"status": "no_data"}
 
     monkeypatch.setattr(cb, "AnalyticsService", lambda: FakeService())
-    result = cb.run_unique_patterns_analysis()
+    result = cb.run_unique_patterns_analysis("service:test")
     assert isinstance(result, dbc.Alert)


### PR DESCRIPTION
## Summary
- allow `get_unique_patterns_analysis` to accept a data source
- simplify unique patterns callback to match new signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68626fb7eec48320ab19570cfa5ff640