### PR TITLE
Implement secrets validator

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ import os
 import sys
 import importlib
 
+from core.exceptions import ConfigurationError
+
 # Configure logging first
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -105,6 +107,17 @@ def main():
 
         # Print startup information
         print_startup_info(app_config)
+
+        try:
+            from core.secrets_validator import validate_all_secrets
+
+            validated = validate_all_secrets()
+            for k, v in validated.items():
+                os.environ.setdefault(k, v)
+            logger.info("✅ Secrets validated successfully")
+        except ConfigurationError as e:
+            logger.error(f"❌ Secret validation failed: {e}")
+            sys.exit(1)
 
         # Import and create the Dash application
         try:

--- a/config/config.py
+++ b/config/config.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List
 
 from .dynamic_config import dynamic_config
+from core.secrets_validator import SecretsValidator
+from core.exceptions import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +91,7 @@ class ConfigManager:
     def __init__(self, config_path: Optional[str] = None):
         self.config_path = config_path
         self.config = Config()
+        self.validated_secrets: Dict[str, str] = {}
         self._load_config()
 
     def _load_config(self) -> None:
@@ -102,6 +105,11 @@ class ConfigManager:
 
         # Apply environment overrides
         self._apply_env_overrides()
+
+        # Validate secrets and store values
+        validator = SecretsValidator()
+        self.validated_secrets = validator.validate_all_secrets()
+        self._apply_validated_secrets()
 
         # Validate configuration
         self._validate_config()
@@ -304,6 +312,18 @@ class ConfigManager:
         if sample_json is not None:
             self.config.sample_files.json_path = sample_json
 
+    def _apply_validated_secrets(self) -> None:
+        """Apply secrets validated by SecretsValidator."""
+        if "SECRET_KEY" in self.validated_secrets:
+            secret = self.validated_secrets["SECRET_KEY"]
+            self.config.app.secret_key = secret
+            self.config.security.secret_key = secret
+            os.environ.setdefault("SECRET_KEY", secret)
+        if "DB_PASSWORD" in self.validated_secrets:
+            pwd = self.validated_secrets["DB_PASSWORD"]
+            self.config.database.password = pwd
+            os.environ.setdefault("DB_PASSWORD", pwd)
+
     def _validate_config(self) -> None:
         """Validate configuration and log warnings"""
         warnings = []
@@ -342,7 +362,7 @@ class ConfigManager:
         if errors:
             error_msg = "; ".join(errors)
             logger.error(error_msg)
-            raise ValueError(error_msg)
+            raise ConfigurationError(error_msg)
 
     def get_app_config(self) -> AppConfig:
         """Get app configuration"""

--- a/core/secrets_validator.py
+++ b/core/secrets_validator.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Runtime secrets validation utilities."""
+
+import logging
+from typing import Dict, Optional
+
+from .secret_manager import SecretManager
+from core.exceptions import ConfigurationError
+
+
+class SecretsValidator:
+    """Validate presence of required runtime secrets."""
+
+    REQUIRED_SECRETS = [
+        "SECRET_KEY",
+        "DB_PASSWORD",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_CLIENT_SECRET",
+        "AUTH0_DOMAIN",
+        "AUTH0_AUDIENCE",
+    ]
+
+    def __init__(self, manager: Optional[SecretManager] = None) -> None:
+        self.manager = manager or SecretManager()
+        self.logger = logging.getLogger(__name__)
+
+    def validate_all_secrets(self) -> Dict[str, str]:
+        """Ensure all required secrets are available."""
+        secrets: Dict[str, str] = {}
+        missing = []
+        for key in self.REQUIRED_SECRETS:
+            try:
+                value = self.manager.get(key)
+            except Exception:
+                value = None
+            if not value:
+                missing.append(key)
+            else:
+                secrets[key] = value
+        if missing:
+            raise ConfigurationError(f"Missing required secrets: {', '.join(missing)}")
+        return secrets
+
+
+def validate_all_secrets(manager: Optional[SecretManager] = None) -> Dict[str, str]:
+    """Convenience wrapper for :class:`SecretsValidator`."""
+    validator = SecretsValidator(manager)
+    return validator.validate_all_secrets()
+
+
+__all__ = ["SecretsValidator", "validate_all_secrets"]


### PR DESCRIPTION
## Summary
- add `SecretsValidator` for runtime secret checking
- validate secrets in `ConfigManager` and propagate to env
- call `validate_all_secrets` before building the app
- raise `ConfigurationError` when production checks fail

## Testing
- `black core/secrets_validator.py config/config.py app.py`
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: found 31 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863f9946f7483209e55b3611e447418