### PR TITLE
Add navbar icon helper with Font-Awesome fallbacks

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -9,7 +9,7 @@ from flask_babel import lazy_gettext as _l, refresh
 from flask import session
 from core.plugins.decorators import safe_callback
 from core.theme_manager import DEFAULT_THEME, sanitize_theme
-from utils import check_navbar_assets, navbar_icon
+from utils.assets_utils import get_nav_icon
 
 import logging
 
@@ -68,6 +68,34 @@ PAGE_TITLES = {
     "/login": _l("Login"),
 }
 
+# Font-Awesome glyphs used when a PNG icon is unavailable
+fallback_icons = {
+    "dashboard": "fas fa-home",
+    "analytics": "fas fa-chart-bar",
+    "graphs": "fas fa-chart-line",
+    "upload": "fas fa-cloud-upload-alt",
+    "print": "fas fa-print",
+    "settings": "fas fa-cog",
+    "logout": "fas fa-sign-out-alt",
+}
+
+
+def nav_icon(name: str, alt: str) -> Any:
+    """Return ``Img`` tag or Font-Awesome fallback for the given icon name."""
+    try:
+        import dash  # Imported here to avoid ImportError in safe mode
+
+        app = dash.get_app()
+        url = get_nav_icon(app, name)
+    except Exception:  # pragma: no cover - graceful fallback
+        url = None
+
+    if url:
+        return html.Img(src=url, className="nav-icon", alt=alt)
+
+    glyph = fallback_icons.get(name, "fas fa-circle")
+    return html.I(className=f"{glyph} nav-icon", **{"aria-hidden": "true"})
+
 
 def create_navbar_layout() -> Optional[Any]:
     """Create navbar layout with responsive grid design"""
@@ -75,17 +103,6 @@ def create_navbar_layout() -> Optional[Any]:
         return None
 
     try:
-        check_navbar_assets(
-            [
-                "dashboard.png",
-                "analytics.png",
-                "analytics.png",
-                "upload.png",
-                "print.png",
-                "settings.png",
-                "logout.png",
-            ]
-        )
         return dbc.Navbar(
             [
                 dbc.Container(
@@ -159,24 +176,19 @@ def create_navbar_layout() -> Optional[Any]:
                                                 html.Div(
                                                     [
                                                         html.A(
-                                                            navbar_icon(
-                                                                "dashboard.png",
-                                                                str(_l("Dashboard")),
-                                                                "🏠",
-                                                            ),
+                                                            nav_icon("dashboard", str(_l("Dashboard"))),
                                                             href="/dashboard",
                                                             className="navbar-nav-link",
                                                             title=str(_l("Dashboard")),
                                                         ),
                                                         html.A(
-                                                            navbar_icon(
-                                                                "analytics.png",
+                                                            nav_icon(
+                                                                "analytics",
                                                                 str(
                                                                     _l(
                                                                         "Deep Analytics Page"
                                                                     )
                                                                 ),
-                                                                "📊",
                                                             ),
                                                             href="/analytics",
                                                             className="navbar-nav-link",
@@ -187,20 +199,18 @@ def create_navbar_layout() -> Optional[Any]:
                                                             ),
                                                         ),
                                                         html.A(
-                                                            navbar_icon(
-                                                                "analytics.png",
+                                                            nav_icon(
+                                                                "graphs",
                                                                 str(_l("Graphs")),
-                                                                "📈",
                                                             ),
                                                             href="/graphs",
                                                             className="navbar-nav-link",
                                                             title=str(_l("Graphs")),
                                                         ),
                                                         html.A(
-                                                            navbar_icon(
-                                                                "upload.png",
+                                                            nav_icon(
+                                                                "upload",
                                                                 str(_l("Upload")),
-                                                                "⬆️",
                                                             ),
                                                             href="/file-upload",
                                                             className="navbar-nav-link",
@@ -219,10 +229,9 @@ def create_navbar_layout() -> Optional[Any]:
                                                             ],
                                                             nav=True,
                                                             in_navbar=True,
-                                                            label=navbar_icon(
-                                                                "print.png",
+                                                            label=nav_icon(
+                                                                "print",
                                                                 str(_l("Export")),
-                                                                "🖨️",
                                                             ),
                                                             toggle_class_name="navbar-nav-link",
                                                             menu_variant="dark",
@@ -265,10 +274,9 @@ def create_navbar_layout() -> Optional[Any]:
                                                             ],
                                                             nav=True,
                                                             in_navbar=True,
-                                                            label=navbar_icon(
-                                                                "settings.png",
+                                                            label=nav_icon(
+                                                                "settings",
                                                                 str(_l("Settings")),
-                                                                "⚙️",
                                                             ),
                                                             toggle_class_name="navbar-nav-link",
                                                             menu_variant="dark",
@@ -305,10 +313,9 @@ def create_navbar_layout() -> Optional[Any]:
                                                     id="language-toggle",
                                                 ),
                                                 html.A(
-                                                    navbar_icon(
-                                                        "logout.png",
+                                                    nav_icon(
+                                                        "logout",
                                                         str(_l("Logout")),
-                                                        "🚪",
                                                     ),
                                                     href="/login",  # Changed from /logout to /login
                                                     className="navbar-nav-link",

--- a/tests/utils/test_assets_utils.py
+++ b/tests/utils/test_assets_utils.py
@@ -1,0 +1,20 @@
+from core.app_factory import create_app
+from utils.assets_utils import get_nav_icon
+
+
+def _make_app(monkeypatch):
+    monkeypatch.setenv("YOSAI_ENV", "development")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    return create_app(mode="simple")
+
+
+def test_get_nav_icon_existing(monkeypatch):
+    app = _make_app(monkeypatch)
+    assert get_nav_icon(app, "analytics") is not None
+
+
+def test_get_nav_icon_missing(monkeypatch):
+    app = _make_app(monkeypatch)
+    assert get_nav_icon(app, "missing_icon_xyz") is None
+
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -15,6 +15,7 @@ try:
         debug_dash_asset_serving,
         navbar_icon,
     )
+    from .assets_utils import get_nav_icon
 except Exception:  # pragma: no cover - fallback when utils unavailable
     from .unicode_utils import (
         safe_unicode_encode,
@@ -30,6 +31,7 @@ except Exception:  # pragma: no cover - fallback when utils unavailable
         debug_dash_asset_serving,
         navbar_icon,
     )
+    from .assets_utils import get_nav_icon
 
 __all__: list[str] = [
     "sanitize_unicode_input",
@@ -42,4 +44,5 @@ __all__: list[str] = [
     "check_navbar_assets",
     "debug_dash_asset_serving",
     "navbar_icon",
+    "get_nav_icon",
 ]

--- a/utils/assets_utils.py
+++ b/utils/assets_utils.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+ASSET_ICON_DIR = Path(__file__).resolve().parent.parent / "assets" / "navbar_icons"
+
+
+def get_nav_icon(app, name: str) -> str | None:
+    """Return an asset URL for the given navbar icon if it exists."""
+    png_path = ASSET_ICON_DIR / f"{name}.png"
+    if png_path.is_file():
+        return app.get_asset_url(f"navbar_icons/{name}.png")
+    return None
+


### PR DESCRIPTION
## Summary
- provide `utils.assets_utils.get_nav_icon` for safer navbar icon lookups
- use new helper in navbar layout with Font-Awesome fallbacks
- export helper from `utils` package
- add tests for icon lookup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866a9e5c40c8320bb9b80a7de4efbb2