### PR TITLE
Ignore compiled translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ node_modules/
 
 # Compiled translations
 translations/**/*.mo
+translations/**/LC_MESSAGES/*.mo


### PR DESCRIPTION
## Summary
- ignore compiled translation files (`.mo`)

## Testing
- `git ls-files | grep '\.mo$'`

------
https://chatgpt.com/codex/tasks/task_e_6866632758f883208cb6b4e2fb8e77a4