### PR TITLE
Add central unicode handler via service locator

### DIFF
--- a/file_conversion/unicode_handler.py
+++ b/file_conversion/unicode_handler.py
@@ -6,30 +6,22 @@ import logging
 import pandas as pd
 from pandas import DataFrame
 
+from plugins.service_locator import PluginServiceLocator
+
 _logger = logging.getLogger(__name__)
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 
 
 class UnicodeCleaner:
     """Helper class to remove invalid Unicode surrogate characters."""
 
-    _SURROGATE_RANGE = (0xD800, 0xDFFF)
-
     @staticmethod
     def clean_string(text: str) -> str:
         """Return ``text`` with surrogate characters removed."""
         try:
-            if not isinstance(text, str):
-                text = str(text)
-            cleaned = "".join(
-                ch
-                for ch in text
-                if not (
-                    UnicodeCleaner._SURROGATE_RANGE[0]
-                    <= ord(ch)
-                    <= UnicodeCleaner._SURROGATE_RANGE[1]
-                )
-            )
-            return cleaned
+            return UnicodeProcessor.clean_surrogate_chars(text)
         except Exception as exc:  # pragma: no cover - best effort
             _logger.error("Error cleaning string: %s", exc)
             return text
@@ -38,15 +30,7 @@ class UnicodeCleaner:
     def clean_dataframe(df: DataFrame) -> DataFrame:
         """Return a copy of ``df`` with surrogate characters removed."""
         try:
-            df_clean = df.copy()
-            # Clean column names
-            df_clean.columns = [
-                UnicodeCleaner.clean_string(c) for c in df_clean.columns
-            ]
-            # Clean string values
-            for col in df_clean.select_dtypes(include=["object"]).columns:
-                df_clean[col] = df_clean[col].map(UnicodeCleaner.clean_string)
-            return df_clean
+            return UnicodeProcessor.sanitize_dataframe(df)
         except Exception as exc:  # pragma: no cover - best effort
             _logger.error("Error cleaning DataFrame: %s", exc)
             return df

--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -8,7 +8,10 @@ from typing import Any
 
 from core.plugins.protocols import PluginMetadata
 
-from utils.unicode_utils import handle_surrogate_characters
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 from core.serialization import SafeJSONSerializer
 
 # Optional Babel import
@@ -65,7 +68,7 @@ def _is_lazy_string(obj: Any) -> bool:
 
 def _sanitize_text(text: str) -> str:
     text = unicodedata.normalize("NFKC", text)
-    text = handle_surrogate_characters(text)
+    text = UnicodeProcessor.clean_surrogate_chars(text)
     return text
 
 

--- a/plugins/service_locator.py
+++ b/plugins/service_locator.py
@@ -1,0 +1,9 @@
+class PluginServiceLocator:
+    """Central access point for optional plugin utilities."""
+
+    @staticmethod
+    def get_unicode_handler():
+        """Return the unified Unicode handler module."""
+        import unicode_handler
+
+        return unicode_handler

--- a/security/auth_service.py
+++ b/security/auth_service.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Any, Dict
 
 from config.dynamic_config import dynamic_config
-from core.unicode_utils import sanitize_unicode_input
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 from core.security import RateLimiter
 
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
@@ -46,7 +49,7 @@ class SecurityService:
         self.logger.info("File validation enabled")
 
     def validate_file(self, filename: str, size: int) -> Dict[str, Any]:
-        filename = sanitize_unicode_input(filename)
+        filename = UnicodeProcessor.safe_encode_text(filename)
         issues: list[str] = []
 
         max_size_bytes = dynamic_config.security.max_upload_mb * 1024 * 1024

--- a/security/dataframe_validator.py
+++ b/security/dataframe_validator.py
@@ -3,7 +3,10 @@
 import pandas as pd
 from config.dynamic_config import dynamic_config
 from config.constants import DataProcessingLimits
-from utils.unicode_utils import sanitize_data_frame
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 from .validation_exceptions import ValidationError
 import logging
 
@@ -132,6 +135,6 @@ class DataFrameSecurityValidator:
                 logger.warning(f"Potential CSV injection detected in column '{col}'")
                 raise ValidationError(f"Formula detected in column '{col}'")
 
-        sanitized = sanitize_data_frame(df)
+        sanitized = UnicodeProcessor.sanitize_dataframe(df)
 
         return sanitized

--- a/security/file_validator.py
+++ b/security/file_validator.py
@@ -7,7 +7,10 @@ from typing import Any
 import pandas as pd
 
 from utils.file_validator import safe_decode_file, process_dataframe
