### PR TITLE
Limit dataframe preview size

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -260,11 +260,16 @@ def create_analytics_charts(analytics_data: Dict[str, Any]) -> html.Div:
 
 
 def create_data_preview(df: pd.DataFrame, filename: str = "") -> html.Div:
-    """Create data preview component"""
+    """Create data preview component.
+
+    The preview table always uses ``df.head(5)`` and the DataFrame is
+    clamped to fewer than 100 rows before rendering.
+    """
     if df is None or df.empty:
         return dbc.Alert("No data to preview", color="info")
 
-    # Get basic info
+    # Clamp to avoid huge previews
+    df = df.head(99)
     num_rows, num_cols = df.shape
 
     return dbc.Card(
@@ -287,7 +292,7 @@ def create_data_preview(df: pd.DataFrame, filename: str = "") -> html.Div:
                     # Data preview table
                     html.H6("Sample Data:", className="mt-3"),
                     dbc.Table.from_dataframe(
-                        df.head(10),
+                        df.head(5),
                         striped=True,
                         bordered=True,
                         hover=True,

--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -24,6 +24,7 @@ import plotly.graph_objects as go
 # Add this import
 from services import AnalyticsService, get_analytics_service
 from utils.unicode_utils import sanitize_unicode_input, safe_format_number
+from utils.preview_utils import serialize_dataframe_preview
 
 # Internal service imports with CORRECTED paths
 ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
@@ -248,7 +249,7 @@ def process_suggests_analysis(data_source: str) -> Dict[str, Any]:
                     )
 
                     try:
-                        data_preview = df.head(5).to_dict("records")
+                        data_preview = serialize_dataframe_preview(df)
                     except Exception as e:
                         logger.exception("Failed to build data preview: %s", e)
                         data_preview = []

--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -102,10 +102,15 @@ def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 
 
 def create_file_preview(df: pd.DataFrame, filename: str) -> dbc.Card | dbc.Alert:
-    """Create a preview card showing the correct row count."""
+    """Create a preview card showing the correct row count.
+
+    The preview table uses ``df.head(5)`` and clamps ``df`` to fewer than
+    100 rows before rendering.
+    """
     try:
         # CRITICAL: Get actual DataFrame size
         actual_rows, actual_cols = df.shape
+        df = df.head(99)
         preview_rows = min(5, actual_rows)  # Only for table display
 
         logger.info(

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -16,6 +16,7 @@ try:
         navbar_icon,
     )
     from .assets_utils import get_nav_icon
+    from .preview_utils import serialize_dataframe_preview
 except Exception:  # pragma: no cover - fallback when utils unavailable
     from .unicode_utils import (
         safe_unicode_encode,
@@ -32,6 +33,7 @@ except Exception:  # pragma: no cover - fallback when utils unavailable
         navbar_icon,
     )
     from .assets_utils import get_nav_icon
+    from .preview_utils import serialize_dataframe_preview
 
 __all__: list[str] = [
     "sanitize_unicode_input",
@@ -45,4 +47,5 @@ __all__: list[str] = [
     "debug_dash_asset_serving",
     "navbar_icon",
     "get_nav_icon",
+    "serialize_dataframe_preview",
 ]

--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -1,0 +1,26 @@
+import json
+import logging
+from typing import Any, List, Dict
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def serialize_dataframe_preview(df: pd.DataFrame) -> List[Dict[str, Any]]:
+    """Return a JSON-safe preview of ``df`` for callbacks.
+
+    The preview always uses ``df.head(5)`` and the DataFrame is first clamped to
+    fewer than 100 rows. If the serialized preview exceeds 5MB, an empty list is
+    returned.
+    """
+    try:
+        limited_df = df.head(99)  # clamp DataFrame to <100 rows
+        preview = limited_df.head(5).to_dict("records")
+        serialized = json.dumps(preview, ensure_ascii=False)
+        if len(serialized.encode("utf-8")) >= 5 * 1024 * 1024:
+            logger.warning("Serialized preview exceeds 5MB; omitting preview")
+            return []
+        return preview
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.exception("Failed to serialize dataframe preview: %s", exc)
+        return []


### PR DESCRIPTION
## Summary
- clamp dataframe preview to <100 rows
- trim preview to first 5 rows for UI and callbacks
- skip preview if serialized size exceeds 5MB
- document new limits in docstrings
- add helper to generate safe previews

## Testing
- `python -m py_compile utils/preview_utils.py pages/deep_analytics/analysis.py components/__init__.py services/upload_service.py core/json_serialization_plugin.py`
- `pytest -k json_serialization_plugin -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_686725eeda188320bdc56ffb4c40344a