### PR TITLE
Fix analytics service reuse

### DIFF
--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -22,7 +22,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 # Add this import
-from services import AnalyticsService
+from services import AnalyticsService, get_analytics_service
 from utils.unicode_handler import sanitize_unicode_input, safe_format_number
 
 # Internal service imports with CORRECTED paths
@@ -78,11 +78,11 @@ def _get_display_title(analysis_type: str) -> str:
 
 
 def get_analytics_service_safe():
-    """Safely instantiate the analytics service if available."""
-    if AnalyticsService is None:
+    """Safely return the shared analytics service instance."""
+    if get_analytics_service is None:
         return None
     try:
-        return AnalyticsService()
+        return get_analytics_service()
     except Exception as e:
         logger.exception("Failed to initialize AnalyticsService: %s", e)
         return None

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -18,7 +18,6 @@ from .analysis import (
     create_analysis_results_display_safe,
     AI_SUGGESTIONS_AVAILABLE,
 )
-from services import AnalyticsService
 
 
 def run_suggests_analysis(data_source: str):
@@ -48,7 +47,9 @@ def run_service_analysis(data_source: str, analysis_type: str):
 def run_unique_patterns_analysis(data_source: str):
     """Run unique patterns analysis using the analytics service."""
     try:
-        analytics_service = AnalyticsService()
+        analytics_service = get_analytics_service_safe()
+        if not analytics_service:
+            return dbc.Alert("Analytics service not available", color="danger")
         results = analytics_service.get_unique_patterns_analysis(data_source)
 
 


### PR DESCRIPTION
## Summary
- use the globally shared analytics service in deep analytics helpers
- update unique patterns analysis to use the shared service

## Testing
- `python - <<'EOF'
import logging
import os
logging.basicConfig(level=logging.INFO)
from pages.deep_analytics.analysis import get_analytics_service_safe
os.environ['SECRET_KEY']='foo'
os.environ['DB_PASSWORD']='foo'
os.environ['AUTH0_CLIENT_ID']='foo'
os.environ['AUTH0_CLIENT_SECRET']='foo'
os.environ['AUTH0_DOMAIN']='foo'
os.environ['AUTH0_AUDIENCE']='foo'
s1 = get_analytics_service_safe()
s2 = get_analytics_service_safe()
print('service objects equal:', s1 is s2)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686652ed0eec8320b91c5c374b0df132