### PR TITLE
Add secrets validation health endpoint

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -12,6 +12,7 @@ from dash import html, dcc, Input, Output
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from core.container import Container as DIContainer
 from core.plugins.manager import PluginManager
+from core.secret_manager import validate_secrets
 import pandas as pd
 
 # ✅ FIXED IMPORTS - Use correct config system
@@ -137,6 +138,11 @@ def _create_full_app() -> dash.Dash:
             """
             return {"status": "ok"}, 200
 
+        @server.route("/health/secrets", methods=["GET"])
+        def health_secrets():
+            """Return validation summary for required secrets"""
+            return validate_secrets(), 200
+
         logger.info("✅ Complete Dash application created successfully")
         return app
 
@@ -203,6 +209,11 @@ def _create_simple_app() -> dash.Dash:
             """
             return {"status": "ok"}, 200
 
+        @server.route("/health/secrets", methods=["GET"])
+        def health_secrets():
+            """Return validation summary for required secrets"""
+            return validate_secrets(), 200
+
         logger.info("Simple Dash application created successfully")
         return app
 
@@ -268,6 +279,11 @@ def _create_json_safe_app() -> dash.Dash:
                             example: ok
             """
             return {"status": "ok"}, 200
+
+        @server.route("/health/secrets", methods=["GET"])
+        def health_secrets():
+            """Return validation summary for required secrets"""
+            return validate_secrets(), 200
 
         logger.info("JSON-safe Dash application created")
         return app

--- a/tests/test_secret_health.py
+++ b/tests/test_secret_health.py
@@ -1,0 +1,18 @@
+import os
+from core.app_factory import create_app
+
+
+def test_secrets_health_endpoint(monkeypatch):
+    monkeypatch.setenv("YOSAI_ENV", "development")
+    monkeypatch.setenv("SECRET_KEY", "testkey")
+    app = create_app(mode="simple")
+    server = app.server
+    rules = [r.rule for r in server.url_map.iter_rules()]
+    assert "/health/secrets" in rules
+
+    client = server.test_client()
+    res = client.get("/health/secrets")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["checks"]["SECRET_KEY"] is True
+    assert data["valid"] is True


### PR DESCRIPTION
## Summary
- expose `validate_secrets` helper
- register `/health/secrets` on all app modes
- test that the endpoint is registered and returns status

## Testing
- `black core/secret_manager.py core/app_factory.py tests/test_secret_health.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f994c2808320aff7ddda01195996