### PR TITLE
Use semantic nav/main containers

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -338,10 +338,13 @@ def _create_main_layout() -> html.Div:
         [
             # URL routing component
             dcc.Location(id="url", refresh=False),
-            # Navigation bar
-            _create_navbar(),
+            # Navigation bar wrapped in semantic <nav> element
+            html.Nav(
+                _create_navbar(),
+                className="top-panel",
+            ),
             # Main content area (dynamically populated)
-            html.Div(id="page-content", className="main-content p-4"),
+            html.Main(id="page-content", className="main-content p-4"),
             # Global data stores
             dcc.Store(id="global-store", data={}),
             dcc.Store(id="session-store", data={}),


### PR DESCRIPTION
## Summary
- wrap the navbar with `<nav>`
- use `<main>` element for `page-content`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866111bfdf4832089762a3495ba7871