### PR TITLE
Fix Pylance error when assigning callback manager

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,7 +166,7 @@ def main():
                 manager.trigger(CallbackEvent.AFTER_REQUEST, current)
                 return current
 
-            app._callback_manager = manager  # type: ignore[attr-defined]
+            app._callback_manager = manager  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
             # Validate that Dash can serve static assets after request hooks
             # have been registered. This avoids triggering a request before the
             # hooks are in place, which previously caused Flask to raise a


### PR DESCRIPTION
## Summary
- suppress Pylance `reportAttributeAccessIssue` when attaching the custom callback manager

## Testing
- `pytest tests/test_callback_manager_events.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `flake8 app.py` *(fails: command not found)*
- `mypy app.py` *(fails: found 292 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68669fe4117c8320b89d08e3e799b05d