### PR TITLE
Lazy load optional models

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -11,13 +11,28 @@ from .enums import (
 
 from .entities import Person, Door, Facility
 from .events import AccessEvent, AnomalyDetection, IncidentTicket
-from services.registry import get_service
+from services import registry
 
-BaseModel = get_service("BaseModel")
-AccessEventModel = get_service("AccessEventModel")
-AnomalyDetectionModel = get_service("AnomalyDetectionModel")
-ModelFactory = get_service("ModelFactory")
-BASE_MODELS_AVAILABLE = BaseModel is not None
+# Flag indicating if the core models are available. This is updated when
+# ``BaseModel`` is first resolved via ``__getattr__``.
+BASE_MODELS_AVAILABLE = False
+
+
+def __getattr__(name: str):
+    """Dynamically resolve optional model services.
+
+    The services for ``BaseModel``, ``AccessEventModel``, ``AnomalyDetectionModel``
+    and ``ModelFactory`` are optional and retrieved from the ``services``
+    registry when first accessed. The resolved value is cached in ``globals`` to
+    avoid repeated lookups.
+    """
+    if name in {"BaseModel", "AccessEventModel", "AnomalyDetectionModel", "ModelFactory"}:
+        service = registry.get_service(name)
+        globals()[name] = service
+        if name == "BaseModel":
+            globals()["BASE_MODELS_AVAILABLE"] = service is not None
+        return service
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 __all__ = [
     'AnomalyType', 'AccessResult', 'BadgeStatus', 'SeverityLevel',


### PR DESCRIPTION
## Summary
- implement module-level `__getattr__` for `models` to lazily resolve optional
  services
- cache resolved services and update `BASE_MODELS_AVAILABLE`

## Testing
- `pytest tests/test_analytics_integration.py::test_model_factory_absent -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f31da6a88320b6805d5b86de6e3e