### PR TITLE
Add secret management guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ When `YOSAI_ENV=production` the application will refuse to start unless both
 `DB_PASSWORD` and `SECRET_KEY` are provided via environment variables or Docker
 secrets.
 
+Configuration validation runs automatically at startup and logs any missing
+critical settings.
+
 ### Environment Overrides
 
 `ConfigManager` loads YAML files from `config/` and then checks for
@@ -352,6 +355,11 @@ All secrets can be provided via the `SecretManager` which supports `env`,
 `aws`, and `vault` backends. Place these values in `.env` or mount them as
 Docker secrets. See the [architecture diagram](docs/auth_flow.png) for
 implementation details.
+
+The configuration loader performs a validation step on startup to ensure
+required secrets are set. See
+[docs/secret_management.md](docs/secret_management.md) for rotation
+procedures, Docker/cloud secret usage, and incident handling guidance.
 
 ## 🌐 Language Toggle
 

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -1,0 +1,51 @@
+# Secret Management
+
+This guide covers how secrets are handled in the Yōsai Intel Dashboard.
+
+## Required Secrets
+
+The application expects several secrets to be provided via environment
+variables, Docker secrets, or a cloud secret manager:
+
+- `SECRET_KEY` – Flask and Dash session signing key
+- `DB_PASSWORD` – database account password
+- `AUTH0_CLIENT_ID` – Auth0 application identifier
+- `AUTH0_CLIENT_SECRET` – Auth0 client secret
+- `AUTH0_DOMAIN` – Auth0 domain used for OIDC
+- `AUTH0_AUDIENCE` – expected API audience
+
+Ensure these values are defined before starting the application. When
+`YOSAI_ENV=production` the configuration validation step will refuse to
+start if `SECRET_KEY` or `DB_PASSWORD` is missing.
+
+## Rotation Procedures
+
+1. Generate a new secret using your preferred password manager.
+2. Update the value in your environment or secret store.
+3. Restart or redeploy the application so the new secret is loaded.
+4. Revoke any credentials that were replaced, such as old Auth0
+   application secrets or database passwords.
+
+Routine rotation should be scheduled at least every 90 days or according
+to your organization policy.
+
+## Docker and Cloud Secret Usage
+
+Secrets can be supplied as Docker secrets when running with Docker
+Compose. Mount files under `/run/secrets` and the application will read
+them via environment variables. For cloud deployments the
+`SecretManager` supports `env`, `aws`, and `vault` backends. Set the
+`SECRET_BACKEND` variable to select the desired provider.
+
+## Incident Handling
+
+If you suspect a secret has been exposed:
+
+1. Rotate the affected secret immediately following the procedure above.
+2. Audit application logs for suspicious activity.
+3. Revoke any tokens or credentials that may have been compromised.
+4. Investigate the source of the leak and update processes to prevent
+   recurrence.
+
+For major incidents follow your organizational incident response plan and
+notify the security team.


### PR DESCRIPTION
## Summary
- document secret handling, rotation, Docker/cloud use and incidents
- cross-link new doc from README and mention config validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f99a4d2083209ca736d7f1521780