### PR TITLE
Refactor navbar styles

### DIFF
--- a/assets/css/05-pages/_dashboard.css
+++ b/assets/css/05-pages/_dashboard.css
@@ -73,3 +73,35 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ------------------------------------------------------------------- */
+/* Navbar Custom Classes                                                */
+/* ------------------------------------------------------------------- */
+
+.navbar-main {
+  background-color: var(--color-primary);
+  border-bottom: 2px solid var(--color-accent);
+}
+
+.navbar-logo-link {
+  text-decoration: none;
+}
+
+.navbar-icon-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.navbar-icon-group {
+  gap: var(--space-4);
+}
+
+.navbar-language-toggle {
+  margin-left: var(--space-8);
+}
+
+.navbar-row {
+  min-height: 60px;
+}

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -77,7 +77,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                 alt="logo",
                                             ),
                                             href="/",
-                                            style={"textDecoration": "none"},
+                                            className="navbar-logo-link",
                                         )
                                     ],
                                     width=3,
@@ -182,14 +182,8 @@ def create_navbar_layout() -> Optional[Any]:
                                                                 alt="Settings",
                                                             ),
                                                             id="navbar-settings-btn",
-                                                            className="navbar-nav-link",
+                                                            className="navbar-nav-link navbar-icon-btn",
                                                             title="Settings",
-                                                            style={
-                                                                "background": "none",
-                                                                "border": "none",
-                                                                "padding": "0",
-                                                                "cursor": "pointer",
-                                                            },
                                                         ),
                                                         html.A(
                                                             html.Img(
@@ -209,10 +203,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                             className="ms-1",
                                                         ),
                                                     ],
-                                                    className="d-flex align-items-center",
-                                                    style={
-                                                        "gap": "1rem"
-                                                    },  # Increased from 0.75rem
+                                                    className="d-flex align-items-center navbar-icon-group",
                                                 ),
                                                 dcc.Download(id="download-csv"),
                                                 dcc.Download(id="download-json"),
@@ -231,8 +222,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                             className="language-btn",
                                                         ),
                                                     ],
-                                                    className="d-flex align-items-center text-sm",
-                                                    style={"marginLeft": "2rem"},
+                                                    className="d-flex align-items-center text-sm navbar-language-toggle",
                                                     id="language-toggle",
                                                 ),
                                             ],
@@ -243,8 +233,7 @@ def create_navbar_layout() -> Optional[Any]:
                                     className="d-flex align-items-center justify-content-end pr-4",
                                 ),
                             ],
-                            className="w-100 align-items-center",
-                            style={"minHeight": "60px"},
+                            className="w-100 align-items-center navbar-row",
                         ),
                     ],
                     fluid=True,
@@ -254,7 +243,6 @@ def create_navbar_layout() -> Optional[Any]:
             dark=True,
             sticky="top",
             className="navbar-main",
-            style={"backgroundColor": "#1B2A47"},
         )
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- add navbar styling classes to dashboard page stylesheet
- remove inline styles from `dashboard/layout/navbar.py`

## Testing
- `pytest tests/components/test_callback_helpers.py::test_toggle_custom_field -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686611bd10d08320b816da89860a248a