### PR TITLE
Add plugin registry and Unicode integration tests

### DIFF
--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+from core.container import Container as DIContainer
+from core.plugins.manager import PluginManager
+from core.plugins.protocols import PluginMetadata
+from config.config import ConfigManager
+from services.consolidated_learning_service import ConsolidatedLearningService
+
+
+class LearningPlugin:
+    metadata = PluginMetadata(
+        name="learning",
+        version="0.1",
+        description="learning plugin",
+        author="tester",
+    )
+
+    def __init__(self):
+        self.service = None
+
+    def load(self, container, config):
+        self.service = ConsolidatedLearningService()
+        container.register("learning_service", self.service)
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        return True
+
+    def stop(self):
+        return True
+
+    def health_check(self):
+        return {"healthy": True}
+
+
+def test_plugin_learning_service(tmp_path, monkeypatch):
+    # Provide required secrets so ConfigManager does not fail
+    for key in [
+        "SECRET_KEY",
+        "DB_PASSWORD",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_CLIENT_SECRET",
+        "AUTH0_DOMAIN",
+        "AUTH0_AUDIENCE",
+    ]:
+        monkeypatch.setenv(key, "x")
+
+    container = DIContainer()
+    manager = PluginManager(container, ConfigManager(), health_check_interval=1)
+    plugin = LearningPlugin()
+    assert manager.load_plugin(plugin)
+    service = container.get("learning_service")
+    df = pd.DataFrame({"door_id": ["d1"], "timestamp": ["2024-01-01"]})
+    fp = service.save_complete_mapping(df, "file.csv", {"d1": {"floor": 1}})
+    learned = service.get_learned_mappings(df, "file.csv")
+    assert learned["match_type"] == "exact"
+    assert fp in service.learned_data
+    manager.stop_all_plugins()
+    manager.stop_health_monitor()

--- a/tests/integration/test_unicode_handling_integration.py
+++ b/tests/integration/test_unicode_handling_integration.py
@@ -1,0 +1,23 @@
+from callback_controller import CallbackController, CallbackEvent
+from robust_file_processor import RobustFileProcessor
+
+
+def test_unicode_processing_and_events():
+    csv = "name\uD83D,value\ntest\uDE00,1".encode("utf-8", "surrogatepass")
+    controller = CallbackController()
+    events = []
+
+    def track(ctx):
+        events.append(ctx.event_type)
+
+    controller.clear_all_callbacks()
+    controller.register_callback(CallbackEvent.FILE_PROCESSING_START, track)
+    controller.register_callback(CallbackEvent.FILE_PROCESSING_COMPLETE, track)
+
+    proc = RobustFileProcessor(controller)
+    df, err = proc.process_file(csv, "test.csv", "src")
+    assert err is None
+    assert CallbackEvent.FILE_PROCESSING_START in events
+    assert CallbackEvent.FILE_PROCESSING_COMPLETE in events
+    assert "\uD83D" not in str(df.columns[0])
+    assert "\uDE00" not in str(df.iloc[0, 0])

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+import core.plugins.config as plugin_config
+
+
+def test_fallback_service_locator():
+    importlib.reload(plugin_config)
+    assert plugin_config.get_service_locator() is None
+    assert plugin_config.__all__ == ["get_service_locator"]
+
+
+def test_imported_unified_config(monkeypatch):
+    fake_module = types.ModuleType("config.unified_config")
+
+    class DummyConfig:
+        pass
+
+    def get_config():
+        return DummyConfig()
+
+    fake_module.UnifiedConfig = DummyConfig
+    fake_module.get_config = get_config
+    monkeypatch.setitem(sys.modules, "config.unified_config", fake_module)
+    importlib.reload(plugin_config)
+
+    locator = plugin_config.get_service_locator()
+    assert isinstance(locator, DummyConfig)
+    assert "UnifiedConfig" in plugin_config.__all__
+
+    monkeypatch.delitem(sys.modules, "config.unified_config", raising=False)
+    importlib.reload(plugin_config)

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -1,0 +1,40 @@
+from dash.dependencies import Output, Input
+from dash import Dash
+
+from core.callback_manager import CallbackManager
+from core.callback_events import CallbackEvent
+from core.callback_migration import UnifiedCallbackCoordinatorWrapper
+
+
+def test_event_registration_delegates():
+    app = Dash(__name__)
+    manager = CallbackManager()
+    wrapper = UnifiedCallbackCoordinatorWrapper(app, manager)
+
+    called = []
+
+    def handler(value):
+        called.append(value)
+
+    wrapper.register_event(CallbackEvent.ANALYSIS_START, handler, priority=5)
+    manager.trigger(CallbackEvent.ANALYSIS_START, 1)
+
+    assert called == [1]
+
+
+def test_callback_registration():
+    app = Dash(__name__)
+    manager = CallbackManager()
+    wrapper = UnifiedCallbackCoordinatorWrapper(app, manager)
+
+    @wrapper.register_callback(
+        Output("out", "children"),
+        Input("in", "value"),
+        callback_id="cb",
+        component_name="test",
+    )
+    def cb(v):
+        return v
+
+    assert "out.children" in app.callback_map
+    assert "cb" in wrapper.registered_callbacks

