### PR TITLE
Update docs for Unicode processor and callback controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ dashboard. Key entry points include `tests/test_integration.py`,
 - **CSRF Protection Plugin**: Optional production-ready CSRF middleware for Dash
 - **Machine-Learned Column Mapping**: Trainable model for smarter CSV header recognition
 - **Hardened SQL Injection Prevention**: Uses `sqlparse` and `bleach` to validate queries
+- **Centralized Unicode Processing**: Normalize text with `core.unicode_processor`.
+- **Event Driven Callbacks**: Plugins react to `core.callback_controller` events.
+- **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance.
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run
@@ -459,7 +462,28 @@ switch themes at runtime.
 
 See the [data model diagram](docs/data_model.md) for an overview of key entities.
 The running application exposes Swagger-based API docs at `http://<host>:<port>/api/docs`.
+- Performance metrics: [docs/performance_monitoring.md](docs/performance_monitoring.md)
 Update the spec by running `python tools/generate_openapi.py` which writes `docs/openapi.json` for the UI.
+## Usage Examples
+
+### Cleaning text
+```python
+from core.unicode_processor import UnicodeProcessor
+raw = "Bad\uD83DText"
+clean = UnicodeProcessor.safe_encode_text(raw)
+```
+
+### Firing events
+```python
+from core.callback_controller import fire_event, CallbackEvent
+fire_event(CallbackEvent.ANALYSIS_COMPLETE, "analytics", {"rows": 42})
+```
+
+Performance metrics can be retrieved via:
+```python
+from core.performance import get_performance_monitor
+summary = get_performance_monitor().get_metrics_summary()
+```
 ## 📜 Data Migration
 Use the storage utilities to convert legacy pickle files to Parquet and load them:
 ```python

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -19,7 +19,7 @@ services/
 - **`DataEnhancer`** – Applies normalisation and adds computed columns.
 - **`DataProcessor`** – High level wrapper that uses `FileHandler` and `DataEnhancer` to produce a clean dataframe.
 - **`AnalyticsEngine`** – Generates statistics from the processed dataframe.
-- **`CallbackController`** – Emits events throughout the pipeline so plugins can react.
+- **``core.callback_controller.CallbackController``** – Emits events throughout the pipeline so plugins can react.
 
 ## Relationships
 
@@ -32,3 +32,9 @@ classDiagram
 ```
 
 This separation makes the pipeline extensible and easier to test as new data sources are added.
+
+Example event:
+```python
+from core.callback_controller import fire_event, CallbackEvent
+fire_event(CallbackEvent.FILE_UPLOAD_COMPLETE, "uploader", {"rows": len(df)})
+```

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -1,0 +1,14 @@
+# Performance Monitoring
+
+The dashboard collects runtime metrics through the `core.performance` module. A global
+`PerformanceMonitor` instance records execution times, memory usage and CPU load.
+Use `get_performance_monitor()` to access it and view summaries.
+
+```python
+from core.performance import get_performance_monitor
+summary = get_performance_monitor().get_metrics_summary()
+```
+
+Snapshots are taken automatically in the background and can be visualized or exported
+for further analysis.
+

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -7,6 +7,7 @@ This dashboard includes several validators that sanitize input and uploaded data
 ### InputValidator
 - **Purpose**: Clean individual strings using Unicode normalization and simple XSS pattern checks.
 - **Use when**: Accepting form fields, query parameters or any user supplied text.
+- Internally uses `core.unicode_processor.UnicodeProcessor` for thorough text cleaning.
 
 ### SecureFileValidator
 - **Purpose**: Safely decode base64 uploads, enforce filename rules and parse CSV/JSON/XLSX files.
@@ -44,3 +45,9 @@ This dashboard includes several validators that sanitize input and uploaded data
 - **CSV upload**: `SecureFileValidator` to parse the file, then `DataFrameSecurityValidator` before analysis.
 - **Displaying comments**: `InputValidator` when accepting the comment and `XSSPrevention` when rendering it.
 
+
+Example usage of the processor:
+```python
+from core.unicode_processor import UnicodeProcessor
+cleaned = UnicodeProcessor.safe_encode_text(user_input)
+```


### PR DESCRIPTION
## Summary
- document new `core.unicode_processor` and `core.callback_controller`
- show example usage snippets in README and docs
- add performance monitoring documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686895cb491083209355b2cee314e635