### PR TITLE
Refactor analytics modules into packages

### DIFF
--- a/analytics/anomaly_detection/__init__.py
+++ b/analytics/anomaly_detection/__init__.py
@@ -1,0 +1,29 @@
+"""Anomaly detection subpackage."""
+
+from .analyzer import (
+    AnomalyDetector,
+    AnomalyDetection,
+    create_anomaly_detector,
+    EnhancedAnomalyDetector,
+)
+from .data_prep import prepare_anomaly_data
+from .statistical_detection import (
+    detect_frequency_anomalies,
+    detect_statistical_anomalies,
+    calculate_severity_from_zscore,
+)
+from .ml_inference import detect_ml_anomalies
+from .types import AnomalyAnalysis
+
+__all__ = [
+    "AnomalyDetector",
+    "AnomalyDetection",
+    "create_anomaly_detector",
+    "EnhancedAnomalyDetector",
+    "prepare_anomaly_data",
+    "detect_frequency_anomalies",
+    "detect_statistical_anomalies",
+    "calculate_severity_from_zscore",
+    "detect_ml_anomalies",
+    "AnomalyAnalysis",
+]

--- a/analytics/anomaly_detection/data_prep.py
+++ b/analytics/anomaly_detection/data_prep.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
+import logging
+from typing import Optional
+
+__all__ = ["prepare_anomaly_data"]
+
+
+def prepare_anomaly_data(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> pd.DataFrame:
+    """Prepare and clean data for anomaly detection."""
+    logger = logger or logging.getLogger(__name__)
+    df_clean = df.copy()
+
+    string_columns = df_clean.select_dtypes(include=["object"]).columns
+    for col in string_columns:
+        df_clean[col] = (
+            df_clean[col]
+            .astype(str)
+            .apply(lambda x: x.encode("utf-8", errors="ignore").decode("utf-8"))
+        )
+
+    required_cols = ["timestamp", "person_id", "door_id", "access_result"]
+    for col in required_cols:
+        if col not in df_clean.columns:
+            if col == "timestamp":
+                df_clean[col] = pd.Timestamp.now()
+            elif col in ["person_id", "door_id"]:
+                df_clean[col] = f"unknown_{col}"
+            elif col == "access_result":
+                df_clean[col] = "Unknown"
+
+    if not pd.api.types.is_datetime64_any_dtype(df_clean["timestamp"]):
+        try:
+            df_clean["timestamp"] = pd.to_datetime(df_clean["timestamp"])
+        except Exception:
+            df_clean["timestamp"] = pd.Timestamp.now()
+
+    df_clean["hour"] = df_clean["timestamp"].dt.hour
+    df_clean["day_of_week"] = df_clean["timestamp"].dt.dayofweek
+    df_clean["is_weekend"] = df_clean["day_of_week"].isin([5, 6])
+    df_clean["is_after_hours"] = df_clean["hour"].isin(list(range(0, 6)) + list(range(22, 24)))
+    df_clean["access_granted"] = (df_clean["access_result"] == "Granted").astype(int)
+
+    return df_clean

--- a/analytics/anomaly_detection/ml_inference.py
+++ b/analytics/anomaly_detection/ml_inference.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+__all__ = ["detect_ml_anomalies"]
+
+
+def detect_ml_anomalies(
+    df: pd.DataFrame,
+    sensitivity: float,
+    isolation_forest: IsolationForest,
+    logger: Optional[logging.Logger] = None,
+) -> List[Dict[str, Any]]:
+    """Detect anomalies using an IsolationForest model."""
+    logger = logger or logging.getLogger(__name__)
+    anomalies: List[Dict[str, Any]] = []
+    try:
+        features = ['hour', 'day_of_week', 'is_weekend', 'is_after_hours', 'access_granted']
+        feature_df = df[features].copy()
+        if len(feature_df) < 10:
+            return anomalies
+        isolation_forest.set_params(contamination=1 - sensitivity)
+        outliers = isolation_forest.fit_predict(feature_df)
+        anomaly_indices = np.where(outliers == -1)[0]
+        for idx in anomaly_indices:
+            original_row = df.iloc[idx]
+            anomalies.append({
+                "type": "ml_anomaly",
+                "details": {
+                    "person_id": original_row["person_id"],
+                    "door_id": original_row["door_id"],
+                    "timestamp": original_row["timestamp"].isoformat(),
+                    "features": feature_df.iloc[idx].to_dict(),
+                },
+                "severity": "medium",
+                "confidence": 0.6,
+                "timestamp": datetime.now(),
+            })
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("ML anomaly detection failed: %s", exc)
+    return anomalies

--- a/analytics/anomaly_detection/statistical_detection.py
+++ b/analytics/anomaly_detection/statistical_detection.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+__all__ = [
+    "detect_frequency_anomalies",
+    "detect_statistical_anomalies",
+    "calculate_severity_from_zscore",
+]
+
+
+def detect_frequency_anomalies(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> List[Dict[str, Any]]:
+    """Detect frequency-based anomalies."""
+    logger = logger or logging.getLogger(__name__)
+    anomalies: List[Dict[str, Any]] = []
+    try:
+        person_stats = df.groupby('person_id').agg({
+            'timestamp': ['count', 'min', 'max'],
+            'access_granted': 'sum'
+        }).round(2)
+        person_stats.columns = ['total_attempts', 'first_access', 'last_access', 'successful_attempts']
+        freq_threshold = person_stats['total_attempts'].quantile(0.95)
+        high_freq_users = person_stats[person_stats['total_attempts'] > freq_threshold]
+        for person_id, stats in high_freq_users.iterrows():
+            anomalies.append({
+                "type": "activity_burst",
+                "user_id": person_id,
+                "details": {
+                    "total_attempts": int(stats['total_attempts']),
+                    "successful_attempts": int(stats['successful_attempts']),
+                    "time_span": str(stats['last_access'] - stats['first_access'])
+                },
+                "severity": "medium",
+                "confidence": 0.8,
+                "timestamp": datetime.now()
+            })
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("Frequency anomaly detection failed: %s", exc)
+    return anomalies
+
+
+def calculate_severity_from_zscore(z_score: float) -> str:
+    """Calculate severity level from Z-score."""
+    if z_score >= 4.0:
+        return "critical"
+    elif z_score >= 3.5:
+        return "high"
+    elif z_score >= 3.0:
+        return "medium"
+    else:
+        return "low"
+
+
+def detect_statistical_anomalies(df: pd.DataFrame, sensitivity: float, logger: Optional[logging.Logger] = None) -> List[Dict[str, Any]]:
+    """Detect statistical anomalies using Z-score and IQR methods."""
+    logger = logger or logging.getLogger(__name__)
+    anomalies: List[Dict[str, Any]] = []
+    try:
+        hourly_access = df.groupby(df['timestamp'].dt.hour).size()
+        z_scores = np.abs(stats.zscore(hourly_access))
+        anomalous_hours = hourly_access[z_scores > (3.0 * (1 - sensitivity))]
+        for hour, count in anomalous_hours.items():
+            anomalies.append({
+                "type": "unusual_hour_activity",
+                "details": {
+                    "hour": int(hour),
+                    "access_count": int(count),
+                    "z_score": float(z_scores[hour])
+                },
+                "severity": calculate_severity_from_zscore(z_scores[hour]),
+                "confidence": min(0.95, abs(z_scores[hour]) / 4.0),
+                "timestamp": datetime.now()
+            })
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("Statistical anomaly detection failed: %s", exc)
+    return anomalies

--- a/analytics/anomaly_detection/tests/test_anomaly_modules.py
+++ b/analytics/anomaly_detection/tests/test_anomaly_modules.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+from analytics.anomaly_detection.data_prep import prepare_anomaly_data
+from analytics.anomaly_detection.ml_inference import detect_ml_anomalies
+
+
+def test_prepare_anomaly_data_basic():
+    df = pd.DataFrame({
+        "timestamp": ["2024-01-01 00:00:00"],
+        "person_id": ["u1"],
+        "door_id": ["d1"],
+        "access_result": ["Granted"],
+    })
+    cleaned = prepare_anomaly_data(df)
+    assert "hour" in cleaned.columns
+    assert cleaned["access_granted"].iloc[0] == 1
+
+
+def test_detect_ml_anomalies_runs():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=20, freq="min"),
+        "person_id": ["u1"] * 20,
+        "door_id": ["d1"] * 20,
+        "access_result": ["Granted"] * 20,
+    })
+    cleaned = prepare_anomaly_data(df)
+    model = IsolationForest(random_state=42, n_estimators=10, contamination=0.1)
+    anomalies = detect_ml_anomalies(cleaned, 0.9, model)
+    assert isinstance(anomalies, list)

