### PR TITLE
Fix asset ignore pattern

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -61,6 +61,10 @@ def _create_full_app() -> dash.Dash:
         if built_css.exists():
             external_stylesheets.append("/assets/dist/main.min.css")
             assets_ignore += r"|css/main\.css"
+        assets_ignore = rf"^\..*|.*\.txt$|{assets_ignore}"
+        assets_ignore = rf"^\..*|.*\.txt$|{assets_ignore}"
+        # Ignore hidden files and text assets but allow everything else
+        assets_ignore = rf"^\..*|.*\.txt$|{assets_ignore}"
 
         app = dash.Dash(
             __name__,
@@ -69,7 +73,6 @@ def _create_full_app() -> dash.Dash:
             assets_folder=str(ASSETS_DIR),
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -261,7 +264,6 @@ def _create_simple_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -370,7 +372,6 @@ def _create_json_safe_app() -> dash.Dash:
             suppress_callback_exceptions=True,
             assets_ignore=assets_ignore,
         )
-        app.config.assets_ignore = r"^\..*|.*\.txt$"
 
         app.index_string = f"""
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- combine dotfile filter with existing asset ignore pattern
- remove duplicate assignment that overwrote the pattern

## Testing
- `pytest tests/utils/test_asset_serving.py::test_debug_dash_asset_serving -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866bc3e332c8320a71a1bbd02b3d04f