### PR TITLE
Enable threaded CSS build minification

### DIFF
--- a/tests/test_css_optimizer_production.py
+++ b/tests/test_css_optimizer_production.py
@@ -1,0 +1,22 @@
+from models.css_build_optimizer import CSSOptimizer
+
+
+def test_build_production_css_multifile(tmp_path):
+    css_dir = tmp_path / "css"
+    css_dir.mkdir()
+    output_dir = tmp_path / "out"
+
+    # create multiple css files
+    (css_dir / "main.css").write_text("body { color: red; }\n")
+    (css_dir / "extra.css").write_text(".x { margin: 0; }\n")
+    (css_dir / "theme.css").write_text("/* comment */\n.y{padding:5px;}\n")
+
+    optimizer = CSSOptimizer(css_dir, output_dir)
+    optimizer.build_production_css()
+
+    for name in ["main", "extra", "theme"]:
+        out = output_dir / f"{name}.min.css"
+        gz = out.with_suffix(out.suffix + ".gz")
+        assert out.exists()
+        assert gz.exists()
+


### PR DESCRIPTION
## Summary
- parallelize CSSOptimizer.build_production_css using ThreadPoolExecutor
- handle worker exceptions and log errors
- add unit test covering multi-file production build

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e8c19b748320ba86c6ef45992c84