-from core.unicode_utils import sanitize_unicode_input
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 from config.dynamic_config import dynamic_config
 
 from .validation_exceptions import ValidationError
@@ -19,7 +22,7 @@ class SecureFileValidator:
     ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 
     def sanitize_filename(self, filename: str) -> str:
-        filename = sanitize_unicode_input(filename)
+        filename = UnicodeProcessor.safe_encode_text(filename)
         if os.path.basename(filename) != filename:
             raise ValidationError("Path separators not allowed in filename")
         if len(filename) > 100:

--- a/security/unicode_security_handler.py
+++ b/security/unicode_security_handler.py
@@ -6,8 +6,10 @@ from typing import Any
 
 import pandas as pd
 
-from core.unicode_utils import sanitize_unicode_input as _sanitize_input
-from utils.unicode_utils import sanitize_dataframe as _sanitize_dataframe
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 
 
 class UnicodeSecurityHandler:
@@ -16,12 +18,12 @@ class UnicodeSecurityHandler:
     @staticmethod
     def sanitize_unicode_input(text: Any) -> str:
         """Sanitize input text for unsafe Unicode characters."""
-        return _sanitize_input(text)
+        return UnicodeProcessor.safe_encode_text(text)
 
     @staticmethod
     def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         """Sanitize all string data within a DataFrame."""
-        return _sanitize_dataframe(df)
+        return UnicodeProcessor.sanitize_dataframe(df)
 
 
 __all__ = ["UnicodeSecurityHandler"]

--- a/tests/integration/test_unicode_handling_integration.py
+++ b/tests/integration/test_unicode_handling_integration.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from plugins.service_locator import PluginServiceLocator
+
+handler = PluginServiceLocator.get_unicode_handler()
+
+
+def test_unicode_handler_centralization():
+    text = "A" + chr(0xD800) + "B"
+    cleaned = handler.UnicodeProcessor.clean_surrogate_chars(text)
+    assert cleaned == "AB"
+
+    from file_conversion.unicode_handler import UnicodeCleaner
+    assert UnicodeCleaner.clean_string(text) == cleaned
+
+    df = pd.DataFrame({"c" + chr(0xD800): ["x" + chr(0xDC00)]})
+    cleaned_df = UnicodeCleaner.clean_dataframe(df)
+    assert list(cleaned_df.columns) == ["c"]
+    assert cleaned_df.iloc[0, 0] == "x"
+
+    from security.unicode_security_handler import UnicodeSecurityHandler
+    assert UnicodeSecurityHandler.sanitize_unicode_input(text) == cleaned
+    sec_df = UnicodeSecurityHandler.sanitize_dataframe(df)
+    assert list(sec_df.columns) == ["c"]
+    assert sec_df.iloc[0, 0] == "x"
+

