### PR TITLE
Add logging for YAML config load errors

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Dict, Any
 from .constants import (
     SecurityConstants,
@@ -43,8 +44,10 @@ class DynamicConfigManager:
                     if hasattr(self.analytics, key):
                         setattr(self.analytics, key, value)
 
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "Failed to load %s: %s", config_path, exc
+            )
 
     def _apply_env_overrides(self) -> None:
         """Override defaults from environment variables with validation."""


### PR DESCRIPTION
## Summary
- log YAML loading issues in `DynamicConfigManager`
- import logging for new warning handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68640912bcf88320b758231d84a71be7