### PR TITLE
Fix plugin health endpoint and callback registration

### DIFF
--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -24,4 +24,8 @@ class TrulyUnifiedCallbacks:
 
     # Basic pass-through for Dash.callback ---------------------------------
     def register_callback(self, outputs, inputs=None, states=None, **kwargs):
+        if inputs is None:
+            inputs = []
+        if states is None:
+            states = []
         return self.app.callback(outputs, inputs, states, **kwargs)


### PR DESCRIPTION
## Summary
- avoid duplicate registration of plugin health route
- handle None inputs/states in `register_callback`

## Testing
- `flake8 core/plugins/manager.py core/truly_unified_callbacks.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6867b81a5a1c832091f7c56eff957256