### PR TITLE
Refactor deep analytics helpers

### DIFF
--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -24,34 +24,16 @@ import plotly.graph_objects as go
 # Add this import
 from services import AnalyticsService
 from utils.unicode_handler import sanitize_unicode_input, safe_format_number
+from utils.analysis_helpers import (
+    build_ai_suggestions,
+    render_results_card,
+    get_display_title,
+)
 
 # Internal service imports with CORRECTED paths
 ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
-from services.ai_suggestions import generate_column_suggestions
 
-
-def get_ai_suggestions_for_file(df: pd.DataFrame, filename: str) -> Dict[str, Dict[str, Any]]:
-    """Return AI column suggestions for ``df`` columns."""
-    try:
-        return generate_column_suggestions(list(df.columns))
-    except Exception:
-        suggestions: Dict[str, Dict[str, Any]] = {}
-        for col in df.columns:
-            col_lower = col.lower().strip()
-            if any(word in col_lower for word in ["time", "date", "stamp"]):
-                suggestions[col] = {"field": "timestamp", "confidence": 0.8}
-            elif any(word in col_lower for word in ["person", "user", "employee"]):
-                suggestions[col] = {"field": "person_id", "confidence": 0.7}
-            elif any(word in col_lower for word in ["door", "location", "device"]):
-                suggestions[col] = {"field": "door_id", "confidence": 0.7}
-            elif any(word in col_lower for word in ["access", "result", "status"]):
-                suggestions[col] = {"field": "access_result", "confidence": 0.6}
-            elif any(word in col_lower for word in ["token", "badge", "card"]):
-                suggestions[col] = {"field": "token_id", "confidence": 0.6}
-            else:
-                suggestions[col] = {"field": "", "confidence": 0.0}
-        return suggestions
 
 
 AI_SUGGESTIONS_AVAILABLE = True
@@ -59,16 +41,7 @@ AI_SUGGESTIONS_AVAILABLE = True
 # Logger setup
 logger = logging.getLogger(__name__)
 
-# Helper for display titles
-def _get_display_title(analysis_type: str) -> str:
-    """Get proper display title for analysis type"""
-    title_map = {
-        'security': 'Security Results',
-        'trends': 'Trends Results',
-        'behavior': 'Behavior Results',
-        'anomaly': 'Anomaly Results'
-    }
-    return title_map.get(analysis_type.lower(), f"{analysis_type.title()} Results")
+# Helper for display titles moved to utils.analysis_helpers
 
 # =============================================================================
 # SECTION 2: SAFE SERVICE UTILITIES
@@ -187,51 +160,7 @@ def process_suggests_analysis(data_source: str) -> Dict[str, Any]:
             # Get AI suggestions
             if AI_SUGGESTIONS_AVAILABLE:
                 try:
-                    suggestions = get_ai_suggestions_for_file(df, filename)
-
-                    processed_suggestions = []
-                    total_confidence = 0
-                    confident_mappings = 0
-
-                    for column, suggestion in suggestions.items():
-                        field = suggestion.get("field", "")
-                        confidence = suggestion.get("confidence", 0.0)
-
-                        status = (
-                            "🟢 High"
-                            if confidence >= 0.7
-                            else "🟡 Medium" if confidence >= 0.4 else "🔴 Low"
-                        )
-
-                        try:
-                            sample_data = (
-                                df[column].dropna().head(3).astype(str).tolist()
-                            )
-                        except KeyError:
-                            logger.warning("Column %s missing when sampling data", column)
-                            sample_data = ["N/A"]
-                        except Exception as e:
-                            logger.exception("Error sampling data for column %s: %s", column, e)
-                            sample_data = ["N/A"]
-
-                        processed_suggestions.append(
-                            {
-                                "column": column,
-                                "suggested_field": field if field else "No suggestion",
-                                "confidence": confidence,
-                                "status": status,
-                                "sample_data": sample_data,
-                            }
-                        )
-
-                        total_confidence += confidence
-                        if confidence >= 0.6:
-                            confident_mappings += 1
-
-                    avg_confidence = (
-                        total_confidence / len(suggestions) if suggestions else 0
-                    )
-
+                    processed_suggestions, avg_confidence, confident_mappings = build_ai_suggestions(df)
                     try:
                         data_preview = df.head(5).to_dict("records")
                     except Exception as e:
