### PR TITLE
Fix unique count returns

### DIFF
--- a/analytics/analytics_controller.py
+++ b/analytics/analytics_controller.py
@@ -290,10 +290,14 @@ class AnalyticsController:
             return {
                 "total_records": len(df),
                 "unique_users": (
-                    df["person_id"].nunique() if "person_id" in df.columns else 0
+                    int(df["person_id"].nunique())
+                    if "person_id" in df.columns
+                    else 0
                 ),
                 "unique_doors": (
-                    df["door_id"].nunique() if "door_id" in df.columns else 0
+                    int(df["door_id"].nunique())
+                    if "door_id" in df.columns
+                    else 0
                 ),
                 "date_range": {
                     "start": (

--- a/analytics/unique_patterns_analyzer.py
+++ b/analytics/unique_patterns_analyzer.py
@@ -423,18 +423,18 @@ class UniquePatternAnalyzer:
                 ),
             },
             "unique_entities": {
-                "users": df["person_id"].nunique() if "person_id" in df.columns else 0,
-                "devices": df["door_id"].nunique() if "door_id" in df.columns else 0,
-                "unique_days": df["date"].nunique() if "date" in df.columns else 0,
+                "users": int(df["person_id"].nunique()) if "person_id" in df.columns else 0,
+                "devices": int(df["door_id"].nunique()) if "door_id" in df.columns else 0,
+                "unique_days": int(df["date"].nunique()) if "date" in df.columns else 0,
             },
             "data_quality": {
-                "missing_timestamps": (
+                "missing_timestamps": int(
                     df["timestamp"].isna().sum() if "timestamp" in df.columns else 0
                 ),
-                "missing_users": (
+                "missing_users": int(
                     df["person_id"].isna().sum() if "person_id" in df.columns else 0
                 ),
-                "missing_devices": (
+                "missing_devices": int(
                     df["door_id"].isna().sum() if "door_id" in df.columns else 0
                 ),
             },

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -148,7 +148,7 @@ class UserBehaviorAnalyzer:
 
             # Basic activity features
             total_events = len(user_data)
-            unique_doors = user_data["door_id"].nunique()
+            unique_doors = int(user_data["door_id"].nunique())
             success_rate = user_data["access_granted"].mean()
 
             # Temporal features
@@ -377,7 +377,7 @@ class UserBehaviorAnalyzer:
             # Overall activity patterns
             global_patterns["activity_distribution"] = {
                 "total_events": len(df),
-                "unique_users": df["person_id"].nunique(),
+                "unique_users": int(df["person_id"].nunique()),
                 "avg_events_per_user": user_features["total_events"].mean(),
                 "avg_success_rate": user_features["success_rate"].mean(),
             }

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -484,8 +484,12 @@ class AnalyticsService:
         logger = logging.getLogger(__name__)
 
         total_records = len(df)
-        unique_users = df["person_id"].nunique() if "person_id" in df.columns else 0
-        unique_devices = df["door_id"].nunique() if "door_id" in df.columns else 0
+        unique_users = (
+            int(df["person_id"].nunique()) if "person_id" in df.columns else 0
+        )
+        unique_devices = (
+            int(df["door_id"].nunique()) if "door_id" in df.columns else 0
+        )
 
         date_span = 0
         if "timestamp" in df.columns:

--- a/tests/test_security_display_fix.py
+++ b/tests/test_security_display_fix.py
@@ -6,8 +6,8 @@ def test_security_display_fix():
     """Test the security display with corrected data"""
     mock_results = {
         "total_events": 395852,
-        "unique_users": {"user1", "user2", "user3"},
-        "unique_doors": {"door1", "door2"},
+        "unique_users": 3,
+        "unique_doors": 2,
         "successful_events": 350000,
         "failed_events": 45852,
         "security_score": {"score": 75.5, "threat_level": "medium"},


### PR DESCRIPTION
## Summary
- always return `int` for unique user and door counts
- update security display test to provide integer values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6867505cf6788320bd3022bf69db94ba