### PR TITLE
Fix navbar imports

### DIFF
--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -8,6 +8,7 @@ from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from flask_babel import lazy_gettext as _l
 from core.plugins.decorators import safe_callback
 from core.theme_manager import DEFAULT_THEME, sanitize_theme
+from utils import check_navbar_assets, navbar_icon
 
 import logging
 


### PR DESCRIPTION
## Summary
- import `check_navbar_assets` and `navbar_icon` in the navbar layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python` execution of `create_navbar_layout` with stub modules

------
https://chatgpt.com/codex/tasks/task_e_68662925eaa483209ab34900a211cd84