### PR TITLE
Fix asset directory handling

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -20,6 +20,8 @@ from flask_babel import Babel
 from flask_compress import Compress
 from core.theme_manager import apply_theme_settings
 
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
+
 # Use the config system from the project
 from config.config import get_config
 
@@ -54,7 +56,7 @@ def _create_full_app() -> dash.Dash:
     """Create complete Dash application with full integration"""
     try:
         external_stylesheets = [dbc.themes.BOOTSTRAP]
-        built_css = Path("assets/dist/main.min.css")
+        built_css = ASSETS_DIR / "dist" / "main.min.css"
         if built_css.exists():
             external_stylesheets.append("/assets/dist/main.min.css")
 
@@ -62,7 +64,7 @@ def _create_full_app() -> dash.Dash:
             __name__,
             external_stylesheets=external_stylesheets,
             suppress_callback_exceptions=True,
-            assets_folder="assets",
+            assets_folder=str(ASSETS_DIR),
         )
         apply_theme_settings(app)
         Compress(app.server)
@@ -187,7 +189,7 @@ def _create_simple_app() -> dash.Dash:
         from dash import html, dcc
 
         external_stylesheets = [dbc.themes.BOOTSTRAP]
-        built_css = Path("assets/dist/main.min.css")
+        built_css = ASSETS_DIR / "dist" / "main.min.css"
         if built_css.exists():
             external_stylesheets.append("/assets/dist/main.min.css")
 
@@ -265,7 +267,7 @@ def _create_json_safe_app() -> dash.Dash:
         from dash import html
 
         external_stylesheets = [dbc.themes.BOOTSTRAP]
-        built_css = Path("assets/dist/main.min.css")
+        built_css = ASSETS_DIR / "dist" / "main.min.css"
         if built_css.exists():
             external_stylesheets.append("/assets/dist/main.min.css")
 

--- a/tools/build_css.py
+++ b/tools/build_css.py
@@ -1,13 +1,15 @@
 from pathlib import Path
 from models import css_build_optimizer
 
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
+
 # Alias to maintain naming from documentation
 CSSBuildOptimizer = css_build_optimizer.CSSOptimizer
 
 
 def main() -> None:
-    css_dir = Path("assets/css")
-    output_dir = Path("assets/dist")
+    css_dir = ASSETS_DIR / "css"
+    output_dir = ASSETS_DIR / "dist"
     optimizer = CSSBuildOptimizer(css_dir, output_dir)
     optimizer.build_production_css()
 

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -7,7 +7,7 @@ from dash import html  # type: ignore
 
 logger = logging.getLogger(__name__)
 
-ASSETS_DIR = Path("assets")
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 NAVBAR_ICON_DIR = ASSETS_DIR / "navbar_icons"
 
 


### PR DESCRIPTION
## Summary
- resolve assets directory relative to package locations
- update Dash factory to use resolved assets path
- update CSS build script to use same path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866373f02a083208b12bfd65582fc5f