### PR TITLE
Fix Pylance type issues

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -790,7 +790,9 @@ class Callbacks:
             {"field": "entry_type", "label": "Entry/Exit Type", "description": "Direction of access"},
         ]
 
-        csv_column_options = [{"label": f'"{col}"', "value": col} for col in columns]
+        csv_column_options: List[Dict[str, str]] = [
+            {"label": f'"{col}"', "value": col} for col in columns
+        ]
         csv_column_options.append({"label": "Skip this field", "value": "skip"})
 
         table_rows = []

--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -84,8 +84,14 @@ def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert
 
         # Display sample (but show actual count in stats)
         preview_df = df.head(preview_rows).copy()
-        preview_df.columns = [XSSPrevention.sanitize_html_output(str(c)) for c in preview_df.columns]
-        preview_df = preview_df.applymap(lambda x: XSSPrevention.sanitize_html_output(str(x)))
+        preview_df.columns = [
+            XSSPrevention.sanitize_html_output(str(c)) for c in preview_df.columns
+        ]
+
+        def _sanitize(value: Any) -> str:
+            return XSSPrevention.sanitize_html_output(str(value))
+
+        preview_df = preview_df.applymap(_sanitize)
 
         # Display status messaging based on file size
         if actual_rows <= 10:
@@ -144,7 +150,7 @@ def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert
                             hover=True,
                             responsive=True,
                             size="sm",
-                        ),
+                        ),  # type: ignore[attr-defined]
 
                         # ADDITIONAL: Clear indication of processing vs display
                         dbc.Alert(


### PR DESCRIPTION
## Summary
- implement local `get_ai_suggestions_for_file` and import correct AI helper
- widen return type annotations for analysis UI helpers
- fix dropdown options typing in file_upload
- ensure database config types align in AnalyticsService
- guard FileProcessor usage, clarify Pandas comparisons, annotate health check
- sanitize preview dataframe safely and mark Table helper for pylance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864b5a02ee08320bbb17c08d31baa45