### PR TITLE
Fix user device mapping key

### DIFF
--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -190,7 +190,7 @@ class DeviceLearningService:
                 "filename": filename,
                 "fingerprint": fingerprint,
                 "saved_at": datetime.now().isoformat(),
-                "device_mappings": user_mappings,
+                "mappings": user_mappings,
                 "source": "user_confirmed",
                 "device_count": len(user_mappings),
             }


### PR DESCRIPTION
## Summary
- correct key when saving user device mappings so `get_learned_mappings` can read them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864ef6530d08320a83bd7d44a37682c