### PR TITLE
Add plugin dependency resolver tests

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -1,22 +1,21 @@
 import importlib
-import pkgutil
 import logging
+import pkgutil
 import threading
 import time
-from typing import List, Any, Dict
+from typing import Any, Dict, List
 
-from core.callback_manager import CallbackManager
-from core.plugins.protocols import (
-    PluginProtocol,
-    CallbackPluginProtocol,
-    PluginStatus,
-    PluginPriority,
-)
-from .dependency_resolver import PluginDependencyResolver
-
-from core.container import Container as DIContainer
 from config.config import ConfigManager
+from core.callback_manager import CallbackManager
+from core.container import Container as DIContainer
+from core.plugins.protocols import (
+    CallbackPluginProtocol,
+    PluginPriority,
+    PluginProtocol,
+    PluginStatus,
+)
 
+from .dependency_resolver import PluginDependencyResolver
 
 logger = logging.getLogger(__name__)
 
@@ -124,11 +123,14 @@ class PluginManager:
 
             success = plugin.load(self.container, config)
             if success:
-                plugin.start()
-                self.plugins[name] = plugin
-                self.plugin_status[name] = PluginStatus.STARTED
-                logger.info("Loaded plugin %s", name)
-                return True
+                started = plugin.start()
+                if started:
+                    self.plugins[name] = plugin
+                    self.plugin_status[name] = PluginStatus.STARTED
+                    logger.info("Loaded plugin %s", name)
+                    return True
+                self.plugin_status[name] = PluginStatus.FAILED
+                return False
             self.plugin_status[name] = PluginStatus.FAILED
             return False
         except Exception as exc:

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,0 +1,30 @@
+import types
+
+import pytest
+
+from core.plugins.dependency_resolver import PluginDependencyResolver
+
+
+class FakePlugin:
+    def __init__(self, name, deps=None):
+        self.metadata = types.SimpleNamespace(name=name, dependencies=deps)
+
+
+def test_resolver_orders_by_dependencies():
+    a = FakePlugin("a", ["b"])
+    b = FakePlugin("b", ["c"])
+    c = FakePlugin("c")
+    resolver = PluginDependencyResolver()
+
+    ordered = resolver.resolve([a, c, b])
+    names = [p.metadata.name for p in ordered]
+    assert names == ["c", "b", "a"]
+
+
+def test_resolver_detects_cycles():
+    a = FakePlugin("a", ["b"])
+    b = FakePlugin("b", ["a"])
+    resolver = PluginDependencyResolver()
+
+    with pytest.raises(ValueError):
+        resolver.resolve([a, b])


### PR DESCRIPTION
## Summary
- add tests for PluginDependencyResolver
- test PluginManager failure states on load and start failure
- validate health endpoint with Flask test client
- update PluginManager to mark failure if `start` returns False

## Testing
- `isort --profile black --check core/plugins/manager.py tests/test_plugin_manager_core.py tests/test_dependency_resolver.py`
- `black --check core/plugins/manager.py tests/test_plugin_manager_core.py tests/test_dependency_resolver.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686412ceef4083208e482a844fb32b20