### PR TITLE
Add roadmap and diagrams docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project follows a fully modular design built around a dependency injection 
 - [System Diagram](docs/system_diagram.md)
 - [Deployment Diagram](docs/deployment_diagram.md)
 - [Analytics Upload Sequence](docs/analytics_sequence.md)
+- [Roadmap](docs/roadmap.md)
+- [Sequence Diagrams](docs/sequence_diagrams.md)
 
 The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery and configuration details.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,13 @@
+# Project Roadmap
+
+This roadmap outlines the major milestones planned for the Yōsai Intel Dashboard.
+
+## Milestones
+
+- **Q1:** Implement user authentication and session management
+- **Q2:** Improve file ingestion pipeline with better validation
+- **Q3:** Add advanced analytics generation and reporting features
+- **Q4:** Launch plugin marketplace and developer SDK
+
+The timeline may adjust as priorities evolve, but these phases capture the
+current goals for the upcoming releases.

--- a/docs/sequence_diagrams.md
+++ b/docs/sequence_diagrams.md
@@ -1,0 +1,55 @@
+# Sequence Diagrams
+
+The following mermaid diagrams illustrate key interactions in the system.
+
+## User Login
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant A as AuthService
+    participant DB as Database
+
+    U->>B: Enter credentials
+    B->>A: POST /login
+    A->>DB: Verify user
+    DB-->>A: Success
+    A-->>B: Set session cookie
+    B-->>U: Redirect to dashboard
+```
+
+## File Upload
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant S as Server
+    participant FS as FileStorage
+
+    U->>B: Choose file
+    B->>S: POST /files
+    S->>FS: Save
+    FS-->>S: Path
+    S-->>B: Acknowledge
+    B-->>U: Show upload success
+```
+
+## Analytics Generation
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Server
+    participant AS as AnalyticsService
+    participant DB as Database
+
+    U->>S: Request analytics
+    S->>AS: fetch data()
+    AS->>DB: Query dataset
+    DB-->>AS: Results
+    AS->>AS: Compute metrics
+    AS-->>S: Aggregated data
+    S-->>U: Render charts
+```


### PR DESCRIPTION
## Summary
- add project roadmap
- document login, file upload, and analytics sequence diagrams
- reference roadmap and diagrams from the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: Duplicate module named "test_callback_helpers")*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649ac64cf8832087ab062955bbd9d4