### PR TITLE
Add unified FileProcessingError hierarchy

### DIFF
--- a/core/error_handling.py
+++ b/core/error_handling.py
@@ -73,15 +73,6 @@ class DatabaseError(YosaiError):
         super().__init__(message, ErrorCategory.DATABASE, ErrorSeverity.HIGH, details)
 
 
-class FileProcessingError(YosaiError):
-    """File processing errors"""
-
-    def __init__(self, message: str, details: Dict[str, Any] = None):
-        super().__init__(
-            message, ErrorCategory.FILE_PROCESSING, ErrorSeverity.MEDIUM, details
-        )
-
-
 class ConfigurationError(YosaiError):
     """Configuration errors"""
 

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -34,9 +34,5 @@ class SecurityError(YosaiBaseException):
     """Security-related errors"""
 
 
-class FileProcessingError(YosaiBaseException):
-    """File processing errors"""
-
-
 class ServiceUnavailableError(YosaiBaseException):
     """Service unavailable errors"""

--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,6 +1,13 @@
 """Data processing utilities."""
 
-from .file_handler import FileHandler, process_file_simple, FileProcessingError
+from .file_handler import FileHandler, process_file_simple
+from .core.exceptions import (
+    FileProcessingError,
+    FileValidationError,
+    FileFormatError,
+    FileSizeError,
+    FileSecurityError,
+)
 
 # Analytics helpers are intentionally loaded lazily in environments where the
 # full analytics stack is unavailable. ``AI_SUGGESTIONS_AVAILABLE`` defaults to
@@ -47,4 +54,8 @@ __all__ = [
     "FileHandler",
     "process_file_simple",
     "FileProcessingError",
+    "FileValidationError",
+    "FileFormatError",
+    "FileSizeError",
+    "FileSecurityError",
 ]

--- a/services/data_processing/core/exceptions.py
+++ b/services/data_processing/core/exceptions.py
@@ -1,0 +1,32 @@
+"""File processing exception hierarchy."""
+
+from core.exceptions import YosaiBaseException
+
+
+class FileProcessingError(YosaiBaseException):
+    """Base exception for file processing errors."""
+
+
+class FileValidationError(FileProcessingError):
+    """Raised when validation of a file fails."""
+
+
+class FileFormatError(FileProcessingError):
+    """Raised for unsupported or corrupt file formats."""
+
+
+class FileSizeError(FileProcessingError):
+    """Raised when a file exceeds allowed size limits."""
+
+
+class FileSecurityError(FileProcessingError):
+    """Raised when a security issue is detected in a file."""
+
+
+__all__ = [
+    "FileProcessingError",
+    "FileValidationError",
+    "FileFormatError",
+    "FileSizeError",
+    "FileSecurityError",
+]

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -25,13 +25,10 @@ import pandas as pd
 
 from security.file_validator import SecureFileValidator
 from services.input_validator import InputValidator, ValidationResult
-from security.validation_exceptions import ValidationError
-from core.error_handling import FileProcessingError
-
-
-class FileProcessingError(Exception):
-    """Placeholder exception for processing errors."""
-    pass
+from services.data_processing.core.exceptions import (
+    FileProcessingError,
+    FileValidationError,
+)
 
 
 def process_file_simple(content: bytes, filename: str):
@@ -59,7 +56,7 @@ class FileHandler:
         df = self.secure_validator.validate_file_contents(contents, sanitized)
         result = self.basic_validator.validate_file_upload(df)
         if not result.valid:
-            raise ValidationError(result.message)
+            raise FileValidationError(result.message)
         return df
 
 

--- a/services/file_processing_service.py
+++ b/services/file_processing_service.py
@@ -6,6 +6,7 @@ import logging
 from typing import List, Tuple
 
 from services.data_processing.file_handler import FileHandler
+from services.data_processing.core.exceptions import FileFormatError
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class FileProcessingService:
             return pd.DataFrame(data)
         if path.endswith((".xlsx", ".xls")):
             return pd.read_excel(path)
-        raise ValueError(f"Unsupported file type: {path}")
+        raise FileFormatError(f"Unsupported file type: {path}")
 
     def process_files(
         self, file_paths: List[str]

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -12,9 +12,9 @@ import tempfile
 
 from services.data_processing.file_handler import (
     FileHandler as RobustFileProcessor,
-    FileProcessingError,
     process_file_simple,
 )
+from services.data_processing.core.exceptions import FileProcessingError
 
 
 class TestRobustFileProcessor:

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -20,8 +20,8 @@ from services.data_processing.callback_controller import (
 from services.data_processing.file_handler import (
     FileHandler as RobustFileProcessor,
     process_file_simple,
-    FileProcessingError,
 )
+from services.data_processing.core.exceptions import FileProcessingError
 
 
 class TestUnicodeProcessor:


### PR DESCRIPTION
## Summary
- centralize file processing exceptions under `services.data_processing.core`
- replace old `FileProcessingError` definitions with imports
- use `FileValidationError` and `FileFormatError` in data processing
- expose new exceptions from `services.data_processing`
- update tests to import from new location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.unicode_utils')*

------
https://chatgpt.com/codex/tasks/task_e_686892d432ec8320a8dffc6a7ec877c4