--- a/tests/test_plugin_service_locator.py
+++ b/tests/test_plugin_service_locator.py
@@ -1,0 +1,33 @@
+import pytest
+
+from core.enhanced_container import ServiceContainer
+
+
+def test_singleton_registration_and_retrieval():
+    container = ServiceContainer()
+    obj = object()
+    container.register_singleton("obj", obj)
+    assert container.get("obj") is obj
+    assert container.has("obj")
+
+
+def test_factory_registration_and_caching():
+    container = ServiceContainer()
+    calls = []
+
+    def factory():
+        calls.append(1)
+        return {"value": len(calls)}
+
+    container.register_factory("svc", factory)
+
+    first = container.get("svc")
+    second = container.get("svc")
+    assert first == second
+    assert calls == [1]
+
+
+def test_missing_service_raises():
+    container = ServiceContainer()
+    with pytest.raises(ValueError):
+        container.get("missing")

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -1,0 +1,36 @@
+import importlib
+import types
+
+import pytest
+
+from services.registry import ServiceRegistry
+
+
+def test_register_and_get_service(tmp_path, monkeypatch):
+    # create dummy module
+    module_dir = tmp_path / "pkg"
+    module_dir.mkdir()
+    mod_file = module_dir / "mod.py"
+    mod_file.write_text("""\nvalue = 42\n
+def func():\n    return 'hi'\n""")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    registry = ServiceRegistry()
+    registry.register_service("test", "pkg.mod:func")
+    func = registry.get_service("test")
+    assert callable(func)
+    assert func() == "hi"
+
+    registry.register_service("module", "pkg.mod")
+    mod = registry.get_service("module")
+    assert hasattr(mod, "value") and mod.value == 42
+
+
+def test_get_service_missing_module(monkeypatch):
+    registry = ServiceRegistry()
+    registry.register_service("missing", "nope.mod:attr")
+
+    # patch import_module to raise ImportError
+    monkeypatch.setattr(importlib, "import_module", lambda name: (_ for _ in ()).throw(ImportError()))
+
+    assert registry.get_service("missing") is None


### PR DESCRIPTION
## Summary
- add ServiceRegistry tests
- cover ServiceContainer behaviors
- test UnifiedCallbackCoordinatorWrapper
- validate plugin config auto-detection
- integration tests for plugin learning service
- integration tests for Unicode file processing

## Testing
- `pytest tests/test_unified_plugin_registry.py tests/test_plugin_service_locator.py tests/test_callback_unifier.py tests/test_auto_configuration.py tests/integration/test_plugin_consolidation_integration.py tests/integration/test_unicode_handling_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686795b3e73083208233e89147b33501