### PR TITLE
Resolve Pylance issues

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any
+from dash.development.base_component import Component
 import pandas as pd
 import logging
 
@@ -207,34 +208,37 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
     suggestions_store = dcc.Store(id="ai-suggestions-store", data=ai_mapping_store.all())
     status_div = html.Div(id="device-save-status")
 
-    modal_body = html.Div(
-        [
-            device_store,
-            suggestions_store,
-            status_div,
+    modal_children: List[Component] = [
+        device_store,
+        suggestions_store,
+        status_div,
+        dbc.Alert(
+            [
+                "Manually assign floor numbers and security levels to devices. ",
+                (
+                    html.Strong("AI suggestions have been pre-filled!")
+                    if len(ai_mapping_store)
+                    else "Fill in device details manually."
+                ),
+            ],
+            color="info" if len(ai_mapping_store) else "warning",
+        ),
+    ]
+
+    if len(ai_mapping_store):
+        modal_children.append(
             dbc.Alert(
                 [
-                    "Manually assign floor numbers and security levels to devices. ",
-                    (
-                        html.Strong("AI suggestions have been pre-filled!")
-                        if len(ai_mapping_store)
-                        else "Fill in device details manually."
-                    ),
+                    html.Strong("🤖 AI Transfer: "),
+                    f"Loaded {len(ai_mapping_store)} AI-learned device mappings as defaults",
                 ],
-                color="info" if len(ai_mapping_store) else "warning",
-            ),
-            (
-                dbc.Alert(
-                    [
-                        html.Strong(f"🤖 AI Transfer: "),
-                        f"Loaded {len(ai_mapping_store)} AI-learned device mappings as defaults",
-                    ],
-                    color="light",
-                    className="small",
-                )
-                if len(ai_mapping_store)
-                else None
-            ),
+                color="light",
+                className="small",
+            )
+        )
+
+    modal_children.extend(
+        [
             dbc.Row(
                 [
                     dbc.Col(
@@ -260,6 +264,8 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
             ),
         ]
     )
+
+    modal_body = html.Div(modal_children)
 
     return dbc.Modal(
         [

--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -83,7 +83,7 @@ def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert
             column_info.append(f"{safe_col} ({dtype}) - {null_count} nulls")
 
         # Display sample (but show actual count in stats)
-        preview_df = df.head(preview_rows).copy()
+        preview_df: pd.DataFrame = df.head(preview_rows).copy()
         preview_df.columns = [
             XSSPrevention.sanitize_html_output(str(c)) for c in preview_df.columns
         ]
@@ -143,14 +143,14 @@ def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert
                         ),
                         html.Hr(),
                         html.H6(f"Sample Data (first {preview_rows} rows):", className="text-primary mt-3"),
-                        dbc.Table.from_dataframe(
+                        dbc.Table.from_dataframe(  # pyright: ignore[reportAttributeAccessIssue]
                             preview_df,
                             striped=True,
                             bordered=True,
                             hover=True,
                             responsive=True,
                             size="sm",
-                        ),  # type: ignore[attr-defined]
+                        ),
 
                         # ADDITIONAL: Clear indication of processing vs display
                         dbc.Alert(


### PR DESCRIPTION
## Summary
- avoid `None` in modal children
- annotate preview dataframe type
- silence Pylance missing attribute warning for `dbc.Table`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686541c6e4248320beb8461f8f8be406