### PR TITLE
Add parquet conversion utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,14 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 ## 📚 Documentation
 
 See the [data model diagram](docs/data_model.md) for an overview of key entities.
+## 📜 Data Migration
+Use the storage utilities to convert legacy pickle files to Parquet and load them:
+```python
+from file_conversion.migrate_existing_files import main
+main()
+```
+This creates `converted_data/Demo3_data_copy.csv.parquet` and prints the first rows.
+
 
 ## 🤝 Contributing
 

--- a/file_conversion/file_converter.py
+++ b/file_conversion/file_converter.py
@@ -1,0 +1,33 @@
+"""Conversion helpers for .pkl DataFrames to .parquet with Unicode cleanup."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from .unicode_handler import UnicodeCleaner
+
+_logger = logging.getLogger(__name__)
+
+
+class FileConverter:
+    """Utility class for converting pickled DataFrames to Parquet."""
+
+    @staticmethod
+    def pkl_to_parquet(pkl_path: Path, parquet_path: Path) -> Tuple[bool, str]:
+        """Convert ``pkl_path`` DataFrame to ``parquet_path`` removing surrogates."""
+        try:
+            if not pkl_path.exists():
+                return False, f"Pickle file not found: {pkl_path}"
+            df = pd.read_pickle(pkl_path)
+            df = UnicodeCleaner.clean_dataframe(df)
+            parquet_path.parent.mkdir(parents=True, exist_ok=True)
+            df.to_parquet(parquet_path, index=False)
+            return True, f"Converted {pkl_path} to {parquet_path}"
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Conversion failed: %s", exc)
+            return False, str(exc)
+
+__all__ = ["FileConverter"]

--- a/file_conversion/migrate_existing_files.py
+++ b/file_conversion/migrate_existing_files.py
@@ -1,0 +1,24 @@
+"""Script to migrate a pickle file to Parquet format using :class:`StorageManager`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .storage_manager import StorageManager
+
+
+def main() -> None:
+    """Migrate ``Demo3_data_copy.csv.pkl`` to Parquet and load it back."""
+    storage = StorageManager()
+    pkl_file = Path("Demo3_data_copy.csv.pkl")
+    success, message = storage.migrate_pkl_to_parquet(pkl_file)
+    print(message)
+    if success:
+        df, err = storage.load_dataframe(pkl_file.with_suffix("").name)
+        if err:
+            print(f"Load error: {err}")
+        else:
+            print(df.head())
+
+
+if __name__ == "__main__":
+    main()

--- a/file_conversion/storage_manager.py
+++ b/file_conversion/storage_manager.py
@@ -1,0 +1,87 @@
+"""Manage Parquet file storage with metadata tracking."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import pandas as pd
+
+from .file_converter import FileConverter
+from .unicode_handler import UnicodeCleaner
+
+_logger = logging.getLogger(__name__)
+
+
+class StorageManager:
+    """Handle saving/loading Parquet files and tracking metadata."""
+
+    def __init__(self, base_dir: Path | str = "converted_data") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self._metadata_path = self.base_dir / "metadata.json"
+        self._metadata: Dict[str, Any] = {}
+        self._load_metadata()
+
+    # -- metadata helpers -------------------------------------------------
+    def _load_metadata(self) -> None:
+        try:
+            if self._metadata_path.exists():
+                with open(self._metadata_path, "r", encoding="utf-8") as fh:
+                    self._metadata = json.load(fh)
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Failed to load metadata: %s", exc)
+            self._metadata = {}
+
+    def _save_metadata(self) -> None:
+        try:
+            with open(self._metadata_path, "w", encoding="utf-8") as fh:
+                json.dump(self._metadata, fh, indent=2, default=str)
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Failed to save metadata: %s", exc)
+
+    # -- public API -------------------------------------------------------
+    def migrate_pkl_to_parquet(self, pkl_path: Path) -> Tuple[bool, str]:
+        """Convert ``pkl_path`` to Parquet in base directory."""
+        parquet_path = self.base_dir / pkl_path.with_suffix(".parquet").name
+        success, msg = FileConverter.pkl_to_parquet(pkl_path, parquet_path)
+        if success:
+            self._metadata[parquet_path.name] = {
+                "original_file": str(pkl_path),
+                "converted_at": datetime.utcnow().isoformat(),
+            }
+            self._save_metadata()
+        return success, msg
+
+    def save_dataframe(self, df: pd.DataFrame, name: str) -> Tuple[bool, str]:
+        """Save ``df`` to a Parquet file under ``name`` with metadata."""
+        try:
+            df_clean = UnicodeCleaner.clean_dataframe(df)
+            parquet_path = self.base_dir / f"{name}.parquet"
+            df_clean.to_parquet(parquet_path, index=False)
+            self._metadata[parquet_path.name] = {
+                "rows": len(df_clean),
+                "columns": len(df_clean.columns),
+                "saved_at": datetime.utcnow().isoformat(),
+            }
+            self._save_metadata()
+            return True, f"Saved {parquet_path}"
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Failed to save DataFrame: %s", exc)
+            return False, str(exc)
+
+    def load_dataframe(self, name: str) -> Tuple[Optional[pd.DataFrame], str]:
+        """Load a Parquet file previously saved."""
+        parquet_path = self.base_dir / f"{name}.parquet"
+        try:
+            if not parquet_path.exists():
+                return None, f"File not found: {parquet_path}"
+            df = pd.read_parquet(parquet_path)
+            return df, ""
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Failed to load DataFrame: %s", exc)
+            return None, str(exc)
+
+__all__ = ["StorageManager"]

--- a/file_conversion/unicode_handler.py
+++ b/file_conversion/unicode_handler.py
@@ -1,0 +1,45 @@
+"""Utilities for cleaning Unicode surrogate characters."""
+from __future__ import annotations
+
+import logging
+import pandas as pd
+from pandas import DataFrame
+
+_logger = logging.getLogger(__name__)
+
+
+class UnicodeCleaner:
+    """Helper class to remove invalid Unicode surrogate characters."""
+
+    _SURROGATE_RANGE = (0xD800, 0xDFFF)
+
+    @staticmethod
+    def clean_string(text: str) -> str:
+        """Return ``text`` with surrogate characters removed."""
+        try:
+            if not isinstance(text, str):
+                text = str(text)
+            cleaned = "".join(
+                ch for ch in text if not (UnicodeCleaner._SURROGATE_RANGE[0] <= ord(ch) <= UnicodeCleaner._SURROGATE_RANGE[1])
+            )
+            return cleaned
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Error cleaning string: %s", exc)
+            return text
+
+    @staticmethod
+    def clean_dataframe(df: DataFrame) -> DataFrame:
+        """Return a copy of ``df`` with surrogate characters removed."""
+        try:
+            df_clean = df.copy()
+            # Clean column names
+            df_clean.columns = [UnicodeCleaner.clean_string(c) for c in df_clean.columns]
+            # Clean string values
+            for col in df_clean.select_dtypes(include=["object"]).columns:
+                df_clean[col] = df_clean[col].map(UnicodeCleaner.clean_string)
+            return df_clean
+        except Exception as exc:  # pragma: no cover - best effort
+            _logger.error("Error cleaning DataFrame: %s", exc)
+            return df
+
+__all__ = ["UnicodeCleaner"]


### PR DESCRIPTION
## Summary
- add new conversion utilities for pickle-to-Parquet workflows
- document how to migrate Demo3_data_copy.csv.pkl to Parquet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862afbfe0b0832094688e9d8bf73f3c