### PR TITLE
Add security testing helper

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -6,6 +6,7 @@ from .analyzer import (
     EnhancedSecurityAnalyzer,
     SecurityCallbackController,
     SecurityEvent,
+    setup_isolated_security_testing,
 )
 from .data_prep import prepare_security_data
 from .statistical_detection import (
@@ -26,6 +27,7 @@ __all__ = [
     "EnhancedSecurityAnalyzer",
     "SecurityCallbackController",
     "SecurityEvent",
+    "setup_isolated_security_testing",
     "prepare_security_data",
     "detect_failure_rate_anomalies",
     "detect_frequency_anomalies",


### PR DESCRIPTION
## Summary
- implement `setup_isolated_security_testing` and expose it in the package
- record event history inside `SecurityCallbackController`
- adjust tests to use the helper and verify history

## Testing
- `flake8 analytics/security_patterns/analyzer.py analytics/security_patterns/__init__.py callback_tests/test_security_callback_controller.py`
- `PYTHONPATH=. pytest -q callback_tests/test_security_callback_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_68678501b1a0832093814dc82f6c09ff