### PR TITLE
Refactor analytics helpers into dedicated modules

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -7,6 +7,13 @@ from .data_loader import DataLoader
 from .data_validation import DataValidationService
 from .analytics_generator import AnalyticsGenerator
 from .data_loading_service import DataLoadingService
+from .chunked_analysis import analyze_with_chunking
+from .result_formatting import (
+    prepare_regular_result,
+    apply_regular_analysis,
+    calculate_temporal_stats_safe,
+    regular_analysis,
+)
 from .registry import get_service
 
 logger = logging.getLogger(__name__)
@@ -31,5 +38,10 @@ __all__ = [
     "DataValidationService",
     "AnalyticsGenerator",
     "DataLoadingService",
+    "analyze_with_chunking",
+    "prepare_regular_result",
+    "apply_regular_analysis",
+    "calculate_temporal_stats_safe",
+    "regular_analysis",
     "ai_mapping_store",
 ]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -17,12 +17,13 @@ from services.analytics_summary import (
 )
 from services.data_validation import DataValidationService
 from services.data_loading_service import DataLoadingService
+from services.chunked_analysis import analyze_with_chunking
+from services.result_formatting import regular_analysis
 
 from utils.mapping_helpers import map_and_clean
 from datetime import datetime, timedelta
 import os
 
-from analytics.utils import ensure_datetime_columns, safe_datetime_operation
 from analytics.db_interface import AnalyticsDataAccessor
 from analytics.file_processing_utils import (
     stream_uploaded_file,
@@ -204,38 +205,6 @@ class AnalyticsService:
             logger.error(f"Direct processing failed: {e}")
             return {"status": "error", "message": str(e)}
 
-    def _prepare_regular_result(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Create the base result structure for regular analysis."""
-        return {
-            "total_events": len(df),
-            "columns": list(df.columns),
-            "analysis_type": "regular",
-            "processing_summary": {
-                "total_input_rows": len(df),
-                "rows_processed": len(df),
-                "chunking_used": False,
-            },
-        }
-
-    def _apply_regular_analysis(
-        self, df: pd.DataFrame, analysis_types: List[str]
-    ) -> Dict[str, Any]:
-        """Run selected analysis sections for regular analysis."""
-        result: Dict[str, Any] = {}
-
-        if "basic" in analysis_types:
-            result["basic_stats"] = self._calculate_basic_stats(df)
-
-        if "temporal" in analysis_types or "time" in analysis_types:
-            result["temporal_analysis"] = self._calculate_temporal_stats_safe(df)
-
-        if "user" in analysis_types:
-            result["user_analysis"] = self._calculate_user_stats(df)
-
-        if "access" in analysis_types:
-            result["access_analysis"] = self._calculate_access_stats(df)
-
-        return result
 
     def load_uploaded_data(self) -> Dict[str, pd.DataFrame]:
         """Load uploaded data from the file upload page."""
@@ -259,65 +228,7 @@ class AnalyticsService:
         self, df: pd.DataFrame, analysis_types: List[str]
     ) -> Dict[str, Any]:
         """Analyze a DataFrame using chunked processing."""
-        from analytics.chunked_analytics_controller import ChunkedAnalyticsController
-
-        original_rows = len(df)
-        logger.info(f"🚀 Starting COMPLETE analysis for {original_rows:,} rows")
-
-        validator = self.validation_service
-        df, needs_chunking = validator.validate_for_analysis(df)
-
-        validated_rows = len(df)
-        logger.info(
-            f"📋 After validation: {validated_rows:,} rows, chunking needed: {needs_chunking}"
-        )
-
-        # Warn if validation changes the row count
-        if validated_rows != original_rows:
-            logger.warning(
-                f"⚠️  Row count changed during validation: {original_rows:,} → {validated_rows:,}"
-            )
-
-        if not needs_chunking:
-            logger.info("✅ Using regular analysis (no chunking needed)")
-            return self._regular_analysis(df, analysis_types)
-
-        # Determine chunk size using the validator
-        chunk_size = validator.get_optimal_chunk_size(df)
-        chunked_controller = ChunkedAnalyticsController(chunk_size=chunk_size)
-
-        logger.info(
-            f"🔄 Using chunked analysis: {validated_rows:,} rows, {chunk_size:,} per chunk"
-        )
-
-        # Process the DataFrame in chunks
-        result = chunked_controller.process_large_dataframe(df, analysis_types)
-
-        # Attach a processing summary to the result
-        result["processing_summary"] = {
-            "original_input_rows": original_rows,
-            "validated_rows": validated_rows,
-            "rows_processed": result.get("rows_processed", validated_rows),
-            "chunking_used": True,
-            "chunk_size": chunk_size,
-            "processing_complete": result.get("rows_processed", 0) == validated_rows,
-            "data_integrity_check": (
-                "PASS" if result.get("rows_processed", 0) == validated_rows else "FAIL"
-            ),
-        }
-
-        # Verify that all rows were processed
-        rows_processed = result.get("rows_processed", 0)
-        if rows_processed != validated_rows:
-            logger.error(
-                f"❌ PROCESSING ERROR: Expected {validated_rows:,} rows, got {rows_processed:,}"
-            )
-        else:
-            logger.info(
-                f"✅ SUCCESS: Processed ALL {rows_processed:,} rows successfully"
-            )
-
-        return result
+        return analyze_with_chunking(df, self.validation_service, analysis_types)
 
     def diagnose_data_flow(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Diagnostic method to check data processing flow."""
@@ -353,129 +264,6 @@ class AnalyticsService:
             },
         }
 
