### PR TITLE
Update plugin config documentation

### DIFF
--- a/core/plugins/config/plugins.yaml
+++ b/core/plugins/config/plugins.yaml
@@ -1,0 +1,12 @@
+plugins:
+  json_serialization:
+    enabled: true
+    max_dataframe_rows: 2000000  # see JsonSerializationLimits.MAX_DATAFRAME_PROCESSING_ROWS
+    max_string_length: 50000  # see JsonSerializationLimits.MAX_INPUT_STRING_LENGTH_CHARACTERS
+    include_type_metadata: true
+    compress_large_objects: true
+    fallback_to_repr: true
+    auto_wrap_callbacks: true
+    force_complete_analysis: true
+  hello_world:
+    enabled: false  # example plugin shown in docs/plugins.md

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -80,15 +80,21 @@ can monitor all running plugins.
 
 ## Configuration
 
-Plugins are enabled and configured through `config/config.yaml` under the top
-level `plugins:` key. Each section is named after the plugin's metadata name.
+Plugins are enabled and configured through `core/plugins/config/plugins.yaml`.
+This dedicated file centralizes all plugin settings. Reference it in your main
+configuration:
 
 ```yaml
-plugins:
-  my_plugin:
-    enabled: true
-    option_a: 123
-    option_b: "value"
+plugins: !include ../../core/plugins/config/plugins.yaml
+```
+
+Inside `core/plugins/config/plugins.yaml` define each plugin section:
+
+```yaml
+my_plugin:
+  enabled: true
+  option_a: 123
+  option_b: "value"
 ```
 
 The provided configuration dictionary is passed to `configure()` during plugin

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,13 +10,12 @@ You can change the search location by passing a different package name to `Plugi
 
 ## Configuration
 
-Application settings include a top level `plugins:` section in `config/config.yaml`. Each plugin has its own subsection named after its metadata name. Set `enabled: true` to load a plugin and supply any plugin specific options under that key. These options are provided to `configure()` after the plugin is loaded.
+Application settings reference `core/plugins/config/plugins.yaml` for all plugin
+configuration. Add the following line to your main config to include it. This
+dedicated file centralizes every plugin's settings.
 
 ```yaml
-plugins:
-  json_serialization:
-    enabled: true
-    max_dataframe_rows: 1000
+plugins: !include ../../core/plugins/config/plugins.yaml
 ```
 
 ## Hello World Example
@@ -49,12 +48,11 @@ def create_plugin() -> HelloWorldPlugin:
     return HelloWorldPlugin()
 ```
 
-Enable the plugin in `config/config.yaml`:
+Enable the plugin in `core/plugins/config/plugins.yaml`:
 
 ```yaml
-plugins:
-  hello_world:
-    enabled: true
+hello_world:
+  enabled: true
 ```
 
 ## Lifecycle

--- a/integrations/plugin_integrations.txt
+++ b/integrations/plugin_integrations.txt
@@ -17,12 +17,14 @@ container = get_configured_container_with_yaml(config_manager)
 registry = setup_plugins(app, container=container, config_manager=config_manager)
 app._yosai_plugin_manager = registry.plugin_manager
 
-Step 2: Update your config/config.yaml
-======================================
+Step 2: Update your core/plugins/config/plugins.yaml
+====================================================
 
 # Reference the shared plugin configuration:
 
-plugins: !include plugins.yaml
+plugins: !include ../../core/plugins/config/plugins.yaml
+
+This dedicated file centralizes all plugin settings.
 
 Step 3: Use the plugin in your callbacks
 ========================================


### PR DESCRIPTION
## Summary
- centralize plugin configuration docs around `core/plugins/config/plugins.yaml`
- add dedicated file to store all plugin settings
- refresh integration instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867ab445e308320923554935f6efa60