### PR TITLE
Enhance input validation

### DIFF
--- a/security/input_validator.py
+++ b/security/input_validator.py
@@ -1,28 +1,35 @@
 from __future__ import annotations
 
-"""Input validation utilities."""
+"""Input validation utilities with basic XSS protections."""
 
 import re
 from typing import Any
+
+import bleach
 
 from utils.unicode_handler import sanitize_unicode_input
 
 from .validation_exceptions import ValidationError
 from typing import Protocol
 
+
 class Validator(Protocol):
     """Validator protocol"""
 
-    def validate(self, data: Any) -> Any:
-        ...
+    def validate(self, data: Any) -> Any: ...
+
 
 class InputValidator:
     """Simple input validator using unicode sanitization and basic patterns."""
 
-    _dangerous_pattern = re.compile(r"[<>]")
+    _dangerous_pattern = re.compile(
+        r"(<script.*?>.*?</script>|<.*?on\w+\s*=|javascript:|data:text/html|[<>])",
+        re.IGNORECASE | re.DOTALL,
+    )
 
     def validate(self, data: str) -> str:
         cleaned = sanitize_unicode_input(data)
         if self._dangerous_pattern.search(cleaned):
             raise ValidationError("Potentially dangerous characters detected")
-        return cleaned
+        sanitized = bleach.clean(cleaned, strip=True)
+        return sanitized

--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -14,6 +14,17 @@ def test_unicode_normalization():
         validator.validate("<bad>")
 
 
+def test_html_js_injection_attempts():
+    validator = InputValidator()
+    payloads = [
+        "<script>alert('xss')</script>",
+        "<img src=x onerror=alert(1)>",
+    ]
+    for payload in payloads:
+        with pytest.raises(ValidationError):
+            validator.validate(payload)
+
+
 def test_json_input_allowed():
     validator = InputValidator()
     # Should not raise ValidationError for quotes within JSON structures


### PR DESCRIPTION
## Summary
- sanitize inputs with bleach
- detect common script tags and event attributes
- block HTML/JS injection attempts in InputValidator tests

## Testing
- `pytest tests/security/test_validators.py::test_html_js_injection_attempts -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f1502bc88320b2a58372ebc69674