### PR TITLE
Add export dropdown to navbar

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -436,6 +436,8 @@ def _register_router_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             return _get_analytics_page()
         elif pathname == "/graphs":
             return _get_graphs_page()
+        elif pathname == "/export":
+            return _get_export_page()
         elif pathname == "/settings":
             return _get_settings_page()
         elif pathname in {"/upload", "/file-upload"}:
@@ -503,6 +505,21 @@ def _get_graphs_page() -> Any:
             "Graphs",
             "Graphs page is being loaded...",
             "The graphs module is not available. Please check the installation.",
+        )
+
+
+def _get_export_page() -> Any:
+    """Get export page."""
+    try:
+        from pages.export import layout
+
+        return layout()
+    except ImportError as e:
+        logger.error(f"Export page import failed: {e}")
+        return _create_placeholder_page(
+            "Export",
+            "Export page is being loaded...",
+            "The export module is not available. Please check the installation.",
         )
 
 

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 # Type checking imports
 if TYPE_CHECKING:
+    import dash
     import dash_bootstrap_components as dbc
     from dash import html, dcc
     from dash._callback import callback
@@ -142,15 +143,20 @@ def create_navbar_layout() -> Optional[Any]:
                                                             className="navbar-nav-link",
                                                             title="File Upload"
                                                         ),
-                                                        html.A(
-                                                            html.Img(
+                                                        dbc.DropdownMenu(
+                                                            [
+                                                                dbc.DropdownMenuItem("Export CSV", id="nav-export-csv"),
+                                                                dbc.DropdownMenuItem("Export JSON", id="nav-export-json"),
+                                                            ],
+                                                            nav=True,
+                                                            in_navbar=True,
+                                                            label=html.Img(
                                                                 src="/assets/navbar_icons/print.png",
                                                                 className="navbar-icon",
-                                                                alt="Export"
+                                                                alt="Export",
                                                             ),
-                                                            href="/export",
-                                                            className="navbar-nav-link",
-                                                            title="Export"
+                                                            toggle_class_name="navbar-nav-link",
+                                                            menu_variant="dark",
                                                         ),
                                                         html.Button(
                                                             html.Img(
@@ -182,6 +188,8 @@ def create_navbar_layout() -> Optional[Any]:
                                                     className="d-flex align-items-center",
                                                     style={"gap": "1rem"}  # Increased from 0.75rem
                                                 ),
+                                                dcc.Download(id="download-csv"),
+                                                dcc.Download(id="download-json"),
 
                                                 # Language Toggle
                                                 html.Div(
@@ -264,6 +272,40 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                     html.Span("|", className="mx-1"),
                     html.Button("JP", className="language-btn"),
                 ]
+
+        @manager.register_callback(
+            Output("download-csv", "data"),
+            Input("nav-export-csv", "n_clicks"),
+            prevent_initial_call=True,
+            callback_id="navbar_export_csv",
+            component_name="navbar",
+        )
+        def export_csv(n_clicks: Optional[int]):
+            """Export enhanced data as CSV file."""
+            import services.export_service as export_service
+
+            data = export_service.get_enhanced_data()
+            csv_str = export_service.to_csv_string(data)
+            if not csv_str:
+                return dash.no_update
+            return dict(content=csv_str, filename="enhanced_data.csv")
+
+        @manager.register_callback(
+            Output("download-json", "data"),
+            Input("nav-export-json", "n_clicks"),
+            prevent_initial_call=True,
+            callback_id="navbar_export_json",
+            component_name="navbar",
+        )
+        def export_json(n_clicks: Optional[int]):
+            """Export enhanced data as JSON file."""
+            import services.export_service as export_service
+
+            data = export_service.get_enhanced_data()
+            json_str = export_service.to_json_string(data)
+            if not json_str:
+                return dash.no_update
+            return dict(content=json_str, filename="enhanced_data.json")
 
         @manager.register_callback(
             Output("page-context", "children"),

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -39,6 +39,13 @@ except ImportError as e:
     _pages["graphs"] = None
 
 try:
+    from . import export
+    _pages["export"] = export
+except ImportError as e:
+    logger.warning(f"Export page not available: {e}")
+    _pages["export"] = None
+
+try:
     from . import settings
     _pages["settings"] = settings
 except ImportError as e:

--- a/pages/export.py
+++ b/pages/export.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Export page providing download instructions."""
+
+from dash import html
+import dash_bootstrap_components as dbc
+from utils.unicode_handler import sanitize_unicode_input
+
+
+def layout() -> dbc.Container:
+    """Simple export page layout."""
+    header = dbc.Row(
+        dbc.Col(
+            [
+                html.H1("Export", className="text-primary mb-4"),
+                html.P(
+                    "Use the export menu in the navigation bar to download enhanced data.",
+                    className="text-muted",
+                ),
+            ]
+        )
+    )
+
+    return dbc.Container([header], fluid=True)
+
+
+__all__ = ["layout"]

--- a/services/export_service.py
+++ b/services/export_service.py
@@ -1,0 +1,35 @@
+"""Export helpers for enhanced learning data."""
+
+
+import json
+from typing import Dict, Any
+import pandas as pd
+
+from services.consolidated_learning_service import get_learning_service
+
+
+def get_enhanced_data() -> Dict[str, Any]:
+    """Return enhanced mapping data from the learning service."""
+    service = get_learning_service()
+    return service.learned_data
+
+
+def to_json_string(data: Dict[str, Any]) -> str:
+    """Serialize enhanced data to pretty JSON string."""
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def to_csv_string(data: Dict[str, Any]) -> str:
+    """Serialize enhanced data to CSV string using flattened structure."""
+    if not data:
+        return ""
+    records = []
+    for fingerprint, content in data.items():
+        record = {"fingerprint": fingerprint}
+        record.update(content)
+        records.append(record)
+    df = pd.json_normalize(records)
+    return df.to_csv(index=False)
+
+
+__all__ = ["get_enhanced_data", "to_json_string", "to_csv_string"]


### PR DESCRIPTION
## Summary
- add export service for enhanced mapping data
- hook export dropdown in navbar with CSV/JSON download options
- register export routes and create simple export page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865d61a908c83209946f3df905acaf7