### PR TITLE
Compile Babel translations and document .mo requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ data/training/
 
 # Node
 node_modules/
+
+# Compiled translations
+translations/**/*.mo

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ procedures, Docker/cloud secret usage, and incident handling guidance.
 
 Internationalization is built in with Flask-Babel. Click the language dropdown in the navigation bar to switch between English and Japanese. No additional environment variables are required.
 If you encounter an error like `"Babel" object has no attribute "localeselector"` when starting the app, ensure that the `Flask-Babel` package is installed and up to date (version 4 or later). The application now falls back to the new `locale_selector_func` API when needed.
+The compiled `.mo` files in `translations/` must exist at runtime. After editing any `.po` files run `pybabel compile -d translations` and commit the generated files.
 
 ![Language Toggle Demo](docs/i18n_demo.gif)
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -27,21 +27,26 @@ This guide walks new contributors through setting up a local development environ
    ./scripts/setup.sh
    ```
 
-4. **Configure environment variables:**
+4. **Compile translations:**
+   ```bash
+   pybabel compile -d translations
+   ```
+
+5. **Configure environment variables:**
    ```bash
    cp .env.example .env
    # Edit .env as needed
    ```
 
-5. **(Optional) Initialize the database or load sample data.**
+6. **(Optional) Initialize the database or load sample data.**
    Prepare your PostgreSQL database and populate it with any example data if desired.
 
-6. **Run the test suite:**
+7. **Run the test suite:**
    ```bash
    pytest --cov
    ```
 
-7. **Start the application:**
+8. **Start the application:**
    ```bash
    python app.py
    ```


### PR DESCRIPTION
## Summary
- compile JA translations with `pybabel`
- note in README that `.mo` files must exist and how to compile them
- update developer onboarding with translation compile step
- ignore compiled translation files
- remove the compiled `.mo` from version control

## Testing
- `pybabel compile -d translations`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68665df7eab08320be49c3d86127c5c5