### PR TITLE
Cache heavy chart generation

### DIFF
--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -29,10 +29,14 @@ def _generate_sample_figures():
         return {"line": empty, "bar": empty, "other": empty}
 
 
+# Generate figures once at import time to avoid expensive recomputation
+GRAPH_FIGURES = _generate_sample_figures()
+
+
 def layout() -> dbc.Container:
     """Graphs page layout with sample charts."""
 
-    figures = _generate_sample_figures()
+    figures = GRAPH_FIGURES
 
     tabs = dbc.Tabs(
         [


### PR DESCRIPTION
## Summary
- avoid recomputation of sample charts by generating once at import
- use cached figures in `layout`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686725dcdacc8320bdef28cbdc76a6c3