### PR TITLE
Update plugin setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,12 +338,12 @@ Plugins live in the `plugins/` directory. Place any custom plugin package inside
 this folder, for example `plugins/my_plugin/plugin.py` defining a
 `create_plugin()` function. Enable the plugin by adding a section under
 `plugins:` in `config/config.yaml` and setting `enabled: true` plus any plugin
-options. In your app factory create a `PluginManager`, call
-`load_all_plugins()` and then `register_plugin_callbacks(app)` to activate all
- enabled plugins. See [docs/plugins.md](docs/plugins.md) for a detailed overview
- of discovery, configuration and the plugin lifecycle. For step-by-step
- instructions on writing your own plugin check
- [docs/plugin_development.md](docs/plugin_development.md).
+options. Initialize plugins by calling `setup_plugins` from
+`core.plugins.auto_config`. This discovers plugins, registers callbacks, exposes
+`/health/plugins` and attaches the manager as `app._yosai_plugin_manager`.
+See [docs/plugins.md](docs/plugins.md) for a detailed overview of discovery,
+configuration and the plugin lifecycle. For step-by-step instructions on
+writing your own plugin check [docs/plugin_development.md](docs/plugin_development.md).
 For a diagram of the full process see [docs/plugin_lifecycle.md](docs/plugin_lifecycle.md).
 The same document includes a minimal **Hello World** plugin showcasing
 `create_plugin()` and callback registration.

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -68,9 +68,10 @@ def create_plugin() -> MyPlugin:
 ### Callback Registration
 
 Plugins that define `register_callbacks()` should implement
-`CallbackPluginProtocol`. After loading all plugins call
-`register_plugin_callbacks(app)` from the `PluginManager` so each plugin can
-hook into Dash.
+`CallbackPluginProtocol`. Load plugins through `setup_plugins(app)` from
+`core.plugins.auto_config` so each plugin can hook into Dash automatically.
+The helper exposes `/health/plugins` and attaches the plugin manager as
+`app._yosai_plugin_manager`.
 
 ### Health Checks
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -63,6 +63,8 @@ For each enabled plugin the manager calls these methods:
 2. `configure(config)` – apply configuration values.
 3. `start()` – perform any runtime initialization.
 
-After all plugins are loaded call `register_plugin_callbacks(app)` so callback plugins can hook into Dash. Plugins implement `health_check()` and `stop()`. The manager periodically gathers health data and exposes it via `/health/plugins`.
+Initialize plugins using `setup_plugins(app)` from `core.plugins.auto_config`.
+This loads every enabled plugin, registers callbacks, exposes `/health/plugins`
+and attaches the plugin manager as `app._yosai_plugin_manager`.
 
 For a visual overview of discovery, dependency resolution and the lifecycle calls see [plugin_lifecycle.md](plugin_lifecycle.md).


### PR DESCRIPTION
## Summary
- update plugin initialization docs to use `setup_plugins`
- remove references to `load_all_plugins` and `register_plugin_callbacks`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867afad39c483209c51f9a643b51e13