### PR TITLE
Fix duplicate column names in Unicode sanitation

### DIFF
--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -76,6 +76,16 @@ class TestUnicodeProcessor:
         assert out.iloc[2, 0] == "opt"
         assert out.iloc[3, 0] == "imp"
 
+    def test_sanitize_dataframe_duplicate_columns(self):
+        df = pd.DataFrame([[1, 2]], columns=["dup", "dup"])
+        out = UnicodeProcessor.sanitize_dataframe(df)
+        assert list(out.columns) == ["dup", "dup_1"]
+
+    def test_sanitize_dataframe_empty_columns(self):
+        df = pd.DataFrame([[1, 2]], columns=["", None])
+        out = UnicodeProcessor.sanitize_dataframe(df)
+        assert list(out.columns) == ["col_0", "col_1"]
+
 
 class TestChunkedUnicodeProcessor:
     def test_process_large_content_utf8(self):

--- a/utils/unicode_utils.py
+++ b/utils/unicode_utils.py
@@ -79,7 +79,15 @@ class UnicodeProcessor:
             for col in df_clean.columns:
                 safe_col = UnicodeProcessor.safe_encode_text(col)
                 safe_col = re.sub(r"^[=+\-@]+", "", safe_col)
-                new_columns.append(safe_col or f"col_{len(new_columns)}")
+                safe_col = safe_col or f"col_{len(new_columns)}"
+
+                base_name = safe_col
+                counter = 1
+                while safe_col in new_columns:
+                    safe_col = f"{base_name}_{counter}"
+                    counter += 1
+
+                new_columns.append(safe_col)
 
             df_clean.columns = new_columns
 


### PR DESCRIPTION
## Summary
- handle duplicate sanitized DataFrame columns
- test for duplicate and empty column handling

## Testing
- `pytest -q tests/test_unicode_handler_full.py::TestUnicodeProcessor::test_sanitize_dataframe_duplicate_columns -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_68688a86eb1c832081898839cfeafc2e