### PR TITLE
Add production Dockerfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,37 @@
+FROM python:3.11-slim as builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and install requirements
+COPY requirements.txt .
+RUN pip install --no-cache-dir --user -r requirements.txt
+
+# Production stage
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy Python packages from builder
+COPY --from=builder /root/.local /root/.local
+
+# Add user
+RUN groupadd -r yosai && useradd -r -g yosai yosai
+
+# Copy application
+COPY --chown=yosai:yosai . .
+
+# Switch to non-root user
+USER yosai
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD python -c "import requests; requests.get('http://localhost:8050/health')"
+
+EXPOSE 8050
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8050", "--workers", "4", "wsgi:server"]


### PR DESCRIPTION
## Summary
- add optimized multi-stage `Dockerfile.prod` for production deployments

## Testing
- `black --check .` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864a581f8a48320bafabad7ca968281