### PR TITLE
Add UnicodeProcessor module

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -19,7 +19,7 @@ def create_app(mode: str | None = None):
     return _create_app(mode)
 
 
-from .unicode_utils import sanitize_unicode_input
+from utils.unicode_utils import sanitize_unicode_input
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
 
 __all__ = ["create_app", "profile_callback", "sanitize_unicode_input", "TrulyUnifiedCallbacks"]

--- a/core/serialization/safe_json.py
+++ b/core/serialization/safe_json.py
@@ -7,10 +7,7 @@ import logging
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from plugins.service_locator import PluginServiceLocator
-
-_unicode = PluginServiceLocator.get_unicode_handler()
-UnicodeProcessor = _unicode.UnicodeProcessor
+from core.unicode_processor import UnicodeProcessor
 
 try:  # Optional Flask-Babel
     from flask_babel import LazyString
@@ -50,18 +47,16 @@ class SafeJSONSerializer:
                 return obj
 
             if isinstance(obj, bytes):
-                return UnicodeProcessor.clean_surrogate_chars(
-                    obj.decode("utf-8", "replace")
-                )
+                return UnicodeProcessor.safe_decode(obj).text
 
             if isinstance(obj, str):
-                return UnicodeProcessor.clean_surrogate_chars(obj)
+                return UnicodeProcessor.clean_text(obj).text
 
             if MARKUP_AVAILABLE and isinstance(obj, Markup):
-                return UnicodeProcessor.clean_surrogate_chars(str(obj))
+                return UnicodeProcessor.clean_text(str(obj)).text
 
             if BABEL_AVAILABLE and LazyString and isinstance(obj, LazyString):
-                return UnicodeProcessor.clean_surrogate_chars(str(obj))
+                return UnicodeProcessor.clean_text(str(obj)).text
 
             if isinstance(obj, dict):
                 return {self._sanitize(k): self._sanitize(v) for k, v in obj.items()}
@@ -79,6 +74,6 @@ class SafeJSONSerializer:
                 return {k: self._sanitize(v) for k, v in vars(obj).items()}
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning("SafeJSONSerializer failed: %s", exc)
-            return UnicodeProcessor.clean_surrogate_chars(str(obj))
+            return UnicodeProcessor.clean_text(str(obj)).text
 
         return obj

