### PR TITLE
Add analytics upload sequence doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Data Flow](docs/data_flow.md)
 - [System Diagram](docs/system_diagram.md)
 - [Deployment Diagram](docs/deployment_diagram.md)
+- [Analytics Upload Sequence](docs/analytics_sequence.md)
 
 The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery and configuration details.
 

--- a/docs/analytics_sequence.md
+++ b/docs/analytics_sequence.md
@@ -1,0 +1,21 @@
+# Analytics Upload Sequence
+
+The sequence below illustrates how an uploaded file is validated and processed to generate analytics results.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant S as Server
+    participant V as Validator
+    participant AS as AnalyticsService
+
+    U->>B: Select file & click upload
+    B->>S: POST /upload
+    S->>V: Validate file
+    V-->>S: Clean data
+    S->>AS: analyze(data)
+    AS->>AS: Compute metrics
+    AS-->>S: Results
+    S-->>B: Show charts
+```


### PR DESCRIPTION
## Summary
- add a mermaid sequence diagram describing analytics upload steps
- link the new doc from the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68648cfd14a48320a1bca778136fdda1