### PR TITLE
Dynamic navbar titles

### DIFF
--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -55,6 +55,19 @@ except ImportError:
     Input: Any = _stub_callable
 
 
+PAGE_TITLES = {
+    "/": "Dashboard",
+    "/dashboard": "Dashboard",
+    "/analytics": "Deep Analytics",
+    "/graphs": "Graphs",
+    "/export": "Export",
+    "/settings": "Settings",
+    "/upload": "File Upload",
+    "/file-upload": "File Upload",
+    "/login": "Login",
+}
+
+
 def create_navbar_layout() -> Optional[Any]:
     """Create navbar layout with responsive grid design"""
     if not DASH_AVAILABLE:
@@ -105,7 +118,8 @@ def create_navbar_layout() -> Optional[Any]:
                                                     id="facility-header",
                                                     children=[
                                                         html.H5(
-                                                            str(_l("Main Panel")),
+                                                            str(_l("Dashboard")),
+                                                            id="navbar-title",
                                                             className="navbar-title text-primary",
                                                         ),
                                                         html.Small(
@@ -304,6 +318,12 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             """Update live time display"""
             current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return f"Live: {current_time}"
+
+        manager.app.clientside_callback(
+            "function(pathname){const map={\"/\":\"Dashboard\",\"/dashboard\":\"Dashboard\",\"/analytics\":\"Deep Analytics\",\"/graphs\":\"Graphs\",\"/export\":\"Export\",\"/settings\":\"Settings\",\"/upload\":\"File Upload\",\"/file-upload\":\"File Upload\",\"/login\":\"Login\"};return map[pathname]||'Dashboard';}",
+            Output("navbar-title", "children"),
+            Input("url-i18n", "pathname"),
+        )
 
         @manager.register_callback(
             Output("language-toggle", "children"),

--- a/pages/deep_analytics/layout.py
+++ b/pages/deep_analytics/layout.py
@@ -14,22 +14,13 @@ logger = logging.getLogger(__name__)
 def layout():
     """Fixed layout without problematic Unicode characters"""
     try:
-        # Header section - using safe ASCII characters
-        header = dbc.Row([
-            dbc.Col([
-                html.H1("Deep Analytics", className="text-primary"),
-                html.P(
-                    "Advanced data analysis with AI-powered column mapping suggestions",
-                    className="lead text-muted"
-                ),
-                dbc.Alert(
-                    "UI components loaded successfully",
-                    color="success",
-                    dismissable=True,
-                    id="status-alert"
-                )
-            ])
-        ], className="mb-4")
+        status_alert = dbc.Alert(
+            "UI components loaded successfully",
+            color="success",
+            dismissable=True,
+            id="status-alert",
+            className="mb-3",
+        )
 
         # Configuration section
         config_card = dbc.Card([
@@ -163,7 +154,7 @@ def layout():
             html.Div(id="hidden-trigger", className="hidden")
         ]
 
-        return dbc.Container([header, config_card, results_area] + stores, fluid=True)
+        return dbc.Container([status_alert, config_card, results_area] + stores, fluid=True)
 
     except Exception as e:
         logger.error(f"Layout creation error: {e}")

--- a/pages/export.py
+++ b/pages/export.py
@@ -8,19 +8,7 @@ from utils.unicode_handler import sanitize_unicode_input
 
 def layout() -> dbc.Container:
     """Simple export page layout."""
-    header = dbc.Row(
-        dbc.Col(
-            [
-                html.H1("Export", className="text-primary mb-4"),
-                html.P(
-                    "Use the export menu in the navigation bar to download enhanced data.",
-                    className="text-muted",
-                ),
-            ]
-        )
-    )
-
-    return dbc.Container([header], fluid=True)
+    return dbc.Container([], fluid=True)
 
 
 __all__ = ["layout"]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -53,20 +53,7 @@ def layout():
     """File upload page layout with persistent storage"""
     return dbc.Container(
         [
-            # Page header
-            dbc.Row(
-                [
-                    dbc.Col(
-                        [
-                            html.H1("📁 File Upload", className="text-primary mb-2"),
-                            html.P(
-                                "Upload CSV, Excel, or JSON files for analysis",
-                                className="text-muted mb-4",
-                            ),
-                        ]
-                    )
-                ]
-            ),
+            # Removed redundant page header
             # Upload area
             dbc.Row(
                 [
@@ -77,7 +64,7 @@ def layout():
                                     dbc.CardHeader(
                                         [
                                             html.H5(
-                                                "📤 Upload Data Files", className="mb-0"
+                                                "Upload Data Files", className="mb-0"
                                             )
                                         ]
                                     ),

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -8,18 +8,6 @@ from utils.unicode_handler import sanitize_unicode_input
 
 def layout() -> dbc.Container:
     """Graphs page layout."""
-    header = dbc.Row(
-        dbc.Col(
-            [
-                html.H1("Graphs", className="text-primary mb-4"),
-                html.P(
-                    "Interactive charts will be integrated here.",
-                    className="text-muted",
-                ),
-            ]
-        )
-    )
-
     tabs = dbc.Tabs(
         [
             dbc.Tab(label=sanitize_unicode_input("Line Charts"), tab_id="line"),
@@ -33,7 +21,7 @@ def layout() -> dbc.Container:
 
     placeholder = html.Div("Chart placeholders", className="graphs-placeholder")
 
-    return dbc.Container([header, tabs, placeholder], fluid=True)
+    return dbc.Container([tabs, placeholder], fluid=True)
 
 
 __all__ = ["layout"]

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -22,18 +22,6 @@ def _settings_section(title: str) -> dbc.Card:
 
 def layout() -> dbc.Container:
     """Settings page layout."""
-    header = dbc.Row(
-        dbc.Col(
-            [
-                html.H1("Settings", className="text-primary mb-4"),
-                html.P(
-                    "Manage dashboard configuration.",
-                    className="text-muted",
-                ),
-            ]
-        )
-    )
-
     sections = dbc.Row(
         [
             dbc.Col(_settings_section("User Preferences"), md=6),
@@ -41,7 +29,7 @@ def layout() -> dbc.Container:
         ]
     )
 
-    return dbc.Container([header, sections], fluid=True)
+    return dbc.Container([sections], fluid=True)
 
 
 __all__ = ["layout"]


### PR DESCRIPTION
## Summary
- add page title mapping and navbar-title element
- remove page header sections from content layouts
- update upload card wording

## Testing
- `python -m py_compile pages/graphs.py pages/export.py pages/settings.py pages/deep_analytics/layout.py dashboard/layout/navbar.py pages/file_upload.py`
- `pytest tests/utils/test_asset_serving.py::test_debug_dash_asset_serving -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_686646163c288320ac177ac234480ba8