### PR TITLE
Refactor upload page services

### DIFF
--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -1,0 +1,9 @@
+from .processing import UploadProcessingService
+from .ai import AISuggestionService
+from .modal import ModalService
+
+__all__ = [
+    "UploadProcessingService",
+    "AISuggestionService",
+    "ModalService",
+]

--- a/services/upload/ai.py
+++ b/services/upload/ai.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Any, Dict, List
+
+from dash.dash import no_update
+
+logger = logging.getLogger(__name__)
+
+
+class AISuggestionService:
+    """Service for AI-driven helpers used in the upload page."""
+
+    def analyze_device_name_with_ai(self, device_name: str) -> Dict[str, Any]:
+        try:
+            from services.ai_mapping_store import ai_mapping_store
+            mapping = ai_mapping_store.get(device_name)
+            if mapping and mapping.get("source") == "user_confirmed":
+                logger.info("🔐 Using USER CONFIRMED mapping for '%s'", device_name)
+                return mapping
+
+            logger.info("🤖 No user mapping found, generating AI analysis for '%s'", device_name)
+            from services.ai_device_generator import AIDeviceGenerator
+
+            ai_generator = AIDeviceGenerator()
+            result = ai_generator.generate_device_attributes(device_name)
+            return {
+                "floor_number": result.floor_number,
+                "security_level": result.security_level,
+                "confidence": result.confidence,
+                "is_entry": result.is_entry,
+                "is_exit": result.is_exit,
+                "device_name": result.device_name,
+                "ai_reasoning": result.ai_reasoning,
+                "source": "ai_generated",
+            }
+        except Exception as exc:
+            logger.info("❌ Error in device analysis: %s", exc)
+            return {
+                "floor_number": 1,
+                "security_level": 5,
+                "confidence": 0.1,
+                "source": "fallback",
+            }
+
+    def apply_ai_suggestions(self, n_clicks: int | None, file_info: Dict[str, Any]):
+        if not n_clicks or not file_info:
+            return [no_update]
+
+        ai_suggestions = file_info.get("ai_suggestions", {})
+        columns: List[str] = file_info.get("columns", [])
+
+        logger.info("🤖 Applying AI suggestions for %s columns", len(columns))
+        suggested_values: List[Any] = []
+        for column in columns:
+            suggestion = ai_suggestions.get(column, {})
+            confidence = suggestion.get("confidence", 0.0)
+            field = suggestion.get("field", "")
+            if confidence > 0.3 and field:
+                suggested_values.append(field)
+                logger.info("   ✅ %s -> %s (%.0f%%)", column, field, confidence * 100)
+            else:
+                suggested_values.append(None)
+                logger.info("   ❓ %s -> No confident suggestion (%.0f%%)", column, confidence * 100)
+        return [suggested_values]
+
+__all__ = ["AISuggestionService"]

--- a/services/upload/modal.py
+++ b/services/upload/modal.py
@@ -1,0 +1,34 @@
+from typing import Any, Tuple
+import logging
+from dash.dash import no_update
+
+logger = logging.getLogger(__name__)
+
+
+class ModalService:
+    """Service managing modal open/close logic for the upload page."""
+
+    def handle_dialogs(
+        self,
+        verify_clicks: int | None,
+        classify_clicks: int | None,
+        confirm_clicks: int | None,
+        cancel_col_clicks: int | None,
+        cancel_dev_clicks: int | None,
+        trigger_id: str,
+    ) -> Tuple[Any, Any, Any]:
+        if "verify-columns-btn-simple" in trigger_id and verify_clicks:
+            return no_update, True, no_update
+
+        if "classify-devices-btn" in trigger_id and classify_clicks:
+            return no_update, no_update, True
+
+        if "column-verify-confirm" in trigger_id and confirm_clicks:
+            return no_update, False, no_update
+
+        if "column-verify-cancel" in trigger_id or "device-verify-cancel" in trigger_id:
+            return no_update, False, False
+
+        return no_update, no_update, no_update
+
+__all__ = ["ModalService"]

