### PR TITLE
Dynamic resizing for DB connection pool

### DIFF
--- a/config/connection_pool.py
+++ b/config/connection_pool.py
@@ -59,6 +59,8 @@ class DatabaseConnectionPool:
 
     def get_connection(self) -> DatabaseConnection:
         self._shrink_idle_connections()
+        # Check if pool usage is high before handing out a connection
+        self._maybe_expand()
 
         if self._pool:
             conn, _ = self._pool.pop()
@@ -70,7 +72,6 @@ class DatabaseConnectionPool:
             conn = self._factory()
             self._active += 1
 
-        self._maybe_expand()
         return conn
 
     def release_connection(self, conn: DatabaseConnection) -> None:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -28,12 +28,18 @@ def test_pool_health_check():
 
 def test_pool_expands_and_shrinks():
     pool = DatabaseConnectionPool(factory, initial_size=1, max_size=3, timeout=10, shrink_timeout=0)
+
     c1 = pool.get_connection()
+    # First connection should not trigger expansion
+    assert pool._max_size == 1
+
     c2 = pool.get_connection()
+    # Requesting a second concurrent connection should expand the pool
     assert pool._max_size >= 2
+
     pool.release_connection(c1)
     pool.release_connection(c2)
-    time.sleep(0.01)
-    _ = pool.get_connection()
+
+    # Shrink happens immediately due to shrink_timeout=0
     assert pool._max_size == 1
 


### PR DESCRIPTION
## Summary
- refactor connection pool expansion logic to evaluate usage before handing out connections
- update tests for new resizing behavior

## Testing
- `pytest tests/test_connection_pool.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f98219e4832093517f2e9ac6f667