### PR TITLE
Fix import in css optimizer

### DIFF
--- a/models/css_build_optimizer.py
+++ b/models/css_build_optimizer.py
@@ -7,7 +7,6 @@ for Yōsai Intel Dashboard - FIXED version with proper type safety
 import os
 import re
 import json
-import subprocess
 import time
 from pathlib import Path
 from typing import Dict, List, Tuple, Any, Optional, Union


### PR DESCRIPTION
## Summary
- remove unused subprocess import from css optimizer

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f14841f08320aaeca6e00cec4300