### PR TITLE
Implement unified plugin service locator

### DIFF
--- a/components/plugin_adapter.py
+++ b/components/plugin_adapter.py
@@ -7,9 +7,12 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from core.plugins.service_locator import get_ai_classification_service
+from plugins.service_locator import PluginServiceLocator
 from services.ai_suggestions import generate_column_suggestions
-from unicode_handler import sanitize_dataframe, clean_unicode_text
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+sanitize_dataframe = _unicode.sanitize_dataframe
+clean_unicode_text = _unicode.clean_unicode_text
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +21,7 @@ class ComponentPluginAdapter:
     """Adapter providing safe access to optional plugin services."""
 
     def get_ai_plugin(self):
-        return get_ai_classification_service()
+        return PluginServiceLocator.get_ai_classification_service()
 
     # ------------------------------------------------------------------
     # AI column mapping helpers

--- a/core/plugins/service_locator.py
+++ b/core/plugins/service_locator.py
@@ -1,51 +1,122 @@
-"""Simple plugin service locator used by components."""
-
 from __future__ import annotations
+
+"""Central plugin service locator consolidating optional utilities."""
 
 import logging
 from typing import Any, Optional
 
-_ai_plugin: Optional[Any] = None
 logger = logging.getLogger(__name__)
 
 
-def set_ai_classification_plugin(plugin: Any) -> None:
-    """Set the global AI classification plugin (primarily for tests)."""
-    global _ai_plugin
-    _ai_plugin = plugin
+class PluginServiceLocator:
+    """Provide access to optional plugin services with lazy loading."""
 
+    _ai_plugin: Optional[Any] = None
+    _json_plugin: Optional[Any] = None
 
-def reset_ai_classification_plugin() -> None:
-    """Reset the cached AI classification plugin."""
-    global _ai_plugin
-    _ai_plugin = None
+    # ------------------------------------------------------------------
+    @classmethod
+    def set_ai_classification_plugin(cls, plugin: Any) -> None:
+        cls._ai_plugin = plugin
 
+    @classmethod
+    def reset_ai_classification_plugin(cls) -> None:
+        cls._ai_plugin = None
 
-def _load_ai_plugin() -> Optional[Any]:
-    try:
-        from plugins.ai_classification.plugin import AIClassificationPlugin
-        from plugins.ai_classification.config import get_ai_config
-    except Exception as exc:  # pragma: no cover - optional dependency
-        logger.warning("AI classification plugin unavailable: %s", exc)
+    # Internal loaders -------------------------------------------------
+    @classmethod
+    def _load_ai_plugin(cls) -> Optional[Any]:
+        try:
+            from plugins.ai_classification.plugin import AIClassificationPlugin
+            from plugins.ai_classification.config import get_ai_config
+        except Exception as exc:  # pragma: no cover - optional
+            logger.warning("AI classification plugin unavailable: %s", exc)
+            return None
+
+        plugin = AIClassificationPlugin(get_ai_config())
+        if plugin.start():
+            return plugin
+        logger.warning("AI classification plugin failed to start")
         return None
 
-    plugin = AIClassificationPlugin(get_ai_config())
-    if plugin.start():
-        return plugin
-    logger.warning("AI classification plugin failed to start")
-    return None
+    @classmethod
+    def _load_json_plugin(cls) -> Optional[Any]:
+        try:
+            from core.json_serialization_plugin import quick_start
+        except Exception as exc:  # pragma: no cover - optional
+            logger.warning("JSON serialization plugin unavailable: %s", exc)
+            return None
+
+        try:
+            return quick_start()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("JSON serialization plugin failed to start: %s", exc)
+            return None
+
+    # Public API -------------------------------------------------------
+    @classmethod
+    def get_ai_classification_service(cls) -> Optional[Any]:
+        """Return the AI classification plugin instance if available."""
+        if cls._ai_plugin is None:
+            cls._ai_plugin = cls._load_ai_plugin()
+        return cls._ai_plugin
+
+    @classmethod
+    def get_json_serialization_service(cls) -> Optional[Any]:
+        """Return the JSON serialization service if available."""
+        if cls._json_plugin is None:
+            cls._json_plugin = cls._load_json_plugin()
+        if cls._json_plugin is not None:
+            return cls._json_plugin.serialization_service
+        return None
+
+    @staticmethod
+    def get_unicode_handler():
+        """Return the unified Unicode handler module."""
+        import unicode_handler
+
+        return unicode_handler
+
+
+# Convenience module level functions for backward compatibility ------
+
+_ai_plugin: Optional[Any] = None
 
 
 def get_ai_classification_service() -> Optional[Any]:
