### PR TITLE
Fix missing CallbackManager import

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -5,6 +5,7 @@ import threading
 import time
 from typing import List, Any, Dict
 
+from core.callback_manager import CallbackManager
 from core.plugins.protocols import (
     PluginProtocol,
     CallbackPluginProtocol,


### PR DESCRIPTION
## Summary
- add missing CallbackManager import to plugin manager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863ee3e272c8320894766b0cea8255c