### PR TITLE
Fix duplicate python-dotenv entry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,3 @@ flasgger==0.9.7.1
 python-dotenv==1.0.0
 pytest==7.4.0
 pyarrow>=10.0.0
-python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- remove repeated `python-dotenv` line from `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68648cdfb2408320b4a63861118794b4