--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -1,0 +1,230 @@
+import logging
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+from dash import html
+from dash.dash import no_update
+import dash_bootstrap_components as dbc
+
+from services.upload_service import process_uploaded_file, create_file_preview
+from services.device_learning_service import get_device_learning_service
+from services.ai_suggestions import generate_column_suggestions
+from utils.upload_store import UploadedDataStore
+
+logger = logging.getLogger(__name__)
+
+
+class UploadProcessingService:
+    """Service handling processing of uploaded files."""
+
+    def __init__(self, store: UploadedDataStore):
+        self.store = store
+
+    def build_success_alert(
+        self,
+        filename: str,
+        rows: int,
+        cols: int,
+        prefix: str = "Successfully uploaded",
+        processed: bool = True,
+    ) -> dbc.Alert:
+        details = f"📊 {rows:,} rows × {cols} columns"
+        if processed:
+            details += " processed"
+        timestamp = pd.Timestamp.now().strftime("%H:%M:%S")
+        return dbc.Alert(
+            [
+                html.H6(
+                    [html.I(className="fas fa-check-circle me-2"), f"{prefix} {filename}"],
+                    className="alert-heading",
+                ),
+                html.P(
+                    [
+                        details,
+                        html.Br(),
+                        html.Small(f"Processed at {timestamp}", className="text-muted"),
+                    ]
+                ),
+            ],
+            color="success",
+            className="mb-3",
+        )
+
+    def build_failure_alert(self, message: str) -> dbc.Alert:
+        return dbc.Alert(
+            [html.H6("Upload Failed", className="alert-heading"), html.P(message)],
+            color="danger",
+        )
+
+    def auto_apply_learned_mappings(self, df: pd.DataFrame, filename: str) -> bool:
+        try:
+            learning_service = get_device_learning_service()
+            learned = learning_service.get_learned_mappings(df, filename)
+            if learned:
+                learning_service.apply_learned_mappings_to_global_store(df, filename)
+                logger.info(
+                    "🤖 Auto-applied %s learned device mappings", len(learned)
+                )
+                return True
+            return False
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Failed to auto-apply learned mappings: %s", exc)
+            return False
+
+    def build_file_preview_component(self, df: pd.DataFrame, filename: str) -> html.Div:
+        return html.Div(
+            [
+                create_file_preview(df, filename),
+                dbc.Card(
+                    [
+                        dbc.CardHeader(
+                            [html.H6("📋 Data Configuration", className="mb-0")]
+                        ),
+                        dbc.CardBody(
+                            [
+                                html.P(
+                                    "Configure your data for analysis:", className="mb-3"
+                                ),
+                                dbc.ButtonGroup(
+                                    [
+                                        dbc.Button(
+                                            "📋 Verify Columns",
+                                            id="verify-columns-btn-simple",
+                                            color="primary",
+                                            size="sm",
+                                        ),
+                                        dbc.Button(
+                                            "🤖 Classify Devices",
+                                            id="classify-devices-btn",
+                                            color="info",
+                                            size="sm",
+                                        ),
+                                    ],
+                                    className="w-100",
+                                ),
+                            ]
+                        ),
+                    ],
+                    className="mb-3",
+                ),
+            ]
+        )
+
+    def process_files(
+        self, contents_list: List[str] | str, filenames_list: List[str] | str
+    ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
+        if not contents_list:
+            return (
+                no_update,
+                no_update,
+                no_update,
+                no_update,
+                no_update,
+                no_update,
+                no_update,
+            )
+
+        self.store.clear_all()
+
+        if not isinstance(contents_list, list):
+            contents_list = [contents_list]
+        if not isinstance(filenames_list, list):
+            filenames_list = [filenames_list]
+
+        upload_results: List[Any] = []
+        file_preview_components: List[Any] = []
+        file_info_dict: Dict[str, Any] = {}
+        current_file_info: Dict[str, Any] = {}
+
+        file_parts: Dict[str, List[str]] = {}
+        for content, filename in zip(contents_list, filenames_list):
+            file_parts.setdefault(filename, []).append(content)
+
+        for filename, parts in file_parts.items():
+            if len(parts) > 1:
+                prefix, first = parts[0].split(",", 1)
+                combined_data = first
+                for part in parts[1:]:
+                    _pfx, data = part.split(",", 1)
+                    combined_data += data
+                content = f"{prefix},{combined_data}"
+            else:
+                content = parts[0]
+
+            try:
+                result = process_uploaded_file(content, filename)
+                if result["success"]:
+                    df = result["data"]
+                    rows = len(df)
+                    cols = len(df.columns)
+
+                    self.store.add_file(filename, df)
+                    upload_results.append(self.build_success_alert(filename, rows, cols))
+                    file_preview_components.append(self.build_file_preview_component(df, filename))
+
+                    column_names = df.columns.tolist()
+                    file_info_dict[filename] = {
+                        "filename": filename,
+                        "rows": rows,
+                        "columns": cols,
+                        "column_names": column_names,
+                        "upload_time": result["upload_time"].isoformat(),
+                        "ai_suggestions": generate_column_suggestions(column_names),
+                    }
+                    current_file_info = file_info_dict[filename]
+
+                    try:
+                        learning_service = get_device_learning_service()
+                        user_mappings = learning_service.get_user_device_mappings(filename)
+                        if user_mappings:
+                            from services.ai_mapping_store import ai_mapping_store
+
+                            ai_mapping_store.clear()
+                            for device, mapping in user_mappings.items():
+                                mapping["source"] = "user_confirmed"
+                                ai_mapping_store.set(device, mapping)
+                            logger.info(
+                                "✅ Loaded %s saved mappings - AI SKIPPED",
+                                len(user_mappings),
+                            )
+                        else:
+                            logger.info("🆕 First upload - AI will be used")
+                            from services.ai_mapping_store import ai_mapping_store
+
+                            ai_mapping_store.clear()
+                            self.auto_apply_learned_mappings(df, filename)
+                    except Exception as exc:  # pragma: no cover - best effort
+                        logger.info("⚠️ Error: %s", exc)
+                else:
+                    upload_results.append(self.build_failure_alert(result["error"]))
+            except Exception as exc:  # pragma: no cover - best effort
+                upload_results.append(
+                    self.build_failure_alert(f"Error processing {filename}: {str(exc)}")
+                )
+
+        upload_nav = []
+        if file_info_dict:
+            upload_nav = html.Div(
+                [
+                    html.Hr(),
+                    html.H5("Ready to analyze?"),
+                    dbc.Button(
+                        "🚀 Go to Analytics",
+                        href="/analytics",
+                        color="success",
+                        size="lg",
+                    ),
+                ]
+            )
+
+        return (
+            upload_results,
+            file_preview_components,
+            file_info_dict,
+            upload_nav,
+            current_file_info,
+            no_update,
+            no_update,
+        )
+
+__all__ = ["UploadProcessingService"]

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -2,6 +2,7 @@ import base64
 import pandas as pd
 
 from pages.file_upload import Callbacks, _uploaded_data_store
+from services.upload import UploadProcessingService
 
 
 def test_multi_part_upload_row_count():
@@ -17,6 +18,7 @@ def test_multi_part_upload_row_count():
     part2 = prefix + b64[mid:]
 
     cb = Callbacks()
+    cb.processing = UploadProcessingService(_uploaded_data_store)
     res = cb.process_uploaded_files([part1, part2], ["sample.csv", "sample.csv"])
     info = res[2]
     assert info["sample.csv"]["rows"] == len(df)

--- a/tests/test_process_uploaded_files_split.py
+++ b/tests/test_process_uploaded_files_split.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from pages import file_upload
 from pages.file_upload import Callbacks
+from services.upload import UploadProcessingService
 from utils.upload_store import UploadedDataStore
 
 
@@ -25,6 +26,7 @@ def test_process_uploaded_files_split(monkeypatch, tmp_path):
     monkeypatch.setattr(file_upload, "_uploaded_data_store", store)
 
     cb = Callbacks()
+    cb.processing = UploadProcessingService(store)
     result = cb.process_uploaded_files(contents_list, filenames_list)
     info = result[2]
 


### PR DESCRIPTION
## Summary
- split upload helpers into `services/upload/`
- delegate processing, AI logic and modal handling to new service classes
- inject services into page callbacks
- update tests for new service classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865c6253cdc8320906ac075e4164a70