### PR TITLE
Remove hardcoded development secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 # Flask Configuration
 FLASK_ENV=development
 FLASK_DEBUG=1
-SECRET_KEY=change-me
+SECRET_KEY=
+# Provide a strong 32+ character value for production
 
 # Yosai Configuration
 YOSAI_ENV=development

--- a/config/config.py
+++ b/config/config.py
@@ -25,7 +25,7 @@ class AppConfig:
     debug: bool = True
     host: str = "127.0.0.1"
     port: int = 8050
-    secret_key: str = "dev-key-change-in-production"
+    secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
     environment: str = "development"
 
 
@@ -59,7 +59,7 @@ class DatabaseConfig:
 class SecurityConfig:
     """Security configuration"""
 
-    secret_key: str = "dev-key-change-in-production"
+    secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
     session_timeout: int = 3600
     cors_origins: List[str] = field(default_factory=list)
     csrf_enabled: bool = True

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,10 +11,10 @@ database:
   port: 5432
   name: "yosai_db"
   user: "yosai_user"
-  password: "change-me"
+  password: "${DB_PASSWORD}"
 
 security:
-  secret_key: "change-me"
+  secret_key: "${SECRET_KEY}"
   session_timeout: 3600
 
 sample_files:

--- a/core/plugins/config/production.yaml
+++ b/core/plugins/config/production.yaml
@@ -207,7 +207,7 @@ cache:
   key_prefix: 'yosai:test:'
 
 security:
-  secret_key: test-secret-key-for-testing-only
+  secret_key: ${SECRET_KEY}
   session_timeout_minutes: 5
   max_file_size_mb: 100
   rate_limiting_enabled: false

--- a/core/secret_manager.py
+++ b/core/secret_manager.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 """Secret management abstraction"""
 
 import os
+import secrets
 from typing import Optional, Dict, Any, List
+
+from core.exceptions import SecurityError
 
 from config.config import get_config
 
@@ -27,6 +30,21 @@ class SecretManager:
         if value is None and default is None:
             raise KeyError(f"Secret '{key}' not found")
         return value
+
+    @staticmethod
+    def generate_secret_key(length: int = 32) -> str:
+        """Generate a cryptographically secure secret key."""
+        return secrets.token_urlsafe(length)
+
+    @staticmethod
+    def get_secret_key() -> str:
+        """Retrieve SECRET_KEY from the environment and validate it."""
+        key = os.environ.get("SECRET_KEY")
+        if not key:
+            raise SecurityError("SECRET_KEY environment variable required")
+        if len(key) < 32:
+            raise SecurityError("SECRET_KEY must be at least 32 characters")
+        return key
 
     def _get_aws_secret(self, key: str) -> Optional[str]:
         raise NotImplementedError("AWS secrets backend not configured")


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY retrieval from env via `SecretManager`
- default config secrets now load from environment
- sanitize example and YAML configs to avoid embedded secrets

## Testing
- `pytest tests/security/test_secrets_validator.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863fdfed56083208fd5f4f34b2d5317