### PR TITLE
Enhance UI transitions and analysis feedback

### DIFF
--- a/assets/css/03-components/_buttons.css
+++ b/assets/css/03-components/_buttons.css
@@ -32,6 +32,8 @@
   outline-offset: 2px;
 }
 
+/* General hover effect for all buttons */
+
 /* Button Sizes */
 .btn--xs {
   padding: var(--space-1) var(--space-2);
@@ -137,6 +139,16 @@
 
 .btn--critical:hover:not(:disabled) {
   background: var(--color-critical-hover);
+}
+
+/* General hover effect for all buttons */
+.btn:hover:not(:disabled) {
+  filter: brightness(1.05);
+  transform: translateY(-2px);
+}
+
+.btn:active {
+  transform: translateY(0);
 }
 
 /* Legacy button utility classes */

--- a/assets/css/03-components/_cards.css
+++ b/assets/css/03-components/_cards.css
@@ -10,10 +10,12 @@
   overflow: hidden;
   box-shadow: var(--shadow-sm);
   transition: all var(--duration-normal) var(--ease-out);
+  animation: fade-slide-in 0.3s ease-out;
 }
 
 .card:hover {
   box-shadow: var(--shadow-md);
+  transform: translateY(-4px);
 }
 
 /* Card Sections */

--- a/assets/css/05-pages/_analytics.css
+++ b/assets/css/05-pages/_analytics.css
@@ -4,3 +4,8 @@
 .hidden {
   display: none;
 }
+
+/* Page transition effect */
+.main-content {
+  animation: fade-slide-in 0.4s ease-out;
+}

--- a/assets/css/07-utilities/_animations.css
+++ b/assets/css/07-utilities/_animations.css
@@ -1,0 +1,18 @@
+/* =================================================================== */
+/* 07-utilities/_animations.css - Common animations */
+/* =================================================================== */
+
+@keyframes fade-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-slide-in {
+  animation: fade-slide-in 0.4s ease-out both;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -45,6 +45,7 @@
 /* Utility Classes */
 @import './07-utilities/_display.css';
 @import './07-utilities/_flexbox.css';
+@import './07-utilities/_animations.css';
 @import './07-utilities/_colors.css';
 @import './07-utilities/_sizing.css';
 @import './07-utilities/_text.css';

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -369,7 +369,11 @@ def _create_main_layout() -> html.Div:
                 className="top-panel",
             ),
             # Main content area (dynamically populated)
-            html.Main(id="page-content", className="main-content p-4"),
+            dcc.Loading(
+                id="page-loading",
+                type="circle",
+                children=html.Main(id="page-content", className="main-content p-4"),
+            ),
             # Global data stores
             dcc.Store(id="global-store", data={}),
             dcc.Store(id="session-store", data={}),

--- a/pages/deep_analytics/layout.py
+++ b/pages/deep_analytics/layout.py
@@ -136,16 +136,20 @@ def layout():
         ], className="mb-4")
 
         # Results display area
-        results_area = html.Div(
-            id="analytics-display-area",
-            children=[
-                dbc.Alert([
-                    html.H6("Get Started"),
-                    html.P("1. Select a data source from the dropdown"),
-                    html.P("2. Click any analysis button to run immediately"),
-                    html.P("Each button runs its analysis type automatically")
-                ], color="info")
-            ]
+        results_area = dcc.Loading(
+            id="analytics-loading",
+            type="circle",
+            children=html.Div(
+                id="analytics-display-area",
+                children=[
+                    dbc.Alert([
+                        html.H6("Get Started"),
+                        html.P("1. Select a data source from the dropdown"),
+                        html.P("2. Click any analysis button to run immediately"),
+                        html.P("Each button runs its analysis type automatically")
+                    ], color="info")
+                ]
+            )
         )
 
         # Hidden stores


### PR DESCRIPTION
## Summary
- animate buttons and cards
- fade pages on navigation
- show spinners while pages and analyses load
- add common animations utilities

## Testing
- `pytest -q` *(fails: numpy dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_68665812dd988320a867a73543c9c65f