### PR TITLE
Update docs for clean test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ gunicorn wsgi:server
 
 ## 🧪 Testing
 
+Install dependencies before running the tests:
+```bash
+./scripts/setup.sh  # or `pip install -r requirements.txt`
+```
+
 Run the complete test suite:
 ```bash
 # Run all unit and integration tests


### PR DESCRIPTION
## Summary
- document how to install dependencies before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `./scripts/setup.sh` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686299158fe48320b86c022871f47528