### PR TITLE
Add Hello World plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Deployment Diagram](docs/deployment_diagram.md)
 - [Analytics Upload Sequence](docs/analytics_sequence.md)
 
-The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery and configuration details.
+The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example.
 
 ```
 yosai_intel_dashboard/
@@ -286,6 +286,8 @@ options. In your app factory create a `PluginManager`, call
  of discovery, configuration and the plugin lifecycle. For step-by-step
  instructions on writing your own plugin check
  [docs/plugin_development.md](docs/plugin_development.md).
+The same document includes a minimal **Hello World** plugin showcasing
+`create_plugin()` and callback registration.
 
 ### Migration Notes
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,3 +36,5 @@ plugins:
     fallback_to_repr: true
     auto_wrap_callbacks: true
     force_complete_analysis: true
+  hello_world:
+    enabled: false  # example plugin shown in docs/plugins.md

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,6 +19,44 @@ plugins:
     max_dataframe_rows: 1000
 ```
 
+## Hello World Example
+
+A very small plugin can simply register a Dash callback. The module must expose
+a `create_plugin()` function so the `PluginManager` can instantiate it.
+
+```python
+# plugins/hello_world.py
+from dash import Input, Output
+from core.plugins.protocols import CallbackPluginProtocol, PluginMetadata
+
+
+class HelloWorldPlugin(CallbackPluginProtocol):
+    metadata = PluginMetadata(
+        name="hello_world",
+        version="1.0.0",
+        description="Example plugin",
+        author="Example",
+    )
+
+    def register_callbacks(self, manager, container):
+        @manager.app.callback(Output("hello-output", "children"), Input("hello-btn", "n_clicks"))
+        def _say_hello(_):
+            return "Hello World!"
+        return True
+
+
+def create_plugin() -> HelloWorldPlugin:
+    return HelloWorldPlugin()
+```
+
+Enable the plugin in `config/config.yaml`:
+
+```yaml
+plugins:
+  hello_world:
+    enabled: true
+```
+
 ## Lifecycle
 
 For each enabled plugin the manager calls these methods:


### PR DESCRIPTION
## Summary
- show how to write a Hello World plugin in docs/plugins.md
- document enabling it in config/config.yaml
- mention the example from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68649abfcb6c832092580c1d44b1b94d