### PR TITLE
Add flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist


### PR DESCRIPTION
## Summary
- configure flake8 defaults in `.flake8`
- CI already runs `flake8 .` so it will pick up the configuration automatically

## Testing
- `flake8 .` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865427b69508320b8f765d9b55c74e1