### PR TITLE
Introduce unified callback decorator

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -728,7 +728,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the coordinator."""
 
-    manager.register_callback(
+    manager.unified_callback(
         Output({"type": "custom-field", "index": MATCH}, "style"),
         Input({"type": "column-mapping", "index": MATCH}, "value"),
         callback_id="toggle_custom_field",

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -280,7 +280,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.register_callback(
+    manager.unified_callback(
         Output({"type": "device-edited", "index": MATCH}, "data"),
         [
             Input({"type": "device-floor", "index": MATCH}, "value"),

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -545,7 +545,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.register_callback(
+    manager.unified_callback(
         Output("simple-device-modal", "children"),
         Input("simple-device-modal", "is_open"),
         prevent_initial_call=True,
@@ -553,7 +553,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(populate_simple_device_modal)
 
-    manager.register_callback(
+    manager.unified_callback(
         Output("simple-device-modal", "is_open"),
         [
             Input("open-device-mapping", "n_clicks"),
@@ -566,7 +566,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(toggle_simple_device_modal)
 
-    manager.register_callback(
+    manager.unified_callback(
         Output("device-save-status", "children"),
         [
             Input({"type": "device-floor", "index": ALL}, "value"),
@@ -580,7 +580,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(save_user_inputs)
 
-    manager.register_callback(
+    manager.unified_callback(
         [
             Output({"type": "device-floor", "index": ALL}, "value"),
             Output({"type": "device-access", "index": ALL}, "value"),

--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -412,7 +412,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
 
     try:
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("live-time", "children"),
             Input("url-i18n", "pathname"),
             callback_id="navbar_live_time",
@@ -423,7 +423,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             return f"Live: {current_time}"
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("language-toggle", "children"),
             Input("language-toggle", "n_clicks"),
             prevent_initial_call=True,
@@ -477,7 +477,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                     ),
                 ]
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("theme-store", "data"),
             Input("theme-dropdown", "value"),
             callback_id="navbar_select_theme",
@@ -492,7 +492,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             Input("theme-store", "data"),
         )
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("navbar-logo", "src"),
             Input("theme-store", "data"),
             callback_id="navbar_logo_theme",
@@ -504,7 +504,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                 return "/assets/yosai_logo_name_white.png"
             return "/assets/yosai_logo_name_black.png"
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("download-csv", "data"),
             Input("nav-export-csv", "n_clicks"),
             prevent_initial_call=True,
@@ -521,7 +521,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                 return dash.no_update
             return dict(content=csv_str, filename="device_learning_data.csv")
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("download-json", "data"),
             Input("nav-export-json", "n_clicks"),
             prevent_initial_call=True,
@@ -538,7 +538,7 @@ def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
                 return dash.no_update
             return dict(content=json_str, filename="device_learning_data.json")
 
-        @manager.register_callback(
+        @manager.unified_callback(
             Output("page-context", "children"),
             Input("url-i18n", "pathname"),
             callback_id="navbar_page_context",

--- a/core/callback_registry.py
+++ b/core/callback_registry.py
@@ -19,6 +19,14 @@ class CallbackRegistry:
         self.registered_callbacks = {}
         self.clientside_callbacks = {}
 
+    # New unified decorator -----------------------------------------------
+    def unified_callback(self, *args, **kwargs):
+        """Return :class:`CallbackUnifier` bound to this registry."""
+        from .plugins.callback_unifier import CallbackUnifier
+        from .plugins.decorators import safe_callback
+
+        return CallbackUnifier(self, safe_callback(self.app))(*args, **kwargs)
+
     def register_callback(
         self,
         outputs,

--- a/core/plugins/callback_unifier.py
+++ b/core/plugins/callback_unifier.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+import inspect
+
+
+class CallbackUnifier:
+    """Utility to unify callback registration across different managers."""
+
+    def __init__(self, target: Any, safe_wrapper: Callable[[Callable], Callable] | None = None) -> None:
+        self._target = target
+        self._safe_wrapper = safe_wrapper
+
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        outputs: Any,
+        inputs: Any = None,
+        states: Any = None,
+        **kwargs: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Return decorator registering callbacks on the wrapped target."""
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            wrapped = self._safe_wrapper(func) if self._safe_wrapper else func
+
+            if hasattr(self._target, "register_callback"):
+                try:
+                    return self._target.register_callback(
+                        outputs, inputs, states, **kwargs
+                    )(wrapped)
+                except TypeError:
+                    sig = inspect.signature(self._target.register_callback)
+                    filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
+                    return self._target.register_callback(
+                        outputs, inputs, states, **filtered
+                    )(wrapped)
+            if hasattr(self._target, "callback"):
+                return self._target.callback(outputs, inputs, states, **kwargs)(wrapped)
+
+            raise TypeError("Unsupported callback target")
+
+        return decorator
+

