### PR TITLE
Add concurrent unicode processing tests

### DIFF
--- a/thread_tests/test_unicode_threading.py
+++ b/thread_tests/test_unicode_threading.py
@@ -1,0 +1,40 @@
+from concurrent.futures import ThreadPoolExecutor
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from unicode_handler import UnicodeProcessor, ChunkedUnicodeProcessor
+
+
+def test_clean_surrogate_chars_threaded():
+    pattern = "Hello" + chr(0xD800) + "World" + chr(0xDC00)
+    text = pattern * 100000  # >1MB
+
+    expected = UnicodeProcessor.clean_surrogate_chars(text)
+
+    def worker(_: int) -> str:
+        return UnicodeProcessor.clean_surrogate_chars(text)
+
+    with ThreadPoolExecutor(max_workers=5) as exc:
+        results = list(exc.map(worker, range(10)))
+
+    for result in results:
+        assert result == expected
+
+
+def test_process_large_content_threaded():
+    pattern = "Test" + chr(0xD83D) + chr(0xDE00) + "Content"
+    content = (pattern * 100000).encode("utf-8", "surrogatepass")  # >1MB
+    chunk_size = 50 * 1024
+
+    expected = ChunkedUnicodeProcessor.process_large_content(content, chunk_size=chunk_size)
+
+    def worker(_: int) -> str:
+        return ChunkedUnicodeProcessor.process_large_content(content, chunk_size=chunk_size)
+
+    with ThreadPoolExecutor(max_workers=5) as exc:
+        results = list(exc.map(worker, range(10)))
+
+    for result in results:
+        assert result == expected


### PR DESCRIPTION
## Summary
- add concurrency tests for UnicodeProcessor and ChunkedUnicodeProcessor
- run threaded unicode utilities on >1MB of data

## Testing
- `pytest thread_tests/test_unicode_threading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68688a88f3b88320b2deda69ae096313