### PR TITLE
Add diagrams and enhance OpenAPI generator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,9 @@ OpenAPI specification run:
 python tools/generate_openapi.py
 ```
 
+The script writes `docs/openapi.json`. Once generated, this file can be served
+by Swagger UI to display the complete API reference.
+
 ## Database Manager
 
 ### `DatabaseManager`

--- a/docs/architecture_diagrams.md
+++ b/docs/architecture_diagrams.md
@@ -1,0 +1,33 @@
+# Additional Architecture Diagrams
+
+These diagrams complement `architecture.md` by illustrating component interactions and a typical data flow.
+
+## Component Interaction
+
+```mermaid
+graph TD
+    UI[Browser UI] --> D(Dash frontend)
+    D --> F(Flask backend)
+    F --> S(Service layer)
+    S --> M(Data models)
+    M --> DB[(Database)]
+```
+
+## Upload Processing Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Dash frontend
+    participant BE as Flask backend
+    participant S as Service layer
+    participant DB as Database
+
+    U->>FE: Upload file
+    FE->>BE: POST /upload
+    BE->>S: Validate and parse
+    S->>DB: Store records
+    S-->>BE: Processed analytics
+    BE-->>FE: Return results
+    FE-->>U: Show analytics
+```

--- a/tools/generate_openapi.py
+++ b/tools/generate_openapi.py
@@ -1,6 +1,16 @@
 from pathlib import Path
 import json
-from flasgger import Swagger
+import sys
+
+try:
+    from flasgger import Swagger
+except ImportError as exc:
+    print(
+        "Flasgger is required to generate the OpenAPI specification.\n"
+        "Install it with 'pip install flasgger'."
+    )
+    sys.exit(1)
+
 from core.app_factory import create_app
 
 


### PR DESCRIPTION
## Summary
- add additional architecture diagrams
- clarify how to regenerate the API spec
- handle missing Flasgger dependency gracefully

## Testing
- `python tools/generate_openapi.py` *(fails: Flasgger missing)*
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864aea3c9f483209664bdf837493227