### PR TITLE
Add Gunicorn configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ Docker Compose reads variables from a `.env` file in this directory. Set
 starting the services.
 
 Alternatively you can launch the app with Gunicorn or uWSGI. This is the
-recommended approach for any production deployment:
+recommended approach for any production deployment. A sample Gunicorn
+configuration is provided at `gunicorn.conf.py`:
 ```bash
-gunicorn wsgi:server
+gunicorn -c gunicorn.conf.py wsgi:server
 # or
 uwsgi --module wsgi:server
 ```
@@ -254,6 +255,9 @@ HOST=0.0.0.0         # Bind to all interfaces for production
 PORT=8050            # Application port
 SECRET_KEY=your-key  # Change for production
 ```
+
+For Gunicorn deployments, host, port and log level defaults are also
+defined in `gunicorn.conf.py`.
 
 The secret key is not included in the default YAML files. Define
 `SECRET_KEY` in your environment or a `.env` file before starting the

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,4 @@
+bind = "0.0.0.0:8050"
+workers = 4
+threads = 2
+loglevel = "info"


### PR DESCRIPTION
## Summary
- add `gunicorn.conf.py` with default bind, worker and thread counts
- document the new config in deployment instructions

## Testing
- `pip install -r requirements.txt` *(fails: dependency conflict)*
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*
- `mypy .` *(fails: many import and typing errors)*
- `black . --check` *(fails: files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686725f715988320a2653ace266887df