### PR TITLE
Initialize security and validation callbacks on import

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -12,3 +12,24 @@ __all__ = [
     "file_processing_utils",
     "utils",
 ]
+
+import logging
+
+
+def initialize_security_callbacks() -> None:
+    """Initialize security callbacks for the analytics package."""
+    try:
+        from security import SecurityModuleIntegration  # type: ignore
+    except Exception:
+        # Security integration not available
+        return
+
+    try:
+        SecurityModuleIntegration.setup_analytics_callbacks()
+    except Exception as exc:  # pragma: no cover - log and continue
+        logging.getLogger(__name__).warning(
+            "Failed to initialize security callbacks: %s", exc
+        )
+
+
+initialize_security_callbacks()

--- a/core/security.py
+++ b/core/security.py
@@ -544,3 +544,25 @@ def rate_limit_decorator(max_requests: int = 100, window_minutes: int = 1):
         return wrapper
 
     return decorator
+
+
+def initialize_validation_callbacks() -> None:
+    """Set up request validation callbacks on import."""
+    try:
+        from security.validation_middleware import ValidationMiddleware
+        from core.callback_manager import CallbackManager
+    except Exception:
+        # Optional components may be missing in minimal environments
+        return
+
+    try:
+        middleware = ValidationMiddleware()
+        manager = CallbackManager()
+        middleware.register_callbacks(manager)
+    except Exception as exc:  # pragma: no cover - log and continue
+        logging.getLogger(__name__).warning(
+            "Failed to initialize validation callbacks: %s", exc
+        )
+
+
+initialize_validation_callbacks()


### PR DESCRIPTION
## Summary
- initialize security callbacks on analytics import
- set up validation callbacks from `core.security`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sklearn and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6867850027988320be608295eadbaf4c