### PR TITLE
Enable DashCSRFPlugin in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Alternatively you can launch the app with Gunicorn:
 gunicorn wsgi:server
 ```
 
+When `YOSAI_ENV=production` and CSRF protection is enabled, the application
+initializes the `DashCSRFPlugin` to enforce strict CSRF checks.
+
 ### Production Build
 
 Build optimized CSS assets before deployment:

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -13,6 +13,7 @@ from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from core.container import Container as DIContainer
 from core.plugins.manager import PluginManager
 from core.secret_manager import validate_secrets
+from dash_csrf_plugin import setup_enhanced_csrf_protection, CSRFMode
 import pandas as pd
 
 # ✅ FIXED IMPORTS - Use correct config system
@@ -59,6 +60,17 @@ def _create_full_app() -> dash.Dash:
 
         # ✅ FIXED: Use the working config system
         config_manager = get_config()
+
+        if (
+            config_manager.get_security_config().csrf_enabled
+            and config_manager.get_app_config().environment == "production"
+        ):
+            try:
+                app._csrf_plugin = setup_enhanced_csrf_protection(
+                    app, CSRFMode.PRODUCTION
+                )
+            except Exception as e:  # pragma: no cover - best effort
+                logger.warning(f"Failed to initialize CSRF plugin: {e}")
 
         # Initialize plugin system
         container = DIContainer()

--- a/tests/test_csrf_plugin.py
+++ b/tests/test_csrf_plugin.py
@@ -1,0 +1,20 @@
+import os
+from core import app_factory
+from config.config import reload_config
+
+
+def test_csrf_plugin_enabled_in_production(monkeypatch):
+    monkeypatch.setenv("YOSAI_ENV", "production")
+    monkeypatch.setenv("SECRET_KEY", "testkey")
+    monkeypatch.setenv("DB_PASSWORD", "dummy")
+    reload_config()
+
+    monkeypatch.setattr(app_factory.PluginManager, "load_all_plugins", lambda self: None)
+    monkeypatch.setattr(app_factory, "_initialize_services", lambda: None)
+    monkeypatch.setattr(app_factory, "_register_router_callbacks", lambda manager: None)
+    monkeypatch.setattr(app_factory, "_register_global_callbacks", lambda manager: None)
+
+    app = app_factory.create_app(mode="full")
+    server = app.server
+    assert server.config["WTF_CSRF_ENABLED"] is True
+    assert hasattr(app, "_csrf_plugin")


### PR DESCRIPTION
## Summary
- initialize CSRF plugin when in production mode
- document automatic plugin startup in README
- test that CSRF protection is enabled in production

## Testing
- `pytest -q tests/test_csrf_plugin.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864035b3ad083208e03adf021e58319