### PR TITLE
Add developer onboarding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ yosai_intel_dashboard/
 6. **Access the dashboard:**
    Open http://127.0.0.1:8050 in your browser
 
+## Developer Onboarding
+
+For a more detailed walkthrough of the environment setup and testing workflow,
+see [developer_onboarding.md](docs/developer_onboarding.md).
+
 ### Troubleshooting
 
 If Pylance shows unresolved imports or type errors, your editor may not be

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -1,0 +1,49 @@
+# Developer Onboarding
+
+This guide walks new contributors through setting up a local development environment for the Yōsai Intel Dashboard.
+
+## Prerequisites
+
+- **Python 3.11+**
+- **PostgreSQL 13+**
+- **Redis**
+
+## Setup Steps
+
+1. **Clone the repository:**
+   ```bash
+   git clone <repository>
+   cd yosai_intel_dashboard
+   ```
+
+2. **Create and activate a virtual environment:**
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+
+3. **Install dependencies:**
+   ```bash
+   ./scripts/setup.sh
+   ```
+
+4. **Configure environment variables:**
+   ```bash
+   cp .env.example .env
+   # Edit .env as needed
+   ```
+
+5. **(Optional) Initialize the database or load sample data.**
+   Prepare your PostgreSQL database and populate it with any example data if desired.
+
+6. **Run the test suite:**
+   ```bash
+   pytest --cov
+   ```
+
+7. **Start the application:**
+   ```bash
+   python app.py
+   ```
+
+The dashboard will be available at `http://127.0.0.1:8050` once the server starts.


### PR DESCRIPTION
## Summary
- document project prerequisites and setup steps in new `docs/developer_onboarding.md`
- link to the onboarding guide from `README.md`

## Testing
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f580b0c48320bab2c41a720a0ef0