### PR TITLE
Refactor upload page styles

### DIFF
--- a/assets/css/05-pages/_file_upload.css
+++ b/assets/css/05-pages/_file_upload.css
@@ -1,0 +1,34 @@
+/* =================================================================== */
+/* 05-pages/_file_upload.css - File Upload Page Styles */
+/* =================================================================== */
+
+.file-upload-area {
+  width: 100%;
+  border: 2px dashed #007bff;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  background-color: #f8f9fa;
+}
+
+.file-upload-area--highlight {
+  border: 3px dashed #28a745;
+  background-color: #d4edda;
+  animation: pulse 1s infinite;
+}
+
+.csv-mapping-field-col {
+  width: 40%;
+}
+
+.csv-mapping-column-col {
+  width: 50%;
+}
+
+.csv-mapping-ai-col {
+  width: 10%;
+}
+
+.csv-mapping-dropdown {
+  min-width: 200px;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -36,6 +36,7 @@
 @import './05-pages/_graphs.css';
 @import './05-pages/_settings.css';
 @import './05-pages/_analytics.css';
+@import './05-pages/_file_upload.css';
 
 /* Theme System */
 @import './06-themes/_dark-theme.css';

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -101,14 +101,7 @@ def layout():
                                                         ),
                                                     ]
                                                 ),
-                                                style={
-                                                    "width": "100%",
-                                                    "border": "2px dashed #007bff",
-                                                    "borderRadius": "8px",
-                                                    "textAlign": "center",
-                                                    "cursor": "pointer",
-                                                    "backgroundColor": "#f8f9fa",
-                                                },
+                                                className="file-upload-area",
                                                 multiple=True,
                                             )
                                         ]
@@ -127,17 +120,13 @@ def layout():
             dbc.Row([dbc.Col([html.Div(id="upload-nav")])]),
             # Container for toast notifications
             html.Div(id="toast-container"),
-            # CRITICAL: Hidden placeholder buttons to prevent callback errors
+            # CRITICAL: Hidden placeholder buttons (using `.hidden` utility) to prevent callback errors
             html.Div(
                 [
-                    dbc.Button(
-                        "", id="verify-columns-btn-simple", style={"display": "none"}
-                    ),
-                    dbc.Button(
-                        "", id="classify-devices-btn", style={"display": "none"}
-                    ),
+                    dbc.Button("", id="verify-columns-btn-simple", className="hidden"),
+                    dbc.Button("", id="classify-devices-btn", className="hidden"),
                 ],
-                style={"display": "none"},
+                className="hidden",
             ),
             # Store for uploaded data info
             dcc.Store(id="file-info-store", data={}),
@@ -218,23 +207,8 @@ class Callbacks:
     def highlight_upload_area(self, n_clicks):
         """Highlight upload area when 'upload more' is clicked."""
         if n_clicks:
-            return {
-                "width": "100%",
-                "border": "3px dashed #28a745",
-                "borderRadius": "8px",
-                "textAlign": "center",
-                "cursor": "pointer",
-                "backgroundColor": "#d4edda",
-                "animation": "pulse 1s infinite",
-            }
-        return {
-            "width": "100%",
-            "border": "2px dashed #007bff",
-            "borderRadius": "8px",
-            "textAlign": "center",
-            "cursor": "pointer",
-            "backgroundColor": "#f8f9fa",
-        }
+            return "file-upload-area file-upload-area--highlight"
+        return "file-upload-area"
 
     def restore_upload_state(self, pathname: str):
         """Return stored upload details when revisiting the upload page."""
@@ -669,7 +643,7 @@ class Callbacks:
                                     className="bg-info text-white px-2 py-1 rounded small",
                                 ),
                             ],
-                            style={"width": "40%"},
+                            className="csv-mapping-field-col",
                         ),
                         html.Td(
                             [
@@ -681,10 +655,10 @@ class Callbacks:
                                     options=csv_column_options,
                                     placeholder=f"Select CSV column for {field_name}",
                                     value=suggested_csv_column,
-                                    style={"minWidth": "200px"},
+                                    className="csv-mapping-dropdown",
                                 )
                             ],
-                            style={"width": "50%"},
+                            className="csv-mapping-column-col",
                         ),
                         html.Td(
                             [
@@ -706,7 +680,7 @@ class Callbacks:
                                     className="small",
                                 )
                             ],
-                            style={"width": "10%"},
+                            className="csv-mapping-ai-col",
                         ),
                     ]
                 )
@@ -747,13 +721,16 @@ class Callbacks:
                                 [
                                     html.Th(
                                         "Analytics Field (Fixed)",
-                                        style={"width": "40%"},
+                                        className="csv-mapping-field-col",
                                     ),
                                     html.Th(
                                         "Maps to CSV Column (Variable)",
-                                        style={"width": "50%"},
+                                        className="csv-mapping-column-col",
                                     ),
-                                    html.Th("AI Confidence", style={"width": "10%"}),
+                                    html.Th(
+                                        "AI Confidence",
+                                        className="csv-mapping-ai-col",
+                                    ),
                                 ]
                             )
                         ]
@@ -970,7 +947,7 @@ def register_callbacks(
     callback_defs = [
         (
             cb.highlight_upload_area,
-            Output("upload-data", "style"),
+            Output("upload-data", "className"),
             Input("upload-more-btn", "n_clicks"),
             None,
             "highlight_upload_area",


### PR DESCRIPTION
## Summary
- move upload inline styles to new `_file_upload.css`
- import file upload styles in `main.css`
- use CSS classes in `file_upload.py` and toggle highlight via className
- use `.hidden` utility for placeholder buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686611b7fda08320829f44668ff25c0a