### PR TITLE
Fix theme dropdown

### DIFF
--- a/assets/theme.js
+++ b/assets/theme.js
@@ -6,17 +6,17 @@
     if (dropdown.value !== current) {
       dropdown.value = current;
     }
+    if (!dropdown.__bound) {
+      dropdown.addEventListener('change', function (e) {
+        if (window.setAppTheme) {
+          window.setAppTheme(e.target.value);
+        }
+      });
+      dropdown.__bound = true;
+    }
   }
 
   document.addEventListener('DOMContentLoaded', syncDropdown);
   document.addEventListener('themeChange', syncDropdown);
-
-  var dropdown = document.getElementById('theme-dropdown');
-  if (dropdown) {
-    dropdown.addEventListener('change', function (e) {
-      if (window.setAppTheme) {
-        window.setAppTheme(e.target.value);
-      }
-    });
-  }
+  syncDropdown();
 })();

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -18,7 +18,7 @@ from dash_csrf_plugin import setup_enhanced_csrf_protection, CSRFMode
 import pandas as pd
 from flask_babel import Babel
 from flask_compress import Compress
-from core.theme_manager import apply_theme_settings
+from core.theme_manager import apply_theme_settings, DEFAULT_THEME
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 
@@ -368,6 +368,8 @@ def _create_main_layout() -> html.Div:
             dcc.Store(id="global-store", data={}),
             dcc.Store(id="session-store", data={}),
             dcc.Store(id="app-state-store", data={"initial": True}),
+            dcc.Store(id="theme-store", data=DEFAULT_THEME),
+            html.Div(id="theme-dummy-output", style={"display": "none"}),
         ],
         **{"data-theme": theme},
     )


### PR DESCRIPTION
## Summary
- ensure the theme dropdown event listener is attached even after components reload
- include a persistent store for the selected theme

## Testing
- `black core/app_factory.py`
- `flake8 core/app_factory.py` *(fails: command not found)*
- `bandit -r core/app_factory.py`
- `safety check -r requirements.txt` *(fails: network)*
- `pytest -q` *(fails: missing pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6866491192b08320b7904a227c262fae