### PR TITLE
Introduce Unicode data enhancer

### DIFF
--- a/components/plugin_adapter.py
+++ b/components/plugin_adapter.py
@@ -9,10 +9,10 @@ import pandas as pd
 
 from plugins.service_locator import PluginServiceLocator
 from services.ai_suggestions import generate_column_suggestions
-
-_unicode = PluginServiceLocator.get_unicode_handler()
-sanitize_dataframe = _unicode.sanitize_dataframe
-clean_unicode_text = _unicode.clean_unicode_text
+from services.data_processing.data_enhancer import (
+    sanitize_dataframe,
+    clean_unicode_text,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/services/data_processing/data_enhancer.py
+++ b/services/data_processing/data_enhancer.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Data enhancement helpers wrapping :class:`UnicodeProcessor`."""
+
+from typing import Any
+
+import pandas as pd
+from plugins.service_locator import PluginServiceLocator
+
+_unicode = PluginServiceLocator.get_unicode_handler()
+UnicodeProcessor = _unicode.UnicodeProcessor
+
+
+def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Sanitize DataFrame using :class:`UnicodeProcessor`."""
+    return UnicodeProcessor.sanitize_dataframe(df)
+
+
+def clean_unicode_text(text: str) -> str:
+    """Clean text by removing surrogate characters."""
+    return UnicodeProcessor.clean_surrogate_chars(text)
+
+
+__all__ = ["UnicodeProcessor", "sanitize_dataframe", "clean_unicode_text"]


### PR DESCRIPTION
## Summary
- create `data_enhancer` wrapper for Unicode helpers
- reuse wrapper functions from the new module in `ComponentPluginAdapter`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686871607ec083208013973c9c938cc7