### PR TITLE
Add production CSS build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Alternatively you can launch the app with Gunicorn:
 gunicorn wsgi:server
 ```
 
+### Production Build
+
+Build optimized CSS assets before deployment:
+```bash
+python tools/build_css.py
+```
+This generates `assets/dist/main.min.css` and `assets/dist/main.min.css.gz`.
+
 ## 🧪 Testing
 
 Install dependencies before running the tests:

--- a/tools/build_css.py
+++ b/tools/build_css.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from models import css_build_optimizer
+
+# Alias to maintain naming from documentation
+CSSBuildOptimizer = css_build_optimizer.CSSOptimizer
+
+
+def main() -> None:
+    css_dir = Path("assets/css")
+    output_dir = Path("assets/dist")
+    optimizer = CSSBuildOptimizer(css_dir, output_dir)
+    optimizer.build_production_css()
+
+    built = output_dir / "main.min.css"
+    gzipped = output_dir / "main.min.css.gz"
+    if not (built.exists() and gzipped.exists()):
+        raise SystemExit("CSS build failed to produce expected artifacts")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/build_css.py` wrapper around CSSBuildOptimizer
- document production CSS build step in the README

## Testing
- `black tools/build_css.py`
- `pytest tests/test_css_build_optimizer_utils.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e8bb53448320b1fa3f8da03c3d66