### PR TITLE
Disable HTTPS redirects locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ directory as long as their paths match the references in
 7. **Access the dashboard:**
    Open http://127.0.0.1:8050 in your browser. The application runs over
    plain HTTP by default; configure a reverse proxy with TLS if you need HTTPS.
+   The development server does not support HTTPS, so be sure to visit
+   `http://<host>:<port>` rather than `https://` when testing locally.
 
 ## Developer Onboarding
 

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -103,7 +103,14 @@ def _create_full_app() -> dash.Dash:
 
         apply_theme_settings(app)
         Compress(app.server)
-        Talisman(app.server, content_security_policy=None)
+        config_manager = get_config()
+        https_only = config_manager.get_app_config().environment == "production"
+        Talisman(
+            app.server,
+            content_security_policy=None,
+            force_https=https_only,
+            force_https_permanent=https_only,
+        )
 
         @app.server.after_request  # type: ignore[misc]
         def add_cache_headers(resp):
@@ -133,7 +140,6 @@ def _create_full_app() -> dash.Dash:
             logger.warning(f"Failed to initialize Babel: {e}")
 
         # Use the working config system
-        config_manager = get_config()
 
         if (
             config_manager.get_security_config().csrf_enabled
@@ -284,7 +290,14 @@ def _create_simple_app() -> dash.Dash:
 
         apply_theme_settings(app)
         Compress(app.server)
-        Talisman(app.server, content_security_policy=None)
+        cfg = get_config()
+        https_only = cfg.get_app_config().environment == "production"
+        Talisman(
+            app.server,
+            content_security_policy=None,
+            force_https=https_only,
+            force_https_permanent=https_only,
+        )
 
         @app.server.after_request  # type: ignore[misc]
         def add_cache_headers(resp):
@@ -392,7 +405,14 @@ def _create_json_safe_app() -> dash.Dash:
 
         apply_theme_settings(app)
         Compress(app.server)
-        Talisman(app.server, content_security_policy=None)
+        cfg = get_config()
+        https_only = cfg.get_app_config().environment == "production"
+        Talisman(
+            app.server,
+            content_security_policy=None,
+            force_https=https_only,
+            force_https_permanent=https_only,
+        )
 
         @app.server.after_request  # type: ignore[misc]
         def add_cache_headers(resp):


### PR DESCRIPTION
## Summary
- disable HTTPS enforcement when running locally
- note in README that dev server uses HTTP

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `flake8` *(fails: command not found)*
- `mypy .` *(fails with errors)*
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_6866be3c74808320905e0c9534db9d59