### PR TITLE
Fix plugin integration instructions

### DIFF
--- a/integrations/plugin_integrations.txt
+++ b/integrations/plugin_integrations.txt
@@ -1,13 +1,9 @@
-# integration/plugin_integration.py
-"""
 Integration instructions for adding the JSON Serialization Plugin to your app
-"""
 
-print("""
 🔌 JSON SERIALIZATION PLUGIN INTEGRATION
 
 Step 1: Update your core/app_factory.py
-======================================
+=======================================
 
 # Add after your existing container creation:
 
@@ -21,14 +17,12 @@ container = get_configured_container_with_yaml(config_manager)
 registry = setup_plugins(app, container=container, config_manager=config_manager)
 app._yosai_plugin_manager = registry.plugin_manager
 
-
 Step 2: Update your config/config.yaml
 ======================================
 
 # Reference the shared plugin configuration:
 
 plugins: !include plugins.yaml
-
 
 Step 3: Use the plugin in your callbacks
 ========================================
@@ -45,9 +39,8 @@ def your_callback_function(inputs...):
     # All outputs are now automatically JSON-safe
     return some_dataframe, some_function, some_complex_object
 
-
 Step 4: Test the plugin
-======================
+=======================
 
 # Run the plugin tests:
 python -m pytest tests/test_json_serialization_plugin.py -v
@@ -57,10 +50,8 @@ python3 app.py
 
 # The JSON serialization errors should be completely gone!
 
-
 Step 5: Monitor plugin health
-============================
+=============================
 
 The health endpoint is now registered automatically at `/health/plugins`.
 Simply visit that URL to view the current plugin status.
-


### PR DESCRIPTION
## Summary
- replace `integrations/plugin_integration.txt` with plain text
- rename file to `plugin_integrations.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `black . --check` *(fails: would reformat numerous files)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: found errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867a3d1451483208d9cabc16bb3907e