--- a/analytics/anomaly_detection/types.py
+++ b/analytics/anomaly_detection/types.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Dict, Any, List
+
+__all__ = ["AnomalyAnalysis"]
+
+
+@dataclass
+class AnomalyAnalysis:
+    """Comprehensive anomaly analysis result"""
+
+    total_anomalies: int
+    severity_distribution: Dict[str, int]
+    detection_summary: Dict[str, Any]
+    risk_assessment: Dict[str, Any]
+    recommendations: List[str]

--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -1,0 +1,37 @@
+"""Security patterns analysis subpackage."""
+
+from .analyzer import (
+    SecurityPatternsAnalyzer,
+    create_security_analyzer,
+    EnhancedSecurityAnalyzer,
+    SecurityCallbackController,
+    SecurityEvent,
+)
+from .data_prep import prepare_security_data
+from .statistical_detection import (
+    detect_failure_rate_anomalies,
+    detect_frequency_anomalies,
+    detect_statistical_threats,
+)
+from .pattern_detection import (
+    detect_pattern_threats,
+    detect_rapid_attempts,
+    detect_after_hours_anomalies,
+)
+from .types import ThreatIndicator
+
+__all__ = [
+    "SecurityPatternsAnalyzer",
+    "create_security_analyzer",
+    "EnhancedSecurityAnalyzer",
+    "SecurityCallbackController",
+    "SecurityEvent",
+    "prepare_security_data",
+    "detect_failure_rate_anomalies",
+    "detect_frequency_anomalies",
+    "detect_statistical_threats",
+    "detect_pattern_threats",
+    "detect_rapid_attempts",
+    "detect_after_hours_anomalies",
+    "ThreatIndicator",
+]

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -11,19 +11,22 @@ with actionable recommendations.
 import pandas as pd
 import numpy as np
 from typing import Dict, List, Any, Tuple, Optional, Callable
