### PR TITLE
Add restricted device support

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -410,7 +410,7 @@ def toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open)
     return is_open
 
 
-def save_user_inputs(floors, security, access, devices):
+def save_user_inputs(floors, security, access, special, devices):
     """Save user inputs immediately when they change"""
 
     if not devices:
@@ -423,6 +423,7 @@ def save_user_inputs(floors, security, access, devices):
             security[i] if i < len(security) and security[i] is not None else 5
         )
         user_access = access[i] if i < len(access) else []
+        user_special = special[i] if i < len(special) else []
 
         ai_mapping_store.set(
             device,
@@ -431,6 +432,10 @@ def save_user_inputs(floors, security, access, devices):
                 "security_level": user_security,
                 "is_entry": "entry" in user_access,
                 "is_exit": "exit" in user_access,
+                "is_elevator": "is_elevator" in user_special,
+                "is_stairwell": "is_stairwell" in user_special,
+                "is_fire_escape": "is_fire_escape" in user_special,
+                "is_restricted": "is_restricted" in user_special,
                 "confidence": 1.0,
                 "device_name": device,
                 "ai_reasoning": "User input",
@@ -567,6 +572,7 @@ def register_callbacks(
             Input({"type": "device-floor", "index": ALL}, "value"),
             Input({"type": "device-security", "index": ALL}, "value"),
             Input({"type": "device-access", "index": ALL}, "value"),
+            Input({"type": "device-special", "index": ALL}, "value"),
         ],
         [State("current-devices-list", "data")],
         prevent_initial_call=True,

--- a/services/ai_device_generator.py
+++ b/services/ai_device_generator.py
@@ -23,6 +23,7 @@ class DeviceAttributes:
     is_elevator: bool
     is_stairwell: bool
     is_fire_escape: bool
+    is_restricted: bool  # ADD THIS LINE
     confidence: float
     ai_reasoning: str
 
@@ -80,7 +81,8 @@ class AIDeviceGenerator:
             "exit": [r"exit|egress|out\b", r"gate.*exit"],
             "elevator": [r"elevator|lift|elev"],
             "stairwell": [r"staircase|stairs|stairwell"],
-            "fire_escape": [r"fire.*(?:exit|escape)|emergency.*exit"],
+            "fire_escape": [r"fire.*(?:exit|escape)|emergency.*(?:exit|escape)"],  # FIXED: Complete pattern
+            "restricted": [r"restricted|secure|authorized|private|limited"],  # ADD THIS LINE
         }
 
         # Location-specific patterns for better naming
@@ -132,6 +134,7 @@ class AIDeviceGenerator:
             is_elevator=access_flags["elevator"],
             is_stairwell=access_flags["stairwell"],
             is_fire_escape=access_flags["fire_escape"],
+            is_restricted=access_flags["restricted"],  # ADD THIS LINE
             confidence=confidence,
             ai_reasoning="; ".join(reasoning_parts),
         )

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -125,7 +125,7 @@ class DoorMappingService:
             is_elevator=ai_attributes.is_elevator,
             is_stairwell=ai_attributes.is_stairwell,
             is_fire_escape=ai_attributes.is_fire_escape,
-            is_restricted=getattr(ai_attributes, "is_restricted", False),
+            is_restricted=ai_attributes.is_restricted,  # CHANGE: Remove getattr, use direct access
             other=not any(
                 [
                     ai_attributes.is_entry,
@@ -133,6 +133,7 @@ class DoorMappingService:
                     ai_attributes.is_elevator,
                     ai_attributes.is_stairwell,
                     ai_attributes.is_fire_escape,
+                    ai_attributes.is_restricted,  # ADD THIS LINE
                 ]
             ),
             security_level=security_level,

--- a/tests/test_door_mapping_service.py
+++ b/tests/test_door_mapping_service.py
@@ -14,6 +14,7 @@ def test_standardized_output(monkeypatch):
         is_elevator=False,
         is_stairwell=False,
         is_fire_escape=False,
+        is_restricted=False,
         confidence=0.9,
         ai_reasoning="test",
     )


### PR DESCRIPTION
## Summary
- add `is_restricted` to `DeviceAttributes`
- recognize restricted devices and propagate the flag
- include special options when saving manual device mappings
- update door mapping service logic
- adjust test helper

## Testing
- `pytest -q tests/test_door_mapping_service.py::test_standardized_output tests/test_ai_device_generator.py::TestAIDeviceGenerator::test_fire_escape_is_exit -q`

------
https://chatgpt.com/codex/tasks/task_e_68673d5a82648320815608cf7e3406b6