### PR TITLE
Refactor verification styles into CSS classes

### DIFF
--- a/assets/css/03-components/_device-verification.css
+++ b/assets/css/03-components/_device-verification.css
@@ -1,0 +1,10 @@
+/* =================================================================== */
+/* 03-components/_device-verification.css - Device Verification Table */
+/* =================================================================== */
+
+.device-verification__col--name { width: 25%; }
+.device-verification__col--floor { width: 10%; }
+.device-verification__col--access { width: 15%; }
+.device-verification__col--special { width: 20%; }
+.device-verification__col--security { width: 10%; }
+.device-verification__col--hidden { width: 0%; display: none; }

--- a/assets/css/03-components/_safe-components.css
+++ b/assets/css/03-components/_safe-components.css
@@ -1,0 +1,6 @@
+/* =================================================================== */
+/* 03-components/_safe-components.css - Styles for fallback UI elements */
+/* =================================================================== */
+
+.safe-navbar { background-color: #1B2A47; }
+.safe-map-placeholder { height: 300px; text-align: center; padding: 50px; }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -22,6 +22,8 @@
 @import './03-components/_forms.css';
 @import './03-components/_navigation.css';
 @import './03-components/_modals.css';
+@import './03-components/_safe-components.css';
+@import './03-components/_device-verification.css';
 
 /* Dashboard Panels */
 @import './04-panels/_panel-base.css';

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -47,7 +47,7 @@ def create_device_verification_modal(
                                 ),
                             ),
                         ],
-                        style={"width": "25%"},
+                        className="device-verification__col--name",
                     ),
                     # Floor number
                     html.Td(
@@ -62,7 +62,7 @@ def create_device_verification_modal(
                                 size="sm",
                             )
                         ],
-                        style={"width": "10%"},
+                        className="device-verification__col--floor",
                     ),
                     # Entry/Exit checkboxes
                     html.Td(
@@ -81,7 +81,7 @@ def create_device_verification_modal(
                                 inline=True,
                             )
                         ],
-                        style={"width": "15%"},
+                        className="device-verification__col--access",
                     ),
                     # Special areas
                     html.Td(
@@ -103,7 +103,7 @@ def create_device_verification_modal(
                                 className="small",
                             )
                         ],
-                        style={"width": "20%"},
+                        className="device-verification__col--special",
                     ),
                     # Security level
                     html.Td(
@@ -118,7 +118,7 @@ def create_device_verification_modal(
                                 size="sm",
                             )
                         ],
-                        style={"width": "10%"},
+                        className="device-verification__col--security",
                     ),
                     # Manually edited flag (hidden input)
                     html.Td(
@@ -130,7 +130,7 @@ def create_device_verification_modal(
                                 id={"type": "device-edited", "index": i}, data=False
                             ),
                         ],
-                        style={"width": "0%", "display": "none"},
+                        className="device-verification__col--hidden",
                     ),
                 ]
             )
@@ -153,11 +153,11 @@ def create_device_verification_modal(
                         [
                             html.Tr(
                                 [
-                                    html.Th("Device Name", style={"width": "25%"}),
-                                    html.Th("Floor", style={"width": "10%"}),
-                                    html.Th("Access Type", style={"width": "15%"}),
-                                    html.Th("Special Areas", style={"width": "20%"}),
-                                    html.Th("Security (0-10)", style={"width": "10%"}),
+                                    html.Th("Device Name", className="device-verification__col--name"),
+                                    html.Th("Floor", className="device-verification__col--floor"),
+                                    html.Th("Access Type", className="device-verification__col--access"),
+                                    html.Th("Special Areas", className="device-verification__col--special"),
+                                    html.Th("Security (0-10)", className="device-verification__col--security"),
                                 ]
                             )
                         ]

--- a/utils/safe_components.py
+++ b/utils/safe_components.py
@@ -22,7 +22,7 @@ def safe_navbar():
                             alt="logo",
                         ),
                         href="/",
-                        style={"textDecoration": "none"},
+                        className="no-underline",
                     ),
                     dbc.Nav(
                         [
@@ -71,8 +71,7 @@ def safe_navbar():
         ],
         color="dark",
         dark=True,
-        className="mb-3",
-        style={"backgroundColor": "#1B2A47"},
+        className="mb-3 safe-navbar",
     )
 
 
@@ -84,11 +83,14 @@ def safe_map_panel():
             dbc.Badge("🟢 All systems operational", color="success")
         ]),
         dbc.CardBody([
-            html.Div([
-                html.P("Interactive security map"),
-                html.P("Real-time monitoring active"),
-                dbc.Progress(value=100, color="success")
-            ], style={"height": "300px", "textalign": "center", "padding": "50px"})
+            html.Div(
+                [
+                    html.P("Interactive security map"),
+                    html.P("Real-time monitoring active"),
+                    dbc.Progress(value=100, color="success"),
+                ],
+                className="safe-map-placeholder",
+            )
         ])
     ])
 


### PR DESCRIPTION
## Summary
- add device verification and safe component stylesheets
- import the new styles in `main.css`
- replace inline widths with CSS classes in `device_verification` component
- refactor style attributes in safe components to use classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686611bec8148320b5f47756f5f8453b