### PR TITLE
Fix multi-part file upload grouping

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -436,7 +436,24 @@ def process_uploaded_files(
     file_info_dict: Dict[str, Any] = {}
     current_file_info: Dict[str, Any] = {}
 
+    file_parts: Dict[str, List[str]] = {}
+
+    # Group any repeated filenames together for multi-part uploads
     for content, filename in zip(contents_list, filenames_list):
+        file_parts.setdefault(filename, []).append(content)
+
+    for filename, parts in file_parts.items():
+        # Concatenate multiple parts for the same file into a single base64 string
+        if len(parts) > 1:
+            prefix, first = parts[0].split(",", 1)
+            combined_data = first
+            for part in parts[1:]:
+                _pfx, data = part.split(",", 1)
+                combined_data += data
+            content = f"{prefix},{combined_data}"
+        else:
+            content = parts[0]
+
         try:
             result = process_uploaded_file(content, filename)
 

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -1,0 +1,23 @@
+import base64
+import pandas as pd
+
+from pages.file_upload import process_uploaded_files, _uploaded_data_store
+
+
+def test_multi_part_upload_row_count():
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4],
+        "B": ["a", "b", "c", "d"],
+    })
+    csv = df.to_csv(index=False)
+    b64 = base64.b64encode(csv.encode()).decode()
+    prefix = "data:text/csv;base64,"
+    mid = len(b64) // 2
+    part1 = prefix + b64[:mid]
+    part2 = prefix + b64[mid:]
+
+    res = process_uploaded_files([part1, part2], ["sample.csv", "sample.csv"])
+    info = res[2]
+    assert info["sample.csv"]["rows"] == len(df)
+    stored = _uploaded_data_store.get_all_data()["sample.csv"]
+    assert len(stored) == len(df)


### PR DESCRIPTION
## Summary
- concatenate chunks by filename before calling `process_uploaded_file`
- add regression test for multi-part uploads

## Testing
- `pytest -q tests/test_process_uploaded_files.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686299123d788320863302e52b1947e8