### PR TITLE
Fix plugin callback typing

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -3,7 +3,7 @@ import pkgutil
 import logging
 import threading
 import time
-from typing import List, Any, Dict
+from typing import List, Any, Dict, cast
 
 from core.callback_manager import CallbackManager
 from core.plugins.protocols import (
@@ -161,11 +161,14 @@ class PluginManager:
             if isinstance(plugin, CallbackPluginProtocol) or hasattr(
                 plugin, "register_callbacks"
             ):
+                cb_plugin = cast(CallbackPluginProtocol, plugin)
                 try:
-                    result = plugin.register_callbacks(manager, self.container)
+                    result = cb_plugin.register_callbacks(manager, self.container)
                     results.append(result)
                 except Exception as exc:  # pragma: no cover - log and continue
-                    logger.error("Failed to register callbacks for %s: %s", plugin, exc)
+                    logger.error(
+                        "Failed to register callbacks for %s: %s", plugin, exc
+                    )
                     results.append(False)
         return results
 


### PR DESCRIPTION
## Summary
- avoid Pylance warning by casting plugin before calling `register_callbacks`
- import `cast` in plugin manager

## Testing
- `mypy core/plugins/manager.py | grep "core/plugins/manager.py" | head`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868667c3fa48320bf6dd7b65f1bab52