### PR TITLE
Introduce unified file validator

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -20,6 +20,7 @@ from .upload_processing import UploadAnalyticsProcessor
 from .db_analytics_helper import DatabaseAnalyticsHelper
 from .summary_reporting import SummaryReporter
 from .data_processing.file_handler import FileHandler
+from .data_processing.unified_file_validator import UnifiedFileValidator
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
 __all__ = [
     "FileHandler",
+    "UnifiedFileValidator",
     "FILE_HANDLER_AVAILABLE",
     "get_analytics_service",
     "create_analytics_service",

--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,6 +1,7 @@
 """Data processing utilities."""
 
 from .file_handler import FileHandler, process_file_simple, FileProcessingError
+from .unified_file_validator import UnifiedFileValidator
 
 # Analytics helpers are intentionally loaded lazily in environments where the
 # full analytics stack is unavailable. ``AI_SUGGESTIONS_AVAILABLE`` defaults to
@@ -45,6 +46,7 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
 
 __all__ = [
     "FileHandler",
+    "UnifiedFileValidator",
     "process_file_simple",
     "FileProcessingError",
 ]

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -1,31 +1,12 @@
 """Unified file validation and security handling."""
 
-import io
-import json
 from pathlib import Path
+from typing import Any, Optional
 
 import pandas as pd
 
-from utils.file_validator import safe_decode_with_unicode_handling
-from utils.unicode_utils import (
-    sanitize_unicode_input,
-    sanitize_dataframe,
-    process_large_csv_content,
-)
-from services.data_processing.callback_controller import (
-    CallbackController,
-    CallbackEvent,
-)
-from config.dynamic_config import dynamic_config
-
-
-from typing import Any, Optional, Tuple
-
-import pandas as pd
-
-from security.file_validator import SecureFileValidator
-from services.input_validator import InputValidator, ValidationResult
-from security.validation_exceptions import ValidationError
+from services.input_validator import ValidationResult
+from services.data_processing.unified_file_validator import UnifiedFileValidator
 from core.error_handling import FileProcessingError
 
 
@@ -43,23 +24,46 @@ class FileHandler:
     """Combine security and basic validation for uploaded files."""
 
     def __init__(self, max_size_mb: Optional[int] = None) -> None:
-        self.basic_validator = InputValidator(max_size_mb)
-        self.secure_validator = SecureFileValidator()
+        self.validator = UnifiedFileValidator(max_size_mb)
 
     def sanitize_filename(self, filename: str) -> str:
-        return self.secure_validator.sanitize_filename(filename)
+        return self.validator.sanitize_filename(filename)
 
     def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        """Run basic checks on ``file_obj`` using :class:`InputValidator`."""
-        return self.basic_validator.validate_file_upload(file_obj)
+        """Run basic checks on ``file_obj`` using :class:`UnifiedFileValidator`."""
+        if file_obj is None:
+            return ValidationResult(False, "No file provided")
+        try:
+            import pandas as pd
+            if isinstance(file_obj, pd.DataFrame):
+                metrics = self.validator.validate_dataframe(file_obj)
+                return ValidationResult(metrics.get("valid", False), metrics.get("error", "ok") if not metrics.get("valid", False) else "ok")
+        except Exception:
+            pass
+        if isinstance(file_obj, (str, Path)):
+            path = Path(file_obj)
+            if not path.exists():
+                return ValidationResult(False, "File not found")
+            size_mb = path.stat().st_size / (1024 * 1024)
+            if size_mb == 0:
+                return ValidationResult(False, "File is empty")
+            if size_mb > self.validator.max_size_mb:
+                return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.validator.max_size_mb}MB")
+            return ValidationResult(True, "ok")
+
+        if isinstance(file_obj, (bytes, bytearray)):
+            size_mb = len(file_obj) / (1024 * 1024)
+            if size_mb == 0:
+                return ValidationResult(False, "File is empty")
+            if size_mb > self.validator.max_size_mb:
+                return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.validator.max_size_mb}MB")
+            return ValidationResult(True, "ok")
+
+        return ValidationResult(False, "Unsupported file type")
 
     def process_base64_contents(self, contents: str, filename: str) -> pd.DataFrame:
         """Decode ``contents`` and return a validated :class:`~pandas.DataFrame`."""
