### PR TITLE
Remove insecure defaults for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ SECRET_KEY=your-key  # Change for production
 ```
 
 The secret key is not included in the default YAML files. Define
-`SECRET_KEY` in your environment or a `.env` file before starting the
+`SECRET_KEY` in a `.env` file or via Docker secrets before starting the
 application. The example scripts under `examples/` also rely on this
 variable through the `SecretManager` helper.
 
@@ -367,9 +367,11 @@ variables or Docker secrets:
 - `AUTH0_DOMAIN`
 - `AUTH0_AUDIENCE`
 
-All secrets can be provided via the `SecretManager` which supports `env`,
-`aws`, and `vault` backends. Place these values in `.env` or mount them as
-Docker secrets. See the [architecture diagram](docs/auth_flow.png) for
+All secrets **must** be provided via `.env` files or Docker secrets. The
+`SecretManager` supports `env`, `aws`, and `vault` backends so you can mount
+files under `/run/secrets` or rely on environment variables. Default
+credentials have been removed, so missing variables will now trigger a
+warning during startup. See the [architecture diagram](docs/auth_flow.png) for
 implementation details.
 
 The configuration loader performs a validation step on startup to ensure

--- a/config/dev_mode.py
+++ b/config/dev_mode.py
@@ -4,19 +4,30 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def setup_dev_mode():
-    """Set development defaults for missing Auth0 secrets"""
-    if os.getenv("YOSAI_ENV", "development") == "development":
-        defaults = {
-            "AUTH0_CLIENT_ID": "dev-client-id",
-            "AUTH0_CLIENT_SECRET": "dev-secret",
-            "AUTH0_DOMAIN": "dev.auth0.com",
-            "AUTH0_AUDIENCE": "dev-audience",
-            "SECRET_KEY": "dev-secret-key",
-            "DB_PASSWORD": "dev-password",
-        }
-        for key, value in defaults.items():
-            if not os.getenv(key):
-                os.environ[key] = value
-                logger.info(f"\ud83d\udd27 Set dev default: {key}")
+def setup_dev_mode() -> None:
+    """Warn about missing secrets and optionally load test defaults."""
+
+    env = os.getenv("YOSAI_ENV", "development").lower()
+
+    defaults = {
+        "AUTH0_CLIENT_ID": "test-client-id",
+        "AUTH0_CLIENT_SECRET": "test-secret",
+        "AUTH0_DOMAIN": "test.auth0.com",
+        "AUTH0_AUDIENCE": "test-audience",
+        "SECRET_KEY": "test-secret-key",
+        "DB_PASSWORD": "test-password",
+    }
+
+    for key, value in defaults.items():
+        if os.getenv(key):
+            continue
+
+        if env == "test":
+            os.environ[key] = value
+            logger.info("\ud83d\udd27 Loaded test default: %s", key)
+        else:
+            logger.warning(
+                "Environment variable %s is not set; application may fail", key
+            )
+
 

--- a/dash_csrf_plugin/__init__.py
+++ b/dash_csrf_plugin/__init__.py
@@ -54,7 +54,7 @@ class CSRFConfig:
         defaults = {
             'enabled': False,
             'ssl_strict': False,
-            'secret_key': 'change-me'
+            'secret_key': None
         }
         defaults.update(kwargs)
         return cls(**defaults)
@@ -149,10 +149,15 @@ class EnhancedCSRFManager:
     def _configure_server(self) -> None:
         """Configure Flask server for CSRF protection"""
         server = self.app.server
-        
+
         # Set secret key if not present
         if not server.config.get('SECRET_KEY'):
-            server.config['SECRET_KEY'] = self.config.secret_key or 'change-me'
+            if self.config.secret_key:
+                server.config['SECRET_KEY'] = self.config.secret_key
+            else:
+                logger.warning(
+                    "SECRET_KEY is not set; CSRF protection may be disabled"
+                )
         
         # Configure CSRF based on mode
         if self.mode in [CSRFMode.ENABLED, CSRFMode.PRODUCTION]:

--- a/dash_csrf_plugin/config.py
+++ b/dash_csrf_plugin/config.py
@@ -84,7 +84,7 @@ class CSRFConfig:
             'enabled': False,
             'ssl_strict': False,
             'check_referer': False,
-            'secret_key': 'change-me'
+            'secret_key': None
         }
         defaults.update(kwargs)
         return cls(**defaults)


### PR DESCRIPTION
## Summary
- prevent default secrets from being injected unless running tests
- drop fallback secret key from CSRF plugin
- warn when `SECRET_KEY` is missing instead of populating a placeholder
- document that secrets must come from `.env` or Docker secrets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68649abccc58832099ff162d4cbd870f