### PR TITLE
Fix service analysis callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 - Initial changelog with standard sections.
 
 ### Changed
-- N/A
+- Updated `run_service_analysis` to use `analyze_data_with_service` and
+  `create_analysis_results_display`.
 
 ### Fixed
 - N/A

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -10,10 +10,11 @@ import dash_bootstrap_components as dbc
 from .analysis import (
     process_suggests_analysis_safe,
     process_quality_analysis_safe,
-    analyze_data_with_service_safe,
+    analyze_data_with_service,
     get_initial_message_safe,
     get_data_source_options_safe,
     get_analytics_service_safe,
+    create_analysis_results_display,
     create_analysis_results_display_safe,
     AI_SUGGESTIONS_AVAILABLE,
 )
@@ -38,10 +39,10 @@ def run_quality_analysis(data_source: str):
 
 def run_service_analysis(data_source: str, analysis_type: str):
     """Return display for service based analyses (security, trends, etc.)."""
-    results = analyze_data_with_service_safe(data_source, analysis_type)
+    results = analyze_data_with_service(data_source, analysis_type)
     if isinstance(results, dict) and "error" in results:
         return dbc.Alert(str(results["error"]), color="danger")
-    return create_analysis_results_display_safe(results, analysis_type)
+    return create_analysis_results_display(results, analysis_type)
 
 
 def run_unique_patterns_analysis(data_source: str):

--- a/tests/test_callback_helpers.py
+++ b/tests/test_callback_helpers.py
@@ -16,7 +16,7 @@ def test_run_service_analysis_success(monkeypatch):
             "success_rate": 0.9,
         }
 
-    monkeypatch.setattr(cb, "analyze_data_with_service_safe", fake_analyze)
+    monkeypatch.setattr(cb, "analyze_data_with_service", fake_analyze)
 
     result = cb.run_service_analysis("service:test", "security")
     assert isinstance(result, dbc.Card)
@@ -26,7 +26,7 @@ def test_run_service_analysis_error(monkeypatch):
     def fake_analyze(ds, at):
         return {"error": "boom"}
 
-    monkeypatch.setattr(cb, "analyze_data_with_service_safe", fake_analyze)
+    monkeypatch.setattr(cb, "analyze_data_with_service", fake_analyze)
 
     result = cb.run_service_analysis("service:test", "security")
     assert isinstance(result, dbc.Alert)


### PR DESCRIPTION
## Summary
- update `run_service_analysis` to use normal helper functions
- update tests for new helper names
- document change in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68629606180083208e08518e36e7e287