### PR TITLE
Fix __all__ entry list in database_manager

### DIFF
--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -325,7 +325,8 @@ __all__ = [
     "DatabaseManager",
     "ThreadSafeDatabaseManager",
     "DatabaseError",
-    "create_database_manager" "EnhancedPostgreSQLManager",
+    "create_database_manager",
+    "EnhancedPostgreSQLManager",
 ]
 
 


### PR DESCRIPTION
## Summary
- fix missing comma in `config/database_manager.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68640911553c8320a650aacb75c2bdb2