### PR TITLE
Add PluginManager unit tests

### DIFF
--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,90 @@
+import sys
+import time
+from pathlib import Path
+
+from core.plugins.manager import PluginManager
+from core.container import Container as DIContainer
+from config.config import ConfigManager
+
+
+class SimplePlugin:
+    class metadata:
+        name = "simple"
+
+    def __init__(self):
+        self.started = False
+
+    def load(self, container, config):
+        container.register("simple_service", object())
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        self.started = True
+        return True
+
+    def stop(self):
+        self.started = False
+        return True
+
+    def health_check(self):
+        return {"healthy": True}
+
+
+def test_load_plugin_registers_plugin(tmp_path):
+    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    plugin = SimplePlugin()
+    assert manager.load_plugin(plugin) is True
+    assert "simple" in manager.plugins
+    health = manager.get_plugin_health()
+    assert health["simple"]["health"] == {"healthy": True}
+    manager.stop_health_monitor()
+
+
+def test_load_all_plugins(tmp_path):
+    pkg_dir = tmp_path / "sampleplugins"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    plugin_file = pkg_dir / "plug.py"
+    plugin_file.write_text(
+        """
+class Plug:
+    class metadata:
+        name = 'auto'
+    def load(self, c, conf):
+        return True
+    def configure(self, conf):
+        return True
+    def start(self):
+        return True
+    def stop(self):
+        return True
+    def health_check(self):
+        return {'healthy': True}
+
+def create_plugin():
+    return Plug()
+"""
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        manager = PluginManager(DIContainer(), ConfigManager(), package="sampleplugins", health_check_interval=1)
+        plugins = manager.load_all_plugins()
+        assert len(plugins) == 1
+        assert "auto" in manager.plugins
+    finally:
+        sys.path.remove(str(tmp_path))
+        manager.stop_health_monitor()
+
+
+def test_get_plugin_health_snapshot():
+    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    plugin = SimplePlugin()
+    manager.load_plugin(plugin)
+    time.sleep(1.2)
+    snapshot = manager.health_snapshot
+    assert "simple" in snapshot
+    assert snapshot["simple"]["health"] == {"healthy": True}
+    manager.stop_health_monitor()


### PR DESCRIPTION
## Summary
- add a new test module `test_plugin_manager.py`
- cover plugin registration, package loading and health snapshot

## Testing
- `pytest tests/test_plugin_manager.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e377b2d8832081e148cbdd9c1194