### PR TITLE
Improve CSS bundling in production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ Build optimized CSS assets before deployment:
 ```bash
 python tools/build_css.py
 ```
-This generates `assets/dist/main.min.css` and `assets/dist/main.min.css.gz`.
+The build script bundles the files referenced by `assets/css/main.css`,
+minifies the result and writes `assets/dist/main.min.css`. A gzipped version
+(`main.min.css.gz`) is always produced and a Brotli file (`main.min.css.br`) is
+created when the `brotli` module is available.
 
 ## 🧪 Testing
 

--- a/tests/test_css_optimizer_production.py
+++ b/tests/test_css_optimizer_production.py
@@ -1,22 +1,29 @@
 from models.css_build_optimizer import CSSOptimizer
 
 
-def test_build_production_css_multifile(tmp_path):
+def test_build_production_css_bundle(tmp_path):
     css_dir = tmp_path / "css"
     css_dir.mkdir()
     output_dir = tmp_path / "out"
 
-    # create multiple css files
-    (css_dir / "main.css").write_text("body { color: red; }\n")
-    (css_dir / "extra.css").write_text(".x { margin: 0; }\n")
-    (css_dir / "theme.css").write_text("/* comment */\n.y{padding:5px;}\n")
+    # create imported css files
+    (css_dir / "_a.css").write_text(".a { color: red; }\n")
+    (css_dir / "_b.css").write_text(".b { margin: 0; }\n")
+
+    # main.css with imports
+    main_content = "@import './_a.css';\n@import \"./_b.css\";\n"
+    (css_dir / "main.css").write_text(main_content)
 
     optimizer = CSSOptimizer(css_dir, output_dir)
     optimizer.build_production_css()
 
-    for name in ["main", "extra", "theme"]:
-        out = output_dir / f"{name}.min.css"
-        gz = out.with_suffix(out.suffix + ".gz")
-        assert out.exists()
-        assert gz.exists()
+    out = output_dir / "main.min.css"
+    gz = out.with_suffix(out.suffix + ".gz")
+    assert out.exists()
+    assert gz.exists()
+
+    text = out.read_text()
+    assert "@import" not in text
+    assert ".a{color:red}" in text
+    assert ".b{margin:0}" in text
 


### PR DESCRIPTION
## Summary
- bundle imported CSS files referenced by `main.css`
- compress bundled CSS with gzip and optionally brotli
- update test for new bundling behaviour
- document CSS bundling in the README

## Testing
- `pytest tests/test_css_optimizer_production.py::test_build_production_css_bundle -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6865d34ec6588320a135b886dffce82e