-    """Return the cached :class:`AIClassificationPlugin` instance if available."""
+    """Module-level helper used by legacy code and tests."""
     global _ai_plugin
     if _ai_plugin is None:
         _ai_plugin = _load_ai_plugin()
     return _ai_plugin
 
 
+def set_ai_classification_plugin(plugin: Any) -> None:
+    global _ai_plugin
+    _ai_plugin = plugin
+
+
+def reset_ai_classification_plugin() -> None:
+    global _ai_plugin
+    _ai_plugin = None
+
+
+def get_json_serialization_service() -> Optional[Any]:
+    return PluginServiceLocator.get_json_serialization_service()
+
+
+def get_unicode_handler():
+    return PluginServiceLocator.get_unicode_handler()
+
+
 __all__ = [
+    "PluginServiceLocator",
     "get_ai_classification_service",
     "set_ai_classification_plugin",
     "reset_ai_classification_plugin",
+    "get_json_serialization_service",
+    "get_unicode_handler",
 ]
+
+# Backwards compatibility for tests that patch _load_ai_plugin
+_load_ai_plugin = PluginServiceLocator._load_ai_plugin

--- a/plugins/service_locator.py
+++ b/plugins/service_locator.py
@@ -1,9 +1,4 @@
-class PluginServiceLocator:
-    """Central access point for optional plugin utilities."""
+"""Compatibility wrapper importing :class:`PluginServiceLocator`."""
+from core.plugins.service_locator import PluginServiceLocator
 
-    @staticmethod
-    def get_unicode_handler():
-        """Return the unified Unicode handler module."""
-        import unicode_handler
-
-        return unicode_handler
+__all__ = ["PluginServiceLocator"]

--- a/tests/components/test_plugin_adapter.py
+++ b/tests/components/test_plugin_adapter.py
@@ -15,7 +15,11 @@ def test_get_ai_column_suggestions_with_plugin(monkeypatch):
                 "confidence_scores": {h: 0.8 for h in headers},
             }
 
-    monkeypatch.setattr(plugin_adapter, "get_ai_classification_service", lambda: Dummy())
+    monkeypatch.setattr(
+        plugin_adapter.PluginServiceLocator,
+        "get_ai_classification_service",
+        lambda: Dummy(),
+    )
     df = pd.DataFrame(columns=["A", "B"])
     result = adapter.get_ai_column_suggestions(df, "f.csv")
     assert result["A"]["field"] == "field"
@@ -24,7 +28,11 @@ def test_get_ai_column_suggestions_with_plugin(monkeypatch):
 
 def test_get_ai_column_suggestions_fallback(monkeypatch):
     adapter = ComponentPluginAdapter()
-    monkeypatch.setattr(plugin_adapter, "get_ai_classification_service", lambda: None)
+    monkeypatch.setattr(
+        plugin_adapter.PluginServiceLocator,
+        "get_ai_classification_service",
+        lambda: None,
+    )
     df = pd.DataFrame(columns=["Mystery"])
     result = adapter.get_ai_column_suggestions(df, "x.csv")
     assert result["Mystery"]["field"] == ""


### PR DESCRIPTION
## Summary
- centralize plugin service resolution in `PluginServiceLocator`
- update `ComponentPluginAdapter` to use new service locator
- keep compatibility wrapper for `plugins.service_locator`
- adjust tests for adapter and service locator

## Testing
- `pytest tests/test_service_locator.py::test_service_locator_returns_set_plugin -q`
- `pytest tests/test_service_locator.py::test_service_locator_loads_via_helper -q`
- `pytest tests/components/test_plugin_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68679b0ddb3883208232d68978013191