### PR TITLE
Fix assets_ignore regex

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -69,7 +69,7 @@ def _create_full_app() -> dash.Dash:
             assets_folder=str(ASSETS_DIR),
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
+        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -261,7 +261,7 @@ def _create_simple_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
+        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -370,7 +370,7 @@ def _create_json_safe_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = "*"
+        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- ensure Dash `assets_ignore` uses a valid regex pattern

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866a7e2d8ac83209e5b1fa03c6d8c80