### PR TITLE
Improve DB timeout handling and retry logic

### DIFF
--- a/tests/test_connection_retry.py
+++ b/tests/test_connection_retry.py
@@ -11,7 +11,9 @@ def test_retry_success(monkeypatch):
         attempts.append(1)
         return "ok"
 
-    retry = ConnectionRetryManager(RetryConfig(max_attempts=3, base_delay=0))
+    retry = ConnectionRetryManager(
+        RetryConfig(max_attempts=3, base_delay=0, jitter=False)
+    )
     result = retry.run_with_retry(func)
     assert result == "ok"
     assert len(attempts) == 1
@@ -26,7 +28,9 @@ def test_retry_attempts(monkeypatch):
             raise ValueError("boom")
         return "done"
 
-    retry = ConnectionRetryManager(RetryConfig(max_attempts=5, base_delay=0))
+    retry = ConnectionRetryManager(
+        RetryConfig(max_attempts=5, base_delay=0, jitter=False)
+    )
     result = retry.run_with_retry(func)
     assert result == "done"
     assert len(calls) == 3
@@ -36,7 +40,36 @@ def test_retry_exhausted(monkeypatch):
     def func():
         raise RuntimeError("fail")
 
-    retry = ConnectionRetryManager(RetryConfig(max_attempts=2, base_delay=0))
+    retry = ConnectionRetryManager(
+        RetryConfig(max_attempts=2, base_delay=0, jitter=False)
+    )
     with pytest.raises(ConnectionRetryExhausted):
         retry.run_with_retry(func)
 
+
+def test_backoff_and_max_delay(monkeypatch):
+    delays = []
+
+    def fake_sleep(d):
+        delays.append(d)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    calls = []
+
+    def func():
+        calls.append(1)
+        if len(calls) < 3:
+            raise RuntimeError("boom")
+        return "ok"
+
+    cfg = RetryConfig(
+        max_attempts=3,
+        base_delay=1,
+        backoff_factor=3,
+        max_delay=2,
+        jitter=False,
+    )
+    result = ConnectionRetryManager(cfg).run_with_retry(func)
+    assert result == "ok"
+    assert delays == [1, 2]


### PR DESCRIPTION
## Summary
- define module logger in `database_manager`
- pass connection timeout to SQLite and PostgreSQL connectors
- enforce wait timeout in `DatabaseConnectionPool.get_connection`
- extend retry backoff configuration and tests

## Testing
- `pytest -q tests/test_connection_retry.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864af8b76848320a5630f8d32da6c44