### PR TITLE
Fix theme switching for light/dark mode

### DIFF
--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -37,11 +37,12 @@ def generate_theme_script() -> str:
         const saved = sanitize(localStorage.getItem('app-theme'));
         const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         const initial = saved || sanitize(system);
-        document.documentElement.dataset.theme = initial;
+        const target = document.querySelector("[data-theme]") || document.documentElement;
+        target.dataset.theme = initial;
         document.dispatchEvent(new CustomEvent('themeChange', {{ detail: initial }}));
         window.setAppTheme = function(theme) {{
             const clean = sanitize(theme);
-            document.documentElement.dataset.theme = clean;
+            target.dataset.theme = clean;
             localStorage.setItem('app-theme', clean);
             document.dispatchEvent(new CustomEvent('themeChange', {{ detail: clean }}));
         }};


### PR DESCRIPTION
## Summary
- update theme script to change the element that holds `data-theme`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68667e1b05f88320a577a3260f2d1b68