### PR TITLE
Remove learned_mappings.pkl instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ assets/.webassets-cache
 # Data
 data/uploads/*
 !data/uploads/.gitkeep
-data/learned_mappings.pkl
+data/learned_mappings.json
 *.csv
 *.xlsx
 *.json

--- a/docs/device_learning_service.md
+++ b/docs/device_learning_service.md
@@ -30,19 +30,9 @@ when similar files are uploaded again.
 3. When a matching file is processed later, mappings are loaded and
    applied automatically.
 
-### Regenerating `learned_mappings.pkl`
+### Legacy pickle file
 
-Older versions of the dashboard stored learned mappings in
-`data/learned_mappings.pkl`. The current service writes mappings to
-`data/learned_mappings.json` instead and will automatically migrate the
-pickle file if it exists. If you need to recreate the legacy
-`learned_mappings.pkl` for testing, run the application and save some
-device mappings, then manually convert the JSON output:
-
-```bash
-python app.py  # upload a file and confirm mappings
-cp data/learned_mappings.json data/learned_mappings.pkl
-```
-
-Alternatively, download a sample file from
-`docs/example_data/training/` and place it in the `data` directory.
+Earlier versions of the dashboard stored learned mappings in
+`data/learned_mappings.pkl`. Loading this pickle file has been
+completely removed for security reasons. The service now persists and
+loads mappings only from `data/learned_mappings.json`.


### PR DESCRIPTION
## Summary
- document JSON as the only supported format for learned device mappings
- ignore learned_mappings.json instead of the old pickle file

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ee60bf4c8320a0c2bc22cb9ffb08