### PR TITLE
Avoid running diagnosis on import

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -160,4 +160,5 @@ def diagnose_upload_config():
         print("   Run: unset MAX_UPLOAD_MB")
 
 
-diagnose_upload_config()
+if __name__ == "__main__":
+    diagnose_upload_config()


### PR DESCRIPTION
## Summary
- prevent `diagnose_upload_config()` from running when `dynamic_config` is imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686344ecfeb0832093011ab7b7996fdd