### PR TITLE
Fix pyright warning for plugin auto-config

### DIFF
--- a/core/plugins/auto_config.py
+++ b/core/plugins/auto_config.py
@@ -25,7 +25,7 @@ class PluginAutoConfiguration:
         self.app = app
         self.container = container or DIContainer()
         # Expose container on the app for decorators like ``safe_callback``
-        self.app._yosai_container = self.container
+        self.app._yosai_container = self.container  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
         self.config_manager = config_manager or ConfigManager()
         self.package = package
         self.registry = UnifiedPluginRegistry(


### PR DESCRIPTION
## Summary
- silence pyright attribute access issue on `_yosai_container`

## Testing
- `pip install -r requirements.txt`
- `black . --check` *(fails: 49 files would be reformatted)*
- `flake8 .` *(fails: various style violations)*
- `mypy .` *(fails: 65 errors in 44 files)*
- `pytest -q` *(fails: numpy dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_686866650bf48320b2c7f986af038c09