### PR TITLE
Add note about navbar icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ yosai_intel_dashboard/
     └── css/                  # Modular CSS architecture
 ```
 
+**Note:** Navbar icons live under `assets/navbar_icons/` and are loaded by Dash
+components using relative paths such as `/assets/navbar_icons/dashboard.png`.
+Keep this directory structure intact to avoid broken links.
+
 ## 🚀 Quick Start
 
 ### Development Setup

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -2,6 +2,9 @@
 Navigation bar component with grid layout using existing framework
 """
 
+# Icons for the navigation bar are stored in ``assets/navbar_icons/`` and
+# referenced below via relative paths like ``/assets/navbar_icons/dashboard.png``.
+
 import datetime
 from typing import TYPE_CHECKING, Optional, Any, Union
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator


### PR DESCRIPTION
## Summary
- document location of navbar icon assets
- explain relative references to icons in code

## Testing
- `pytest tests/test_ai_device_generator.py::TestAIDeviceGenerator::test_floor_extraction_patterns -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68661ab9be3c8320aa7ffd8c7d440fe8