-from datetime import datetime, timedelta
+
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler
 from sklearn.exceptions import DataConversionWarning
-from scipy import stats
 import logging
 from dataclasses import dataclass
 from enum import Enum, auto
 from collections import defaultdict
 import warnings
 
-from .security_score_calculator import SecurityScoreCalculator
-from .security_metrics import SecurityMetrics
+from ..security_score_calculator import SecurityScoreCalculator
+from ..security_metrics import SecurityMetrics
+from .types import ThreatIndicator
+from .data_prep import prepare_security_data
+from .statistical_detection import detect_statistical_threats
+from .pattern_detection import detect_pattern_threats
 
 # Ignore warnings from scikit-learn about missing feature names and automatic
 # data type conversions. These arise during DataFrame-based model training and
@@ -79,19 +82,6 @@ class SecurityCallbackController:
 
     def clear_all_callbacks(self) -> None:
         self._callbacks.clear()
-
-
-@dataclass
-class ThreatIndicator:
-    """Individual threat indicator"""
-
-    threat_type: str
-    severity: str  # 'critical', 'high', 'medium', 'low'
-    confidence: float  # 0.0 to 1.0
-    description: str
-    evidence: Dict[str, Any]
-    timestamp: datetime
-    affected_entities: List[str]
 
 
 @dataclass
