### PR TITLE
Unify callback API

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -7,7 +7,7 @@ Feeds back to AI training data
 
 import pandas as pd
 from dash import html, dcc, callback, Input, Output, State, ALL, MATCH
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -651,7 +651,7 @@ def toggle_custom_field(selected_value):
 
 
 def register_callbacks(
-    manager: UnifiedCallbackCoordinator,
+    manager: TrulyUnifiedCallbacks,
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the coordinator."""

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from dash import html, dcc
 from dash.dependencies import Input, Output, State, ALL, MATCH
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -275,7 +275,7 @@ def mark_device_as_edited(floor, access, special, security):
 
 
 def register_callbacks(
-    manager: UnifiedCallbackCoordinator,
+    manager: TrulyUnifiedCallbacks,
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the provided coordinator."""

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -3,7 +3,7 @@
 from dash import html, dcc
 from dash._callback_context import callback_context
 import dash
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -540,7 +540,7 @@ def populate_simple_device_modal(is_open):
 
 
 def register_callbacks(
-    manager: UnifiedCallbackCoordinator,
+    manager: TrulyUnifiedCallbacks,
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the provided coordinator."""

--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -4,7 +4,7 @@ Navigation bar component with grid layout using existing framework
 
 import datetime
 from typing import TYPE_CHECKING, Optional, Any, Union
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from flask_babel import lazy_gettext as _l, refresh
 from flask import session
 from core.plugins.decorators import safe_callback
@@ -405,7 +405,7 @@ def _create_fallback_navbar() -> str:
 
 
 @safe_callback
-def register_navbar_callbacks(manager: UnifiedCallbackCoordinator) -> None:
+def register_navbar_callbacks(manager: TrulyUnifiedCallbacks) -> None:
     """Register navbar callbacks for live updates"""
     if not DASH_AVAILABLE or not manager:
         return

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,5 +20,6 @@ def create_app(mode: str | None = None):
 
 
 from .unicode_utils import sanitize_unicode_input
+from .truly_unified_callbacks import TrulyUnifiedCallbacks
 
-__all__ = ["create_app", "profile_callback", "sanitize_unicode_input"]
+__all__ = ["create_app", "profile_callback", "sanitize_unicode_input", "TrulyUnifiedCallbacks"]

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -9,7 +9,7 @@ from flasgger import Swagger
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Input, Output
 from components.ui.navbar import create_navbar_layout
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from core.container import Container as DIContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.secret_manager import validate_secrets
@@ -183,8 +183,8 @@ def _create_full_app() -> dash.Dash:
 
         app.layout = _serve_layout
 
-        # Register all callbacks using UnifiedCallbackCoordinator
-        coordinator = UnifiedCallbackCoordinator(app)
+        # Register all callbacks using TrulyUnifiedCallbacks
+        coordinator = TrulyUnifiedCallbacks(app)
         _register_router_callbacks(coordinator)
         _register_global_callbacks(coordinator)
 
@@ -553,7 +553,7 @@ def _create_placeholder_page(title: str, subtitle: str, message: str) -> html.Di
     )
 
 
-def _register_router_callbacks(manager: UnifiedCallbackCoordinator) -> None:
+def _register_router_callbacks(manager: TrulyUnifiedCallbacks) -> None:
     """Register page routing callbacks."""
 
     @manager.register_callback(
@@ -669,7 +669,7 @@ def _get_upload_page() -> Any:
         )
 
 
-def _register_global_callbacks(manager: UnifiedCallbackCoordinator) -> None:
+def _register_global_callbacks(manager: TrulyUnifiedCallbacks) -> None:
     """Register global application callbacks"""
 
     # Register device learning callbacks

--- a/core/callback_migration.py
+++ b/core/callback_migration.py
@@ -6,10 +6,10 @@ from dash import Dash
 
 from .callback_manager import CallbackManager
 from .callback_events import CallbackEvent
-from .unified_callback_coordinator import UnifiedCallbackCoordinator
+from .truly_unified_callbacks import TrulyUnifiedCallbacks
 
 
-class UnifiedCallbackCoordinatorWrapper(UnifiedCallbackCoordinator):
+class UnifiedCallbackCoordinatorWrapper(TrulyUnifiedCallbacks):
     """Wrapper exposing a callback manager for backward compatibility."""
 
     def __init__(self, app: Dash, callback_manager: CallbackManager) -> None:

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -5,7 +5,7 @@ import logging
 
 from dash import Dash
 
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from core.callback_manager import CallbackManager
 from core.plugins.manager import PluginManager
 from core.plugins.protocols import PluginProtocol
@@ -30,7 +30,7 @@ class UnifiedPluginRegistry:
         self.app = app
         self.container = container
         self.callback_manager = callback_manager or CallbackManager()
-        self.coordinator = UnifiedCallbackCoordinator(app)
+        self.coordinator = TrulyUnifiedCallbacks(app)
         self.plugin_manager = PluginManager(container, config_manager, package=package)
         # Register health endpoint immediately
         try:

--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Truly unified callback system combining registry and coordinator."""
+
+from typing import Any
+from dash import Dash
+
+from .plugins.callback_unifier import CallbackUnifier
+
+
+class TrulyUnifiedCallbacks:
+    """Single callback system replacing all others."""
+
+    def __init__(self, app: Dash) -> None:
+        self.app = app
+        self.coordinator = None  # backwards compat
+        self.registry = None
+
+    def callback(self, *args: Any, **kwargs: Any):
+        """Unified callback decorator."""
+        return CallbackUnifier(self)(*args, **kwargs)
+
+    unified_callback = callback
+
+    # Basic pass-through for Dash.callback ---------------------------------
+    def register_callback(self, outputs, inputs=None, states=None, **kwargs):
+        return self.app.callback(outputs, inputs, states, **kwargs)

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -2,7 +2,7 @@
 
 from dash import Input, Output, State, callback_context, html
 from dash.exceptions import PreventUpdate
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 from core.dash_profile import profile_callback
 import logging
@@ -500,7 +500,7 @@ class Callbacks:
 
 
 def register_callbacks(
-    manager: UnifiedCallbackCoordinator,
+    manager: TrulyUnifiedCallbacks,
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Instantiate :class:`Callbacks` and register its methods."""

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -13,7 +13,7 @@ from typing import Optional, Dict, Any, List, Tuple
 from dash import html, dcc
 from dash.dash import no_update
 from dash._callback_context import callback_context
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 from core.dash_profile import profile_callback
 import logging
@@ -1143,7 +1143,7 @@ def save_ai_training_data(filename: str, mappings: Dict[str, str], file_info: Di
 
 
 def register_callbacks(
-    manager: UnifiedCallbackCoordinator,
+    manager: TrulyUnifiedCallbacks,
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Instantiate :class:`Callbacks` and register its methods."""

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pandas as pd
 from dash import html
 from dash.dependencies import Input, Output
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from services.consolidated_learning_service import get_learning_service
 from dash._callback_context import callback_context
 
@@ -344,7 +344,7 @@ def get_device_learning_service() -> DeviceLearningService:
     return _device_learning_service
 
 
-def create_learning_callbacks(manager: UnifiedCallbackCoordinator) -> None:
+def create_learning_callbacks(manager: TrulyUnifiedCallbacks) -> None:
     """Register device learning callback with coordinator."""
 
     @manager.unified_callback(


### PR DESCRIPTION
## Summary
- implement `TrulyUnifiedCallbacks` that absorbs previous coordinators
- export new API from `core`
- update app factory and plugin registry to use new unified callbacks
- update components and services to depend on new system

## Testing
- `python scripts/migrate_plugin_system.py --dry-run` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867b5a6fad08320899f7fa5cd0caed7