@@ -670,152 +599,10 @@ def process_quality_analysis(data_source: str) -> Dict[str, Any]:
             }
 
         return {"error": "Data quality analysis only available for uploaded files"}
-    except Exception as e:
-        logger.exception("Quality analysis processing error: %s", e)
-        return {"error": f"Quality analysis error: {str(e)}"}
-
-
-# Helper extraction functions for results processing
-def _extract_counts(results: Dict[str, Any]) -> Dict[str, int]:
-    """Extract proper counts from results handling sets and other data types"""
-    total_events = results.get('total_events', 0)
-
-    unique_users_raw = results.get('unique_users', 0)
-    if isinstance(unique_users_raw, (set, list)):
-        unique_users = len(unique_users_raw)
-    else:
-        unique_users = int(unique_users_raw) if unique_users_raw else 0
-
-    unique_doors_raw = results.get('unique_doors', 0)
-    if isinstance(unique_doors_raw, (set, list)):
-        unique_doors = len(unique_doors_raw)
-    else:
-        unique_doors = int(unique_doors_raw) if unique_doors_raw else 0
-
-    success_rate = results.get('success_rate', 0)
-    if success_rate == 0:
-        successful = results.get('successful_events', 0)
-        failed = results.get('failed_events', 0)
-        if (successful + failed) > 0:
-            success_rate = successful / (successful + failed)
-
-    return {
-        'total_events': total_events,
-        'unique_users': unique_users,
-        'unique_doors': unique_doors,
-        'success_rate': success_rate,
-    }
-
-
-def _extract_security_metrics(results: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract security-specific metrics from results"""
-    security_score_raw = results.get('security_score', {})
-
-    if hasattr(security_score_raw, 'score'):
-        score_val = float(security_score_raw.score)
-        risk_level = security_score_raw.threat_level.title()
-    elif isinstance(security_score_raw, dict):
-        score_val = float(security_score_raw.get('score', 0.0))
-        risk_level = security_score_raw.get('threat_level', 'unknown').title()
-    else:
-        score_val = float(security_score_raw) if security_score_raw else 0.0
-        risk_level = 'Unknown'
-
-    failed_attempts = results.get('failed_attempts', 0)
-    if failed_attempts == 0:
-        failed_attempts = results.get('failed_events', 0)
-
-    return {
-        'score': score_val,
-        'risk_level': risk_level,
-        'failed_attempts': failed_attempts,
-    }
-
 def create_analysis_results_display(results: Dict[str, Any], analysis_type: str) -> html.Div | dbc.Card | dbc.Alert:
     """Create display for different analysis types"""
-    try:
-        counts = _extract_counts(results)
-        total_events = counts['total_events']
-        unique_users = counts['unique_users']
-        unique_doors = counts['unique_doors']
-        success_rate = counts['success_rate']
-        analysis_focus = results.get('analysis_focus', '')
+    return render_results_card(results, analysis_type)
 
-        # Create type-specific content
-        if analysis_type == "security":
-            sec_metrics = _extract_security_metrics(results)
-            specific_content = [
-                html.P(f"Security Score: {sec_metrics['score']:.1f}/100"),
-                html.P(f"Failed Attempts: {sec_metrics['failed_attempts']:,}"),
-                html.P(f"Risk Level: {sec_metrics['risk_level']}")
-            ]
-            color = "danger" if sec_metrics['risk_level'] == "High" else "warning" if sec_metrics['risk_level'] == "Medium" else "success"
-
-        elif analysis_type == "trends":
-            specific_content = [
-                html.P(f"Daily Average: {results.get('daily_average', 0):.0f} events"),
-                html.P(f"Peak Usage: {results.get('peak_usage', 'Unknown')}"),
-                html.P(f"Trend: {results.get('trend_direction', 'Unknown')}")
-            ]
-            color = "info"
-
-        elif analysis_type == "behavior":
-            specific_content = [
-                html.P(f"Avg Accesses/User: {results.get('avg_accesses_per_user', 0):.1f}"),
-                html.P(f"Heavy Users: {results.get('heavy_users', 0)}"),
-                html.P(f"Behavior Score: {results.get('behavior_score', 'Unknown')}")
-            ]
-            color = "success"
-
-        elif analysis_type == "anomaly":
-            specific_content = [
-                html.P(f"Anomalies Detected: {results.get('anomalies_detected', 0):,}"),
-                html.P(f"Threat Level: {results.get('threat_level', 'Unknown')}"),
-                html.P(f"Status: {results.get('suspicious_activities', 'Unknown')}")
-            ]
-            color = "danger" if results.get('threat_level') == "Critical" else "warning"
-
-        else:
-            specific_content = [html.P("Standard analysis completed")]
-            color = "info"
-
-        title_safe = sanitize_unicode_input(_get_display_title(analysis_type))
-        events_safe = safe_format_number(total_events)
-        users_safe = safe_format_number(unique_users)
-        doors_safe = safe_format_number(unique_doors)
-
-        return dbc.Card([
-            dbc.CardHeader([
-                html.H5(f"📊 {title_safe}")
-            ]),
-            dbc.CardBody([
-                dbc.Row([
-                    dbc.Col([
-                        html.H6("📈 Summary"),
-                        html.P(f"Total Events: {events_safe}"),
-                        html.P(f"Unique Users: {users_safe}"),
-                        html.P(f"Unique Doors: {doors_safe}"),
-                        dbc.Progress(
-                            value=success_rate * 100,
-                            label=f"Success Rate: {success_rate:.1%}",
-                            color="success" if success_rate > 0.8 else "warning"
-                        )
-                    ], width=6),
-                    dbc.Col([
-                        html.H6(f"🎯 {analysis_type.title()} Specific"),
-                        html.Div(specific_content)
-                    ], width=6)
-                ]),
-                html.Hr(),
-                dbc.Alert([
-                    html.H6("Analysis Focus"),
-                    html.P(analysis_focus)
-                ], color=color)
-            ])
-        ])
-    except Exception as e:
-        logger.exception("Error displaying results: %s", e)
-        return dbc.Alert(f"Error displaying results: {str(e)}", color="danger")
 
 
 def create_limited_analysis_display(data_source: str, analysis_type: str) -> html.Div | dbc.Card:

--- a/tests/test_analysis_helpers.py
+++ b/tests/test_analysis_helpers.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import dash_bootstrap_components as dbc
+
+from utils.analysis_helpers import build_ai_suggestions, render_results_card
+
+
+def test_build_ai_suggestions_basic():
+    df = pd.DataFrame({"Time": [1, 2, 3], "Person": ["a", "b", "c"]})
+    suggestions, avg, confident = build_ai_suggestions(df)
+    assert len(suggestions) == 2 or len(suggestions) == 3
+    assert avg >= 0
+    assert confident >= 0
+
+
+def test_render_results_card_simple():
+    results = {
+        "total_events": 10,
+        "unique_users": {"u1", "u2"},
+        "unique_doors": {"d1"},
+        "successful_events": 8,
+        "failed_events": 2,
+        "security_score": {"score": 80, "threat_level": "low"},
+    }
+    card = render_results_card(results, "security")
+    assert isinstance(card, dbc.Card)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,9 +8,23 @@ try:
         process_large_csv_content,
     )
     from .unicode_handler import sanitize_unicode_input
+    from .analysis_helpers import (
+        build_ai_suggestions,
+        extract_counts,
+        extract_security_metrics,
+        render_results_card,
+        get_display_title,
+    )
 except Exception:  # pragma: no cover - fallback when processor unavailable
     from .unicode_handler import sanitize_unicode_input, handle_surrogate_characters
     from .unicode_processor import safe_unicode_encode, sanitize_data_frame, clean_unicode_surrogates, process_large_csv_content  # type: ignore
+    from .analysis_helpers import (
+        build_ai_suggestions,
+        extract_counts,
+        extract_security_metrics,
+        render_results_card,
+        get_display_title,
+    )
 
 __all__: list[str] = [
     "sanitize_unicode_input",
@@ -19,5 +33,10 @@ __all__: list[str] = [
     "sanitize_data_frame",
     "clean_unicode_surrogates",
     "process_large_csv_content",
+    "build_ai_suggestions",
+    "extract_counts",
+    "extract_security_metrics",
+    "render_results_card",
+    "get_display_title",
 ]
 

--- a/utils/analysis_helpers.py
+++ b/utils/analysis_helpers.py
@@ -1,0 +1,194 @@
+import logging
+from typing import Dict, Any, List, Tuple
+
+import pandas as pd
+from dash import html
+import dash_bootstrap_components as dbc
+
+from services.ai_suggestions import generate_column_suggestions
+from utils.unicode_handler import sanitize_unicode_input, safe_format_number
+
+logger = logging.getLogger(__name__)
+
+
+def get_display_title(analysis_type: str) -> str:
+    """Return a human friendly title for an analysis type."""
+    title_map = {
+        "security": "Security Results",
+        "trends": "Trends Results",
+        "behavior": "Behavior Results",
+        "anomaly": "Anomaly Results",
+    }
+    return title_map.get(analysis_type.lower(), f"{analysis_type.title()} Results")
+
+
+def build_ai_suggestions(df: pd.DataFrame) -> Tuple[List[Dict[str, Any]], float, int]:
+    """Generate processed AI column suggestions for a dataframe."""
+    try:
+        suggestions = generate_column_suggestions(list(df.columns))
+    except Exception as e:  # pragma: no cover - fallback
+        logger.exception("AI suggestions failed: %s", e)
+        suggestions = {col: {"field": "", "confidence": 0.0} for col in df.columns}
+
+    processed: List[Dict[str, Any]] = []
+    total_conf = 0.0
+    confident = 0
+    for column, info in suggestions.items():
+        field = info.get("field", "")
+        confidence = info.get("confidence", 0.0)
+
+        status = "🟢 High" if confidence >= 0.7 else "🟡 Medium" if confidence >= 0.4 else "🔴 Low"
+        try:
+            sample = df[column].dropna().head(3).astype(str).tolist()
+        except Exception:  # pragma: no cover - defensive
+            sample = ["N/A"]
+
+        processed.append({
+            "column": column,
+            "suggested_field": field if field else "No suggestion",
+            "confidence": confidence,
+            "status": status,
+            "sample_data": sample,
+        })
+
+        total_conf += confidence
+        if confidence >= 0.6:
+            confident += 1
+
+    avg_conf = total_conf / len(processed) if processed else 0.0
+    return processed, avg_conf, confident
+
+
+def extract_counts(results: Dict[str, Any]) -> Dict[str, int]:
+    """Extract common count metrics from analysis results."""
+    total_events = results.get("total_events", 0)
+
+    users_raw = results.get("unique_users", 0)
+    unique_users = len(users_raw) if isinstance(users_raw, (set, list)) else int(users_raw or 0)
+
+    doors_raw = results.get("unique_doors", 0)
+    unique_doors = len(doors_raw) if isinstance(doors_raw, (set, list)) else int(doors_raw or 0)
+
+    success_rate = results.get("success_rate", 0)
+    if success_rate == 0:
+        successful = results.get("successful_events", 0)
+        failed = results.get("failed_events", 0)
+        if (successful + failed) > 0:
+            success_rate = successful / (successful + failed)
+
+    return {
+        "total_events": total_events,
+        "unique_users": unique_users,
+        "unique_doors": unique_doors,
+        "success_rate": success_rate,
+    }
+
+
+def extract_security_metrics(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract security specific metrics from results."""
+    raw = results.get("security_score", {})
+    if hasattr(raw, "score"):
+        score_val = float(raw.score)
+        risk_level = raw.threat_level.title()
+    elif isinstance(raw, dict):
+        score_val = float(raw.get("score", 0.0))
+        risk_level = raw.get("threat_level", "unknown").title()
+    else:
+        score_val = float(raw) if raw else 0.0
+        risk_level = "Unknown"
+
+    failed_attempts = results.get("failed_attempts", 0) or results.get("failed_events", 0)
+    return {
+        "score": score_val,
+        "risk_level": risk_level,
+        "failed_attempts": failed_attempts,
+    }
+
+
+def render_results_card(results: Dict[str, Any], analysis_type: str) -> dbc.Card | dbc.Alert:
+    """Render a results card for a given analysis type."""
+    try:
+        counts = extract_counts(results)
+        total_events = counts["total_events"]
+        unique_users = counts["unique_users"]
+        unique_doors = counts["unique_doors"]
+        success_rate = counts["success_rate"]
+        analysis_focus = results.get("analysis_focus", "")
+
+        if analysis_type == "security":
+            sec = extract_security_metrics(results)
+            specific_content = [
+                html.P(f"Security Score: {sec['score']:.1f}/100"),
+                html.P(f"Failed Attempts: {sec['failed_attempts']:,}"),
+                html.P(f"Risk Level: {sec['risk_level']}")
+            ]
+            color = "danger" if sec["risk_level"] == "High" else "warning" if sec["risk_level"] == "Medium" else "success"
+        elif analysis_type == "trends":
+            specific_content = [
+                html.P(f"Daily Average: {results.get('daily_average', 0):.0f} events"),
+                html.P(f"Peak Usage: {results.get('peak_usage', 'Unknown')}"),
+                html.P(f"Trend: {results.get('trend_direction', 'Unknown')}")
+            ]
+            color = "info"
+        elif analysis_type == "behavior":
+            specific_content = [
+                html.P(f"Avg Accesses/User: {results.get('avg_accesses_per_user', 0):.1f}"),
+                html.P(f"Heavy Users: {results.get('heavy_users', 0)}"),
+                html.P(f"Behavior Score: {results.get('behavior_score', 'Unknown')}")
+            ]
+            color = "success"
+        elif analysis_type == "anomaly":
+            specific_content = [
+                html.P(f"Anomalies Detected: {results.get('anomalies_detected', 0):,}"),
+                html.P(f"Threat Level: {results.get('threat_level', 'Unknown')}") ,
+                html.P(f"Status: {results.get('suspicious_activities', 'Unknown')}")
+            ]
+            color = "danger" if results.get("threat_level") == "Critical" else "warning"
+        else:
+            specific_content = [html.P("Standard analysis completed")]
+            color = "info"
+
+        title_safe = sanitize_unicode_input(get_display_title(analysis_type))
+        events_safe = safe_format_number(total_events)
+        users_safe = safe_format_number(unique_users)
+        doors_safe = safe_format_number(unique_doors)
+
+        return dbc.Card([
+            dbc.CardHeader([html.H5(f"\U0001F4CA {title_safe}")]),
+            dbc.CardBody([
+                dbc.Row([
+                    dbc.Col([
+                        html.H6("\U0001F4C8 Summary"),
+                        html.P(f"Total Events: {events_safe}"),
+                        html.P(f"Unique Users: {users_safe}"),
+                        html.P(f"Unique Doors: {doors_safe}"),
+                        dbc.Progress(
+                            value=success_rate * 100,
+                            label=f"Success Rate: {success_rate:.1%}",
+                            color="success" if success_rate > 0.8 else "warning",
+                        ),
+                    ], width=6),
+                    dbc.Col([
+                        html.H6(f"\U0001F3AF {analysis_type.title()} Specific"),
+                        html.Div(specific_content),
+                    ], width=6),
+                ]),
+                html.Hr(),
+                dbc.Alert([
+                    html.H6("Analysis Focus"),
+                    html.P(analysis_focus),
+                ], color=color),
+            ]),
+        ])
+    except Exception as e:  # pragma: no cover - defensive
+        logger.exception("Error displaying results: %s", e)
+        return dbc.Alert(f"Error displaying results: {str(e)}", color="danger")
+
+
+__all__ = [
+    "build_ai_suggestions",
+    "extract_counts",
+    "extract_security_metrics",
+    "render_results_card",
+    "get_display_title",
+]


### PR DESCRIPTION
## Summary
- extract AI helper utilities into `utils.analysis_helpers`
- simplify `pages/deep_analytics.analysis` by using new helpers
- expose helper APIs through `utils.__init__`
- add unit tests for helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865c63b123c832082a3db23bba8e285