### PR TITLE
Refactor upload analytics

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -20,12 +20,15 @@ from .upload_processing import UploadAnalyticsProcessor
 from .db_analytics_helper import DatabaseAnalyticsHelper
 from .summary_reporting import SummaryReporter
 from .data_processing.file_handler import FileHandler
+from .data_processing.file_processor import FileProcessor
 
 logger = logging.getLogger(__name__)
 
 # Resolve optional services from the registry
 FileHandlerService = get_service("FileHandler")
 FILE_HANDLER_AVAILABLE = FileHandlerService is not None
+FileProcessorService = get_service("FileProcessor")
+FILE_PROCESSOR_AVAILABLE = FileProcessorService is not None
 
 get_analytics_service = get_service("get_analytics_service")
 create_analytics_service = get_service("create_analytics_service")
@@ -35,6 +38,7 @@ ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 __all__ = [
     "FileHandler",
     "FILE_HANDLER_AVAILABLE",
+    "FILE_PROCESSOR_AVAILABLE",
     "get_analytics_service",
     "create_analytics_service",
     "AnalyticsService",
@@ -54,4 +58,5 @@ __all__ = [
     "DatabaseAnalyticsHelper",
     "SummaryReporter",
     "FileHandler",
+    "FileProcessor",
 ]

--- a/services/analytics/__init__.py
+++ b/services/analytics/__init__.py
@@ -1,0 +1,8 @@
+"""Analytics utilities for uploaded data."""
+
+from .upload_analytics import (
+    summarize_dataframes,
+    run_anomaly_detection,
+)
+
+__all__ = ["summarize_dataframes", "run_anomaly_detection"]

--- a/services/analytics/upload_analytics.py
+++ b/services/analytics/upload_analytics.py
@@ -1,0 +1,28 @@
+"""Analytics helpers for uploaded DataFrame objects."""
+
+from __future__ import annotations
+
+from typing import Dict, Any, List
+import pandas as pd
+
+from services.analytics_summary import summarize_dataframe, generate_basic_analytics
+from services.chunked_analysis import analyze_with_chunking
+from services.data_validation import DataValidationService
+
+
+def summarize_dataframes(dfs: List[pd.DataFrame]) -> Dict[str, Any]:
+    """Combine ``dfs`` and return a summary dictionary."""
+    if not dfs:
+        return {"status": "no_data"}
+    combined = pd.concat(dfs, ignore_index=True)
+    summary = summarize_dataframe(combined)
+    summary.update({"status": "success", "files_processed": len(dfs)})
+    return summary
+
+
+def run_anomaly_detection(df: pd.DataFrame, validator: DataValidationService) -> Dict[str, Any]:
+    """Run anomaly detection using chunked analysis."""
+    return analyze_with_chunking(df, validator, ["anomaly"])
+
+
+__all__ = ["summarize_dataframes", "run_anomaly_detection"]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -9,7 +9,6 @@ import pandas as pd
 import logging
 from typing import Dict, Any, List, Optional, Tuple
 
-from services.file_processing_service import FileProcessingService
 from services.data_loader import DataLoader
 from services.analytics_summary import generate_sample_analytics
 from services.data_validation import DataValidationService
@@ -45,17 +44,11 @@ class AnalyticsService:
     def __init__(self):
         self.database_manager: Optional[Any] = None
         self._initialize_database()
-        self.file_processing_service = FileProcessingService()
         self.validation_service = DataValidationService()
         self.data_loading_service = DataLoadingService(self.validation_service)
-        from services.data_processing.file_handler import FileHandler
-
-        self.file_handler = FileHandler()
         self.upload_processor = UploadAnalyticsProcessor(
-            self.file_processing_service,
             self.validation_service,
             self.data_loading_service,
-            self.file_handler,
         )
         self.db_helper = DatabaseAnalyticsHelper(self.database_manager)
         self.summary_reporter = SummaryReporter(self.database_manager)

--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,6 +1,7 @@
 """Data processing utilities."""
 
 from .file_handler import FileHandler, process_file_simple, FileProcessingError
+from .file_processor import FileProcessor, UnifiedFileValidator
 
 # Analytics helpers are intentionally loaded lazily in environments where the
 # full analytics stack is unavailable. ``AI_SUGGESTIONS_AVAILABLE`` defaults to
@@ -45,6 +46,8 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
 
 __all__ = [
     "FileHandler",
+    "FileProcessor",
+    "UnifiedFileValidator",
     "process_file_simple",
     "FileProcessingError",
 ]

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -1,0 +1,83 @@
+"""FileProcessor for reading and validating uploaded files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+import logging
+
+import pandas as pd
+
+from services.input_validator import InputValidator, ValidationResult
+from security.file_validator import SecureFileValidator
+from security.dataframe_validator import DataFrameSecurityValidator
+from security.validation_exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class UnifiedFileValidator:
+    """Combine file and DataFrame validation helpers."""
+
+    def __init__(self, max_size_mb: Optional[int] = None) -> None:
+        self.input_validator = InputValidator(max_size_mb)
+        self.secure_validator = SecureFileValidator()
+        self.df_validator = DataFrameSecurityValidator()
+
+    # ------------------------------------------------------------------
+    # Basic helpers
+    # ------------------------------------------------------------------
+    def validate_path(self, path: Path) -> None:
+        result = self.input_validator.validate_file_upload(path)
+        if not result.valid:
+            raise ValidationError(result.message)
+
+    def _read_path(self, path: Path) -> pd.DataFrame:
+        if path.suffix.lower() == ".csv":
+            df = pd.read_csv(path)
+        elif path.suffix.lower() == ".json":
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+            df = pd.DataFrame(data)
+        elif path.suffix.lower() in {".xlsx", ".xls"}:
+            df = pd.read_excel(path)
+        else:
+            raise ValidationError(f"Unsupported file type: {path.suffix}")
+        return df
+
+    def load_dataframe(self, path: Path) -> pd.DataFrame:
+        self.validate_path(path)
+        df = self._read_path(path)
+        df = self.df_validator.validate_for_upload(df)
+        return df
+
+    def validate_contents(self, contents: str, filename: str) -> pd.DataFrame:
+        df = self.secure_validator.validate_file_contents(contents, filename)
+        result = self.input_validator.validate_file_upload(df)
+        if not result.valid:
+            raise ValidationError(result.message)
+        df = self.df_validator.validate_for_upload(df)
+        return df
+
+
+class FileProcessor:
+    """High level processor that delegates to :class:`UnifiedFileValidator`."""
+
+    def __init__(self, validator: Optional[UnifiedFileValidator] = None) -> None:
+        self.validator = validator or UnifiedFileValidator()
+
+    def process_path(self, file_path: str | Path) -> pd.DataFrame:
+        path = Path(file_path)
+        logger.info("Processing file %s", path)
+        return self.validator.load_dataframe(path)
+
+    def process_uploaded_contents(self, contents: str, filename: str) -> pd.DataFrame:
+        logger.info("Processing uploaded contents for %s", filename)
+        return self.validator.validate_contents(contents, filename)
+
+    def health_check(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+
+__all__ = ["FileProcessor", "UnifiedFileValidator"]

--- a/services/registry.py
+++ b/services/registry.py
@@ -44,7 +44,7 @@ get_service = registry.get_service
 
 
 # Register built-in optional services
-register_service("FileProcessor", "services.data_processing.file_handler:FileHandler")
+register_service("FileProcessor", "services.data_processing.file_processor:FileProcessor")
 register_service("FileHandler", "services.data_processing.file_handler:FileHandler")
 register_service(
     "get_analytics_service", "services.analytics_service:get_analytics_service"

--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -19,87 +19,20 @@ logger = logging.getLogger(__name__)
 
 
 class UploadAnalyticsProcessor:
-    """Handle analytics generation from uploaded datasets."""
+    """Handle analytics generation from already loaded DataFrames."""
 
-    def __init__(
-        self,
-        file_processing_service: Any,
-        validation_service: Any,
-        data_loading_service: Any,
-        file_handler: Any,
-    ) -> None:
-        self.file_processing_service = file_processing_service
+    def __init__(self, validation_service: Any, data_loading_service: Any) -> None:
         self.validation_service = validation_service
         self.data_loading_service = data_loading_service
-        self.file_handler = file_handler
 
     def get_analytics_from_uploaded_data(self) -> Dict[str, Any]:
         """Generate analytics from uploaded files."""
-        try:
-            from services.upload_data_service import get_uploaded_filenames
-
-            uploaded_files = get_uploaded_filenames()
-            if not uploaded_files:
-                return {"status": "no_data", "message": "No uploaded files available"}
-
-            valid_files: List[str] = []
-            processing_info: Dict[str, Any] = {}
-            for path in uploaded_files:
-                result = self.file_handler.validate_file_upload(path)
-                if result.valid:
-                    valid_files.append(path)
-                else:
-                    processing_info[path] = f"invalid: {result.message}"
-
-            if not valid_files:
-                return {
-                    "status": "error",
-                    "message": "No valid files to process",
-                    "processing_info": processing_info,
-                }
-
-            (
-                combined_df,
-                info,
-                processed_files,
-                total_records,
-            ) = self.file_processing_service.process_files(valid_files)
-            if isinstance(info, list):
-                processing_info["logs"] = info
-
-            if combined_df.empty:
-                return {
-                    "status": "error",
-                    "message": "No files could be processed successfully",
-                    "processing_info": processing_info,
-                }
-
-            analytics = generate_basic_analytics(combined_df)
-            analytics.update(
-                {
-                    "data_source": "uploaded_files_fixed",
-                    "total_files_processed": processed_files,
-                    "total_files_attempted": len(uploaded_files),
-                    "processing_info": processing_info,
-                    "total_events": total_records,
-                    "active_users": combined_df["person_id"].nunique()
-                    if "person_id" in combined_df.columns
-                    else 0,
-                    "active_doors": combined_df["door_id"].nunique()
-                    if "door_id" in combined_df.columns
-                    else 0,
-                    "timestamp": datetime.now().isoformat(),
-                }
-            )
-            return analytics
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Error getting analytics from uploaded data: %s", exc)
-            return {"status": "error", "message": str(exc)}
+        return self._get_real_uploaded_data()
 
     def _process_uploaded_data_directly(
-        self, uploaded_data: Dict[str, Any]
+        self, uploaded_data: Dict[str, pd.DataFrame]
     ) -> Dict[str, Any]:
-        """Process uploaded files using streaming."""
+        """Process already loaded DataFrames using streaming."""
         try:
             from collections import Counter
             from analytics.file_processing_utils import (
@@ -118,13 +51,6 @@ class UploadAnalyticsProcessor:
             max_ts: Optional[pd.Timestamp] = None
 
             for filename, source in uploaded_data.items():
-                validation = self.file_handler.validate_file_upload(source)
-                if not validation.valid:
-                    processing_info[filename] = {
-                        "rows": 0,
-                        "status": f"invalid: {validation.message}",
-                    }
-                    continue
                 try:
                     chunks = stream_uploaded_file(self.data_loading_service, source)
                     file_events, min_ts, max_ts = aggregate_counts(

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -1,18 +1,14 @@
 import pandas as pd
 from services.upload_processing import UploadAnalyticsProcessor
-from services.file_processing_service import FileProcessingService
 from services.data_validation import DataValidationService
 from services.data_processing.processor import Processor
-from services.input_validator import InputValidator
 
 
 
 def _make_processor():
-    fps = FileProcessingService()
     vs = DataValidationService()
     dls = Processor(validator=vs)
-    iv = InputValidator()
-    return UploadAnalyticsProcessor(fps, vs, dls, iv)
+    return UploadAnalyticsProcessor(vs, dls)
 
 
 
@@ -26,10 +22,8 @@ def test_direct_processing_helper(tmp_path):
             "Access result": ["Granted"],
         }
     )
-    path = tmp_path / "f1.csv"
-    df1.to_csv(path, index=False)
     proc = _make_processor()
-    result = proc._process_uploaded_data_directly({"f1.csv": path})
+    result = proc._process_uploaded_data_directly({"f1.csv": df1})
     assert result["total_events"] == 1
     assert result["active_users"] == 1
     assert result["active_doors"] == 1


### PR DESCRIPTION
## Summary
- implement UnifiedFileValidator and FileProcessor for validating/reading uploaded files
- move analytics helpers to `services/analytics`
- refactor `UploadAnalyticsProcessor` to work with pre-loaded DataFrames
- update service registry and init modules
- adjust analytics service and unit test

## Testing
- `pip install pandas`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.unicode_utils')*

------
https://chatgpt.com/codex/tasks/task_e_686892d3f1dc8320bcdcdaf4befa2126