### PR TITLE
Refactor validation imports via UnifiedFileValidator

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -19,13 +19,13 @@ from .registry import get_service
 from .upload_processing import UploadAnalyticsProcessor
 from .db_analytics_helper import DatabaseAnalyticsHelper
 from .summary_reporting import SummaryReporter
-from .data_processing.file_handler import FileHandler
+from .unified_file_validator import UnifiedFileValidator
 
 logger = logging.getLogger(__name__)
 
 # Resolve optional services from the registry
-FileHandlerService = get_service("FileHandler")
-FILE_HANDLER_AVAILABLE = FileHandlerService is not None
+UnifiedFileValidatorService = get_service("UnifiedFileValidator")
+FILE_VALIDATOR_AVAILABLE = UnifiedFileValidatorService is not None
 
 get_analytics_service = get_service("get_analytics_service")
 create_analytics_service = get_service("create_analytics_service")
@@ -33,8 +33,8 @@ AnalyticsService = get_service("AnalyticsService")
 ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
 __all__ = [
-    "FileHandler",
-    "FILE_HANDLER_AVAILABLE",
+    "UnifiedFileValidator",
+    "FILE_VALIDATOR_AVAILABLE",
     "get_analytics_service",
     "create_analytics_service",
     "AnalyticsService",
@@ -53,5 +53,4 @@ __all__ = [
     "UploadAnalyticsProcessor",
     "DatabaseAnalyticsHelper",
     "SummaryReporter",
-    "FileHandler",
 ]

--- a/services/analytics/__init__.py
+++ b/services/analytics/__init__.py
@@ -1,0 +1,22 @@
+"""Consolidated analytics helpers."""
+
+from ..analytics_summary import generate_basic_analytics, summarize_dataframe
+from ..chunked_analysis import analyze_with_chunking
+from ..result_formatting import (
+    prepare_regular_result,
+    apply_regular_analysis,
+    calculate_temporal_stats_safe,
+    regular_analysis,
+)
+from utils.mapping_helpers import map_and_clean
+
+__all__ = [
+    "generate_basic_analytics",
+    "summarize_dataframe",
+    "analyze_with_chunking",
+    "prepare_regular_result",
+    "apply_regular_analysis",
+    "calculate_temporal_stats_safe",
+    "regular_analysis",
+    "map_and_clean",
+]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Analytics Service - Enhanced with Unique Patterns Analysis
 
-Uploaded files are validated with :class:`services.data_processing.file_handler.FileHandler`
+Uploaded files are validated with :class:`services.unified_file_validator.UnifiedFileValidator`
 before processing to ensure they are present, non-empty and within the configured
 size limits.
 """
@@ -48,9 +48,9 @@ class AnalyticsService:
         self.file_processing_service = FileProcessingService()
         self.validation_service = DataValidationService()
         self.data_loading_service = DataLoadingService(self.validation_service)
-        from services.data_processing.file_handler import FileHandler
+        from services.unified_file_validator import UnifiedFileValidator
 
-        self.file_handler = FileHandler()
+        self.file_handler = UnifiedFileValidator()
         self.upload_processor = UploadAnalyticsProcessor(
             self.file_processing_service,
             self.validation_service,

--- a/services/file_processing_service.py
+++ b/services/file_processing_service.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import List, Tuple
 
-from services.data_processing.file_handler import FileHandler
+from services.unified_file_validator import UnifiedFileValidator
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 class FileProcessingService:
     """Service for reading and validating uploaded files."""
 
-    def __init__(self, processor: FileHandler | None = None):
-        self.processor = processor or FileHandler()
+    def __init__(self, processor: UnifiedFileValidator | None = None):
+        self.processor = processor or UnifiedFileValidator()
 
     def _read_file(self, path: str) -> pd.DataFrame:
         """Read a single file into a DataFrame."""

--- a/services/registry.py
+++ b/services/registry.py
@@ -44,8 +44,10 @@ get_service = registry.get_service
 
 
 # Register built-in optional services
-register_service("FileProcessor", "services.data_processing.file_handler:FileHandler")
-register_service("FileHandler", "services.data_processing.file_handler:FileHandler")
+register_service("FileProcessor", "services.unified_file_validator:UnifiedFileValidator")
+register_service("FileHandler", "services.unified_file_validator:UnifiedFileValidator")
+register_service("UnifiedFileValidator", "services.unified_file_validator:UnifiedFileValidator")
+register_service("UploadAnalyticsProcessor", "services.upload_processing:UploadAnalyticsProcessor")
 register_service(
     "get_analytics_service", "services.analytics_service:get_analytics_service"
 )

--- a/services/unified_file_validator.py
+++ b/services/unified_file_validator.py
@@ -1,0 +1,35 @@
+"""High level validator combining security and size checks."""
+
+from __future__ import annotations
+
+import pandas as pd
+from typing import Any, Optional
+
+from services.input_validator import InputValidator, ValidationResult
+from security.file_validator import SecureFileValidator
+from security.validation_exceptions import ValidationError
+
+
+class UnifiedFileValidator:
+    """Validate uploaded files with security and size limits."""
+
+    def __init__(self, max_size_mb: Optional[int] = None) -> None:
+        self.basic_validator = InputValidator(max_size_mb)
+        self.secure_validator = SecureFileValidator()
+
+    def sanitize_filename(self, filename: str) -> str:
+        return self.secure_validator.sanitize_filename(filename)
+
+    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
+        return self.basic_validator.validate_file_upload(file_obj)
+
+    def process_base64_contents(self, contents: str, filename: str) -> pd.DataFrame:
+        sanitized = self.secure_validator.sanitize_filename(filename)
+        df = self.secure_validator.validate_file_contents(contents, sanitized)
+        result = self.basic_validator.validate_file_upload(df)
+        if not result.valid:
+            raise ValidationError(result.message)
+        return df
+
+
+__all__ = ["UnifiedFileValidator", "ValidationResult"]

--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -11,9 +11,12 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from .analytics_summary import generate_basic_analytics, summarize_dataframe
-from .chunked_analysis import analyze_with_chunking
-from utils.mapping_helpers import map_and_clean
+from services.analytics import (
+    generate_basic_analytics,
+    summarize_dataframe,
+    analyze_with_chunking,
+    map_and_clean,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -253,9 +256,9 @@ class UploadAnalyticsProcessor:
         json_file = os.getenv("SAMPLE_JSON_PATH", sample_cfg.json_path)
 
         try:
-            from services.data_processing.file_handler import FileHandler
+            from services.unified_file_validator import UnifiedFileValidator
 
-            processor = FileHandler()
+            processor = UnifiedFileValidator()
             all_data = []
             if os.path.exists(csv_file):
                 df_csv = pd.read_csv(csv_file)

--- a/services/upload_service.py
+++ b/services/upload_service.py
@@ -7,17 +7,17 @@ from datetime import datetime
 from typing import Any, Dict
 
 from config.dynamic_config import dynamic_config
-from services.data_processing.file_handler import FileHandler
+from services.unified_file_validator import UnifiedFileValidator
 from security.xss_validator import XSSPrevention
 from services.data_validation import DataValidationService
-from utils.mapping_helpers import map_and_clean
+from services.analytics import map_and_clean
 
 import pandas as pd
 import dash_bootstrap_components as dbc
 from dash import html
 
 logger = logging.getLogger(__name__)
-_handler = FileHandler()
+_handler = UnifiedFileValidator()
 
 
 def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from services.data_processing.file_handler import FileHandler
+from services.unified_file_validator import UnifiedFileValidator
 
 
 @pytest.mark.parametrize("sep", [";", "\t"])
@@ -17,7 +17,7 @@ def test_parse_csv_with_various_delimiters(tmp_path, sep):
     csv_path = tmp_path / "sample.csv"
     df.to_csv(csv_path, index=False, sep=sep)
 
-    processor = FileHandler()
+    processor = UnifiedFileValidator()
     with open(csv_path, "rb") as f:
         text, _ = processor.validate_and_decode(str(csv_path), f.read())
     parsed = processor._parse_csv(text)

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -10,11 +10,8 @@ import json
 from pathlib import Path
 import tempfile
 
-from services.data_processing.file_handler import (
-    FileHandler as RobustFileProcessor,
-    FileProcessingError,
-    process_file_simple,
-)
+from services.unified_file_validator import UnifiedFileValidator as RobustFileProcessor
+from services.data_processing.file_handler import FileProcessingError, process_file_simple
 
 
 class TestRobustFileProcessor:

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import base64
 
-from services.data_processing.file_handler import FileHandler
+from services.unified_file_validator import UnifiedFileValidator
 from services.upload_service import process_uploaded_file
 from config.dynamic_config import dynamic_config
 
@@ -18,7 +18,7 @@ def test_enhanced_processor(tmp_path):
     csv_path = tmp_path / "sample.csv"
     df.to_csv(csv_path, index=False)
 
-    processor = FileHandler()
+    processor = UnifiedFileValidator()
 
     df_loaded = pd.read_csv(csv_path)
     suggestions = processor.get_mapping_suggestions(df_loaded)

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,22 +1,22 @@
 import pandas as pd
-from services.data_processing.file_handler import FileHandler
+from services.unified_file_validator import UnifiedFileValidator
 
 
 def test_none_upload_rejected():
-    validator = FileHandler(max_size_mb=1)
+    validator = UnifiedFileValidator(max_size_mb=1)
     res = validator.validate_file_upload(None)
     assert not res.valid
 
 
 def test_empty_dataframe_rejected():
-    validator = FileHandler(max_size_mb=1)
+    validator = UnifiedFileValidator(max_size_mb=1)
     df = pd.DataFrame()
     res = validator.validate_file_upload(df)
     assert not res.valid
 
 
 def test_valid_dataframe_allowed():
-    validator = FileHandler(max_size_mb=1)
+    validator = UnifiedFileValidator(max_size_mb=1)
     df = pd.DataFrame({"a": [1, 2]})
     res = validator.validate_file_upload(df)
     assert res.valid

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -17,11 +17,8 @@ from services.data_processing.callback_controller import (
     fire_event,
     callback_handler,
 )
-from services.data_processing.file_handler import (
-    FileHandler as RobustFileProcessor,
-    process_file_simple,
-    FileProcessingError,
-)
+from services.unified_file_validator import UnifiedFileValidator as RobustFileProcessor
+from services.data_processing.file_handler import process_file_simple, FileProcessingError
 
 
 class TestUnicodeProcessor:

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -3,7 +3,7 @@ from services.upload_processing import UploadAnalyticsProcessor
 from services.file_processing_service import FileProcessingService
 from services.data_validation import DataValidationService
 from services.data_processing.processor import Processor
-from services.input_validator import InputValidator
+from services.unified_file_validator import UnifiedFileValidator
 
 
 
@@ -11,8 +11,8 @@ def _make_processor():
     fps = FileProcessingService()
     vs = DataValidationService()
     dls = Processor(validator=vs)
-    iv = InputValidator()
-    return UploadAnalyticsProcessor(fps, vs, dls, iv)
+    handler = UnifiedFileValidator()
+    return UploadAnalyticsProcessor(fps, vs, dls, handler)
 
 
 


### PR DESCRIPTION
## Summary
- provide `UnifiedFileValidator` to combine security and size checks
- consolidate analytics helpers under `services.analytics`
- update `UploadAnalyticsProcessor` and services to use the new modules
- expose new classes in `services/__init__` and registry
- adjust tests for validator rename

## Testing
- `pip install pandas`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.unicode_utils')*

------
https://chatgpt.com/codex/tasks/task_e_686892d82160832098f17e79b3e94960