### PR TITLE
Fix nav icon class usage

### DIFF
--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -184,7 +184,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                                 "⚙️",
                                                             ),
                                                             id="navbar-settings-btn",
-                                                            className="navbar-nav-link navbar-icon-btn",
+                                                            className="navbar-nav-link nav-icon-btn",
                                                             title="Settings",
                                                         ),
                                                         html.A(
@@ -226,7 +226,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                             style={"width": "120px"},
                                                         ),
                                                     ],
-                                                    className="d-flex align-items-center navbar-icon-group",
+                                                    className="d-flex align-items-center nav-icon-group",
                                                 ),
                                                 dcc.Download(id="download-csv"),
                                                 dcc.Download(id="download-json"),

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -45,10 +45,12 @@ def navbar_icon(filename: str, alt: str, fallback_text: str):
     path = NAVBAR_ICON_DIR / filename
     if path.is_file():
         return html.Img(
-            src=f"/assets/navbar_icons/{filename}", className="navbar-icon", alt=alt
+            src=f"/assets/navbar_icons/{filename}",
+            className="nav-icon",
+            alt=alt,
         )
     logger.warning("Missing navbar icon: %s", safe_unicode_encode(filename))
-    return html.Span(fallback_text, className="navbar-icon-fallback")
+    return html.Span(fallback_text, className="nav-icon")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- adjust `navbar_icon` util to use `.nav-icon` class
- update navbar layout icon classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686631572d0c83209dd70efa80d79dd0