### PR TITLE
Add Safety CVE auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install black flake8 mypy bandit pytest pytest-cov safety
+          pip install -r requirements_ui.txt
+          pip install black flake8 mypy bandit pytest pytest-cov safety==2.3.5
 
       - name: 🔤 Extract translations
         run: pybabel extract -F babel.cfg -o messages.pot .
@@ -52,7 +53,7 @@ jobs:
         run: bandit -r .
 
       - name: 📚 Safety (dependency CVE scan)
-        run: safety check --full-report
+        run: python scripts/audit_dependencies.py
 
       # ----- Tests -----
       - name: ✅ Run PyTest

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,4 +29,11 @@ pip install --upgrade <package>
 # update requirements*.txt with the new versions and commit the changes
 ```
 
+After updating dependencies, run the Safety audit script to ensure no new high
+severity vulnerabilities are introduced:
+
+```bash
+python scripts/audit_dependencies.py
+```
+
 

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+
+REQ_FILES = ["requirements.txt", "requirements_ui.txt"]
+
+cmd = ["safety", "check", "--full-report", "--json"]
+for req in REQ_FILES:
+    cmd.extend(["-r", req])
+
+result = subprocess.run(cmd, capture_output=True, text=True)
+if result.returncode not in (0, 1):
+    print(result.stdout)
+    print(result.stderr, file=sys.stderr)
+    sys.exit(result.returncode)
+
+try:
+    vulnerabilities = json.loads(result.stdout)
+except json.JSONDecodeError as exc:
+    print("Failed to parse Safety output", file=sys.stderr)
+    print(result.stdout)
+    raise SystemExit(1) from exc
+
+high_vulns = [
+    v for v in vulnerabilities if v.get("severity", "").lower() in {"high", "critical"}
+]
+
+if high_vulns:
+    print("High severity vulnerabilities detected:")
+    for vuln in high_vulns:
+        pkg = vuln.get("package_name")
+        version = vuln.get("analyzed_version")
+        ident = vuln.get("vulnerability_id")
+        sev = vuln.get("severity")
+        print(f"- {pkg} {version}: {ident} ({sev})")
+    sys.exit(1)
+
+print("No high severity vulnerabilities found.")


### PR DESCRIPTION
## Summary
- integrate Safety scans into CI using pinned 2.3.5 release
- fail the build on high-severity vulnerabilities via `audit_dependencies.py`
- document how to run the audit script after updating packages

## Testing
- `black scripts/audit_dependencies.py --line-length 88`
- `pytest -k nothing -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68677ca44a908320adb98247e2dff110