### PR TITLE
Fix Babel init and other warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,11 +19,8 @@ from core.exceptions import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
-# Initialize global device learning service
-from services.device_learning_service import DeviceLearningService
+# Consolidated learning service utilities
 from services.consolidated_learning_service import get_learning_service
-
-learning_service = DeviceLearningService()
 
 
 def check_learning_status():

--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -27,6 +27,7 @@ class DatabaseConfig:
     name: str = "yosai.db"
     user: str = "user"
     password: str = ""
+    connection_timeout: float = 5.0
 
 
 class DatabaseConnection(Protocol):

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -13,6 +13,7 @@ from core.plugins.manager import PluginManager
 from core.secret_manager import validate_secrets
 from dash_csrf_plugin import setup_enhanced_csrf_protection, CSRFMode
 import pandas as pd
+from flask_babel import Babel
 
 # Use the config system from the project
 from config.config import get_config
@@ -55,6 +56,12 @@ def _create_full_app() -> dash.Dash:
         )
 
         app.title = "Yōsai Intel Dashboard"
+
+        # Initialize Flask-Babel before any layouts use gettext
+        try:
+            Babel(app.server)
+        except Exception as e:  # pragma: no cover - optional dependency
+            logger.warning(f"Failed to initialize Babel: {e}")
 
         # Use the working config system
         config_manager = get_config()

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -762,6 +762,10 @@ class AnalyticsService:
 
         return options
 
+    def get_available_sources(self) -> list[str]:
+        """Return identifiers for available data sources."""
+        return [opt.get("value", "") for opt in self.get_data_source_options()]
+
     def get_date_range_options(self) -> Dict[str, str]:
         """Get default date range options"""
         from datetime import datetime, timedelta

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -310,10 +310,14 @@ class DeviceLearningService:
         return overlap / total >= 0.6
 
 
-_device_learning_service = DeviceLearningService()
+_device_learning_service: Optional[DeviceLearningService] = None
 
 
 def get_device_learning_service() -> DeviceLearningService:
+    """Return a singleton instance of :class:`DeviceLearningService`."""
+    global _device_learning_service
+    if _device_learning_service is None:
+        _device_learning_service = DeviceLearningService()
     return _device_learning_service
 
 

--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -91,7 +91,7 @@ def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert
         def _sanitize(value: Any) -> str:
             return XSSPrevention.sanitize_html_output(str(value))
 
-        preview_df = preview_df.applymap(_sanitize)
+        preview_df = preview_df.map(_sanitize)
 
         # Display status messaging based on file size
         if actual_rows <= 10:


### PR DESCRIPTION
## Summary
- avoid duplicate device mapping loads by lazily creating the learning service
- initialise Flask‑Babel before layouts are built
- add missing `connection_timeout` to `DatabaseConfig`
- implement `get_available_sources` helper
- replace deprecated `applymap` usage
- remove unused learning service from `app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865e0cdbde88320876f17c0f03d5954