### PR TITLE
Improve plugin dependency resolution

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -99,7 +99,11 @@ class PluginManager:
             except Exception as exc:
                 logger.error("Failed to load plugin %s: %s", module_name, exc)
 
-        ordered = self._resolver.resolve(discovered)
+        try:
+            ordered = self._resolver.resolve(discovered)
+        except Exception as exc:
+            logger.error("Failed to resolve plugin dependencies: %s", exc)
+            return []
         ordered.sort(key=self._get_priority)
 
         results: List[PluginProtocol] = []

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,0 +1,54 @@
+import pytest
+
+from core.plugins.dependency_resolver import PluginDependencyResolver
+from core.plugins.protocols import PluginMetadata
+
+
+class DummyPlugin:
+    def __init__(self, name, deps=None):
+        self.metadata = PluginMetadata(
+            name=name,
+            version="0.1",
+            description=name,
+            author="tester",
+            dependencies=deps,
+        )
+
+    def load(self, container, config):
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        return True
+
+    def stop(self):
+        return True
+
+    def health_check(self):
+        return {"healthy": True}
+
+
+def test_resolver_orders_dependencies():
+    a = DummyPlugin("a")
+    b = DummyPlugin("b", ["a"])
+    c = DummyPlugin("c", ["b"])
+    resolver = PluginDependencyResolver()
+    ordered = resolver.resolve([c, b, a])
+    assert [p.metadata.name for p in ordered][:3] == ["a", "b", "c"]
+
+
+def test_resolver_unknown_dependency():
+    p = DummyPlugin("a", ["missing"])
+    resolver = PluginDependencyResolver()
+    with pytest.raises(ValueError, match="Unknown dependencies"):  # noqa: PT011
+        resolver.resolve([p])
+
+
+def test_resolver_cycle_detection():
+    a = DummyPlugin("a", ["b"])
+    b = DummyPlugin("b", ["a"])
+    resolver = PluginDependencyResolver()
+    with pytest.raises(ValueError, match="Circular dependency"):  # noqa: PT011
+        resolver.resolve([a, b])


### PR DESCRIPTION
## Summary
- implement Kahn-style topological sort for resolving plugin dependencies
- validate unknown dependencies and detect dependency cycles
- gracefully handle dependency resolution errors in `PluginManager`
- add regression tests for dependency resolution behaviour

## Testing
- `pytest tests/test_dependency_resolver.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686411a883388320b9836376eaa7261f