### PR TITLE
Add theme manager with navbar selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 
 ![Language Toggle Demo](docs/i18n_demo.gif)
 
+## 🎨 Theme Support
+
+The dashboard provides light, dark and high‑contrast themes. The current
+selection is saved in the browser and applied before CSS loads to avoid a flash
+of unstyled content. Use the new dropdown on the right side of the navbar to
+switch themes at runtime.
+
 ## 📚 Documentation
 
 See the [data model diagram](docs/data_model.md) for an overview of key entities.

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,22 @@
+(function () {
+  function syncDropdown() {
+    var dropdown = document.getElementById('theme-dropdown');
+    if (!dropdown) return;
+    var current = document.documentElement.dataset.theme || 'dark';
+    if (dropdown.value !== current) {
+      dropdown.value = current;
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', syncDropdown);
+  document.addEventListener('themeChange', syncDropdown);
+
+  var dropdown = document.getElementById('theme-dropdown');
+  if (dropdown) {
+    dropdown.addEventListener('change', function (e) {
+      if (window.setAppTheme) {
+        window.setAppTheme(e.target.value);
+      }
+    });
+  }
+})();

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -17,6 +17,7 @@ from dash_csrf_plugin import setup_enhanced_csrf_protection, CSRFMode
 import pandas as pd
 from flask_babel import Babel
 from flask_compress import Compress
+from core.theme_manager import apply_theme_settings
 
 # Use the config system from the project
 from config.config import get_config
@@ -62,6 +63,7 @@ def _create_full_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_folder="assets",
         )
+        apply_theme_settings(app)
         Compress(app.server)
 
         app.title = "Yōsai Intel Dashboard"
@@ -193,6 +195,7 @@ def _create_simple_app() -> dash.Dash:
             external_stylesheets=external_stylesheets,
             suppress_callback_exceptions=True,
         )
+        apply_theme_settings(app)
         Compress(app.server)
 
         app.title = "Yōsai Intel Dashboard"
@@ -270,6 +273,7 @@ def _create_json_safe_app() -> dash.Dash:
             external_stylesheets=external_stylesheets,
             suppress_callback_exceptions=True,
         )
+        apply_theme_settings(app)
         Compress(app.server)
 
         app.title = "🏯 Yōsai Intel Dashboard"
@@ -349,6 +353,8 @@ def _create_main_layout() -> html.Div:
             dcc.Store(id="global-store", data={}),
             dcc.Store(id="session-store", data={}),
             dcc.Store(id="app-state-store", data={"initial": True}),
+            dcc.Store(id="theme-store"),
+            html.Div(id="theme-dummy-output", style={"display": "none"}),
         ]
     )
 
@@ -577,9 +583,7 @@ def _configure_swagger(server: Any) -> None:
         Swagger(server, template=template)
         logger.info("✅ Swagger configured successfully")
     except Exception as e:
-        logger.warning(
-            f"Swagger configuration failed, continuing without it: {e}"
-        )
+        logger.warning(f"Swagger configuration failed, continuing without it: {e}")
         # Don't crash the app if Swagger fails
 
 

