### PR TITLE
Expose container property on Dash app

### DIFF
--- a/core/plugins/auto_config.py
+++ b/core/plugins/auto_config.py
@@ -24,6 +24,8 @@ class PluginAutoConfiguration:
     ) -> None:
         self.app = app
         self.container = container or DIContainer()
+        # Expose container on the app for decorators like ``safe_callback``
+        self.app._yosai_container = self.container
         self.config_manager = config_manager or ConfigManager()
         self.package = package
         self.registry = UnifiedPluginRegistry(


### PR DESCRIPTION
## Summary
- attach the DI container to the Dash app when configuring plugins
- extend the auto configuration tests to verify container exposure and `safe_callback`

## Testing
- `flake8 core/plugins/auto_config.py tests/test_auto_configuration.py`
- `pytest tests/test_auto_configuration.py::test_setup_exposes_container_and_safe_callback -q` *(fails: ModuleNotFoundError: No module named 'unicode_handler')*

------
https://chatgpt.com/codex/tasks/task_e_6867b0763df88320bef835efb93370d0