### PR TITLE
Add secrets validation tests

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -10,6 +10,7 @@ from .business_logic_validator import BusinessLogicValidator
 from .validation_middleware import ValidationMiddleware, ValidationOrchestrator
 from .attack_detection import AttackDetection
 from .validation_exceptions import ValidationError, SecurityViolation
+from .secrets_validator import SecretsValidator, register_health_endpoint
 
 __all__ = [
     "SecurityService",
@@ -26,4 +27,6 @@ __all__ = [
     "AttackDetection",
     "ValidationError",
     "SecurityViolation",
+    "SecretsValidator",
+    "register_health_endpoint",
 ]

--- a/security/secrets_validator.py
+++ b/security/secrets_validator.py
@@ -1,0 +1,63 @@
+import math
+import re
+from collections import Counter
+from typing import Dict, List, Optional
+
+from core.secret_manager import SecretManager
+
+
+class SecretsValidator:
+    """Validate application secrets for strength and patterns."""
+
+    DEFAULT_PATTERNS = [
+        re.compile(p, re.IGNORECASE)
+        for p in ["dev", "development", "test", "secret", "change[-_]?me"]
+    ]
+    MIN_ENTROPY = 3.5
+
+    def __init__(self, manager: Optional[SecretManager] = None) -> None:
+        self.manager = manager or SecretManager()
+
+    @staticmethod
+    def _entropy(value: str) -> float:
+        if not value:
+            return 0.0
+        length = len(value)
+        counts = Counter(value)
+        return -sum((c / length) * math.log2(c / length) for c in counts.values())
+
+    def validate_secret(self, secret: str, environment: str = "development") -> Dict[str, List[str] | float]:
+        warnings: List[str] = []
+        errors: List[str] = []
+
+        entropy = self._entropy(secret)
+
+        if not secret:
+            msg = "Secret missing"
+            (errors if environment == "production" else warnings).append(msg)
+        else:
+            if any(p.search(secret) for p in self.DEFAULT_PATTERNS):
+                msg = "Secret matches insecure pattern"
+                (errors if environment == "production" else warnings).append(msg)
+            if entropy < self.MIN_ENTROPY:
+                msg = "Secret entropy too low"
+                (errors if environment == "production" else warnings).append(msg)
+
+        return {"warnings": warnings, "errors": errors, "entropy": entropy}
+
+
+def register_health_endpoint(app, validator: Optional[SecretsValidator] = None) -> None:
+    """Register /health/secrets endpoint on a Flask or Dash app."""
+    validator = validator or SecretsValidator()
+    server = app.server if hasattr(app, "server") else app
+
+    @server.route("/health/secrets", methods=["GET"])
+    def secrets_health():
+        env = server.config.get("ENV", "development")
+        secret = server.config.get("SECRET_KEY", "")
+        result = validator.validate_secret(secret, environment=env)
+        status = 200 if not result["errors"] else 500
+        return result, status
+
+
+__all__ = ["SecretsValidator", "register_health_endpoint"]

--- a/tests/security/test_secrets_validator.py
+++ b/tests/security/test_secrets_validator.py
@@ -1,0 +1,69 @@
+import json
+from flask import Flask
+import pytest
+
+from security.secrets_validator import SecretsValidator, register_health_endpoint
+from core.secret_manager import SecretManager
+
+
+class DummyManager(SecretManager):
+    def __init__(self, secret: str):
+        super().__init__(backend="env")
+        self._secret = secret
+
+    def get(self, key: str, default=None):  # type: ignore[override]
+        return self._secret
+
+
+def _create_app(secret: str, env: str) -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = secret
+    app.config["ENV"] = env
+    validator = SecretsValidator(DummyManager(secret))
+    register_health_endpoint(app, validator)
+    return app
+
+
+def test_production_failure():
+    validator = SecretsValidator(DummyManager("dev"))
+    result = validator.validate_secret("dev", environment="production")
+    assert result["errors"]
+
+
+def test_staging_warning():
+    validator = SecretsValidator(DummyManager("dev"))
+    result = validator.validate_secret("dev", environment="staging")
+    assert result["warnings"] and not result["errors"]
+
+
+def test_entropy_check():
+    low_entropy = "aaaaaaaaaaaaaa"
+    validator = SecretsValidator(DummyManager(low_entropy))
+    result = validator.validate_secret(low_entropy, environment="production")
+    assert result["entropy"] < SecretsValidator.MIN_ENTROPY
+    assert result["errors"]
+
+
+def test_pattern_matching():
+    insecure = "change-me-now"
+    validator = SecretsValidator(DummyManager(insecure))
+    result = validator.validate_secret(insecure, environment="production")
+    assert any("pattern" in e or "pattern" in w for e in result["errors"] + result["warnings"])
+
+
+def test_health_endpoint():
+    app = _create_app("dev", "production")
+    client = app.test_client()
+    resp = client.get("/health/secrets")
+    data = json.loads(resp.data)
+    assert resp.status_code == 500
+    assert data["errors"]
+
+
+def test_health_endpoint_warning():
+    app = _create_app("dev", "staging")
+    client = app.test_client()
+    resp = client.get("/health/secrets")
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data["warnings"]


### PR DESCRIPTION
## Summary
- add SecretsValidator module and `/health/secrets` endpoint registration
- expose SecretsValidator from `security` package
- test secret validation behaviour and `/health/secrets` integration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q tests/security/test_secrets_validator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f998c6648320b5d3dde0a758d70a