### PR TITLE
Performance tuning for Dash assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,9 @@ data/training/
 # Node
 node_modules/
 
+# Exclude raw CSS partials but keep the compiled bundle
+assets/css/*
+!assets/dist/main.min.css
+
 # Compiled translations
 translations/**/*.mo

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ numpy>=1.24.0
 Flask-Babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
-Flask-Compress==1.13
+Flask-Compress~=1.14
+Flask-Talisman==1.1.0
 authlib==1.2.1
 python-jose==3.3.0
 cssutils==2.8.0


### PR DESCRIPTION
## Summary
- bundle assets and disable automatic scanning for dash
- add gzip compression, caching headers and security policy
- cache layout object instead of recreating each visit
- ignore raw CSS partials
- use newer Flask-Compress and add Flask-Talisman

## Testing
- `black --check core/app_factory.py`
- `flake8 core/app_factory.py` *(fails: command not found)*
- `mypy core/app_factory.py` *(fails: found 287 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866a3c11ce08320acc110a2b35dda5f