### PR TITLE
Update flasgger version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ bleach==6.0.0
 PyYAML==6.0.1
 
 # API documentation
-flasgger==0.9.7
+flasgger==0.9.7.1
 
 # Development
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- replace deprecated `flasgger==0.9.7` with `flasgger==0.9.7.1`

## Testing
- `./scripts/setup.sh` *(fails: Could not connect to PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_686402ad9fac8320bacb14f70a12c0ab