@@ -202,39 +192,7 @@ class SecurityPatternsAnalyzer:
 
     def _prepare_security_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Prepare and clean data for security analysis"""
-        df_clean = df.copy()
-
-        # Handle Unicode issues
-        string_columns = df_clean.select_dtypes(include=["object"]).columns
-        for col in string_columns:
-            df_clean[col] = (
-                df_clean[col]
-                .astype(str)
-                .apply(lambda x: x.encode("utf-8", errors="ignore").decode("utf-8"))
-            )
-
-        # Ensure required columns exist
-        required_cols = ["timestamp", "person_id", "door_id", "access_result"]
-        missing_cols = [col for col in required_cols if col not in df_clean.columns]
-        if missing_cols:
-            raise ValueError(f"Missing required columns: {missing_cols}")
-
-        # Convert timestamp
-        if not pd.api.types.is_datetime64_any_dtype(df_clean["timestamp"]):
-            df_clean["timestamp"] = pd.to_datetime(df_clean["timestamp"])
-
-        # Add derived features
-        df_clean["hour"] = df_clean["timestamp"].dt.hour
-        df_clean["day_of_week"] = df_clean["timestamp"].dt.dayofweek
-        df_clean["is_weekend"] = df_clean["day_of_week"].isin([5, 6])
-        df_clean["is_after_hours"] = df_clean["hour"].isin(
-            list(range(0, 6)) + list(range(22, 24))
-        )
-        df_clean["access_granted"] = (df_clean["access_result"] == "Granted").astype(
-            int
-        )
-
-        return df_clean
+        return prepare_security_data(df, self.logger)
 
     def _prepare_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Alias for backward compatibility."""
