### PR TITLE
Improve config loading with validation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ When `YOSAI_ENV=production` the application will refuse to start unless both
 secrets.
 
 Configuration validation runs automatically at startup and logs any missing
-critical settings.
+critical settings. The new `ConfigValidator` checks that the `app`, `database`
+and `security` sections exist before the server starts.
 
 ### Environment Overrides
 
@@ -241,7 +242,8 @@ These values override `database.host`, `database.username`, `cache.host` and
 
 ### Additional Environment Variables
 
-Two optional variables control which configuration file is loaded:
+The helper functions in `config/environment.py` pick the correct YAML file.
+They look at two variables:
 
 - `YOSAI_ENV` – set to `development`, `staging`, `production` or `test` to
   automatically load the matching file in `config/` (default: `development`).

--- a/config/config_validator.py
+++ b/config/config_validator.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Dict, Any
+
+from core.exceptions import ConfigurationError
+from .config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigValidator:
+    """Validate configuration dictionaries."""
+
+    REQUIRED_SECTIONS = {"app", "database", "security"}
+
+    @classmethod
+    def validate(cls, data: Dict[str, Any]) -> Config:
+        """Validate config data and return a Config object."""
+        if not isinstance(data, dict):
+            raise ConfigurationError("Configuration data must be a mapping")
+
+        missing = cls.REQUIRED_SECTIONS - data.keys()
+        if missing:
+            raise ConfigurationError(
+                "Missing configuration sections: " + ", ".join(sorted(missing))
+            )
+
+        config = Config()
+        for section in ["app", "database", "security", "sample_files"]:
+            if section in data:
+                section_data = data.get(section, {})
+                if not isinstance(section_data, dict):
+                    raise ConfigurationError(f"Section '{section}' must be a mapping")
+                section_obj = getattr(config, section)
+                for key, value in section_data.items():
+                    if hasattr(section_obj, key):
+                        setattr(section_obj, key, value)
+        if "environment" in data:
+            config.environment = str(data["environment"])
+        return config

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,6 +1,8 @@
 import os
 import logging
 from typing import Dict, Any
+
+from .environment import select_config_file
 from .constants import (
     SecurityConstants,
     PerformanceConstants,
@@ -22,20 +24,11 @@ class DynamicConfigManager:
     def _load_yaml_config(self) -> None:
         """Load configuration from YAML files."""
         import yaml
-        from pathlib import Path
 
         try:
-            config_env = os.getenv("YOSAI_ENV", "development")
-            config_file = os.getenv("YOSAI_CONFIG_FILE")
+            config_path = select_config_file()
 
-            if config_file:
-                config_path = Path(config_file)
-            else:
-                config_path = Path(f"config/{config_env}.yaml")
-                if not config_path.exists():
-                    config_path = Path("config/production.yaml")
-
-            if config_path.exists():
+            if config_path and config_path.exists():
                 with open(config_path, 'r', encoding='utf-8') as f:
                     config_data = yaml.safe_load(f)
 

--- a/config/environment.py
+++ b/config/environment.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def get_environment() -> str:
+    """Return the current environment name."""
+    env = os.getenv("YOSAI_ENV", "development").lower()
+    if env.startswith("stag"):
+        return "staging"
+    return env
+
+
+def select_config_file(explicit_path: Optional[str] = None) -> Optional[Path]:
+    """Select the configuration YAML file based on environment variables."""
+    if explicit_path:
+        return Path(explicit_path)
+
+    env_file = os.getenv("YOSAI_CONFIG_FILE")
+    if env_file:
+        return Path(env_file)
+
+    env = get_environment()
+    config_dir = Path("config")
+    env_files = {
+        "production": config_dir / "production.yaml",
+        "staging": config_dir / "staging.yaml",
+        "test": config_dir / "test.yaml",
+        "development": config_dir / "config.yaml",
+    }
+    path = env_files.get(env, config_dir / "config.yaml")
+    return path if path.exists() else None

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,31 @@
+import pytest
+
+from config.config import ConfigManager
+from core.exceptions import ConfigurationError
+
+
+def _write(tmp_path, text: str) -> str:
+    p = tmp_path / "config.yaml"
+    p.write_text(text)
+    return str(p)
+
+
+def test_missing_required_sections(monkeypatch, tmp_path):
+    path = _write(tmp_path, "app:\n  title: Test")
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", path)
+    with pytest.raises(ConfigurationError):
+        ConfigManager()
+
+
+def test_invalid_section_type(monkeypatch, tmp_path):
+    yaml = """
+app:
+  title: Test
+database: []
+security:
+  secret_key: abc
+"""
+    path = _write(tmp_path, yaml)
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", path)
+    with pytest.raises(ConfigurationError):
+        ConfigManager()


### PR DESCRIPTION
## Summary
- add ConfigValidator to ensure required sections exist
- add environment helpers to pick YAML file
- use helpers in `ConfigManager` and `DynamicConfigManager`
- raise `ConfigurationError` when YAML sections are missing
- document new validation and helpers
- add tests for config validation

## Testing
- `pytest tests/test_config_validator.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68641168ef608320bc08c2402224c5e6