### PR TITLE
Refactor services into modular helpers

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -4,6 +4,9 @@ import logging
 
 from .ai_mapping_store import ai_mapping_store
 from .data_loader import DataLoader
+from .data_validation import DataValidationService
+from .analytics_generator import AnalyticsGenerator
+from .data_loading_service import DataLoadingService
 from .registry import get_service
 
 logger = logging.getLogger(__name__)
@@ -25,5 +28,8 @@ __all__ = [
     "AnalyticsService",
     "ANALYTICS_SERVICE_AVAILABLE",
     "DataLoader",
+    "DataValidationService",
+    "AnalyticsGenerator",
+    "DataLoadingService",
     "ai_mapping_store",
 ]

--- a/services/analytics_generator.py
+++ b/services/analytics_generator.py
@@ -1,0 +1,161 @@
+"""Analytics generation helpers packaged as a service."""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyticsGenerator:
+    """Generate summaries and sample analytics."""
+
+    def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        total_events = len(df)
+        active_users = df["person_id"].nunique() if "person_id" in df.columns else 0
+        active_doors = df["door_id"].nunique() if "door_id" in df.columns else 0
+
+        date_range = {"start": "Unknown", "end": "Unknown"}
+        if "timestamp" in df.columns:
+            valid_ts = df["timestamp"].dropna()
+            if not valid_ts.empty:
+                date_range = {
+                    "start": str(valid_ts.min().date()),
+                    "end": str(valid_ts.max().date()),
+                }
+
+        access_patterns = {}
+        if "access_result" in df.columns:
+            access_patterns = df["access_result"].value_counts().to_dict()
+
+        top_users = []
+        if "person_id" in df.columns:
+            user_counts = df["person_id"].value_counts().head(10)
+            top_users = [
+                {"user_id": uid, "count": int(cnt)} for uid, cnt in user_counts.items()
+            ]
+
+        top_doors = []
+        if "door_id" in df.columns:
+            door_counts = df["door_id"].value_counts().head(10)
+            top_doors = [
+                {"door_id": did, "count": int(cnt)} for did, cnt in door_counts.items()
+            ]
+
+        return {
+            "total_events": total_events,
+            "active_users": active_users,
+            "active_doors": active_doors,
+            "unique_users": active_users,
+            "unique_doors": active_doors,
+            "data_source": "uploaded",
+            "date_range": date_range,
+            "access_patterns": access_patterns,
+            "top_users": top_users,
+            "top_doors": top_doors,
+        }
+
+    def create_sample_data(self, n_events: int = 1000) -> pd.DataFrame:
+        np.random.seed(42)
+        end_date = datetime.now()
+        start_date = end_date - timedelta(days=30)
+        timestamps = [
+            start_date
+            + timedelta(
+                days=np.random.randint(0, 30),
+                hours=np.random.randint(0, 24),
+                minutes=np.random.randint(0, 60),
+            )
+            for _ in range(n_events)
+        ]
+        users = [f"USER{i:04d}" for i in range(1, 51)]
+        doors = [f"DOOR{i:03d}" for i in range(1, 6)]
+        data = {
+            "event_id": [f"EVT{i:06d}" for i in range(n_events)],
+            "timestamp": timestamps,
+            "person_id": np.random.choice(users, n_events),
+            "door_id": np.random.choice(doors, n_events),
+            "access_result": np.random.choice(["Granted", "Denied"], n_events, p=[0.85, 0.15]),
+            "badge_status": np.random.choice(["Valid", "Invalid", "Expired"], n_events, p=[0.9, 0.08, 0.02]),
+            "device_status": np.random.choice(["normal", "maintenance"], n_events, p=[0.95, 0.05]),
+        }
+        df = pd.DataFrame(data).sort_values("timestamp").reset_index(drop=True)
+        return df
+
+    def analyze_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        if df.empty:
+            return {"total_events": 0}
+
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        total_events = len(df)
+        unique_users = df["person_id"].nunique()
+        unique_doors = df["door_id"].nunique()
+
+        access_counts = df["access_result"].value_counts()
+        granted = access_counts.get("Granted", 0)
+        denied = access_counts.get("Denied", 0)
+        success_rate = (granted / total_events) * 100 if total_events else 0
+
+        date_range = {
+            "start": df["timestamp"].min().isoformat(),
+            "end": df["timestamp"].max().isoformat(),
+            "days": (df["timestamp"].max() - df["timestamp"].min()).days + 1,
+        }
+        hourly_dist = df["timestamp"].dt.hour.value_counts().sort_index().to_dict()
+        daily_dist = df["timestamp"].dt.day_name().value_counts().to_dict()
+
+        return {
+            "total_events": total_events,
+            "unique_users": unique_users,
+            "unique_doors": unique_doors,
+            "success_rate": round(success_rate, 2),
+            "granted_events": int(granted),
+            "denied_events": int(denied),
+            "date_range": date_range,
+            "hourly_distribution": hourly_dist,
+            "daily_distribution": daily_dist,
+        }
+
+    def generate_basic_analytics(self, df: pd.DataFrame) -> Dict[str, Any]:
+        try:
+            analytics: Dict[str, Any] = {
+                "status": "success",
+                "total_events": len(df),
+                "total_rows": len(df),
+                "total_columns": len(df.columns),
+                "summary": {},
+                "timestamp": datetime.now().isoformat(),
+            }
+            for col in df.columns:
+                if pd.api.types.is_numeric_dtype(df[col]):
+                    analytics["summary"][col] = {
+                        "type": "numeric",
+                        "mean": float(df[col].mean()),
+                        "min": float(df[col].min()),
+                        "max": float(df[col].max()),
+                        "null_count": int(df[col].isnull().sum()),
+                    }
+                else:
+                    counts = df[col].value_counts().head(10)
+                    analytics["summary"][col] = {
+                        "type": "categorical",
+                        "unique_values": int(df[col].nunique()),
+                        "top_values": {str(k): int(v) for k, v in counts.items()},
+                        "null_count": int(df[col].isnull().sum()),
+                    }
+            return analytics
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Error generating basic analytics: %s", exc)
+            return {"status": "error", "message": str(exc)}
+
+    def generate_sample_analytics(self) -> Dict[str, Any]:
+        df = self.create_sample_data()
+        basic = self.generate_basic_analytics(df)
+        basic.update(self.analyze_dataframe(df))
+        return basic
+
+
+__all__ = ["AnalyticsGenerator"]

