### PR TITLE
Fix callback manager typing warning

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,7 +166,7 @@ def main():
                 manager.trigger(CallbackEvent.AFTER_REQUEST, current)
                 return current
 
-            app._callback_manager = manager
+            app._callback_manager = manager  # type: ignore[attr-defined]
             # Validate that Dash can serve static assets after request hooks
             # have been registered. This avoids triggering a request before the
             # hooks are in place, which previously caused Flask to raise a


### PR DESCRIPTION
## Summary
- keep the custom callback manager but silence Pylance

## Testing
- `python app.py` *(fails: No module named 'flask_compress')*


------
https://chatgpt.com/codex/tasks/task_e_68669e1075e88320bc6731d559c5edfd