### PR TITLE
Fix custom Dash templates for new renderer

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -86,7 +86,7 @@ def _create_full_app() -> dash.Dash:
   </head>
   <body>
     {{%app_entry%}}
-    <footer>{{%config%}}{{%scripts%}}</footer>
+    <footer>{{%config%}}{{%scripts%}}{{%renderer%}}</footer>
   </body>
 </html>
 """
@@ -283,7 +283,7 @@ def _create_simple_app() -> dash.Dash:
   </head>
   <body>
     {{%app_entry%}}
-    <footer>{{%config%}}{{%scripts%}}</footer>
+    <footer>{{%config%}}{{%scripts%}}{{%renderer%}}</footer>
   </body>
 </html>
 """
@@ -398,7 +398,7 @@ def _create_json_safe_app() -> dash.Dash:
   </head>
   <body>
     {{%app_entry%}}
-    <footer>{{%config%}}{{%scripts%}}</footer>
+    <footer>{{%config%}}{{%scripts%}}{{%renderer%}}</footer>
   </body>
 </html>
 """


### PR DESCRIPTION
## Summary
- update custom index template strings to include `{%renderer%}` placeholder so Dash inserts the required renderer script

## Testing
- `PORT=8061 python app.py` (server started and served page successfully)


------
https://chatgpt.com/codex/tasks/task_e_6866c5ae299c83209cc3e3f18637be5f