### PR TITLE
Fix typography tokens

### DIFF
--- a/assets/css/01-foundation/_variables.css
+++ b/assets/css/01-foundation/_variables.css
@@ -16,6 +16,16 @@
   --color-text-primary: #F7FAFC;
   --color-text-secondary: #E2E8F0;
   --color-text-tertiary: #A0AEC0;
+
+  /* Additional text colors used by utilities */
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --text-tertiary: var(--color-text-tertiary);
+  --text-disabled: var(--color-text-tertiary);
+  --text-inverse: var(--color-background);
+
+  /* Semantic color */
+  --color-info: #3FA7D6;
   
   /* Spacing system (8pt grid) */
   --space-0: 0;
@@ -38,18 +48,36 @@
   
   /* Typography */
   --font-family-system: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
   --text-xs: 0.75rem;     /* 12px */
   --text-sm: 0.875rem;    /* 14px */
   --text-base: 1rem;      /* 16px */
   --text-lg: 1.125rem;    /* 18px */
   --text-xl: 1.25rem;     /* 20px */
   --text-2xl: 1.5rem;     /* 24px */
+  --text-3xl: 1.875rem;   /* 30px */
+  --text-4xl: 2.25rem;    /* 36px */
+  --text-5xl: 3rem;       /* 48px */
+  --text-6xl: 3.75rem;    /* 60px */
+  --text-2xs: 0.625rem;   /* 10px */
   
   /* Font weights */
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  --font-weight-thin: 100;
+  --font-weight-light: 300;
+  --font-weight-extrabold: 800;
+  --font-weight-black: 900;
+
+  /* Line heights */
+  --leading-none: 1;
+  --leading-tight: 1.25;
+  --leading-snug: 1.375;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.625;
+  --leading-loose: 2;
   
   /* Transitions */
   --duration-fast: 150ms;


### PR DESCRIPTION
## Summary
- define missing design tokens used by typography utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686609c0610083208363e896953e6a54