### PR TITLE
Refactor magic numbers into constants

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,8 +29,8 @@ logging:
 plugins:
   json_serialization:
     enabled: true
-    max_dataframe_rows: 2000000
-    max_string_length: 50000
+    max_dataframe_rows: 2000000  # see JsonSerializationLimits.MAX_DATAFRAME_PROCESSING_ROWS_ROWS
+    max_string_length: 50000  # see JsonSerializationLimits.MAX_INPUT_STRING_LENGTH_CHARACTERS
     include_type_metadata: true
     compress_large_objects: true
     fallback_to_repr: true

--- a/config/constants.py
+++ b/config/constants.py
@@ -1,8 +1,45 @@
+"""Application-wide constants for Yōsai Intel Dashboard."""
+
 from dataclasses import dataclass
+
+
+class SecurityLimits:
+    """Security-related validation limits."""
+
+    MAX_INPUT_STRING_LENGTH_CHARACTERS: int = 50_000
+    """Maximum characters allowed in user-provided strings.
+
+    Range: 1_000-100_000. Higher values increase XSS risk; lower may truncate
+    legitimate data.
+    """
+
+
+class DataProcessingLimits:
+    """Data processing and memory management limits."""
+
+    MAX_DATAFRAME_PROCESSING_ROWS_ROWS: int = 2_000_000
+    """Maximum DataFrame rows processed in a single operation.
+
+    Range: 100_000-5_000_000. Higher values risk memory exhaustion; lower
+    reduces functionality.
+    """
+
+
+class FileProcessingLimits:
+    """File upload and processing limits."""
+
+    MAX_FILE_UPLOAD_SIZE_MB: int = 10
+    """Default maximum file upload size for validation in megabytes.
+
+    Range: 1-500. Higher values risk denial of service; lower may block
+    legitimate uploads.
+    """
+
 
 @dataclass
 class SecurityConstants:
-    """Security related default values with large file support"""
+    """Security related default values with large file support."""
+
     pbkdf2_iterations: int = 100000
     salt_bytes: int = 32
     rate_limit_requests: int = 100
@@ -11,15 +48,19 @@ class SecurityConstants:
     max_file_size_mb: int = 500  # Added for consistency
     max_analysis_mb: int = 1000  # Added for large file processing
 
+
 @dataclass
 class PerformanceConstants:
-    """Performance tuning defaults"""
+    """Performance tuning defaults."""
+
     db_pool_size: int = 10
     ai_confidence_threshold: int = 75
 
+
 @dataclass
 class CSSConstants:
-    """Thresholds for CSS quality metrics"""
+    """Thresholds for CSS quality metrics."""
+
     bundle_excellent_kb: int = 50
     bundle_good_kb: int = 100
     bundle_warning_kb: int = 200
@@ -29,7 +70,8 @@ class CSSConstants:
 
 @dataclass
 class AnalyticsConstants:
-    """Analytics processing defaults for large datasets"""
+    """Analytics processing defaults for large datasets."""
+
     cache_timeout_seconds: int = 60
     max_records_per_query: int = 500000
     enable_real_time: bool = True
@@ -41,3 +83,4 @@ class AnalyticsConstants:
     data_retention_days: int = 30
     max_workers: int = 4
     query_timeout_seconds: int = 300
+

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -35,7 +35,7 @@ sample_files:
 
 analytics:
   cache_timeout_seconds: 60
-  max_records_per_query: 2000000
+  max_records_per_query: 2000000  # see DataProcessingLimits.MAX_DATAFRAME_PROCESSING_ROWS_ROWS
   enable_real_time: true
   batch_size: 25000
   chunk_size: 100000

--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -9,6 +9,8 @@ import os
 import secrets
 from typing import Dict, Any, List, Callable
 
+from config.constants import FileProcessingLimits
+
 from utils.unicode_handler import sanitize_unicode_input
 from dataclasses import dataclass
 from enum import Enum
@@ -221,7 +223,9 @@ class SecurityValidator:
 
     @staticmethod
     def validate_file_upload(
-        filename: str, content: bytes, max_size_mb: int = 10
+        filename: str,
+        content: bytes,
+        max_size_mb: int = FileProcessingLimits.MAX_FILE_UPLOAD_SIZE_MB,
     ) -> Dict[str, Any]:
         """Validate file uploads for security"""
         issues: List[str] = []

--- a/tests/test_lazystring_fix.py
+++ b/tests/test_lazystring_fix.py
@@ -1,6 +1,7 @@
 import pytest
 
 from plugins.lazystring_fix_plugin import sanitize_lazystring
+from config.constants import SecurityLimits
 
 
 def _contains_surrogate(text: str) -> bool:
@@ -45,6 +46,6 @@ def test_nested_structures_and_types():
 
 
 def test_long_string_performance():
-    text = "a" * 50000
+    text = "a" * SecurityLimits.MAX_INPUT_STRING_LENGTH_CHARACTERS
     result = sanitize_lazystring(text)
     assert result == text


### PR DESCRIPTION
## Summary
- centralize limits in `config/constants.py`
- document limits and provide ranges
- use constants in `SecurityValidator`
- reference constants in config yaml files
- update unit test to use new constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f18295fc832083d7bb81b1a97610