### PR TITLE
Enhance prod server guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,16 @@ directory as long as their paths match the references in
    npm run build-css  # or `python tools/build_css.py`
    ```
 
-6. **Run the application:**
+6. **Run the application (development only):**
    The app now loads variables from `.env` automatically.
    ```bash
-   python app.py
+   python app.py  # use only for local development
+   ```
+   For production deployments start a WSGI server instead:
+   ```bash
+   gunicorn wsgi:server
+   # or
+   uwsgi --module wsgi:server
    ```
 7. **Access the dashboard:**
    Open http://127.0.0.1:8050 in your browser
@@ -138,9 +144,12 @@ Docker Compose reads variables from a `.env` file in this directory. Set
 `DB_PASSWORD` **and** `SECRET_KEY` there (or export them in your shell) before
 starting the services.
 
-Alternatively you can launch the app with Gunicorn:
+Alternatively you can launch the app with Gunicorn or uWSGI. This is the
+recommended approach for any production deployment:
 ```bash
 gunicorn wsgi:server
+# or
+uwsgi --module wsgi:server
 ```
 
 When `YOSAI_ENV=production` and CSRF protection is enabled, the application

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,4 +4,14 @@ app = create_app()
 server = app.server
 
 if __name__ == "__main__":
-    app.run()
+    import os
+    import sys
+
+    dev_mode = os.environ.get("YOSAI_DEV") == "1" or "--dev" in sys.argv
+    if dev_mode:
+        app.run()
+    else:
+        print(
+            "Refusing to start the development server without --dev or YOSAI_DEV=1. "
+            "Use 'gunicorn wsgi:server' or an equivalent WSGI server in production."
+        )


### PR DESCRIPTION
## Summary
- update README with clear instructions to use Gunicorn or uWSGI for production
- gate Flask `app.run()` behind a `--dev` flag or `YOSAI_DEV` environment variable

## Testing
- `flake8 wsgi.py`
- `black wsgi.py --check`
- `PYTHONPATH=. pytest tests/test_config_validator.py tests/test_connection_pool.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686652f7296c832089be321e253d5852