### PR TITLE
Add comprehensive security tests

### DIFF
--- a/tests/test_security_comprehensive.py
+++ b/tests/test_security_comprehensive.py
@@ -1,0 +1,29 @@
+class TestSecurityVulnerabilities:
+    """Comprehensive security vulnerability tests."""
+
+    def test_sql_injection_prevention(self):
+        """Test SQL injection attack patterns."""
+        import pytest
+        from security.sql_validator import SQLInjectionPrevention
+        from security.validation_exceptions import ValidationError
+
+        malicious_inputs = [
+            "'; DROP TABLE users; --",
+            "1' OR '1'='1",
+            "admin'/**/OR/**/1=1#",
+        ]
+        validator = SQLInjectionPrevention()
+
+        for malicious_input in malicious_inputs:
+            with pytest.raises(ValidationError):
+                validator.validate_query_parameter(malicious_input)
+
+    def test_unicode_surrogate_handling(self):
+        """Test Unicode surrogate character handling."""
+        from utils.unicode_handler import sanitize_unicode_input
+
+        # Test lone surrogates
+        lone_surrogate = "\uD800\uD801"  # Invalid surrogate pair
+        result = sanitize_unicode_input(lone_surrogate)
+        assert "\uD800" not in result
+        assert "\uD801" not in result


### PR DESCRIPTION
## Summary
- extend security coverage with tests for SQL injection prevention and unicode surrogate handling

## Testing
- `pytest tests/test_security_comprehensive.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f4333ec48320a1988d3417913d2b