### PR TITLE
Fix security pattern score calculation and callbacks

### DIFF
--- a/analytics/controllers/unified_controller.py
+++ b/analytics/controllers/unified_controller.py
@@ -63,6 +63,11 @@ class UnifiedAnalyticsController:
             self._EVENT_MAP[event], callback, priority=priority
         )
 
+    def register_security_callbacks(self, callback_dict: Dict[str, callable]):
+        """Consolidated callback registration for security analysis"""
+        for event_name, callback_func in callback_dict.items():
+            self.register_callback(event_name, callback_func, secure=True)
+
     # ------------------------------------------------------------------
     def unregister_callback(self, event: str, callback: Callable[..., Any]) -> None:
         """Remove a previously registered callback."""


### PR DESCRIPTION
## Summary
- refine data preparation for security pattern analysis
- compute security scores using fixed calculator module
- add unicode-safe text sanitization helper
- consolidate callback registration for unified controller

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863dbc315448320bed75c1c6f2325c6