### PR TITLE
Add health monitor stop test

### DIFF
--- a/tests/plugins/test_health_monitor_stop.py
+++ b/tests/plugins/test_health_monitor_stop.py
@@ -1,0 +1,12 @@
+import time
+from core.plugins.manager import PluginManager
+from core.container import Container as DIContainer
+from config.config import ConfigManager
+
+
+def test_health_monitor_thread_stops():
+    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=0.01)
+    time.sleep(0.05)
+    assert manager._health_thread.is_alive()
+    manager.stop_health_monitor()
+    assert not manager._health_thread.is_alive()


### PR DESCRIPTION
## Summary
- ensure PluginManager health thread stops cleanly

## Testing
- `pytest tests/plugins/test_health_monitor_stop.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865c633de248320b05acb5fd005a693