### PR TITLE
Support plugin config sections

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -87,6 +87,7 @@ class Config:
     security: SecurityConfig = field(default_factory=SecurityConfig)
     sample_files: SampleFilesConfig = field(default_factory=SampleFilesConfig)
     environment: str = "development"
+    plugin_settings: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
 
 class ConfigManager:
@@ -107,6 +108,7 @@ class ConfigManager:
         # Apply YAML config
         if yaml_config:
             self.config = ConfigValidator.validate(yaml_config)
+            self._apply_yaml_config(yaml_config)
 
         # Apply environment overrides
         self._apply_env_overrides()
@@ -225,6 +227,11 @@ class ConfigManager:
             self.config.sample_files.json_path = sample_data.get(
                 "json_path", self.config.sample_files.json_path
             )
+
+        if "plugins" in yaml_config:
+            plugins_data = yaml_config["plugins"]
+            if isinstance(plugins_data, dict):
+                self.config.plugin_settings.update(plugins_data)
 
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides"""
@@ -382,6 +389,10 @@ class ConfigManager:
         """Get sample file path configuration"""
         return self.config.sample_files
 
+    def get_plugin_config(self, name: str) -> Dict[str, Any]:
+        """Return configuration dictionary for the given plugin."""
+        return self.config.plugin_settings.get(name, {})
+
 
 # Global configuration instance
 _config_manager: Optional[ConfigManager] = None
@@ -423,6 +434,11 @@ def get_sample_files_config() -> SampleFilesConfig:
     return get_config().get_sample_files_config()
 
 
+def get_plugin_config(name: str) -> Dict[str, Any]:
+    """Get configuration for a specific plugin"""
+    return get_config().get_plugin_config(name)
+
+
 # Export main classes and functions
 __all__ = [
     "Config",
@@ -437,4 +453,5 @@ __all__ = [
     "get_database_config",
     "get_security_config",
     "get_sample_files_config",
+    "get_plugin_config",
 ]

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -16,10 +16,12 @@ def test_plugin_discovery_and_callback_registration(monkeypatch, tmp_path):
     try:
         app = Dash(__name__)
         app.layout = html.Div()
+        cfg = ConfigManager()
+        cfg.config.plugin_settings["auto_plugin"] = {"enabled": True}
         registry = setup_plugins(
             app,
             container=DIContainer(),
-            config_manager=ConfigManager(),
+            config_manager=cfg,
             package="auto_pkg",
         )
         assert "auto_plugin" in registry.plugin_manager.plugins

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -52,9 +52,11 @@ def test_load_all_plugins_registers_services(tmp_path):
     pkg_dir = create_package(tmp_path)
     sys.path.insert(0, str(tmp_path))
     try:
+        cfg = ConfigManager()
+        cfg.config.plugin_settings["test_plugin"] = {"enabled": True}
         manager = PluginManager(
             DIContainer(),
-            ConfigManager(),
+            cfg,
             package="pm_plugins",
             health_check_interval=1,
         )

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -89,6 +89,7 @@ def test_setup_uses_provided_dependencies(monkeypatch, tmp_path):
         app = Dash(__name__)
         container = DIContainer()
         config = ConfigManager()
+        config.config.plugin_settings["auto_plugin"] = {"enabled": True}
         registry = setup_plugins(app, container=container, config_manager=config, package="auto_pkg")
         assert registry.container is container
         assert registry.plugin_manager.container is container

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -39,7 +39,9 @@ class SimplePlugin:
 
 
 def test_load_plugin_registers_plugin(tmp_path):
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["simple"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = SimplePlugin()
     assert manager.load_plugin(plugin) is True
     assert "simple" in manager.plugins
@@ -81,9 +83,11 @@ def create_plugin():
     )
     sys.path.insert(0, str(tmp_path))
     try:
+        cfg = ConfigManager()
+        cfg.config.plugin_settings["auto"] = {"enabled": True}
         manager = PluginManager(
             DIContainer(),
-            ConfigManager(),
+            cfg,
             package="sampleplugins",
             health_check_interval=1,
         )
@@ -96,7 +100,9 @@ def create_plugin():
 
 
 def test_get_plugin_health_snapshot():
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["simple"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = SimplePlugin()
     manager.load_plugin(plugin)
     time.sleep(1.2)

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -66,7 +66,9 @@ class NoHealthPlugin:
 
 
 def test_load_plugin_success(tmp_path):
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["dummy"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
     result = manager.load_plugin(plugin)
 
@@ -78,7 +80,9 @@ def test_load_plugin_success(tmp_path):
 
 
 def test_load_plugin_failure_missing_health():
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["nohealth"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = NoHealthPlugin()
     result = manager.load_plugin(plugin)
 
@@ -88,7 +92,9 @@ def test_load_plugin_failure_missing_health():
 
 
 def test_get_plugin_health(monkeypatch):
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["dummy"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
     manager.load_plugin(plugin)
 
@@ -131,9 +137,11 @@ def create_plugin():
     )
     sys.path.insert(0, str(tmp_path))
     try:
+        cfg = ConfigManager()
+        cfg.config.plugin_settings["plug_a"] = {"enabled": True}
         manager = PluginManager(
             DIContainer(),
-            ConfigManager(),
+            cfg,
             package="testplugins",
             health_check_interval=1,
         )
@@ -146,7 +154,9 @@ def create_plugin():
 
 
 def test_stop_all_plugins_calls_stop():
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["dummy"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
     manager.load_plugin(plugin)
 
@@ -167,7 +177,9 @@ class FailingStopPlugin(DummyPlugin):
 
 
 def test_stop_all_plugins_handles_errors():
-    manager = PluginManager(DIContainer(), ConfigManager(), health_check_interval=1)
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["failstop"] = {"enabled": True}
+    manager = PluginManager(DIContainer(), cfg, health_check_interval=1)
     plugin = FailingStopPlugin()
     manager.load_plugin(plugin)
 

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -50,9 +50,12 @@ def create_plugin():
 
     sys.path.insert(0, str(tmp_path))
     try:
+        cfg = ConfigManager()
+        cfg.config.plugin_settings["a"] = {}
+        cfg.config.plugin_settings["b"] = {}
         manager = PluginManager(
             DIContainer(),
-            ConfigManager(),
+            cfg,
             package="prio_plugins",
             health_check_interval=1,
         )

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -49,7 +49,9 @@ def test_registry_registration_and_service():
     os.environ.setdefault("AUTH0_AUDIENCE", "aud")
     app = Dash(__name__)
     container = DIContainer()
-    registry = UnifiedPluginRegistry(app, container, ConfigManager())
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["dummy"] = {"enabled": True}
+    registry = UnifiedPluginRegistry(app, container, cfg)
     plugin = DummyPlugin()
     assert registry.register_plugin(plugin)
     registry.auto_configure_callbacks()


### PR DESCRIPTION
## Summary
- track per-plugin configuration via `plugin_settings` in Config
- expose `get_plugin_config` and YAML loader support
- pass plugin settings when loading plugins
- update tests for plugin configuration values

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ComplexWarning' from 'numpy.core.numeric')*

------
https://chatgpt.com/codex/tasks/task_e_6867a8b43a4483208b499cfa061050de