### PR TITLE
Improve filename validation in UploadedDataStore

### DIFF
--- a/tests/test_upload_store_filename_validation.py
+++ b/tests/test_upload_store_filename_validation.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import pytest
+
+from utils.upload_store import UploadedDataStore
+
+
+def test_unsafe_filenames_rejected(tmp_path):
+    store = UploadedDataStore(storage_dir=tmp_path)
+    df = pd.DataFrame({"a": [1]})
+
+    with pytest.raises(ValueError):
+        store.add_file("../bad.csv", df)
+
+    with pytest.raises(ValueError):
+        store.add_file("..\\bad.csv", df)
+
+    with pytest.raises(ValueError):
+        store.add_file("bad\\name.csv", df)

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -31,6 +31,18 @@ class UploadedDataStore:
 
     # -- Internal helpers ---------------------------------------------------
     def _get_file_path(self, filename: str) -> Path:
+        """Return a sanitized path for the given ``filename``.
+
+        Filenames may contain regular characters, spaces or forward slashes,
+        which will be replaced by underscores. Any filename containing ``..``
+        or a backslash is rejected with :class:`ValueError` to avoid directory
+        traversal. The sanitized filename will be stored as ``<name>.parquet``
+        inside :attr:`storage_dir`.
+        """
+
+        if ".." in filename or "\\" in filename:
+            raise ValueError(f"Unsafe filename: {filename}")
+
         safe_name = filename.replace(" ", "_").replace("/", "_")
         return self.storage_dir / f"{safe_name}.parquet"
 


### PR DESCRIPTION
## Summary
- prevent unsafe filenames in `UploadedDataStore._get_file_path`
- add unit test covering invalid filenames

## Testing
- `pytest tests/test_upload_store_threading.py tests/test_upload_store_migration.py tests/test_process_uploaded_files_split.py tests/test_upload_store_filename_validation.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6864793046388320bd460d8352dfa2bc