### PR TITLE
Fix constant name typo

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,7 +29,7 @@ logging:
 plugins:
   json_serialization:
     enabled: true
-    max_dataframe_rows: 2000000  # see JsonSerializationLimits.MAX_DATAFRAME_PROCESSING_ROWS_ROWS
+    max_dataframe_rows: 2000000  # see JsonSerializationLimits.MAX_DATAFRAME_PROCESSING_ROWS
     max_string_length: 50000  # see JsonSerializationLimits.MAX_INPUT_STRING_LENGTH_CHARACTERS
     include_type_metadata: true
     compress_large_objects: true

--- a/config/constants.py
+++ b/config/constants.py
@@ -17,7 +17,7 @@ class SecurityLimits:
 class DataProcessingLimits:
     """Data processing and memory management limits."""
 
-    MAX_DATAFRAME_PROCESSING_ROWS_ROWS: int = 2_000_000
+    MAX_DATAFRAME_PROCESSING_ROWS: int = 2_000_000
     """Maximum DataFrame rows processed in a single operation.
 
     Range: 100_000-5_000_000. Higher values risk memory exhaustion; lower

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -35,7 +35,7 @@ sample_files:
 
 analytics:
   cache_timeout_seconds: 60
-  max_records_per_query: 2000000  # see DataProcessingLimits.MAX_DATAFRAME_PROCESSING_ROWS_ROWS
+  max_records_per_query: 2000000  # see DataProcessingLimits.MAX_DATAFRAME_PROCESSING_ROWS
   enable_real_time: true
   batch_size: 25000
   chunk_size: 100000

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -37,7 +37,7 @@ sample_files:
 
 analytics:
   cache_timeout_seconds: 60
-  max_records_per_query: 2000000  # see DataProcessingLimits.MAX_DATAFRAME_PROCESSING_ROWS_ROWS
+  max_records_per_query: 2000000  # see DataProcessingLimits.MAX_DATAFRAME_PROCESSING_ROWS
   enable_real_time: true
   batch_size: 25000
   chunk_size: 100000


### PR DESCRIPTION
## Summary
- rename `MAX_DATAFRAME_PROCESSING_ROWS_ROWS` to `MAX_DATAFRAME_PROCESSING_ROWS`
- update yaml comments that reference the constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68640911a0988320afa8002466375847