### PR TITLE
Sync navbar title with page header

### DIFF
--- a/assets/navbar_sync.js
+++ b/assets/navbar_sync.js
@@ -1,0 +1,17 @@
+(function(){
+  function updateNavbarTitle(){
+    var header = document.querySelector('h1.text-primary');
+    var navTitle = document.getElementById('navbar-title');
+    if(navTitle && header){
+      var text = header.textContent.trim();
+      if(navTitle.textContent.trim() !== text){
+        navTitle.textContent = text;
+      }
+    }
+    document.querySelectorAll('.navbar-title').forEach(function(el){
+      if(el.tagName.toLowerCase() === 'h5'){ el.remove(); }
+    });
+  }
+  document.addEventListener('DOMContentLoaded', updateNavbarTitle);
+  document.addEventListener('dash:page-load', updateNavbarTitle);
+})();

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -117,10 +117,9 @@ def create_navbar_layout() -> Optional[Any]:
                                                 html.Div(
                                                     id="facility-header",
                                                     children=[
-                                                        html.H5(
-                                                            str(_l("Dashboard")),
+                                                        html.Span(
                                                             id="navbar-title",
-                                                            className="navbar-title text-primary",
+                                                            className="text-primary",
                                                         ),
                                                         html.Small(
                                                             str(
@@ -319,11 +318,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return f"Live: {current_time}"
 
-        manager.app.clientside_callback(
-            "function(pathname){const map={\"/\":\"Dashboard\",\"/dashboard\":\"Dashboard\",\"/analytics\":\"Deep Analytics\",\"/graphs\":\"Graphs\",\"/export\":\"Export\",\"/settings\":\"Settings\",\"/upload\":\"File Upload\",\"/file-upload\":\"File Upload\",\"/login\":\"Login\"};return map[pathname]||'Dashboard';}",
-            Output("navbar-title", "children"),
-            Input("url-i18n", "pathname"),
-        )
+
 
         @manager.register_callback(
             Output("language-toggle", "children"),


### PR DESCRIPTION
## Summary
- remove hardcoded navbar `<h5>` title
- add span placeholder for navbar title
- sync navbar title to first `<h1.text-primary>` via JS
- drop old path-based title callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68664af1bc308320afbbff512c371061