### PR TITLE
Add development secret generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ yosai_intel_dashboard/
 4. **Set up environment:**
    ```bash
    cp .env.example .env
+   # Generate random development secrets
+   python scripts/generate_dev_secrets.py >> .env
    # Edit .env with your configuration (e.g. set HOST and database info)
    ```
 

--- a/scripts/generate_dev_secrets.py
+++ b/scripts/generate_dev_secrets.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Generate strong random secret values for development.
+
+Outputs SECRET_KEY and DB_PASSWORD lines using `secrets.token_urlsafe`.
+"""
+import secrets
+
+
+def main() -> None:
+    print(f"SECRET_KEY={secrets.token_urlsafe(32)}")
+    print(f"DB_PASSWORD={secrets.token_urlsafe(32)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts/generate_dev_secrets.py` for generating random `SECRET_KEY` and `DB_PASSWORD` values
- document using the script in the development setup instructions

## Testing
- `python scripts/generate_dev_secrets.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6863f9974f948320bf87116a5dfb971f