### PR TITLE
Handle missing uploaded files when saving mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,9 @@ Uploaded files are now **lazy loaded**. Only the `file_info.json` metadata is
 read at startup; Parquet files are opened on demand when analytics or previews
 require them. This keeps startup fast even with many large uploads.
 
+**Important:** keep the `temp/uploaded_data` directory intact until device
+mappings have been saved, otherwise the mapping step will fail.
+
 
 ## 🤝 Contributing
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -987,6 +987,20 @@ class Callbacks:
                 }
 
             learning_service = get_device_learning_service()
+
+            safe_name = filename.replace(" ", "_").replace("/", "_")
+            file_path = _uploaded_data_store.storage_dir / f"{safe_name}.parquet"
+            if not file_path.exists():
+                logger.error(f"Uploaded file not found: {file_path}")
+                error_alert = dbc.Toast(
+                    "❌ Uploaded data missing - cannot save mappings.",
+                    header="Error",
+                    is_open=True,
+                    dismissable=True,
+                    duration=5000,
+                )
+                return error_alert, no_update, no_update
+
             df = _uploaded_data_store.load_dataframe(filename)
             learning_service.save_user_device_mappings(df, filename, user_mappings)
 


### PR DESCRIPTION
## Summary
- check for missing file before saving device mappings
- warn users in docs that uploaded data directory must remain intact

## Testing
- `black --check pages/file_upload.py`
- `flake8 pages/file_upload.py` *(fails: various style errors)*
- `pip install -r requirements.txt` *(fails: dependency conflict)
- `pytest -q` *(fails: missing pandas dependency)*


------
https://chatgpt.com/codex/tasks/task_e_68672b326bcc832084fbfb66666723f8