--- a/services/analytics_summary.py
+++ b/services/analytics_summary.py
@@ -1,161 +1,31 @@
-import logging
-from datetime import datetime, timedelta
-from typing import Any, Dict
+"""Public API wrappers for analytics generation."""
 
-import numpy as np
+from typing import Any, Dict
 import pandas as pd
 
-logger = logging.getLogger(__name__)
+from .analytics_generator import AnalyticsGenerator
+
+_generator = AnalyticsGenerator()
 
 
 def summarize_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
-    """Return a basic summary for an uploaded dataframe."""
-    total_events = len(df)
-    active_users = df["person_id"].nunique() if "person_id" in df.columns else 0
-    active_doors = df["door_id"].nunique() if "door_id" in df.columns else 0
-
-    date_range = {"start": "Unknown", "end": "Unknown"}
-    if "timestamp" in df.columns:
-        valid_ts = df["timestamp"].dropna()
-        if not valid_ts.empty:
-            date_range = {
-                "start": str(valid_ts.min().date()),
-                "end": str(valid_ts.max().date()),
-            }
-
-    access_patterns = {}
-    if "access_result" in df.columns:
-        access_patterns = df["access_result"].value_counts().to_dict()
-
-    top_users = []
-    if "person_id" in df.columns:
-        user_counts = df["person_id"].value_counts().head(10)
-        top_users = [
-            {"user_id": uid, "count": int(cnt)} for uid, cnt in user_counts.items()
-        ]
-
-    top_doors = []
-    if "door_id" in df.columns:
-        door_counts = df["door_id"].value_counts().head(10)
-        top_doors = [
-            {"door_id": did, "count": int(cnt)} for did, cnt in door_counts.items()
-        ]
-
-    return {
-        "total_events": total_events,
-        "active_users": active_users,
-        "active_doors": active_doors,
-        "unique_users": active_users,
-        "unique_doors": active_doors,
-        "data_source": "uploaded",
-        "date_range": date_range,
-        "access_patterns": access_patterns,
-        "top_users": top_users,
-        "top_doors": top_doors,
-    }
+    return _generator.summarize_dataframe(df)
 
 
 def create_sample_data(n_events: int = 1000) -> pd.DataFrame:
-    np.random.seed(42)
-    end_date = datetime.now()
-    start_date = end_date - timedelta(days=30)
-    timestamps = [
-        start_date
-        + timedelta(
-            days=np.random.randint(0, 30),
-            hours=np.random.randint(0, 24),
-            minutes=np.random.randint(0, 60),
-        )
-        for _ in range(n_events)
-    ]
-    users = [f"USER{i:04d}" for i in range(1, 51)]
-    doors = [f"DOOR{i:03d}" for i in range(1, 6)]
-    data = {
-        "event_id": [f"EVT{i:06d}" for i in range(n_events)],
-        "timestamp": timestamps,
-        "person_id": np.random.choice(users, n_events),
-        "door_id": np.random.choice(doors, n_events),
-        "access_result": np.random.choice(["Granted", "Denied"], n_events, p=[0.85, 0.15]),
-        "badge_status": np.random.choice(["Valid", "Invalid", "Expired"], n_events, p=[0.9, 0.08, 0.02]),
-        "device_status": np.random.choice(["normal", "maintenance"], n_events, p=[0.95, 0.05]),
-    }
-    df = pd.DataFrame(data).sort_values("timestamp").reset_index(drop=True)
-    return df
+    return _generator.create_sample_data(n_events)
 
 
 def analyze_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
