### PR TITLE
Add tests for component modals and callbacks

### DIFF
--- a/tests/components/test_callback_helpers.py
+++ b/tests/components/test_callback_helpers.py
@@ -1,0 +1,53 @@
+from unittest import mock
+import dash
+
+from components.column_verification import toggle_custom_field, register_callbacks as register_column_callbacks
+from components.simple_device_mapping import apply_ai_device_suggestions, register_callbacks as register_device_callbacks
+from components.device_verification import mark_device_as_edited
+
+
+def test_toggle_custom_field():
+    assert toggle_custom_field("other") == {"display": "block"}
+    assert toggle_custom_field("person_id") == {"display": "none"}
+    assert toggle_custom_field(None) == {"display": "none"}
+
+
+def test_apply_ai_device_suggestions_basic():
+    suggestions = {
+        "door1": {"floor_number": 1, "security_level": 2, "is_entry": True},
+        "door2": {"floor_number": 2, "security_level": 4, "is_stairwell": True},
+    }
+    devices = ["door1", "door2"]
+    floors, access, special, security = apply_ai_device_suggestions(suggestions, devices)
+    assert floors == [1, 2]
+    assert access == [["entry"], []]
+    assert special == [[], ["is_stairwell"]]
+    assert security == [2, 4]
+
+
+def test_apply_ai_device_suggestions_empty():
+    result = apply_ai_device_suggestions({}, [])
+    assert result == (dash.no_update, dash.no_update, dash.no_update, dash.no_update)
+
+
+def test_mark_device_as_edited():
+    assert mark_device_as_edited(None, None, None, None) is True
+
+
+def test_register_callbacks_invoked():
+    manager = mock.Mock()
+
+    def fake_register(*args, **kwargs):
+        def decorator(func):
+            decorator.called_with = kwargs.get("callback_id")
+            decorator.func = func
+            return func
+        return decorator
+
+    manager.register_callback.side_effect = fake_register
+    register_column_callbacks(manager)
+    register_device_callbacks(manager)
+
+    calls = [c.kwargs.get("callback_id") for c in manager.register_callback.mock_calls]
+    assert "toggle_custom_field" in calls
+    assert "apply_ai_device_suggestions" in calls

--- a/tests/components/test_verification_modals.py
+++ b/tests/components/test_verification_modals.py
@@ -1,0 +1,60 @@
+import dash_bootstrap_components as dbc
+from dash import html, dcc
+
+from components.column_verification import create_column_verification_modal
+from components.device_verification import create_device_verification_modal
+
+
+def _collect(component, cls):
+    """Recursively collect components of a given class."""
+    found = []
+    if isinstance(component, cls):
+        found.append(component)
+    children = getattr(component, "children", None)
+    if isinstance(children, (list, tuple)):
+        for c in children:
+            found.extend(_collect(c, cls))
+    elif children is not None:
+        found.extend(_collect(children, cls))
+    return found
+
+
+def test_create_column_verification_modal_basic():
+    info = {
+        "filename": "sample.csv",
+        "columns": ["User", "Door"],
+        "ai_suggestions": {
+            "User": {"field": "person_id", "confidence": 0.9},
+            "Door": {"field": "door_id", "confidence": 0.8},
+        },
+    }
+    modal = create_column_verification_modal(info)
+    assert isinstance(modal, dbc.Modal)
+    assert modal.id == "column-verification-modal"
+    dropdowns = _collect(modal, dcc.Dropdown)
+    assert len(dropdowns) >= len(info["columns"])
+    header = _collect(modal, html.H5)[0]
+    assert "sample.csv" in "".join(str(c) for c in header.children)
+
+
+def test_create_column_verification_modal_empty():
+    modal = create_column_verification_modal({"filename": "x.csv", "columns": []})
+    assert isinstance(modal, html.Div)
+
+
+def test_create_device_verification_modal_basic():
+    mappings = {
+        "door1": {"floor_number": 1, "is_entry": True, "confidence": 0.8},
+        "door2": {"floor_number": 2, "is_exit": True, "confidence": 0.6},
+    }
+    modal = create_device_verification_modal(mappings, "sess")
+    assert isinstance(modal, dbc.Modal)
+    assert modal.id == "device-verification-modal"
+    rows = _collect(modal, html.Tr)
+    # subtract header row
+    assert len(rows) - 1 == len(mappings)
+
+
+def test_create_device_verification_modal_empty():
+    modal = create_device_verification_modal({}, "sess")
+    assert isinstance(modal, html.Div)


### PR DESCRIPTION
## Summary
- add tests for column and device verification modals
- cover toggle_custom_field, apply_ai_device_suggestions and registration logic

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686412cfda9483208d239f237e02d23f