--- a/core/unicode_processor.py
+++ b/core/unicode_processor.py
@@ -1,0 +1,136 @@
+import logging
+import unicodedata
+import re
+from dataclasses import dataclass, field
+from typing import Any, List
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Regular expressions for unsafe characters
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+_CONTROL_RE = re.compile(r"[\u0000-\u001F\u007F]")
+_DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
+
+
+@dataclass
+class UnicodeProcessingResult:
+    """Result of a Unicode processing operation."""
+
+    text: str
+    surrogates_removed: int = 0
+    control_chars_removed: int = 0
+    errors: List[str] = field(default_factory=list)
+
+
+class UnicodeProcessor:
+    """Utilities for safe Unicode handling with metrics tracking."""
+
+    metrics = {
+        "bytes_processed": 0,
+        "surrogates_removed": 0,
+        "control_chars_removed": 0,
+    }
+
+    @classmethod
+    def _update_metrics(cls, byte_len: int, surrogates: int, controls: int) -> None:
+        cls.metrics["bytes_processed"] += byte_len
+        cls.metrics["surrogates_removed"] += surrogates
+        cls.metrics["control_chars_removed"] += controls
+
+    @staticmethod
+    def clean_text(text: Any, *, strict: bool = False) -> UnicodeProcessingResult:
+        if not isinstance(text, str):
+            text = str(text) if text is not None else ""
+        original_bytes = text.encode("utf-8", "surrogatepass")
+        surrogates = len(_SURROGATE_RE.findall(text))
+        controls = len(_CONTROL_RE.findall(text))
+        cleaned = _SURROGATE_RE.sub("", text)
+        cleaned = _CONTROL_RE.sub("", cleaned)
+        cleaned = unicodedata.normalize("NFKC", cleaned)
+        UnicodeProcessor._update_metrics(len(original_bytes), surrogates, controls)
+        result = UnicodeProcessingResult(
+            text=cleaned,
+            surrogates_removed=surrogates,
+            control_chars_removed=controls,
+            errors=[],
+        )
+        logger.debug(
+            "Cleaned text (surrogates=%s, controls=%s)", surrogates, controls
+        )
+        if strict and (surrogates or controls):
+            result.errors.append("unsafe characters removed")
+        return result
+
+    @staticmethod
+    def safe_decode(
+        data: bytes,
+        encoding: str = "utf-8",
+        *,
+        chunk_size: int = 1024 * 1024,
+        strict: bool = False,
+    ) -> UnicodeProcessingResult:
+        pieces: List[str] = []
+        errors: List[str] = []
+        total_surrogates = 0
+        total_controls = 0
+        for start in range(0, len(data), chunk_size):
+            chunk = data[start : start + chunk_size]
+            try:
+                text = chunk.decode(encoding, errors="surrogatepass")
+            except Exception as exc:
+                errors.append(str(exc))
+                text = chunk.decode(encoding, errors="replace")
+            res = UnicodeProcessor.clean_text(text, strict=strict)
+            pieces.append(res.text)
+            total_surrogates += res.surrogates_removed
+            total_controls += res.control_chars_removed
+            errors.extend(res.errors)
+        UnicodeProcessor._update_metrics(len(data), total_surrogates, total_controls)
+        return UnicodeProcessingResult(
+            text="".join(pieces),
+            surrogates_removed=total_surrogates,
+            control_chars_removed=total_controls,
+            errors=errors,
+        )
+
+    @staticmethod
+    def safe_encode(
+        value: Any,
+        encoding: str = "utf-8",
+        *,
+        strict: bool = False,
+    ) -> UnicodeProcessingResult:
+        if isinstance(value, bytes):
+            return UnicodeProcessor.safe_decode(value, encoding, strict=strict)
+        res = UnicodeProcessor.clean_text(value, strict=strict)
+        try:
+            res.text.encode(encoding)
+        except Exception as exc:
+            res.errors.append(str(exc))
+            if strict:
+                res.text = res.text.encode(encoding, "replace").decode(encoding)
+        return res
+
+    @staticmethod
+    def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        new_cols = []
+        for i, col in enumerate(df.columns):
+            name = UnicodeProcessor.safe_encode(col).text
+            name = _DANGEROUS_PREFIX_RE.sub("", name)
+            if not name:
+                name = f"col_{i}"
+            while name in new_cols:
+                name += "_1"
+            new_cols.append(name)
+        df.columns = new_cols
+        for col in df.select_dtypes(include=["object"]).columns:
+            df[col] = df[col].apply(
+                lambda x: _DANGEROUS_PREFIX_RE.sub("", UnicodeProcessor.safe_encode(x).text)
+            )
+        return df
+
+
+__all__ = ["UnicodeProcessor", "UnicodeProcessingResult"]

--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -8,10 +8,7 @@ from typing import Any
 
 from services.data_processing.core.protocols import PluginMetadata
 
-from plugins.service_locator import PluginServiceLocator
-
-_unicode = PluginServiceLocator.get_unicode_handler()
-UnicodeProcessor = _unicode.UnicodeProcessor
+from core.unicode_processor import UnicodeProcessor
 from core.serialization import SafeJSONSerializer
 
 # Optional Babel import
@@ -67,9 +64,8 @@ def _is_lazy_string(obj: Any) -> bool:
 
 
 def _sanitize_text(text: str) -> str:
-    text = unicodedata.normalize("NFKC", text)
-    text = UnicodeProcessor.clean_surrogate_chars(text)
-    return text
+    result = UnicodeProcessor.clean_text(text)
+    return result.text
 
 
 def sanitize_lazystring(obj: Any) -> Any:

--- a/security/unicode_security_handler.py
+++ b/security/unicode_security_handler.py
@@ -6,10 +6,7 @@ from typing import Any
 
 import pandas as pd
 
-from plugins.service_locator import PluginServiceLocator
-
-_unicode = PluginServiceLocator.get_unicode_handler()
-UnicodeProcessor = _unicode.UnicodeProcessor
+from core.unicode_processor import UnicodeProcessor
 
 
 class UnicodeSecurityHandler:
@@ -18,7 +15,7 @@ class UnicodeSecurityHandler:
     @staticmethod
     def sanitize_unicode_input(text: Any) -> str:
         """Sanitize input text for unsafe Unicode characters."""
-        return UnicodeProcessor.safe_encode_text(text)
+        return UnicodeProcessor.safe_encode(text).text
 
     @staticmethod
     def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- introduce `core.unicode_processor` with structured results
- switch several modules to the new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bleach')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*
- `pytest -q` *(fails with many import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686895c599d08320b435bb9ef6322655