### PR TITLE
Implement dev mode defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,6 +92,7 @@ def main():
     """Main application entry point"""
     try:
         load_dotenv()
+        from config.dev_mode import setup_dev_mode; setup_dev_mode()
         # Import configuration
         try:
             from config.config import get_config

--- a/config/dev_mode.py
+++ b/config/dev_mode.py
@@ -1,0 +1,22 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def setup_dev_mode():
+    """Set development defaults for missing Auth0 secrets"""
+    if os.getenv("YOSAI_ENV", "development") == "development":
+        defaults = {
+            "AUTH0_CLIENT_ID": "dev-client-id",
+            "AUTH0_CLIENT_SECRET": "dev-secret",
+            "AUTH0_DOMAIN": "dev.auth0.com",
+            "AUTH0_AUDIENCE": "dev-audience",
+            "SECRET_KEY": "dev-secret-key",
+            "DB_PASSWORD": "dev-password",
+        }
+        for key, value in defaults.items():
+            if not os.getenv(key):
+                os.environ[key] = value
+                logger.info(f"\ud83d\udd27 Set dev default: {key}")
+


### PR DESCRIPTION
## Summary
- add a `config/dev_mode.py` helper to set default secrets for development
- invoke `setup_dev_mode()` in `app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864108045308320bdda51a2fab842eb