### PR TITLE
Fix device mapping save race

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -990,6 +990,7 @@ class Callbacks:
             learning_service = get_device_learning_service()
 
             safe_name = filename.replace(" ", "_").replace("/", "_")
+            _uploaded_data_store.wait_for_pending_saves()
             file_path = _uploaded_data_store.storage_dir / f"{safe_name}.parquet"
             if not file_path.exists():
                 logger.error(f"Uploaded file not found: {file_path}")

--- a/tests/test_device_mapping_save.py
+++ b/tests/test_device_mapping_save.py
@@ -1,0 +1,48 @@
+import base64
+import pandas as pd
+import dash_bootstrap_components as dbc
+from services.upload import UploadProcessingService
+from utils.upload_store import UploadedDataStore
+
+
+def _encode_df(df: pd.DataFrame) -> str:
+    data = df.to_csv(index=False).encode()
+    b64 = base64.b64encode(data).decode()
+    return f"data:text/csv;base64,{b64}"
+
+
+def test_immediate_confirm_after_upload(monkeypatch, tmp_path):
+    import importlib
+    import sys
+    import types
+
+    sys.modules["pages.graphs"] = types.ModuleType("pages.graphs")
+    sys.modules["pages.graphs"].GRAPH_FIGURES = {}
+
+    file_upload = importlib.import_module("pages.file_upload")
+    Callbacks = file_upload.Callbacks
+
+    store = UploadedDataStore(storage_dir=tmp_path)
+    monkeypatch.setattr(file_upload, "_uploaded_data_store", store)
+
+    cb = Callbacks()
+    cb.processing = UploadProcessingService(store)
+
+    df = pd.DataFrame({"device": ["Door1"], "val": [1]})
+    content = _encode_df(df)
+
+    # Simulate upload which triggers async disk save
+    cb.process_uploaded_files(content, "data.csv")
+
+    file_info = {"filename": "data.csv", "devices": ["Door1"]}
+    alert, _, _ = cb.save_confirmed_device_mappings(
+        1,
+        [1],
+        [5],
+        [[]],
+        [[]],
+        file_info,
+    )
+
+    assert isinstance(alert, dbc.Toast)
+    assert "cannot save mappings" not in alert.children


### PR DESCRIPTION
## Summary
- ensure device mappings wait for background file saves
- add regression test for confirming mappings immediately after uploading

## Testing
- `black tests/test_device_mapping_save.py pages/file_upload.py -q`
- `flake8 tests/test_device_mapping_save.py`
- `pytest tests/test_device_mapping_save.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686731ddd0a883208fd3b0aa4172c9ed