### PR TITLE
Fix utils.unicode_utils import error

### DIFF
--- a/utils/unicode_utils.py
+++ b/utils/unicode_utils.py
@@ -151,6 +151,12 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     return UnicodeProcessor.sanitize_dataframe(df)
 
 
+def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Deprecated alias for :func:`sanitize_dataframe`."""
+
+    return sanitize_dataframe(df)
+
+
 # ---------------------------------------------------------------------------
 # Backwards compatibility helpers
 
@@ -204,6 +210,7 @@ __all__ = [
     "safe_decode",
     "safe_encode",
     "sanitize_dataframe",
+    "sanitize_data_frame",
     # Backwards compatible aliases
     "safe_unicode_encode",
     "handle_surrogate_characters",


### PR DESCRIPTION
## Summary
- add alias `sanitize_data_frame` to `unicode_utils`

## Testing
- `pytest tests/test_unicode_processor.py::test_sanitize_data_frame -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `black --check .` *(fails: would reformat 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68671f6c69fc832093ed204433dd400c