-    def _regular_analysis(
-        self, df: pd.DataFrame, analysis_types: List[str]
-    ) -> Dict[str, Any]:
-        """Regular analysis for smaller DataFrames with datetime fixes."""
-
-        logger.info(f"\U0001f4ca Starting regular analysis for {len(df):,} rows")
-
-        # CRITICAL FIX: Ensure datetime columns are properly parsed
-        df = ensure_datetime_columns(df)
-
-        result = self._prepare_regular_result(df)
-        result.update(self._apply_regular_analysis(df, analysis_types))
-
-        logger.info(f"✅ Regular analysis completed for {len(df):,} rows")
-        return result
-
-    def _calculate_temporal_stats_safe(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Calculate temporal statistics with safe datetime handling."""
-
-        temporal_stats: Dict[str, Any] = {}
-
-        timestamp_col = None
-        for col in ["timestamp", "datetime", "date", "time"]:
-            if col in df.columns:
-                timestamp_col = col
-                break
-
-        if not timestamp_col:
-            logger.warning("No timestamp column found for temporal analysis")
-            return {"error": "No timestamp column found"}
-
-        try:
-            if df[timestamp_col].dtype == "object":
-                df[timestamp_col] = pd.to_datetime(df[timestamp_col], errors="coerce")
-
-            dates = safe_datetime_operation(df, timestamp_col, "date")
-            hours = safe_datetime_operation(df, timestamp_col, "hour")
-            weekdays = safe_datetime_operation(df, timestamp_col, "weekday")
-
-            if dates is not None:
-                temporal_stats["date_range"] = {
-                    "start": str(dates.min()),
-                    "end": str(dates.max()),
-                    "total_days": (dates.max() - dates.min()).days,
-                }
-
-            if hours is not None:
-                temporal_stats["hourly_distribution"] = hours.value_counts().to_dict()
-
-            if weekdays is not None:
-                temporal_stats["weekday_distribution"] = (
-                    weekdays.value_counts().to_dict()
-                )
-
-            temporal_stats["total_events"] = len(df)
-
-        except Exception as e:  # pragma: no cover - unexpected
-            logger.error(f"Error in temporal analysis: {e}")
-            temporal_stats["error"] = str(e)
-
-        return temporal_stats
-
-    def _calculate_basic_stats(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Calculate basic statistics safely."""
-
-        stats = {
-            "total_rows": len(df),
-            "total_columns": len(df.columns),
-            "memory_usage_mb": df.memory_usage(deep=True).sum() / 1024 / 1024,
-        }
-
-        key_columns = ["person_id", "door_id", "badge_id", "user_id", "access_result"]
-
-        for col in key_columns:
-            if col in df.columns:
-                stats[f"unique_{col}"] = df[col].nunique()
-                stats[f"total_{col}"] = df[col].count()
-
-        if "access_result" in df.columns:
-            stats["access_distribution"] = df["access_result"].value_counts().to_dict()
-
-        return stats
-
-    def _calculate_user_stats(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Calculate user-related statistics."""
-
-        user_stats: Dict[str, Any] = {}
-
-        user_col = None
-        for col in ["person_id", "user_id", "employee_id"]:
-            if col in df.columns:
-                user_col = col
-                break
-
-        if user_col:
-            user_stats["active_users"] = df[user_col].nunique()
-            user_stats["total_user_events"] = df[user_col].count()
-            user_stats["top_users"] = df[user_col].value_counts().head(10).to_dict()
-        else:
-            user_stats["error"] = "No user identifier column found"
-
-        return user_stats
-
-    def _calculate_access_stats(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Calculate access-related statistics."""
-
-        access_stats: Dict[str, Any] = {}
-
-        if "access_result" in df.columns:
-            access_counts = df["access_result"].value_counts()
-            access_stats["access_results"] = access_counts.to_dict()
-
-            total_events = len(df)
-            access_stats["access_percentages"] = {
-                result: (count / total_events) * 100
-                for result, count in access_counts.items()
-            }
-
-        if "door_id" in df.columns:
-            access_stats["active_doors"] = df["door_id"].nunique()
-            access_stats["door_usage"] = df["door_id"].value_counts().head(10).to_dict()
-
-        return access_stats
 
     def _get_real_uploaded_data(self) -> Dict[str, Any]:
         """Load and summarize all uploaded records."""

--- a/services/chunked_analysis.py
+++ b/services/chunked_analysis.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from analytics.chunked_analytics_controller import ChunkedAnalyticsController
+from services.data_validation import DataValidationService
+from .result_formatting import regular_analysis
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_with_chunking(
+    df: pd.DataFrame, validator: DataValidationService, analysis_types: List[str]
+) -> Dict[str, Any]:
+    """Analyze a DataFrame using chunked processing."""
+    original_rows = len(df)
+    logger.info(f"🚀 Starting COMPLETE analysis for {original_rows:,} rows")
+
+    df, needs_chunking = validator.validate_for_analysis(df)
+
+    validated_rows = len(df)
+    logger.info(
+        f"📋 After validation: {validated_rows:,} rows, chunking needed: {needs_chunking}"
+    )
+
+    if not needs_chunking:
+        logger.info("✅ Using regular analysis (no chunking needed)")
+        return regular_analysis(df, analysis_types)
+
+    chunk_size = validator.get_optimal_chunk_size(df)
+    chunked_controller = ChunkedAnalyticsController(chunk_size=chunk_size)
+
+    logger.info(
+        f"🔄 Using chunked analysis: {validated_rows:,} rows, {chunk_size:,} per chunk"
+    )
+
+    result = chunked_controller.process_large_dataframe(df, analysis_types)
+
+    result["processing_summary"] = {
+        "original_input_rows": original_rows,
+        "validated_rows": validated_rows,
+        "rows_processed": result.get("rows_processed", validated_rows),
+        "chunking_used": True,
+        "chunk_size": chunk_size,
+        "processing_complete": result.get("rows_processed", 0) == validated_rows,
+        "data_integrity_check": (
+            "PASS" if result.get("rows_processed", 0) == validated_rows else "FAIL"
+        ),
+    }
+
+    rows_processed = result.get("rows_processed", 0)
+    if rows_processed != validated_rows:
+        logger.error(
+            f"❌ PROCESSING ERROR: Expected {validated_rows:,} rows, got {rows_processed:,}"
+        )
+    else:
+        logger.info(
+            f"✅ SUCCESS: Processed ALL {rows_processed:,} rows successfully"
+        )
+
+    return result
+
+
+__all__ = ["analyze_with_chunking"]

--- a/services/result_formatting.py
+++ b/services/result_formatting.py
@@ -1,0 +1,170 @@
+import logging
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from analytics.utils import ensure_datetime_columns, safe_datetime_operation
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_regular_result(df: pd.DataFrame) -> Dict[str, Any]:
+    """Create the base result structure for regular analysis."""
+    return {
+        "total_events": len(df),
+        "columns": list(df.columns),
+        "analysis_type": "regular",
+        "processing_summary": {
+            "total_input_rows": len(df),
+            "rows_processed": len(df),
+            "chunking_used": False,
+        },
+    }
+
+
+def calculate_basic_stats(df: pd.DataFrame) -> Dict[str, Any]:
+    """Calculate basic statistics safely."""
+    stats = {
+        "total_rows": len(df),
+        "total_columns": len(df.columns),
+        "memory_usage_mb": df.memory_usage(deep=True).sum() / 1024 / 1024,
+    }
+
+    key_columns = ["person_id", "door_id", "badge_id", "user_id", "access_result"]
+
+    for col in key_columns:
+        if col in df.columns:
+            stats[f"unique_{col}"] = df[col].nunique()
+            stats[f"total_{col}"] = df[col].count()
+
+    if "access_result" in df.columns:
+        stats["access_distribution"] = df["access_result"].value_counts().to_dict()
+
+    return stats
+
+
+def calculate_user_stats(df: pd.DataFrame) -> Dict[str, Any]:
+    """Calculate user-related statistics."""
+    user_stats: Dict[str, Any] = {}
+    user_col = None
+    for col in ["person_id", "user_id", "employee_id"]:
+        if col in df.columns:
+            user_col = col
+            break
+
+    if user_col:
+        user_stats["active_users"] = df[user_col].nunique()
+        user_stats["total_user_events"] = df[user_col].count()
+        user_stats["top_users"] = df[user_col].value_counts().head(10).to_dict()
+    else:
+        user_stats["error"] = "No user identifier column found"
+
+    return user_stats
+
+
+def calculate_access_stats(df: pd.DataFrame) -> Dict[str, Any]:
+    """Calculate access-related statistics."""
+    access_stats: Dict[str, Any] = {}
+
+    if "access_result" in df.columns:
+        access_counts = df["access_result"].value_counts()
+        access_stats["access_results"] = access_counts.to_dict()
+
+        total_events = len(df)
+        access_stats["access_percentages"] = {
+            result: (count / total_events) * 100
+            for result, count in access_counts.items()
+        }
+
+    if "door_id" in df.columns:
+        access_stats["active_doors"] = df["door_id"].nunique()
+        access_stats["door_usage"] = df["door_id"].value_counts().head(10).to_dict()
+
+    return access_stats
+
+
+def calculate_temporal_stats_safe(df: pd.DataFrame) -> Dict[str, Any]:
+    """Calculate temporal statistics with safe datetime handling."""
+    temporal_stats: Dict[str, Any] = {}
+
+    timestamp_col = None
+    for col in ["timestamp", "datetime", "date", "time"]:
+        if col in df.columns:
+            timestamp_col = col
+            break
+
+    if not timestamp_col:
+        logger.warning("No timestamp column found for temporal analysis")
+        return {"error": "No timestamp column found"}
+
+    try:
+        if df[timestamp_col].dtype == "object":
+            df[timestamp_col] = pd.to_datetime(df[timestamp_col], errors="coerce")
+
+        dates = safe_datetime_operation(df, timestamp_col, "date")
+        hours = safe_datetime_operation(df, timestamp_col, "hour")
+        weekdays = safe_datetime_operation(df, timestamp_col, "weekday")
+
+        if dates is not None:
+            temporal_stats["date_range"] = {
+                "start": str(dates.min()),
+                "end": str(dates.max()),
+                "total_days": (dates.max() - dates.min()).days,
+            }
+
+        if hours is not None:
+            temporal_stats["hourly_distribution"] = hours.value_counts().to_dict()
+
+        if weekdays is not None:
+            temporal_stats["weekday_distribution"] = weekdays.value_counts().to_dict()
+
+        temporal_stats["total_events"] = len(df)
+
+    except Exception as e:  # pragma: no cover - unexpected
+        logger.error(f"Error in temporal analysis: {e}")
+        temporal_stats["error"] = str(e)
+
+    return temporal_stats
+
+
+def apply_regular_analysis(df: pd.DataFrame, analysis_types: List[str]) -> Dict[str, Any]:
+    """Run selected analysis sections for regular analysis."""
+    result: Dict[str, Any] = {}
+
+    if "basic" in analysis_types:
+        result["basic_stats"] = calculate_basic_stats(df)
+
+    if "temporal" in analysis_types or "time" in analysis_types:
+        result["temporal_analysis"] = calculate_temporal_stats_safe(df)
+
+    if "user" in analysis_types:
+        result["user_analysis"] = calculate_user_stats(df)
+
+    if "access" in analysis_types:
+        result["access_analysis"] = calculate_access_stats(df)
+
+    return result
+
+
+def regular_analysis(df: pd.DataFrame, analysis_types: List[str]) -> Dict[str, Any]:
+    """Perform regular analysis for smaller DataFrames."""
+    logger.info(f"\U0001f4ca Starting regular analysis for {len(df):,} rows")
+
+    df = ensure_datetime_columns(df)
+
+    result = prepare_regular_result(df)
+    result.update(apply_regular_analysis(df, analysis_types))
+
+    logger.info(f"✅ Regular analysis completed for {len(df):,} rows")
+    return result
+
+
+__all__ = [
+    "prepare_regular_result",
+    "apply_regular_analysis",
+    "calculate_temporal_stats_safe",
+    "regular_analysis",
+    "calculate_basic_stats",
+    "calculate_user_stats",
+    "calculate_access_stats",
+]

--- a/tests/test_regular_analysis_helpers.py
+++ b/tests/test_regular_analysis_helpers.py
@@ -1,11 +1,13 @@
 import pandas as pd
-from services import AnalyticsService
+from services.result_formatting import (
+    prepare_regular_result,
+    apply_regular_analysis,
+)
 
 
 def test_prepare_regular_result():
     df = pd.DataFrame({"a": [1, 2]})
-    service = AnalyticsService()
-    res = service._prepare_regular_result(df)
+    res = prepare_regular_result(df)
     assert res["total_events"] == 2
     assert res["columns"] == ["a"]
     assert res["processing_summary"]["chunking_used"] is False
@@ -20,7 +22,6 @@ def test_apply_regular_analysis():
             "timestamp": pd.to_datetime(["2024-01-01", "2024-01-01", "2024-01-02"]),
         }
     )
-    service = AnalyticsService()
-    res = service._apply_regular_analysis(df, ["basic", "user"])
+    res = apply_regular_analysis(df, ["basic", "user"])
     assert "basic_stats" in res
     assert res["user_analysis"]["active_users"] == 2


### PR DESCRIPTION
## Summary
- move regular analysis helpers into `services.result_formatting`
- add `services.chunked_analysis` for chunked analytics workflow
- update the analytics service to delegate to the new helpers
- expose utilities from the services package
- fix missing `Any` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68649ab4347c8320bc7bf6da6a235c72