### PR TITLE
Refactor analytics helpers

### DIFF
--- a/tests/test_regular_analysis_helpers.py
+++ b/tests/test_regular_analysis_helpers.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from services import AnalyticsService
+
+
+def test_prepare_regular_result():
+    df = pd.DataFrame({"a": [1, 2]})
+    service = AnalyticsService()
+    res = service._prepare_regular_result(df)
+    assert res["total_events"] == 2
+    assert res["columns"] == ["a"]
+    assert res["processing_summary"]["chunking_used"] is False
+
+
+def test_apply_regular_analysis():
+    df = pd.DataFrame(
+        {
+            "person_id": ["u1", "u1", "u2"],
+            "door_id": ["d1", "d1", "d2"],
+            "access_result": ["Granted", "Denied", "Granted"],
+            "timestamp": pd.to_datetime(["2024-01-01", "2024-01-01", "2024-01-02"]),
+        }
+    )
+    service = AnalyticsService()
+    res = service._apply_regular_analysis(df, ["basic", "user"])
+    assert "basic_stats" in res
+    assert res["user_analysis"]["active_users"] == 2

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -39,3 +39,25 @@ def test_summarize_dataframe():
     assert summary["active_doors"] == 2
     assert summary["date_range"]["start"] == "2024-01-01"
     assert summary["date_range"]["end"] == "2024-01-02"
+
+
+def test_count_and_date_helpers():
+    from collections import Counter
+
+    df = pd.DataFrame(
+        {
+            "person_id": ["u1", "u2", "u1"],
+            "door_id": ["d1", "d1", "d2"],
+            "timestamp": ["2024-01-01", "2024-01-03", "2024-01-02"],
+        }
+    )
+    service = AnalyticsService()
+    u_counts, d_counts = Counter(), Counter()
+    service._update_counts(df, u_counts, d_counts)
+    assert u_counts["u1"] == 2
+    assert d_counts["d1"] == 2
+
+    min_ts, max_ts = service._update_timestamp_range(df, None, None)
+    dr = service._calculate_date_range(min_ts, max_ts)
+    assert dr["start"] == "2024-01-01"
+    assert dr["end"] == "2024-01-03"


### PR DESCRIPTION
## Summary
- split `_process_uploaded_data_directly` into helper methods
- break `_regular_analysis` up via `_prepare_regular_result` and `_apply_regular_analysis`
- cover new helpers in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e369d9488320b94358ddd46fe40e