### PR TITLE
Fix asset serving check

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -67,6 +67,11 @@ def _create_full_app() -> dash.Dash:
             assets_folder=str(ASSETS_DIR),
         )
 
+        # Set a temporary layout so Dash can handle requests during
+        # the asset serving check without raising ``NoLayoutException``.
+        # The final layout is assigned later once all plugins are loaded.
+        app.layout = html.Div()
+
         if not debug_dash_asset_serving(app):
             logger.warning("Dash asset serving validation failed")
 


### PR DESCRIPTION
## Summary
- prevent NoLayoutException when verifying asset serving

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68663caf66788320a7e24ad75141f017