--- a/core/plugins/decorators.py
+++ b/core/plugins/decorators.py
@@ -33,10 +33,17 @@ def safe_callback(app_or_container: Any = None) -> Callable:
         return wrapper
 
     # Handle both @safe_callback and @safe_callback(app) usage
-    if callable(app_or_container):
-        # Direct usage: @safe_callback
+    if callable(app_or_container) and not hasattr(app_or_container, "callback_map"):
+        # Direct usage: @safe_callback when a plain function is passed
         func = app_or_container
         return decorator(func)
     else:
         # Parameterized usage: @safe_callback(app)
         return decorator
+
+
+def unified_callback(target: Any, *cb_args: Any, **cb_kwargs: Any) -> Callable:
+    """Return decorator registering callbacks on any supported target."""
+    from .callback_unifier import CallbackUnifier
+
+    return CallbackUnifier(target, safe_callback(target))(*cb_args, **cb_kwargs)

--- a/core/unified_callback_coordinator.py
+++ b/core/unified_callback_coordinator.py
@@ -30,6 +30,14 @@ class UnifiedCallbackCoordinator:
         self._output_map: Dict[str, str] = {}
         self._namespaces: Dict[str, List[str]] = {}
 
+    # Convenience unified decorator ------------------------------------
+    def unified_callback(self, *args: Any, **kwargs: Any):
+        """Return :class:`CallbackUnifier` bound to this coordinator."""
+        from .plugins.callback_unifier import CallbackUnifier
+        from .plugins.decorators import safe_callback
+
+        return CallbackUnifier(self, safe_callback(self.app))(*args, **kwargs)
+
     # ------------------------------------------------------------------
     def register_component_namespace(self, component_name: str) -> None:
         """Ensure a namespace exists for the given component."""

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -542,7 +542,7 @@ def register_callbacks(
     ]
 
     for func, outputs, inputs, states, cid, extra in callback_defs:
-        manager.register_callback(
+        manager.unified_callback(
             outputs,
             inputs,
             states,

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -1303,7 +1303,7 @@ def register_callbacks(
     ]
 
     for func, outputs, inputs, states, cid, extra in callback_defs:
-        manager.register_callback(
+        manager.unified_callback(
             outputs,
             inputs,
             states,

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -347,7 +347,7 @@ def get_device_learning_service() -> DeviceLearningService:
 def create_learning_callbacks(manager: UnifiedCallbackCoordinator) -> None:
     """Register device learning callback with coordinator."""
 
-    @manager.register_callback(
+    @manager.unified_callback(
         Output("device-learning-status", "children"),
         [
             Input("file-upload-store", "data"),

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -1,0 +1,59 @@
+import dash
+from dash import Input, Output
+
+from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.callback_registry import CallbackRegistry
+from core.plugins.decorators import unified_callback
+
+
+def test_unified_decorator_with_coordinator():
+    app = dash.Dash(__name__)
+    coord = UnifiedCallbackCoordinator(app)
+
+    @unified_callback(
+        coord,
+        Output("out", "children"),
+        Input("in", "value"),
+        callback_id="uc1",
+        component_name="test",
+    )
+    def _cb(v):
+        return v
+
+    assert "out.children" in app.callback_map
+    assert "uc1" in coord.registered_callbacks
+
+
+def test_unified_decorator_method():
+    app = dash.Dash(__name__)
+    coord = UnifiedCallbackCoordinator(app)
+
+    @coord.unified_callback(
+        Output("o", "children"),
+        Input("i", "value"),
+        callback_id="uc2",
+        component_name="test",
+    )
+    def _cb2(v):
+        return v
+
+    assert "o.children" in app.callback_map
+    assert "uc2" in coord.registered_callbacks
+
+
+def test_unified_with_registry():
+    app = dash.Dash(__name__)
+    registry = CallbackRegistry(app)
+
+    @unified_callback(
+        registry,
+        Output("r", "children"),
+        Input("x", "value"),
+        callback_id="uc3",
+        component_name="reg",
+    )
+    def _cb3(v):
+        return v
+
+    assert "r.children" in app.callback_map
+    assert "uc3" in registry.registered_callbacks


### PR DESCRIPTION
## Summary
- implement `CallbackUnifier` utility
- add unified decorator adapters to callback registry and coordinator
- expose `unified_callback` decorator in plugin decorators
- migrate a few modules to the new decorator
- test decorator usage

## Testing
- `pytest tests/test_callback_unifier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686795af22888320bd38bace13c98981