### PR TITLE
Fix navbar theme color inheritance

### DIFF
--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -270,7 +270,6 @@ def create_navbar_layout() -> Optional[Any]:
                     fluid=True,
                 )
             ],
-            color="primary",
             dark=True,
             sticky="top",
             className="navbar-main",


### PR DESCRIPTION
## Summary
- remove explicit `color="primary"` so navbar inherits theme CSS variable

## Testing
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 dashboard/layout/navbar.py` *(fails: command not found)*
- `pytest -k navbar -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy dashboard/layout/navbar.py` *(fails: missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_6866315ac6348320b21d7b3e77f50828