### PR TITLE
Add OpenAPI docs for auth callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 
 See the [data model diagram](docs/data_model.md) for an overview of key entities.
 The running application exposes Swagger-based API docs at `http://<host>:<port>/api/docs`.
-Update the spec by running `python tools/generate_openapi.py`.
+Update the spec by running `python tools/generate_openapi.py` which writes `docs/openapi.json` for the UI.
 ## 📜 Data Migration
 Use the storage utilities to convert legacy pickle files to Parquet and load them:
 ```python

--- a/core/auth.py
+++ b/core/auth.py
@@ -133,7 +133,14 @@ def login():
 
 @auth_bp.route("/callback")
 def callback():
-    """Handle OAuth provider callback."""
+    """Handle OAuth provider callback.
+    ---
+    get:
+      description: Process login response and sign in user
+      responses:
+        302:
+          description: Redirect to dashboard
+    """
     auth0 = auth_bp.auth0
     token = auth0.authorize_access_token()
     id_token = token.get("id_token")


### PR DESCRIPTION
## Summary
- document `/callback` in auth blueprint
- clarify how to generate the OpenAPI JSON file

## Testing
- `python tools/generate_openapi.py` *(fails: No module named 'flasgger')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f9a4536883209b4972b97cb31d35