### PR TITLE
Refactor upload helpers into service modules

### DIFF
--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -1,9 +1,13 @@
 from .processing import UploadProcessingService
-from .ai import AISuggestionService
+from .ai import AISuggestionService, analyze_device_name_with_ai
 from .modal import ModalService
+from .helpers import get_trigger_id, save_ai_training_data
 
 __all__ = [
     "UploadProcessingService",
     "AISuggestionService",
     "ModalService",
+    "analyze_device_name_with_ai",
+    "get_trigger_id",
+    "save_ai_training_data",
 ]

--- a/services/upload/ai.py
+++ b/services/upload/ai.py
@@ -76,4 +76,13 @@ class AISuggestionService:
         return [suggested_values]
 
 
-__all__ = ["AISuggestionService"]
+# Shared instance for module level helpers
+_DEFAULT_AI_SERVICE = AISuggestionService()
+
+
+def analyze_device_name_with_ai(device_name: str) -> Dict[str, Any]:
+    """Convenience wrapper calling :class:`AISuggestionService`."""
+    return _DEFAULT_AI_SERVICE.analyze_device_name_with_ai(device_name)
+
+
+__all__ = ["AISuggestionService", "analyze_device_name_with_ai"]

--- a/services/upload/helpers.py
+++ b/services/upload/helpers.py
@@ -1,0 +1,54 @@
+import json
+import logging
+from datetime import datetime
+from typing import Dict
+
+from dash._callback_context import callback_context
+
+logger = logging.getLogger(__name__)
+
+
+def get_trigger_id() -> str:
+    """Return the triggered Dash callback identifier."""
+    ctx = callback_context
+    return ctx.triggered[0]["prop_id"] if ctx.triggered else ""
+
+
+def save_ai_training_data(filename: str, mappings: Dict[str, str], file_info: Dict):
+    """Save confirmed mappings for AI training."""
+    try:
+        logger.info("🤖 Saving AI training data for %s", filename)
+        training_data = {
+            "filename": filename,
+            "timestamp": datetime.now().isoformat(),
+            "mappings": mappings,
+            "reverse_mappings": {v: k for k, v in mappings.items()},
+            "column_count": len(file_info.get("columns", [])),
+            "ai_suggestions": file_info.get("ai_suggestions", {}),
+            "user_verified": True,
+        }
+
+        from components.plugin_adapter import ComponentPluginAdapter
+
+        if ComponentPluginAdapter().save_verified_mappings(filename, mappings, {}):
+            logger.info("✅ AI training data saved via plugin")
+        else:
+            logger.info("⚠️ AI training save failed")
+
+        import os
+
+        os.makedirs("data/training", exist_ok=True)
+        with open(
+            f"data/training/mappings_{datetime.now().strftime('%Y%m%d')}.jsonl",
+            "a",
+            encoding="utf-8",
+            errors="replace",
+        ) as f:
+            f.write(json.dumps(training_data) + "\n")
+
+        logger.info("✅ Training data saved locally")
+    except Exception as e:  # pragma: no cover - best effort
+        logger.info("❌ Error saving training data: %s", e)
+
+
+__all__ = ["get_trigger_id", "save_ai_training_data"]

--- a/tests/test_learning_priority.py
+++ b/tests/test_learning_priority.py
@@ -1,5 +1,5 @@
 import pytest
-from pages.file_upload import analyze_device_name_with_ai
+from services.upload import analyze_device_name_with_ai
 from services.ai_mapping_store import ai_mapping_store
 from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
 

--- a/tests/test_unicode_file_handling.py
+++ b/tests/test_unicode_file_handling.py
@@ -5,7 +5,8 @@ import pandas as pd
 
 from services.consolidated_learning_service import ConsolidatedLearningService
 from analytics.db_interface import AnalyticsDataAccessor
-from pages import file_upload
+import services.upload.helpers as upload_helpers
+from services.upload import save_ai_training_data
 
 
 def test_consolidated_learning_unicode(tmp_path):
@@ -51,7 +52,7 @@ def test_save_ai_training_data_unicode(tmp_path, monkeypatch):
     def fake_makedirs(path, exist_ok=False):
         training_dir.mkdir(exist_ok=True)
 
-    monkeypatch.setattr(file_upload.os, "makedirs", fake_makedirs)
+    monkeypatch.setattr(upload_helpers.os, "makedirs", fake_makedirs)
 
     open_orig = builtins.open
 
@@ -60,16 +61,16 @@ def test_save_ai_training_data_unicode(tmp_path, monkeypatch):
             return open_orig(target, mode, encoding=encoding, errors=errors)
         return open_orig(path, mode, encoding=encoding, errors=errors)
 
-    monkeypatch.setattr(file_upload, "open", fake_open)
+    monkeypatch.setattr(upload_helpers, "open", fake_open)
 
     class DummyDT:
         @classmethod
         def now(cls):
             return datetime(2024, 1, 1, 0, 0, 0)
 
-    monkeypatch.setattr(file_upload, "datetime", DummyDT)
+    monkeypatch.setattr(upload_helpers, "datetime", DummyDT)
 
-    file_upload.save_ai_training_data(
+    save_ai_training_data(
         "файл.csv",
         {"дверь": "timestamp"},
         {"columns": ["a"], "ai_suggestions": {}},


### PR DESCRIPTION
## Summary
- move AI helpers and modal utilities from `pages.file_upload` into `services.upload`
- expose new helpers via `services.upload`
- adjust page and tests to use service functions

## Testing
- `pip install pandas`
- `pip install dash==2.14.2`
- `pip install bleach`
- `pip install sqlparse`
- `pip install flask-caching`
- `pytest -q` *(fails: ImportError cannot import name 'process_file_simple')*

------
https://chatgpt.com/codex/tasks/task_e_68687c801a0883209eb421190c51a81f