@@ -246,224 +204,31 @@ class SecurityPatternsAnalyzer:
 
     def _detect_statistical_threats(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect threats using statistical methods"""
-        threats = []
-
-        # Failure rate anomalies
-        failure_threats = self._detect_failure_rate_anomalies(df)
-        threats.extend(failure_threats)
-
-        # Frequency anomalies
-        frequency_threats = self._detect_frequency_anomalies(df)
-        threats.extend(frequency_threats)
-
-        return threats
+        return detect_statistical_threats(df, self.logger)
 
     def _detect_failure_rate_anomalies(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect unusual failure rate patterns"""
-        threats = []
-
-        try:
-            # Overall failure rate
-            overall_failure_rate = 1 - df["access_granted"].mean()
-
-            # Per-user failure rates
-            user_failure_rates = df.groupby("person_id")["access_granted"].agg(
-                ["mean", "count"]
-            )
-            user_failure_rates["failure_rate"] = 1 - user_failure_rates["mean"]
-
-            # Statistical outlier detection (using IQR method)
-            Q1 = user_failure_rates["failure_rate"].quantile(0.25)
-            Q3 = user_failure_rates["failure_rate"].quantile(0.75)
-            IQR = Q3 - Q1
-            outlier_threshold = Q3 + 1.5 * IQR
-
-            high_failure_users = user_failure_rates[
-                (user_failure_rates["failure_rate"] > outlier_threshold)
-                & (user_failure_rates["count"] >= 5)
-            ]
-
-            for user_id, data in high_failure_users.iterrows():
-                n_attempts = data["count"]
-                n_failures = int(n_attempts * data["failure_rate"])
-                p_value = stats.binomtest(
-                    n_failures, n_attempts, overall_failure_rate
-                ).pvalue
-
-                if p_value < 0.05:
-                    confidence = 1 - p_value
-                    severity = "critical" if data["failure_rate"] > 0.8 else "high"
-
-                    threats.append(
-                        ThreatIndicator(
-                            threat_type="unusual_failure_rate",
-                            severity=severity,
-                            confidence=confidence,
-                            description=f"User {user_id} has unusually high failure rate: {data['failure_rate']:.2%}",
-                            evidence={
-                                "user_id": str(user_id),
-                                "failure_rate": data["failure_rate"],
-                                "attempts": n_attempts,
-                                "p_value": p_value,
-                                "baseline_rate": overall_failure_rate,
-                            },
-                            timestamp=datetime.now(),
-                            affected_entities=[str(user_id)],
-                        )
-                    )
-        except Exception as e:
-            self.logger.warning(f"Failure rate anomaly detection failed: {e}")
-
-        return threats
+        return detect_failure_rate_anomalies(df, self.logger)
 
     def _detect_frequency_anomalies(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect unusual access frequency patterns"""
-        threats = []
-
-        try:
-            # Access frequency per user
-            user_access_counts = df.groupby("person_id").size()
-
-            # Z-score based anomaly detection
-            mean_access = user_access_counts.mean()
-            std_access = user_access_counts.std()
-
-            if std_access > 0:
-                z_scores = (user_access_counts - mean_access) / std_access
-
-                # High frequency anomalies (potential abuse)
-                high_freq_users = user_access_counts[z_scores > 3]
-
-                for user_id, access_count in high_freq_users.items():
-                    z_score_val = float(z_scores.loc[str(user_id)])
-                    confidence = min(0.99, (z_score_val - 3) / 3)
-
-                    threats.append(
-                        ThreatIndicator(
-                            threat_type="excessive_access_frequency",
-                            severity="medium",
-                            confidence=confidence,
-                            description=f"User {user_id} has excessive access frequency: {access_count} events",
-                            evidence={
-                                "user_id": str(user_id),
-                                "access_count": access_count,
-                                "z_score": z_score_val,
-                                "baseline_mean": mean_access,
-                            },
-                            timestamp=datetime.now(),
-                            affected_entities=[str(user_id)],
-                        )
-                    )
-        except Exception as e:
-            self.logger.warning(f"Frequency anomaly detection failed: {e}")
-
-        return threats
+        return detect_frequency_anomalies(df, self.logger)
 
     def _detect_pattern_threats(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect pattern-based security threats"""
-        threats = []
-
-        # Rapid successive attempts
-        rapid_attempts = self._detect_rapid_attempts(df)
-        threats.extend(rapid_attempts)
-
-        # After-hours anomalies
-        after_hours_threats = self._detect_after_hours_anomalies(df)
-        threats.extend(after_hours_threats)
-
-        return threats
+        return detect_pattern_threats(df, self.logger)
 
     def _detect_rapid_attempts(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect rapid successive access attempts"""
-        threats = []
+        from .pattern_detection import detect_rapid_attempts
 
-        try:
-            df_sorted = df.sort_values(["person_id", "timestamp"])
-            df_sorted["time_diff"] = df_sorted.groupby("person_id")["timestamp"].diff()
-
-            # Find attempts within 30 seconds
-            rapid_threshold = pd.Timedelta(seconds=30)
-            rapid_attempts = df_sorted[df_sorted["time_diff"] < rapid_threshold]
-
-            if len(rapid_attempts) > 0:
-                user_rapid_counts = rapid_attempts.groupby("person_id").size()
-
-                for user_id, count in user_rapid_counts.items():
-                    if count >= 3:
-                        user_rapid_data = rapid_attempts[
-                            rapid_attempts["person_id"] == user_id
-                        ]
-                        failure_rate = 1 - user_rapid_data["access_granted"].mean()
-
-                        severity = "critical" if failure_rate > 0.7 else "high"
-                        confidence = min(0.95, count / 10)
-
-                        threats.append(
-                            ThreatIndicator(
-                                threat_type="rapid_access_attempts",
-                                severity=severity,
-                                confidence=confidence,
-                                description=f"User {user_id} made {count} rapid access attempts",
-                                evidence={
-                                    "user_id": str(user_id),
-                                    "rapid_attempts": count,
-                                    "failure_rate": failure_rate,
-                                    "time_window": "within_30_seconds",
-                                },
-                                timestamp=datetime.now(),
-                                affected_entities=[str(user_id)],
-                            )
-                        )
-        except Exception as e:
-            self.logger.warning(f"Rapid attempts detection failed: {e}")
-
-        return threats
+        return detect_rapid_attempts(df, self.logger)
 
     def _detect_after_hours_anomalies(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect suspicious after-hours access patterns"""
-        threats = []
+        from .pattern_detection import detect_after_hours_anomalies
 
-        try:
-            after_hours_data = df[df["is_after_hours"] == True]
-
-            if len(after_hours_data) == 0:
-                return threats
-
-            # Users with excessive after-hours access
-            user_after_hours = (
-                after_hours_data.groupby("person_id").size().astype(float)
-            )
-
-            # Statistical threshold for after-hours access
-            threshold = user_after_hours.quantile(0.9)
-
-            excessive_users = user_after_hours[user_after_hours > threshold]
-
-            for user_id, count in excessive_users.items():
-                user_total = len(df[df["person_id"] == user_id])
-                after_hours_rate = count / user_total
-
-                if after_hours_rate > 0.3:  # More than 30% after hours
-                    threats.append(
-                        ThreatIndicator(
-                            threat_type="excessive_after_hours_access",
-                            severity="medium",
-                            confidence=min(0.9, after_hours_rate),
-                            description=f"User {user_id} has excessive after-hours access: {count} events ({after_hours_rate:.1%})",
-                            evidence={
-                                "user_id": str(user_id),
-                                "after_hours_count": count,
-                                "after_hours_rate": after_hours_rate,
-                                "total_events": user_total,
-                            },
-                            timestamp=datetime.now(),
-                            affected_entities=[str(user_id)],
-                        )
-                    )
-        except Exception as e:
-            self.logger.warning(f"After-hours anomaly detection failed: {e}")
-
-        return threats
+        return detect_after_hours_anomalies(df, self.logger)
 
     def _calculate_comprehensive_score(
         self, df: pd.DataFrame, threats: List[ThreatIndicator]

--- a/analytics/security_patterns/data_prep.py
+++ b/analytics/security_patterns/data_prep.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pandas as pd
+import logging
+from typing import Optional
+
+__all__ = ["prepare_security_data"]
+
+
+def prepare_security_data(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> pd.DataFrame:
+    """Prepare and clean data for security analysis."""
+    logger = logger or logging.getLogger(__name__)
+    df_clean = df.copy()
+
+    # Handle Unicode issues
+    string_columns = df_clean.select_dtypes(include=["object"]).columns
+    for col in string_columns:
+        df_clean[col] = (
+            df_clean[col]
+            .astype(str)
+            .apply(lambda x: x.encode("utf-8", errors="ignore").decode("utf-8"))
+        )
+
+    # Ensure required columns exist
+    required_cols = ["timestamp", "person_id", "door_id", "access_result"]
+    missing_cols = [col for col in required_cols if col not in df_clean.columns]
+    if missing_cols:
+        raise ValueError(f"Missing required columns: {missing_cols}")
+
+    # Convert timestamp
+    if not pd.api.types.is_datetime64_any_dtype(df_clean["timestamp"]):
+        df_clean["timestamp"] = pd.to_datetime(df_clean["timestamp"])
+
+    # Add derived features
+    df_clean["hour"] = df_clean["timestamp"].dt.hour
+    df_clean["day_of_week"] = df_clean["timestamp"].dt.dayofweek
+    df_clean["is_weekend"] = df_clean["day_of_week"].isin([5, 6])
+    df_clean["is_after_hours"] = df_clean["hour"].isin(list(range(0, 6)) + list(range(22, 24)))
+    df_clean["access_granted"] = (df_clean["access_result"] == "Granted").astype(int)
+
+    return df_clean

--- a/analytics/security_patterns/statistical_detection.py
+++ b/analytics/security_patterns/statistical_detection.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from .types import ThreatIndicator
+
+__all__ = [
+    "detect_failure_rate_anomalies",
+    "detect_frequency_anomalies",
+    "detect_statistical_threats",
+]
+
+
+def detect_failure_rate_anomalies(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> List[ThreatIndicator]:
+    """Detect unusual failure rate patterns."""
+    logger = logger or logging.getLogger(__name__)
+    threats: List[ThreatIndicator] = []
+    try:
+        overall_failure_rate = 1 - df["access_granted"].mean()
+        user_failure_rates = df.groupby("person_id")["access_granted"].agg(["mean", "count"])
+        user_failure_rates["failure_rate"] = 1 - user_failure_rates["mean"]
+        Q1 = user_failure_rates["failure_rate"].quantile(0.25)
+        Q3 = user_failure_rates["failure_rate"].quantile(0.75)
+        iqr = Q3 - Q1
+        outlier_threshold = Q3 + 1.5 * iqr
+        high_failure_users = user_failure_rates[(user_failure_rates["failure_rate"] > outlier_threshold) & (user_failure_rates["count"] >= 5)]
+        for user_id, data in high_failure_users.iterrows():
+            n_attempts = data["count"]
+            n_failures = int(n_attempts * data["failure_rate"])
+            p_value = stats.binomtest(n_failures, n_attempts, overall_failure_rate).pvalue
+            if p_value < 0.05:
+                confidence = 1 - p_value
+                severity = "critical" if data["failure_rate"] > 0.8 else "high"
+                threats.append(
+                    ThreatIndicator(
+                        threat_type="unusual_failure_rate",
+                        severity=severity,
+                        confidence=confidence,
+                        description=f"User {user_id} has unusually high failure rate: {data['failure_rate']:.2%}",
+                        evidence={
+                            "user_id": str(user_id),
+                            "failure_rate": data["failure_rate"],
+                            "attempts": n_attempts,
+                            "p_value": p_value,
+                            "baseline_rate": overall_failure_rate,
+                        },
+                        timestamp=datetime.now(),
+                        affected_entities=[str(user_id)],
+                    )
+                )
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("Failure rate anomaly detection failed: %s", exc)
+    return threats
+
+
+def detect_frequency_anomalies(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> List[ThreatIndicator]:
+    """Detect unusual access frequency patterns."""
+    logger = logger or logging.getLogger(__name__)
+    threats: List[ThreatIndicator] = []
+    try:
+        user_access_counts = df.groupby("person_id").size()
+        mean_access = user_access_counts.mean()
+        std_access = user_access_counts.std()
+        if std_access > 0:
+            z_scores = (user_access_counts - mean_access) / std_access
+            high_freq_users = user_access_counts[z_scores > 3]
+            for user_id, access_count in high_freq_users.items():
+                z_score_val = float(z_scores.loc[str(user_id)])
+                confidence = min(0.99, (z_score_val - 3) / 3)
+                threats.append(
+                    ThreatIndicator(
+                        threat_type="excessive_access_frequency",
+                        severity="medium",
+                        confidence=confidence,
+                        description=f"User {user_id} has excessive access frequency: {access_count} events",
+                        evidence={
+                            "user_id": str(user_id),
+                            "access_count": access_count,
+                            "z_score": z_score_val,
+                            "baseline_mean": mean_access,
+                        },
+                        timestamp=datetime.now(),
+                        affected_entities=[str(user_id)],
+                    )
+                )
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("Frequency anomaly detection failed: %s", exc)
+    return threats
+
+
+def detect_statistical_threats(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> List[ThreatIndicator]:
+    """Aggregate statistical threat detectors."""
+    threats = []
+    threats.extend(detect_failure_rate_anomalies(df, logger))
+    threats.extend(detect_frequency_anomalies(df, logger))
+    return threats

--- a/analytics/security_patterns/tests/test_security_modules.py
+++ b/analytics/security_patterns/tests/test_security_modules.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from analytics.security_patterns.data_prep import prepare_security_data
+from analytics.security_patterns.statistical_detection import detect_failure_rate_anomalies
+
+
+def test_prepare_security_data_basic():
+    df = pd.DataFrame({
+        "timestamp": ["2024-01-01 10:00:00"],
+        "person_id": ["u1"],
+        "door_id": ["d1"],
+        "access_result": ["Granted"],
+    })
+    cleaned = prepare_security_data(df)
+    assert "hour" in cleaned.columns
+    assert cleaned["access_granted"].iloc[0] == 1
+
+
+def test_detect_failure_rate_anomalies():
+    rows = []
+    for i in range(8):
+        rows.append({
+            "timestamp": f"2024-01-01 10:0{i}:00",
+            "person_id": "u1",
+            "door_id": "d1",
+            "access_result": "Denied",
+        })
+    for i in range(8):
+        rows.append({
+            "timestamp": f"2024-01-01 11:0{i}:00",
+            "person_id": "u2",
+            "door_id": "d1",
+            "access_result": "Granted",
+        })
+    df = pd.DataFrame(rows)
+    cleaned = prepare_security_data(df)
+    threats = detect_failure_rate_anomalies(cleaned)
+    assert isinstance(threats, list)

--- a/analytics/security_patterns/types.py
+++ b/analytics/security_patterns/types.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Dict, Any, List
+from datetime import datetime
+
+__all__ = ["ThreatIndicator"]
+
+@dataclass
+class ThreatIndicator:
+    """Individual threat indicator used by security analysis"""
+
+    threat_type: str
+    severity: str  # 'critical', 'high', 'medium', 'low'
+    confidence: float  # 0.0 to 1.0
+    description: str
+    evidence: Dict[str, Any]
+    timestamp: datetime
+    affected_entities: List[str]


### PR DESCRIPTION
## Summary
- split monolithic `security_patterns` and `anomaly_detection` into packages
- separate data prep, statistical detection and ML helpers
- keep public APIs via package `__init__`
- add lightweight unit tests for new submodules

## Testing
- `PYTHONPATH=. pytest analytics/security_patterns/tests analytics/anomaly_detection/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68677c9cad20832099c088578dbef169