### PR TITLE
Fix assets_ignore regex in Dash setup

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -69,7 +69,6 @@ def _create_full_app() -> dash.Dash:
             assets_folder=str(ASSETS_DIR),
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -261,7 +260,6 @@ def _create_simple_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -370,7 +368,6 @@ def _create_json_safe_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
 
         app.index_string = f"""
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- remove invalid wildcard override for Dash's assets_ignore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866a737b3e88320a200497f4496e26a