--- a/unicode_handler.py
+++ b/unicode_handler.py
@@ -7,6 +7,8 @@ from utils.unicode_utils import (
     safe_decode,
     safe_encode,
     sanitize_dataframe,
+    process_large_csv_content,
+    safe_format_number,
 )
 
 __all__ = [
@@ -16,4 +18,6 @@ __all__ = [
     "safe_decode",
     "safe_encode",
     "sanitize_dataframe",
+    "process_large_csv_content",
+    "safe_format_number",
 ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,15 +1,15 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
 try:
-    from .unicode_utils import (
-        safe_unicode_encode,
-        handle_surrogate_characters,
-        sanitize_unicode_input,
-        sanitize_data_frame,
-        clean_unicode_surrogates,
-        process_large_csv_content,
-        safe_format_number,
+    from unicode_handler import (
+        safe_encode as safe_unicode_encode,
+        UnicodeProcessor,
+        sanitize_dataframe as sanitize_data_frame,
     )
+    handle_surrogate_characters = UnicodeProcessor.clean_surrogate_chars
+    sanitize_unicode_input = UnicodeProcessor.safe_encode_text
+    clean_unicode_surrogates = UnicodeProcessor.clean_surrogate_chars
+    from unicode_handler import process_large_csv_content, safe_format_number
     from .assets_debug import (
         check_navbar_assets,
         debug_dash_asset_serving,
@@ -18,15 +18,16 @@ try:
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
 except Exception:  # pragma: no cover - fallback when utils unavailable
-    from .unicode_utils import (
-        safe_unicode_encode,
-        handle_surrogate_characters,
-        sanitize_unicode_input,
-        sanitize_data_frame,
-        clean_unicode_surrogates,
+    from unicode_handler import (
+        safe_encode as safe_unicode_encode,
+        UnicodeProcessor,
+        sanitize_dataframe as sanitize_data_frame,
         process_large_csv_content,
         safe_format_number,
     )
+    handle_surrogate_characters = UnicodeProcessor.clean_surrogate_chars
+    sanitize_unicode_input = UnicodeProcessor.safe_encode_text
+    clean_unicode_surrogates = UnicodeProcessor.clean_surrogate_chars
     from .assets_debug import (
         check_navbar_assets,
         debug_dash_asset_serving,

--- a/utils/file_validator.py
+++ b/utils/file_validator.py
@@ -15,12 +15,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
-from utils.unicode_utils import (
-    handle_surrogate_characters,
-    sanitize_unicode_input,
-    safe_unicode_encode,
-    clean_unicode_surrogates,
-)
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -148,9 +146,13 @@ class FileContentValidator:
 
     def _validate_security(self, file_bytes: bytes) -> Dict[str, Any]:
         try:
-            text = safe_unicode_encode(file_bytes.decode("utf-8", "ignore"))
+            text = UnicodeProcessor.safe_encode_text(
+                file_bytes.decode("utf-8", "ignore")
+            )
         except Exception:
-            text = sanitize_unicode_input(file_bytes.decode("utf-8", "ignore"))
+            text = UnicodeProcessor.safe_encode_text(
+                file_bytes.decode("utf-8", "ignore")
+            )
 
         for pattern in self.DANGEROUS_PATTERNS:
             if re.search(pattern, text, re.IGNORECASE):
@@ -177,7 +179,9 @@ class FileContentValidator:
         return {"valid": False, "error": f"Unsupported file type: {ext}"}
 
     def _validate_csv_content(self, file_bytes: bytes) -> Dict[str, Any]:
-        text = safe_unicode_encode(file_bytes.decode("utf-8", "ignore"))
+        text = UnicodeProcessor.safe_encode_text(
+            file_bytes.decode("utf-8", "ignore")
+        )
         lines = text.strip().split("\n")
         if len(lines) < 1:
             return {"valid": False, "error": "CSV file appears to be empty"}
@@ -193,7 +197,9 @@ class FileContentValidator:
 
     def _validate_json_content(self, file_bytes: bytes) -> Dict[str, Any]:
         try:
-            text = safe_unicode_encode(file_bytes.decode("utf-8", "ignore"))
+            text = UnicodeProcessor.safe_encode_text(
+                file_bytes.decode("utf-8", "ignore")
+            )
             data = json.loads(text)
             if isinstance(data, list):
                 rows = len(data)
@@ -210,7 +216,9 @@ class FileContentValidator:
             return {"valid": False, "error": f"JSON validation failed: {exc}"}
 
     def _validate_jsonl_content(self, file_bytes: bytes) -> Dict[str, Any]:
-        text = safe_unicode_encode(file_bytes.decode("utf-8", "ignore"))
+        text = UnicodeProcessor.safe_encode_text(
+            file_bytes.decode("utf-8", "ignore")
+        )
         lines = text.strip().split("\n")
         valid_lines = 0
         cols = 0
@@ -319,7 +327,7 @@ def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
     except UnicodeDecodeError:
         text = data.decode(enc, errors="replace")
 
-    text = handle_surrogate_characters(text)
+    text = UnicodeProcessor.clean_surrogate_chars(text)
 
     from security.unicode_security_handler import UnicodeSecurityHandler
 
@@ -369,14 +377,24 @@ def process_dataframe(decoded: bytes, filename: str) -> Tuple[Optional[pd.DataFr
                     json_data = json.loads(text)
                     if isinstance(json_data, list):
                         cleaned = [
-                            {k: clean_unicode_surrogates(v) for k, v in obj.items()}
+                            {
+                                k: UnicodeProcessor.clean_surrogate_chars(v)
+                                for k, v in obj.items()
+                            }
                             if isinstance(obj, dict)
                             else obj
                             for obj in json_data
                         ]
                         df = pd.DataFrame(cleaned)
                     else:
-                        cleaned = {k: clean_unicode_surrogates(v) for k, v in json_data.items()} if isinstance(json_data, dict) else json_data
+                        cleaned = (
+                            {
+                                k: UnicodeProcessor.clean_surrogate_chars(v)
+                                for k, v in json_data.items()
+                            }
+                            if isinstance(json_data, dict)
+                            else json_data
+                        )
                         df = pd.DataFrame([cleaned])
                     return df, None
                 except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- add PluginServiceLocator with get_unicode_handler
- refactor unicode processing modules to use new locator
- expose additional helpers in unicode_handler
- add integration test covering unified Unicode handling

## Testing
- `pytest -q tests/integration/test_unicode_handling_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_686795b0b9e083209a497f91c5ed3498