### PR TITLE
Unify Unicode utilities

### DIFF
--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -6,7 +6,7 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Any
 
-from utils.unicode_handler import handle_surrogate_characters
+from utils.unicode_utils import handle_surrogate_characters
 
 # Optional Babel import
 try:

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -11,6 +11,7 @@ from .base import BaseService
 from .protocols import FileProcessorProtocol
 from utils.file_validator import safe_decode_with_unicode_handling
 from utils.unicode_handler import sanitize_unicode_input
+from utils.unicode_utils import safe_unicode_encode
 from config.dynamic_config import dynamic_config
 
 logger = logging.getLogger(__name__)
@@ -87,8 +88,8 @@ class FileProcessorService(BaseService):
                     else:
                         text = content.decode(encoding)
 
-                    # Remove Unicode surrogate characters that can't be encoded in UTF-8
-                    text = ''.join(char for char in text if not (0xD800 <= ord(char) <= 0xDFFF))
+                    # Remove Unicode surrogate characters
+                    text = safe_unicode_encode(text)
 
                     # Parse with optimizations for large files
                     df = pd.read_csv(

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,20 +1,21 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
 try:
+    from .unicode_utils import safe_unicode_encode, handle_surrogate_characters
     from .unicode_processor import (
-        safe_unicode_encode,
         sanitize_data_frame,
         clean_unicode_surrogates,
         sanitize_unicode_input,
         process_large_csv_content,
     )
 except Exception:  # pragma: no cover - fallback when processor unavailable
-    from .unicode_handler import sanitize_unicode_input
+    from .unicode_handler import sanitize_unicode_input, handle_surrogate_characters
     from .unicode_processor import safe_unicode_encode, sanitize_data_frame, clean_unicode_surrogates, process_large_csv_content  # type: ignore
 
 __all__: list[str] = [
     "sanitize_unicode_input",
     "safe_unicode_encode",
+    "handle_surrogate_characters",
     "sanitize_data_frame",
     "clean_unicode_surrogates",
     "process_large_csv_content",

--- a/utils/file_validator.py
+++ b/utils/file_validator.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-from .unicode_handler import sanitize_unicode_input
+from .unicode_utils import handle_surrogate_characters
 
 
 def decode_bytes(data: bytes, enc: str) -> str:
@@ -26,8 +26,7 @@ def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
     except UnicodeDecodeError:
         text = data.decode(enc, errors="replace")
 
-    text = sanitize_unicode_input(text)
-    # Re-encode to UTF-8 ignoring any invalid surrogates/characters
+    text = handle_surrogate_characters(text)
     cleaned = text.encode("utf-8", errors="ignore")
     return cleaned.decode("utf-8", errors="ignore")
 

--- a/utils/unicode_utils.py
+++ b/utils/unicode_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Common Unicode helper functions."""
+
+import logging
+import re
+import unicodedata
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def handle_surrogate_characters(text: str) -> str:
+    """Return ``text`` with problematic surrogate characters sanitized."""
+    try:
+        cleaned = re.sub(r"[\uD800-\uDFFF]", "\uFFFD", text)
+        cleaned = unicodedata.normalize("NFKC", cleaned)
+        return cleaned.encode("utf-8", "replace").decode("utf-8")
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Surrogate character handling failed: %s", exc)
+        return text.encode("utf-8", "replace").decode("utf-8")
+
+
+def safe_unicode_encode(value: Any) -> str:
+    """Convert ``value`` to a UTF-8 string, removing invalid surrogates."""
+    try:
+        if isinstance(value, bytes):
+            try:
+                value = value.decode("utf-8", "surrogatepass")
+            except Exception:
+                value = value.decode("latin-1", "surrogatepass")
+        else:
+            value = str(value)
+        value = re.sub(r"[\ud800-\udfff]", "", value)
+        return value.encode("utf-8", "ignore").decode("utf-8", "ignore")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Unicode encoding failed: %s", exc)
+        return handle_surrogate_characters(str(value))
+
+
+__all__ = ["safe_unicode_encode", "handle_surrogate_characters"]


### PR DESCRIPTION
## Summary
- centralize Unicode helpers in `utils/unicode_utils.py`
- re-export helpers from `utils` package
- use the new helpers in `lazystring_fix_plugin`, `FileProcessorService`, and `file_validator`

## Testing
- `python -m py_compile utils/unicode_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863e8b20a64832096f9ea40ffb2b743