-    if df.empty:
-        return {"total_events": 0}
-
-    df["timestamp"] = pd.to_datetime(df["timestamp"])
-    total_events = len(df)
-    unique_users = df["person_id"].nunique()
-    unique_doors = df["door_id"].nunique()
-
-    access_counts = df["access_result"].value_counts()
-    granted = access_counts.get("Granted", 0)
-    denied = access_counts.get("Denied", 0)
-    success_rate = (granted / total_events) * 100 if total_events else 0
-
-    date_range = {
-        "start": df["timestamp"].min().isoformat(),
-        "end": df["timestamp"].max().isoformat(),
-        "days": (df["timestamp"].max() - df["timestamp"].min()).days + 1,
-    }
-    hourly_dist = df["timestamp"].dt.hour.value_counts().sort_index().to_dict()
-    daily_dist = df["timestamp"].dt.day_name().value_counts().to_dict()
-
-    return {
-        "total_events": total_events,
-        "unique_users": unique_users,
-        "unique_doors": unique_doors,
-        "success_rate": round(success_rate, 2),
-        "granted_events": int(granted),
-        "denied_events": int(denied),
-        "date_range": date_range,
-        "hourly_distribution": hourly_dist,
-        "daily_distribution": daily_dist,
-    }
+    return _generator.analyze_dataframe(df)
 
 
 def generate_basic_analytics(df: pd.DataFrame) -> Dict[str, Any]:
-    try:
-        analytics: Dict[str, Any] = {
-            "status": "success",
-            "total_events": len(df),
-            "total_rows": len(df),
-            "total_columns": len(df.columns),
-            "summary": {},
-            "timestamp": datetime.now().isoformat(),
-        }
-        for col in df.columns:
-            if pd.api.types.is_numeric_dtype(df[col]):
-                analytics["summary"][col] = {
-                    "type": "numeric",
-                    "mean": float(df[col].mean()),
-                    "min": float(df[col].min()),
-                    "max": float(df[col].max()),
-                    "null_count": int(df[col].isnull().sum()),
-                }
-            else:
-                counts = df[col].value_counts().head(10)
-                analytics["summary"][col] = {
-                    "type": "categorical",
-                    "unique_values": int(df[col].nunique()),
-                    "top_values": {str(k): int(v) for k, v in counts.items()},
-                    "null_count": int(df[col].isnull().sum()),
-                }
-        return analytics
-    except Exception as exc:  # pragma: no cover - best effort
-        logger.error("Error generating basic analytics: %s", exc)
-        return {"status": "error", "message": str(exc)}
+    return _generator.generate_basic_analytics(df)
 
 
 def generate_sample_analytics() -> Dict[str, Any]:
-    df = create_sample_data()
-    basic = generate_basic_analytics(df)
-    basic.update(analyze_dataframe(df))
-    return basic
+    return _generator.generate_sample_analytics()
 
 
 __all__ = [

--- a/services/data_loading_service.py
+++ b/services/data_loading_service.py
@@ -1,0 +1,34 @@
+"""Data loading helpers for uploaded files."""
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import pandas as pd
+
+from services.data_validation import DataValidationService
+from utils.mapping_helpers import map_and_clean
+
+
+class DataLoadingService:
+    """Load and stream uploaded file data."""
+
+    def __init__(self, validator: DataValidationService | None = None) -> None:
+        self.validator = validator or DataValidationService()
+
+    def load_dataframe(self, source: Any) -> pd.DataFrame:
+        if isinstance(source, (str, Path)):
+            df = pd.read_csv(source, encoding="utf-8")
+        else:
+            df = source
+        df = self.validator.validate(df)
+        return map_and_clean(df)
+
+    def stream_file(self, source: Any, chunksize: int = 50000) -> Iterator[pd.DataFrame]:
+        if isinstance(source, (str, Path)):
+            for chunk in pd.read_csv(source, chunksize=chunksize, encoding="utf-8"):
+                chunk = self.validator.validate(chunk)
+                yield map_and_clean(chunk)
+        else:
+            df = self.validator.validate(source)
+            yield map_and_clean(df)
+

--- a/services/data_validation.py
+++ b/services/data_validation.py
@@ -1,0 +1,26 @@
+"""Wrapper service around DataFrameSecurityValidator."""
+
+from typing import Any, Tuple
+
+import pandas as pd
+from security.dataframe_validator import DataFrameSecurityValidator
+
+
+class DataValidationService:
+    """Service providing DataFrame validation helpers."""
+
+    def __init__(self) -> None:
+        self._validator = DataFrameSecurityValidator()
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._validator, item)
+
+    def validate(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self._validator.validate(df)
+
+    def validate_for_upload(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self._validator.validate_for_upload(df)
+
+    def validate_for_analysis(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, bool]:
+        return self._validator.validate_for_analysis(df)
+


### PR DESCRIPTION
## Summary
- expose new `DataValidationService`, `DataLoadingService` and `AnalyticsGenerator` classes
- wrap analytics utilities through `analytics_summary`
- update `AnalyticsService` to use the new helpers
- export new classes in `services.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68646cabca7c832093e8a786db4a9232