-        sanitized = self.secure_validator.sanitize_filename(filename)
-        df = self.secure_validator.validate_file_contents(contents, sanitized)
-        result = self.basic_validator.validate_file_upload(df)
-        if not result.valid:
-            raise ValidationError(result.message)
+        df = self.validator.validate_file(contents, filename)
         return df
 
 

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""Unified file validation utilities consolidating legacy validators."""
+
+from pathlib import Path
+import os
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from config.dynamic_config import dynamic_config
+from utils.file_validator import (
+    validate_dataframe_content,
+    safe_decode_file,
+    process_dataframe,
+)
+from utils.unicode_utils import UnicodeProcessor, sanitize_dataframe
+from core.input_validation import InputValidator as StringValidator
+from security.auth_service import SecurityService, SAFE_FILENAME_RE
+from security.file_validator import SecureFileValidator
+from security.validation_exceptions import ValidationError
+
+
+class UnifiedFileValidator:
+    """Combine all file validation responsibilities into a single class."""
+
+    ALLOWED_EXTENSIONS = SecureFileValidator.ALLOWED_EXTENSIONS
+
+    def __init__(self, max_size_mb: Optional[int] = None) -> None:
+        self.max_size_mb = max_size_mb or dynamic_config.security.max_upload_mb
+        self._string_validator = StringValidator()
+        self._security_service = SecurityService(None)
+        self._security_service.enable_file_validation()
+
+    # ------------------------------------------------------------------
+    # Filename helpers
+    # ------------------------------------------------------------------
+    def sanitize_filename(self, filename: str) -> str:
+        """Validate and sanitize a filename."""
+        cleaned = self._string_validator.validate(filename)
+        cleaned = UnicodeProcessor.safe_encode_text(cleaned)
+
+        if os.path.basename(cleaned) != cleaned:
+            raise ValidationError("Path separators not allowed in filename")
+        if len(cleaned) > 100:
+            raise ValidationError("Filename too long")
+        if not SAFE_FILENAME_RE.fullmatch(cleaned):
+            raise ValidationError("Invalid filename")
+
+        ext = Path(cleaned).suffix.lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            raise ValidationError(f"Unsupported file type: {ext}")
+        return cleaned
+
+    # ------------------------------------------------------------------
+    # DataFrame helpers
+    # ------------------------------------------------------------------
+    def validate_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Validate a :class:`~pandas.DataFrame` and return metrics."""
+        metrics = validate_dataframe_content(df)
+        if not metrics.get("valid", False):
+            return metrics
+
+        size_mb = df.memory_usage(deep=True).sum() / (1024 * 1024)
+        if size_mb > self.max_size_mb:
+            return {
+                "valid": False,
+                "error": f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                "issues": ["too_large"],
+            }
+        metrics["memory_usage_mb"] = size_mb
+        return metrics
+
+    # ------------------------------------------------------------------
+    # File helpers
+    # ------------------------------------------------------------------
+    def validate_file(self, contents: str, filename: str) -> pd.DataFrame:
+        """Decode ``contents`` and return a validated :class:`~pandas.DataFrame`."""
+        sanitized_name = self.sanitize_filename(filename)
+
+        file_bytes = safe_decode_file(contents)
+        if file_bytes is None:
+            raise ValidationError("Invalid base64 contents")
+
+        sec_result = self._security_service.validate_file(sanitized_name, len(file_bytes))
+        if not sec_result["valid"]:
+            raise ValidationError("; ".join(sec_result["issues"]))
+
+        df, err = process_dataframe(file_bytes, sanitized_name)
+        if df is None:
+            raise ValidationError(err or "Unable to parse file")
+
+        metrics = self.validate_dataframe(df)
+        if not metrics.get("valid", False):
+            raise ValidationError(metrics.get("error", "Invalid dataframe"))
+
+        df = sanitize_dataframe(df)
+        return df
+
+
+__all__ = ["UnifiedFileValidator"]


### PR DESCRIPTION
## Summary
- add `UnifiedFileValidator` consolidating various checks
- refactor `FileHandler` to use new validator
- export `UnifiedFileValidator` from services packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686892d27b9883209a3980d42ee6c3d1