### PR TITLE
Add PluginManager context support

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -42,6 +42,20 @@ class PluginManager:
         )
         self._health_thread.start()
 
+    def __enter__(self):
+        """Start the health monitor when entering the context."""
+        if not self._health_thread.is_alive():
+            self._health_monitor_active = True
+            self._health_thread = threading.Thread(
+                target=self._health_monitor_loop, daemon=True
+            )
+            self._health_thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Ensure the health monitor thread is stopped on exit."""
+        self.stop_health_monitor()
+
     def load_all_plugins(self) -> List[Any]:
         """Dynamically load all plugins from the configured package."""
         try:

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -1,0 +1,19 @@
+import time
+from core.plugins.manager import PluginManager
+from core.container import Container as DIContainer
+from config.config import ConfigManager
+
+
+def test_health_thread_stops_on_exit():
+    mgr = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    assert mgr._health_thread.is_alive()
+    mgr.stop_health_monitor()
+    time.sleep(0.1)
+    assert not mgr._health_thread.is_alive()
+
+
+def test_context_manager_stops_thread():
+    with PluginManager(DIContainer(), ConfigManager(), health_check_interval=1) as mgr:
+        assert mgr._health_thread.is_alive()
+    time.sleep(0.1)
+    assert not mgr._health_thread.is_alive()


### PR DESCRIPTION
## Summary
- use DI container with PluginManager in app factory and stop its health monitor when Flask shuts down
- allow PluginManager to be used as a context manager
- test health monitor thread termination

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_plugin_manager_thread.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e8e1b4c08320944be16ca99a1884