### PR TITLE
Add UI flow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Analytics Upload Sequence](docs/analytics_sequence.md)
 - [Roadmap](docs/roadmap.md)
 - [Sequence Diagrams](docs/sequence_diagrams.md)
+- [UI Flows](docs/ui_flows.md)
 - [Validation Overview](docs/validation_overview.md)
 
 The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example. The [plugin lifecycle diagram](docs/plugin_lifecycle.md) illustrates how plugins are discovered, dependencies resolved and health checks performed.

--- a/docs/ui_flows.md
+++ b/docs/ui_flows.md
@@ -1,0 +1,44 @@
+# UI Flows
+
+This document illustrates the key interactions that users perform in the dashboard UI.
+The focus is on the upload, analytics and export steps that most users follow.
+
+## Upload a File
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant S as Server
+    participant AS as AnalyticsService
+
+    U->>B: Select file
+    B->>S: POST /upload
+    S->>AS: validate_and_store()
+    AS-->>S: confirmation
+    S-->>B: Show upload success
+```
+
+## Run Analytics
+
+```mermaid
+flowchart TD
+    A[File Uploaded] --> B[Run analytics]
+    B --> C[Display charts]
+```
+
+## Export Results
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant S as Server
+    participant DB as Database
+
+    U->>B: Click Export
+    B->>S: GET /export
+    S->>DB: Fetch results
+    DB-->>S: Data
+    S-->>B: Download file
+```


### PR DESCRIPTION
## Summary
- document user flows in new `docs/ui_flows.md`
- link to the new documentation from the README

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: duplicate module)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866111f53e8832095bc1f9161325626