### PR TITLE
Add asset serving check and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,18 @@ directory as long as their paths match the references in
    # Edit .env with your configuration (e.g. set HOST and database info)
    ```
 
-5. **Run the application:**
+5. **Build the CSS bundle:**
+   Ensure `node` and `npm` are available if you use the npm command.
+   ```bash
+   npm run build-css  # or `python tools/build_css.py`
+   ```
+
+6. **Run the application:**
    The app now loads variables from `.env` automatically.
    ```bash
    python app.py
    ```
-
-6. **Access the dashboard:**
+7. **Access the dashboard:**
    Open http://127.0.0.1:8050 in your browser
 
 ## Developer Onboarding

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -66,6 +66,10 @@ def _create_full_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_folder=str(ASSETS_DIR),
         )
+
+        if not debug_dash_asset_serving(app):
+            logger.warning("Dash asset serving validation failed")
+
         apply_theme_settings(app)
         Compress(app.server)
 
@@ -358,8 +362,7 @@ def _create_main_layout() -> html.Div:
             dcc.Store(id="session-store", data={}),
             dcc.Store(id="app-state-store", data={"initial": True}),
         ],
-        **{"data-theme": theme}
-
+        **{"data-theme": theme},
     )
 
 

--- a/tests/utils/test_asset_serving.py
+++ b/tests/utils/test_asset_serving.py
@@ -1,0 +1,10 @@
+import os
+from core.app_factory import create_app
+from utils import debug_dash_asset_serving
+
+
+def test_debug_dash_asset_serving(monkeypatch):
+    monkeypatch.setenv("YOSAI_ENV", "development")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    app = create_app(mode="simple")
+    assert debug_dash_asset_serving(app) is True


### PR DESCRIPTION
## Summary
- advise developers to build CSS before running the app
- validate Dash asset serving when creating the full app
- test asset serving in simple mode

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: duplicate module error)*
- `pytest -k test_asset_serving.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68663b4027a48320b096553421f16169