### PR TITLE
Add production secret validation

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -336,8 +336,14 @@ class ConfigManager:
         warnings = []
         errors = []
 
+        validator = SecretsValidator()
+
+        invalid_secrets: List[str] = []
+
         # Production checks
         if self.config.environment == "production":
+            invalid_secrets = validator.validate_production_secrets()
+
             if self.config.app.secret_key in [
                 "dev-key-change-in-production",
                 "change-me",
@@ -365,6 +371,11 @@ class ConfigManager:
         # Log warnings
         for warning in warnings:
             logger.warning(f"Configuration warning: {warning}")
+
+        if invalid_secrets:
+            secret_list = ", ".join(invalid_secrets)
+            logger.error(f"Invalid production secrets: {secret_list}")
+            raise ValueError(f"Invalid secrets: {secret_list}")
 
         if errors:
             error_msg = "; ".join(errors)

--- a/core/secrets_validator.py
+++ b/core/secrets_validator.py
@@ -42,6 +42,23 @@ class SecretsValidator:
             raise ConfigurationError(f"Missing required secrets: {', '.join(missing)}")
         return secrets
 
+    def validate_production_secrets(self) -> list[str]:
+        """Validate quality of secrets for production environment.
+
+        Returns a list of secret keys that failed validation."""
+        from security.secrets_validator import SecretsValidator as QualityValidator
+
+        secrets = self.validate_all_secrets()
+        quality = QualityValidator()
+        invalid: list[str] = []
+
+        for name, value in secrets.items():
+            result = quality.validate_secret(value, environment="production")
+            if result["errors"]:
+                invalid.append(name)
+
+        return invalid
+
 
 def validate_all_secrets(manager: Optional[SecretManager] = None) -> Dict[str, str]:
     """Convenience wrapper for :class:`SecretsValidator`."""
@@ -49,4 +66,8 @@ def validate_all_secrets(manager: Optional[SecretManager] = None) -> Dict[str, s
     return validator.validate_all_secrets()
 
 
-__all__ = ["SecretsValidator", "validate_all_secrets"]
+__all__ = [
+    "SecretsValidator",
+    "validate_all_secrets",
+    "validate_production_secrets",
+]

--- a/tests/test_config_production_secrets.py
+++ b/tests/test_config_production_secrets.py
@@ -1,0 +1,23 @@
+import pytest
+from config.config import ConfigManager
+
+REQUIRED_AUTH_VARS = [
+    "AUTH0_CLIENT_ID",
+    "AUTH0_CLIENT_SECRET",
+    "AUTH0_DOMAIN",
+    "AUTH0_AUDIENCE",
+]
+
+
+def set_env(monkeypatch, secret: str) -> None:
+    monkeypatch.setenv("YOSAI_ENV", "production")
+    monkeypatch.setenv("SECRET_KEY", secret)
+    monkeypatch.setenv("DB_PASSWORD", secret)
+    for var in REQUIRED_AUTH_VARS:
+        monkeypatch.setenv(var, "value")
+
+
+def test_invalid_secrets_raise(monkeypatch):
+    set_env(monkeypatch, "change-me")
+    with pytest.raises(ValueError):
+        ConfigManager()


### PR DESCRIPTION
## Summary
- check production secrets in ConfigManager
- add validation utility in `core.secrets_validator`
- fail configuration when production secrets are weak
- test production secret validation

## Testing
- `pytest -k test_config_production_secrets.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68640359a72083209dde82c685f5c399