### PR TITLE
Add unicode processor tests

### DIFF
--- a/core/unicode_utils.py
+++ b/core/unicode_utils.py
@@ -1,0 +1,30 @@
+"""Minimal Unicode utilities for tests."""
+import logging
+import re
+import unicodedata
+from typing import Any
+
+logger = logging.getLogger(__name__)
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+_CONTROL_RE = re.compile(r"[\x00-\x1F\x7F]")
+
+
+def sanitize_unicode_input(text: Any, replacement: str = "\uFFFD") -> str:
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            logger.warning("Failed to convert %r to str", text, exc_info=True)
+            return ""
+    try:
+        cleaned = _SURROGATE_RE.sub(replacement, text)
+        cleaned = unicodedata.normalize("NFKC", cleaned)
+        cleaned = _CONTROL_RE.sub("", cleaned)
+        cleaned.encode("utf-8")
+        return cleaned
+    except Exception as exc:
+        logger.error("sanitize_unicode_input failed: %s", exc)
+        return "".join(ch for ch in str(text) if ch.isascii())
+
+
+__all__ = ["sanitize_unicode_input"]

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,0 +1,8 @@
+class Dash:
+    def callback(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+from . import html
+__all__ = ["Dash", "html"]

--- a/dash/html.py
+++ b/dash/html.py
@@ -1,0 +1,3 @@
+class Div:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -1,7 +1,15 @@
 import pandas as pd
 from concurrent.futures import ThreadPoolExecutor
 
-from utils.unicode_utils import safe_unicode_encode, sanitize_data_frame
+import time
+import pytest
+
+from utils.unicode_utils import (
+    safe_unicode_encode,
+    sanitize_data_frame,
+    safe_decode,
+    safe_encode,
+)
 
 
 
@@ -34,4 +42,37 @@ def test_unicode_processor_thread_safety():
 
     for result in results:
         pd.testing.assert_frame_equal(result, expected)
+
+
+
+def test_clean_surrogate_control_nfkc():
+    text = "Ａ" + "\x00" + chr(0xD800) + "B" + "\u212B"
+    result = safe_unicode_encode(text)
+    # fullwidth A and Angstrom sign should normalize, control char and surrogate removed
+    assert result == "ABA"
+
+
+def test_dataframe_sanitization_edge_cases():
+    df = pd.DataFrame({"=bad\x00": ["=cmd" + chr(0xD800), "\x07\u212B"]})
+    cleaned = sanitize_data_frame(df)
+    assert list(cleaned.columns) == ["bad"]
+    assert cleaned.iloc[0, 0] == "cmd"
+    assert cleaned.iloc[1, 0] == "A"
+
+
+def test_safe_decode_encode_no_errors():
+    data = ("X" + chr(0xD800) + "Y").encode("utf-8", "surrogatepass")
+    decoded = safe_decode(data)
+    encoded = safe_encode(decoded + chr(0xDFFF))
+    assert isinstance(decoded, str) and isinstance(encoded, str)
+    assert "\ud800" not in decoded and "\udfff" not in encoded
+
+
+@pytest.mark.slow
+def test_sanitize_dataframe_benchmark():
+    df = pd.DataFrame({"=col": ["=1"] * 100})
+    start = time.time()
+    for _ in range(100):
+        sanitize_data_frame(df)
+    assert time.time() - start < 5
 


### PR DESCRIPTION
## Summary
- add minimal unicode utilities to `core`
- include dash stubs for tests
- expand `test_unicode_processor.py` coverage

## Testing
- `pytest tests/test_unicode_processor.py -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_686895c8ab0c8320a3b35bd160dfd35e