### PR TITLE
Fix Pylance issues

### DIFF
--- a/analytics/anomaly_detection.py
+++ b/analytics/anomaly_detection.py
@@ -162,12 +162,12 @@ class AnomalyDetector:
             if len(user_access_counts) < 3:
                 return anomalies
                 
-            z_scores = np.abs(stats.zscore(user_access_counts))
+            z_scores = np.abs(stats.zscore(user_access_counts.to_numpy()))
             
             outlier_users = user_access_counts[z_scores > z_threshold]
             
             for user_id, access_count in outlier_users.items():
-                z_score = z_scores[user_access_counts.index == user_id].iloc[0]
+                z_score = float(z_scores[user_access_counts.index == user_id].iloc[0])
                 
                 mean_access = user_access_counts.mean()
                 anomaly_type = 'excessive_access_frequency' if access_count > mean_access else 'insufficient_access_frequency'
@@ -275,7 +275,7 @@ class AnomalyDetector:
                 outlier_doors = door_usage[np.abs(modified_z_scores) > mad_threshold]
                 
                 for door_id, usage_count in outlier_doors.items():
-                    z_score = abs(modified_z_scores[door_id])
+                    z_score = float(abs(modified_z_scores[door_id]))
                     
                     anomaly_type = 'door_overuse' if usage_count > median_usage else 'door_underuse'
                     severity = self._calculate_severity_from_zscore(z_score)
@@ -526,7 +526,7 @@ class AnomalyDetector:
             
             for idx in anomaly_indices:
                 original_idx = features_df.index[idx]
-                anomaly_score = abs(anomaly_scores[idx])
+                anomaly_score = float(abs(anomaly_scores[idx]))
                 
                 # Calculate confidence
                 confidence = min(0.95, anomaly_score / 2)

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -127,21 +127,18 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
         if ai_data.get("is_restricted", ai_data.get("restricted")):
             default_special.append("is_restricted")
 
+        col_children = [html.Strong(device)]
+        if ai_data:
+            col_children.append(html.Br())
+            col_children.append(
+                dbc.Badge("AI Suggested", color="info", className="small")
+            )
+
         device_rows.append(
             dbc.Row(
                 [
                     dbc.Col(
-                        [
-                            html.Strong(device),
-                            html.Br() if ai_data else None,
-                            (
-                                dbc.Badge(
-                                    "AI Suggested", color="info", className="small"
-                                )
-                                if ai_data
-                                else None
-                            ),
-                        ],
+                        col_children,
                         width=3,  # CHANGED: from 4 to 3
                     ),
                     dbc.Col(


### PR DESCRIPTION
## Summary
- fix deprecated scipy call and cast IDs to strings when building threat indicators
- ensure statistical calculations cast to plain floats
- avoid None children in device mapping modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865b9acdb288320add249f6039ded14