--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -1,0 +1,67 @@
+"""Theme management utilities for the dashboard."""
+
+from __future__ import annotations
+
+import logging
+from typing import Set
+
+from utils.unicode_handler import sanitize_unicode_input
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THEME = "dark"
+ALLOWED_THEMES: Set[str] = {"dark", "light", "high-contrast"}
+
+
+def sanitize_theme(theme: str | None) -> str:
+    """Sanitize and validate the provided theme string."""
+    cleaned = sanitize_unicode_input(theme or "").lower()
+    if cleaned in ALLOWED_THEMES:
+        return cleaned
+    logger.debug("Invalid theme '%s', falling back to '%s'", theme, DEFAULT_THEME)
+    return DEFAULT_THEME
+
+
+def generate_theme_script() -> str:
+    """Return a script snippet that applies the saved theme early."""
+    allowed_list = ",".join(f"'{t}'" for t in ALLOWED_THEMES)
+    script = f"""
+    <script>
+    (function() {{
+        const DEFAULT_THEME = '{DEFAULT_THEME}';
+        const ALLOWED_THEMES = new Set([{allowed_list}]);
+        function sanitize(theme) {{
+            theme = (theme || '').toString().toLowerCase();
+            return ALLOWED_THEMES.has(theme) ? theme : DEFAULT_THEME;
+        }}
+        const saved = sanitize(localStorage.getItem('app-theme'));
+        const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        const initial = saved || sanitize(system);
+        document.documentElement.dataset.theme = initial;
+        document.dispatchEvent(new CustomEvent('themeChange', {{ detail: initial }}));
+        window.setAppTheme = function(theme) {{
+            const clean = sanitize(theme);
+            document.documentElement.dataset.theme = clean;
+            localStorage.setItem('app-theme', clean);
+            document.dispatchEvent(new CustomEvent('themeChange', {{ detail: clean }}));
+        }};
+    }})();
+    </script>
+    """
+    return script
+
+
+def apply_theme_settings(app) -> None:
+    """Patch ``app.index_string`` to inject the theme management script."""
+    try:
+        snippet = generate_theme_script()
+        marker = "{%css%}"
+        if hasattr(app, "index_string") and app.index_string:
+            if marker in app.index_string:
+                app.index_string = app.index_string.replace(
+                    marker, snippet + "\n    " + marker
+                )
+            else:
+                app.index_string = snippet + app.index_string
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Failed to apply theme settings: %s", exc)

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Any, Union
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from flask_babel import lazy_gettext as _l
 from core.plugins.decorators import safe_callback
+from core.theme_manager import DEFAULT_THEME, sanitize_theme
 import logging
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,27 @@ def create_navbar_layout() -> Optional[Any]:
                                                             size="sm",
                                                             className="ms-1",
                                                         ),
+                                                        dcc.Dropdown(
+                                                            id="theme-dropdown",
+                                                            options=[
+                                                                {
+                                                                    "label": "Dark",
+                                                                    "value": "dark",
+                                                                },
+                                                                {
+                                                                    "label": "Light",
+                                                                    "value": "light",
+                                                                },
+                                                                {
+                                                                    "label": "High Contrast",
+                                                                    "value": "high-contrast",
+                                                                },
+                                                            ],
+                                                            value=DEFAULT_THEME,
+                                                            clearable=False,
+                                                            className="ms-1 theme-dropdown",
+                                                            style={"width": "120px"},
+                                                        ),
                                                     ],
                                                     className="d-flex align-items-center navbar-icon-group",
                                                 ),
@@ -331,6 +353,21 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                         },
                     ),
                 ]
+
+        @manager.register_callback(
+            Output("theme-store", "data"),
+            Input("theme-dropdown", "value"),
+            callback_id="navbar_select_theme",
+            component_name="navbar",
+        )
+        def update_theme_store(value: Optional[str]):
+            return sanitize_theme(value)
+
+        manager.app.clientside_callback(
+            "function(data){if(window.setAppTheme&&data){window.setAppTheme(data);} return '';}",
+            Output("theme-dummy-output", "children"),
+            Input("theme-store", "data"),
+        )
 
         @manager.register_callback(
             Output("download-csv", "data"),


### PR DESCRIPTION
## Summary
- inject theme script early via new ThemeManager
- add theme dropdown to navbar with callbacks
- expose theme store in layout
- sync frontend theme switching using assets/theme.js
- document theme support

## Testing
- `flake8 core/theme_manager.py dashboard/layout/navbar.py core/app_factory.py` *(fails: command not found)*
- `mypy core/theme_manager.py dashboard/layout/navbar.py core/app_factory.py` *(fails: missing imports)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68661aa64f708320b05d4df802a94c76