### PR TITLE
Add centralized unicode sanitization

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -19,4 +19,6 @@ def create_app(mode: str | None = None):
     return _create_app(mode)
 
 
-__all__ = ["create_app", "profile_callback"]
+from .unicode_utils import sanitize_unicode_input
+
+__all__ = ["create_app", "profile_callback", "sanitize_unicode_input"]

--- a/core/input_validation.py
+++ b/core/input_validation.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, Dict
 
 import bleach
 
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 from security.validation_exceptions import ValidationError
 from core.security import InputValidator as _ComprehensiveValidator
 

--- a/core/security.py
+++ b/core/security.py
@@ -27,7 +27,7 @@ from core.security_patterns import (
     PATH_TRAVERSAL_PATTERNS,
 )
 
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 from config.dynamic_config import dynamic_config
 
 

--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, List, Callable
 
 from config.constants import FileProcessingLimits
 
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 from dataclasses import dataclass
 from enum import Enum
 from .security_patterns import (

--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Set
 
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 
 logger = logging.getLogger(__name__)
 

--- a/core/unicode_utils.py
+++ b/core/unicode_utils.py
@@ -1,0 +1,47 @@
+"""Unicode utilities used across the core security modules."""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Regular expressions for surrogate and control characters
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+# Exclude common whitespace (tab/newline/carriage return)
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def sanitize_unicode_input(text: Any, replacement: str = "\uFFFD") -> str:
+    """Return ``text`` with surrogate and control characters removed.
+
+    Parameters
+    ----------
+    text:
+        Input that will be coerced to ``str``.
+    replacement:
+        Character used to replace surrogate code points.
+    """
+
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("Failed to convert %r to str", text, exc_info=True)
+            return ""
+
+    try:
+        cleaned = _SURROGATE_RE.sub(replacement, text)
+        cleaned = _CONTROL_RE.sub("", cleaned)
+        cleaned = unicodedata.normalize("NFKC", cleaned)
+        cleaned.encode("utf-8")
+        return cleaned
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("sanitize_unicode_input failed: %s", exc)
+        return "".join(ch for ch in str(text) if ch.isascii())
+
+
+__all__ = ["sanitize_unicode_input"]

--- a/security/auth_service.py
+++ b/security/auth_service.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from config.dynamic_config import dynamic_config
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 from core.security import RateLimiter
 
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")

--- a/security/file_validator.py
+++ b/security/file_validator.py
@@ -7,7 +7,7 @@ from typing import Any
 import pandas as pd
 
 from utils.file_validator import safe_decode_file, process_dataframe
-from utils.unicode_utils import sanitize_unicode_input
+from core.unicode_utils import sanitize_unicode_input
 from config.dynamic_config import dynamic_config
 
 from .validation_exceptions import ValidationError

--- a/tests/security/test_unicode_utils.py
+++ b/tests/security/test_unicode_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from core.unicode_utils import sanitize_unicode_input
+
+
+def test_sanitize_unicode_removes_surrogates():
+    text = "A" + "\ud800" + "B" + "\udfff"
+    result = sanitize_unicode_input(text)
+    assert "\ud800" not in result
+    assert "\udfff" not in result
+    assert "A" in result and "B" in result
+
+
+def test_sanitize_unicode_handles_bad_str():
+    class Bad:
+        def __str__(self):
+            raise UnicodeError("boom")
+
+    output = sanitize_unicode_input(Bad())
+    assert isinstance(output, str)
+    assert output.isascii()


### PR DESCRIPTION
## Summary
- create `core/unicode_utils.py` with new `sanitize_unicode_input`
- export function via `core.__init__`
- update modules in `core/` and `security/` to use the new helper
- test surrogate handling under `tests/security`

## Testing
- `PYTHONPATH=. pytest tests/security/test_unicode_utils.py -q --confcutdir=tests/security`

------
https://chatgpt.com/codex/tasks/task_e_6867507d97e483208f3ff18395c69eb0