### PR TITLE
Add dash callback profiling decorator

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,7 @@
 Core package initialization - Fixed for streamlined architecture
 """
 import logging
+from .dash_profile import profile_callback
 
 # Configure logging
 logging.basicConfig(
@@ -18,4 +19,4 @@ def create_app(mode: str | None = None):
     return _create_app(mode)
 
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "profile_callback"]

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -3,6 +3,7 @@
 from dash import Input, Output, State, callback_context, html
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from analytics.controllers import UnifiedAnalyticsController
+from core.dash_profile import profile_callback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -543,7 +544,7 @@ def register_callbacks(
             prevent_initial_call=True if cid != "update_status_alert" else False,
             callback_id=cid,
             component_name="deep_analytics",
-        )(func)
+        )(profile_callback(cid)(func))
 
     if controller is not None:
         controller.register_callback(

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -15,6 +15,7 @@ from dash.dash import no_update
 from dash._callback_context import callback_context
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from analytics.controllers import UnifiedAnalyticsController
+from core.dash_profile import profile_callback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1294,7 +1295,7 @@ def register_callbacks(
             callback_id=cid,
             component_name="file_upload",
             **extra,
-        )(func)
+        )(profile_callback(cid)(func))
 
     if controller is not None:
         controller.register_callback(


### PR DESCRIPTION
## Summary
- add `profile_callback` decorator for timing callbacks
- re-export the decorator via `core.__init__`
- wrap analytics and upload callbacks with the new profiler

## Testing
- `flake8 core/dash_profile.py pages/deep_analytics/callbacks.py pages/file_upload.py core/__init__.py` *(fails: E402, F401, E501)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686725f0142c83208c176149c30af3c2