### PR TITLE
Improve accessibility for file upload icon

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -75,8 +75,17 @@ def layout():
                                                 max_size=dynamic_config.get_max_upload_size_bytes(),  # Updated to use new method
                                                 children=html.Div(
                                                     [
-                                                        html.I(
-                                                            className="fas fa-cloud-upload-alt fa-4x mb-3 text-primary"
+                                                        html.Span(
+                                                            [
+                                                                html.I(
+                                                                    className="fas fa-cloud-upload-alt fa-4x mb-3 text-primary",
+                                                                    **{"aria-hidden": "true"},
+                                                                ),
+                                                                html.Span(
+                                                                    "Upload icon",
+                                                                    className="sr-only",
+                                                                ),
+                                                            ]
                                                         ),
                                                         html.H5(
                                                             "Drag and Drop or Click to Upload",


### PR DESCRIPTION
## Summary
- ensure screen readers ignore decorative icons in file upload page

## Testing
- `python quick_test.py`
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6866580bc29483208c0a383c0089b7a5