### PR TITLE
Add data processing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Validation Overview](docs/validation_overview.md)
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)
+- [Data Processing](docs/data_processing.md)
 
 The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example. The [plugin lifecycle diagram](docs/plugin_lifecycle.md) illustrates how plugins are discovered, dependencies resolved and health checks performed.
 

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -1,0 +1,34 @@
+# Data Processing Services
+
+The `services/data_processing/` directory contains the building blocks for uploading, enhancing and analysing raw data.  Each class focuses on a single responsibility so they can be combined in different pipelines.
+
+## Directory Layout
+
+```
+services/
+  data_processing/
+      file_handler.py       # Validate and parse uploads
+      data_enhancer.py      # Enrich DataFrame columns
+      data_processor.py     # Coordinate file handling and enhancement
+      analytics_engine.py   # Produce charts and metrics
+```
+
+## Core Classes
+
+- **`FileHandler`** – Reads CSV/JSON/Excel files and performs validation.
+- **`DataEnhancer`** – Applies normalisation and adds computed columns.
+- **`DataProcessor`** – High level wrapper that uses `FileHandler` and `DataEnhancer` to produce a clean dataframe.
+- **`AnalyticsEngine`** – Generates statistics from the processed dataframe.
+- **`CallbackController`** – Emits events throughout the pipeline so plugins can react.
+
+## Relationships
+
+```mermaid
+classDiagram
+    FileHandler <|-- DataProcessor
+    DataEnhancer <|-- DataProcessor
+    DataProcessor --> AnalyticsEngine
+    AnalyticsEngine --> CallbackController
+```
+
+This separation makes the pipeline extensible and easier to test as new data sources are added.


### PR DESCRIPTION
## Summary
- document the new `services/data_processing` layout
- link to the docs from the README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: found 93 errors)*
- `black . --check` *(fails: 48 files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868716c8c408320810d17688db1e268