### PR TITLE
Add plugin lifecycle diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Sequence Diagrams](docs/sequence_diagrams.md)
 - [Validation Overview](docs/validation_overview.md)
 
-The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example.
+The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example. The [plugin lifecycle diagram](docs/plugin_lifecycle.md) illustrates how plugins are discovered, dependencies resolved and health checks performed.
 
 ```
 yosai_intel_dashboard/
@@ -289,6 +289,7 @@ options. In your app factory create a `PluginManager`, call
  of discovery, configuration and the plugin lifecycle. For step-by-step
  instructions on writing your own plugin check
  [docs/plugin_development.md](docs/plugin_development.md).
+For a diagram of the full process see [docs/plugin_lifecycle.md](docs/plugin_lifecycle.md).
 The same document includes a minimal **Hello World** plugin showcasing
 `create_plugin()` and callback registration.
 

--- a/docs/plugin_lifecycle.md
+++ b/docs/plugin_lifecycle.md
@@ -1,0 +1,12 @@
+# Plugin Lifecycle Diagram
+
+```mermaid
+graph TB
+    A[Discover Plugins] --> B[Resolve Dependencies]
+    B --> C[load()]
+    C --> D[configure()]
+    D --> E[start()]
+    E --> F[Plugin Running]
+    F --> G[periodic health_check()]
+    G --> F
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,3 +66,5 @@ For each enabled plugin the manager calls these methods:
 3. `start()` – perform any runtime initialization.
 
 After all plugins are loaded call `register_plugin_callbacks(app)` so callback plugins can hook into Dash. Plugins implement `health_check()` and `stop()`. The manager periodically gathers health data and exposes it via `/health/plugins`.
+
+For a visual overview of discovery, dependency resolution and the lifecycle calls see [plugin_lifecycle.md](plugin_lifecycle.md).


### PR DESCRIPTION
## Summary
- document plugin lifecycle with discovery, dependency resolution and health checks
- reference new diagram from plugin docs and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: duplicate module named "test_callback_helpers")*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c62a73f08320b308d3a6ff33aafd