### PR TITLE
Handle old pickle uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ main()
 ```
 This creates `converted_data/Demo3_data_copy.csv.parquet` and prints the first rows.
 
+Legacy `.pkl` files placed in `temp/uploaded_data` are automatically converted
+to Parquet the next time the application starts.
+
 
 ## 🤝 Contributing
 

--- a/tests/test_upload_store_migration.py
+++ b/tests/test_upload_store_migration.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from utils.upload_store import UploadedDataStore
+
+
+def test_pkl_migration(tmp_path):
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    pkl_path = tmp_path / "legacy.csv.pkl"
+    df.to_pickle(pkl_path)
+
+    store = UploadedDataStore(storage_dir=tmp_path)
+
+    parquet_path = tmp_path / "legacy.csv.parquet"
+    assert parquet_path.exists()
+    assert not pkl_path.exists()
+    assert store.get_filenames() == ["legacy.csv"]
+    pd.testing.assert_frame_equal(store.get_all_data()["legacy.csv"], df)
+    info = store.get_file_info()["legacy.csv"]
+    assert info["rows"] == 2
+    assert info["columns"] == 2
+


### PR DESCRIPTION
## Summary
- convert any legacy `.pkl` uploads to `.parquet` on startup
- remove converted pickle files
- test migration logic
- document automatic migration of `.pkl` files

## Testing
- `pytest tests/test_upload_store_migration.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863040bbec083209c9a1c8748b03aee