### PR TITLE
Fix enhanced data exports

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -512,14 +512,14 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             component_name="navbar",
         )
         def export_csv(n_clicks: Optional[int]):
-            """Export device learning data as CSV file."""
+            """Export enhanced learning data as CSV file."""
             import services.export_service as export_service
 
-            data = export_service.get_device_learning_data()
+            data = export_service.get_enhanced_data()
             csv_str = export_service.to_csv_string(data)
             if not csv_str:
                 return dash.no_update
-            return dict(content=csv_str, filename="device_learning_data.csv")
+            return dict(content=csv_str, filename="enhanced_data.csv")
 
         @manager.register_callback(
             Output("download-json", "data"),
@@ -529,14 +529,14 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             component_name="navbar",
         )
         def export_json(n_clicks: Optional[int]):
-            """Export device learning data as JSON file."""
+            """Export enhanced learning data as JSON file."""
             import services.export_service as export_service
 
-            data = export_service.get_device_learning_data()
+            data = export_service.get_enhanced_data()
             json_str = export_service.to_json_string(data)
             if not json_str:
                 return dash.no_update
-            return dict(content=json_str, filename="device_learning_data.json")
+            return dict(content=json_str, filename="enhanced_data.json")
 
         @manager.register_callback(
             Output("page-context", "children"),

--- a/services/export_service.py
+++ b/services/export_service.py
@@ -26,15 +26,26 @@ def to_json_string(data: Dict[str, Any]) -> str:
 
 
 def to_csv_string(data: Dict[str, Any]) -> str:
-    """Serialize enhanced data to CSV string using flattened structure."""
+    """Serialize enhanced data to CSV string with JSON encoded mappings."""
     if not data:
         return ""
+
     records = []
     for fingerprint, content in data.items():
-        record = {"fingerprint": fingerprint}
-        record.update(content)
+        stats = content.get("file_stats", {})
+        record = {
+            "fingerprint": fingerprint,
+            "filename": content.get("filename", ""),
+            "saved_at": content.get("saved_at", ""),
+            "device_mappings": json.dumps(content.get("device_mappings", {})),
+            "column_mappings": json.dumps(content.get("column_mappings", {})),
+            "row_count": stats.get("rows", 0),
+            "column_count": len(stats.get("columns", [])),
+            "device_count": stats.get("device_count", 0),
+        }
         records.append(record)
-    df = pd.json_normalize(records)
+
+    df = pd.DataFrame.from_records(records)
     return df.to_csv(index=False)
 
 


### PR DESCRIPTION
## Summary
- update export helpers to return a simplified CSV format
- update navbar export buttons to use the enhanced data again

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'Cache' object has no attribute)*

------
https://chatgpt.com/codex/tasks/task_e_686752c661fc8320ab337779cf1e620f