### PR TITLE
Update dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@ Flask-WTF==1.1.1
 authlib==1.2.1
 python-jose==3.3.0
 cssutils==2.8.0
-scipy>=1.10.1,!=1.11.0,<1.13.0
+scipy>=1.13.0
 scikit-learn==1.3.0
 joblib==1.3.2
 psycopg2-binary==2.9.7
-requests==2.31.0
+requests>=2.32.0
 
 # SQL validation
-sqlparse==0.4.4
+sqlparse>=0.5.0
 bleach==6.0.0
 
 

--- a/requirements_ui.txt
+++ b/requirements_ui.txt
@@ -3,5 +3,5 @@ dash-bootstrap-components==1.6.0
 plotly==5.15.0
 pandas==2.1.1
 numpy>=1.23.2,<1.28
-sqlparse==0.4.4
+sqlparse>=0.5.0
 bleach==6.0.0


### PR DESCRIPTION
## Summary
- bump dependency versions for `sqlparse`, `requests` and `scipy`

## Testing
- `pip install --upgrade sqlparse>=0.5.0 requests>=2.32.0 scipy>=1.13.0` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: cannot find implementations or library stubs)*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f1c97cec83208f50aca20ea08111