### PR TITLE
Fix dependency errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ following steps:
 
 3. Restart your editor so Pylance picks up the correct interpreter.
 
+4. If the dashboard starts with a blank page, required packages are
+   likely missing. Install them before launching the app:
+   ```bash
+   pip install -r requirements.txt  # or ./scripts/setup.sh
+   ```
+
 ### Production Deployment
 
 Using Docker Compose:

--- a/app.py
+++ b/app.py
@@ -13,7 +13,14 @@ import os
 import sys
 import importlib
 
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    logging.error("Required package 'python-dotenv' is missing.")
+    logging.error(
+        "Run `pip install -r requirements.txt` or `./scripts/setup.sh` to install dependencies."
+    )
+    sys.exit(1)
 
 from core.exceptions import ConfigurationError
 from utils import debug_dash_asset_serving
@@ -55,7 +62,7 @@ def check_learning_status():
 
 def verify_dependencies() -> None:
     """Ensure critical third-party libraries are available."""
-    required = ["bleach", "pandas"]
+    required = ["bleach", "pandas", "dash", "flask", "dotenv"]
     missing = []
     for pkg in required:
         try:
@@ -65,7 +72,9 @@ def verify_dependencies() -> None:
 
     if missing:
         logger.error("Missing required dependencies: %s", ", ".join(missing))
-        logger.info("\n💡 Run ./scripts/setup.sh to install them")
+        logger.info(
+            "\n💡 Run `pip install -r requirements.txt` or `./scripts/setup.sh` to install them"
+        )
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- troubleshoot missing packages
- exit gracefully when imports fail

## Testing
- `python app.py` (in clean venv)
- `pytest -q` *(fails: ModuleNotFoundError: dash_bootstrap_components)*
- `black . --check` *(fails: would reformat various files)*
- `flake8 .` *(fails: multiple style issues)*
- `mypy .` *(fails: Duplicate module named "test_callback_helpers")

------
https://chatgpt.com/codex/tasks/task_e_6866613ceb608320b9aa1607a603d397