### PR TITLE
Implement Unicode migration utilities

### DIFF
--- a/scripts/update_unicode_imports.py
+++ b/scripts/update_unicode_imports.py
@@ -1,0 +1,39 @@
+"""Guide to update legacy Unicode utilities to the new API.
+
+This script prints mappings of old function names to the new preferred
+replacements.  It does not modify any files.  Use the output to update the
+codebase manually or with your own tooling.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+REPLACEMENTS = {
+    "safe_unicode_encode": "safe_encode_text",
+    "safe_encode": "safe_encode_text",
+    "safe_decode": "safe_decode_bytes",
+    "sanitize_unicode_input": "safe_encode_text",
+    "sanitize_data_frame": "sanitize_dataframe",
+}
+
+METHOD_PATTERNS = {
+    r"UnicodeProcessor\.clean_surrogate_chars": "UnicodeProcessor.clean_text",
+    r"UnicodeProcessor\.safe_encode_text": "UnicodeProcessor.safe_encode",
+    r"UnicodeProcessor\.safe_decode_bytes": "UnicodeProcessor.safe_decode",
+}
+
+
+def show_mappings() -> None:
+    print("Function replacements:")
+    for old, new in REPLACEMENTS.items():
+        print(f"  {old} -> {new}")
+
+    print("\nRegex-based replacements for method calls:")
+    for pattern, repl in METHOD_PATTERNS.items():
+        print(f"  /{pattern}/ -> {repl}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    show_mappings()

--- a/tests/test_unicode_migration.py
+++ b/tests/test_unicode_migration.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import pytest
+
+from utils.unicode_utils import (
+    UnicodeProcessor,
+    ChunkedUnicodeProcessor,
+    clean_unicode_text,
+    safe_decode_bytes,
+    safe_encode_text,
+    sanitize_dataframe,
+    safe_unicode_encode,
+    safe_encode,
+    safe_decode,
+    handle_surrogate_characters,
+    clean_unicode_surrogates,
+    sanitize_unicode_input,
+    sanitize_data_frame,
+)
+
+
+def test_surrogate_removal():
+    text = "Hello\uD83D\uDE00World"
+    assert clean_unicode_text(text) == "HelloWorld"
+
+
+def test_control_character_removal():
+    assert UnicodeProcessor.clean_text("A\x01B\x7fC") == "ABC"
+
+
+def test_csv_injection_prevention():
+    assert safe_encode_text("=cmd()") == "cmd()"
+
+
+def test_dataframe_sanitization():
+    df = pd.DataFrame({"col\uD83D": ["val\uDE00"]})
+    clean_df = sanitize_dataframe(df)
+    assert list(clean_df.columns) == ["col"]
+    assert clean_df.iloc[0, 0] == "val"
+
+
+def test_chunked_processing():
+    content = ("Hello\uD83D\uDE00World" * 500).encode("utf-8", "surrogatepass")
+    result = ChunkedUnicodeProcessor.process_large_content(content, chunk_size=128)
+    assert result == "HelloWorld" * 500
+
+
+def test_deprecated_functions_issue_warnings():
+    with pytest.warns(DeprecationWarning):
+        assert safe_unicode_encode("test\uD83D") == "test"
+    with pytest.warns(DeprecationWarning):
+        assert safe_encode("test\uD83D") == "test"
+    data = ("X\uD83D").encode("utf-8", "surrogatepass")
+    with pytest.warns(DeprecationWarning):
+        assert safe_decode(data).startswith("X")
+    with pytest.warns(DeprecationWarning):
+        assert handle_surrogate_characters("A\uD83DB") == "A\uFFFDB"
+    with pytest.warns(DeprecationWarning):
+        assert clean_unicode_surrogates("A\uD83DB") == "AB"
+    with pytest.warns(DeprecationWarning):
+        assert sanitize_unicode_input("A\uD83D") == "A"
+    df = pd.DataFrame({"=bad\uD83D": ["=cmd()"]})
+    with pytest.warns(DeprecationWarning):
+        legacy = sanitize_data_frame(df)
+    modern = sanitize_dataframe(df)
+    pd.testing.assert_frame_equal(legacy, modern)
+
+
+def test_error_handling_invalid_bytes():
+    bad = b"\xff\xfe\xfa"
+    out = safe_decode_bytes(bad)
+    assert isinstance(out, str)
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,16 +1,29 @@
-"""Utility helpers for Yōsai Intel Dashboard."""
+"""Utility helpers for Yōsai Intel Dashboard with Unicode migration support."""
 
-try:
-    from core.unicode_processor import (
-        safe_encode as safe_unicode_encode,
+try:  # pragma: no cover - graceful import fallback
+    from .unicode_utils import (
+        # Preferred API
+        clean_unicode_text,
+        safe_decode_bytes,
+        safe_encode_text,
+        sanitize_dataframe,
         UnicodeProcessor,
-        sanitize_dataframe as sanitize_data_frame,
-        process_large_csv_content,
-        safe_format_number,
+        ChunkedUnicodeProcessor,
+        # Deprecated API
+        safe_unicode_encode,
+        safe_encode,
+        safe_decode,
+        handle_surrogate_characters,
+        clean_unicode_surrogates,
+        sanitize_unicode_input,
+        sanitize_data_frame,
     )
-    handle_surrogate_characters = UnicodeProcessor.clean_surrogate_chars
-    sanitize_unicode_input = UnicodeProcessor.safe_encode_text
-    clean_unicode_surrogates = UnicodeProcessor.clean_surrogate_chars
+
+    # Migration aliases for transitional imports
+    unicode_clean_text = clean_unicode_text
+    unicode_safe_encode = safe_encode_text
+    unicode_sanitize_df = sanitize_dataframe
+
     from .assets_debug import (
         check_navbar_assets,
         debug_dash_asset_serving,
@@ -18,17 +31,21 @@ try:
     )
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
-except Exception:  # pragma: no cover - fallback when utils unavailable
+except Exception:  # pragma: no cover - fallback when unicode_utils unavailable
     from core.unicode_processor import (
-        safe_encode as safe_unicode_encode,
-        UnicodeProcessor,
         sanitize_dataframe as sanitize_data_frame,
+        UnicodeProcessor,
+        safe_encode as safe_unicode_encode,
         process_large_csv_content,
         safe_format_number,
     )
     handle_surrogate_characters = UnicodeProcessor.clean_surrogate_chars
     sanitize_unicode_input = UnicodeProcessor.safe_encode_text
     clean_unicode_surrogates = UnicodeProcessor.clean_surrogate_chars
+    unicode_clean_text = UnicodeProcessor.clean_surrogate_chars
+    unicode_safe_encode = UnicodeProcessor.safe_encode_text
+    unicode_sanitize_df = sanitize_data_frame
+
     from .assets_debug import (
         check_navbar_assets,
         debug_dash_asset_serving,
@@ -36,18 +53,33 @@ except Exception:  # pragma: no cover - fallback when utils unavailable
     )
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
+
 
 __all__: list[str] = [
-    "sanitize_unicode_input",
+    # Preferred API
+    "clean_unicode_text",
+    "safe_decode_bytes",
+    "safe_encode_text",
+    "sanitize_dataframe",
+    "UnicodeProcessor",
+    "ChunkedUnicodeProcessor",
+    # Migration aliases
+    "unicode_clean_text",
+    "unicode_safe_encode",
+    "unicode_sanitize_df",
+    # Deprecated API
     "safe_unicode_encode",
+    "safe_encode",
+    "safe_decode",
     "handle_surrogate_characters",
-    "sanitize_data_frame",
     "clean_unicode_surrogates",
-    "process_large_csv_content",
-    "safe_format_number",
+    "sanitize_unicode_input",
+    "sanitize_data_frame",
+    # Existing utilities
     "check_navbar_assets",
     "debug_dash_asset_serving",
     "navbar_icon",
     "get_nav_icon",
     "serialize_dataframe_preview",
 ]
+

--- a/utils/unicode_utils.py
+++ b/utils/unicode_utils.py
@@ -1,4 +1,284 @@
-"""Deprecated compatibility module for Unicode utilities."""
+"""Enterprise-grade Unicode utilities and migration helpers.
 
-from core.unicode_processor import *  # noqa: F401,F403
+This module consolidates fragmented Unicode handling logic into a single,
+robust implementation.  All new code should use the preferred API functions
+defined here.  Legacy helpers remain available for backwards compatibility and
+emit :class:`DeprecationWarning` when called.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+import warnings
+from typing import Any, Callable, Iterable, Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Precompiled regular expressions used throughout the module
+_CONTROL_RE = re.compile(r"[\x00-\x1F\x7F]")
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+_DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
+
+
+def _drop_dangerous_prefix(text: str) -> str:
+    """Remove characters that can trigger spreadsheet formula injection."""
+
+    return _DANGEROUS_PREFIX_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# Core classes
+
+class UnicodeProcessor:
+    """Centralised Unicode processing utilities."""
+
+    REPLACEMENT_CHAR: str = "\uFFFD"
+
+    # ------------------------------------------------------------------
+    # Basic cleaning helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def clean_text(text: Any, replacement: str = "") -> str:
+        """Return ``text`` with unsafe characters removed.
+
+        Parameters
+        ----------
+        text:
+            Input text. Non-string values are coerced via ``str()``.
+        replacement:
+            Replacement text for surrogate characters.  The default is to
+            remove them entirely.
+        """
+
+        if text is None or (isinstance(text, float) and pd.isna(text)):
+            return ""
+
+        if not isinstance(text, str):
+            try:
+                text = str(text)
+            except Exception as exc:  # pragma: no cover - extreme defensive
+                logger.error("Failed to convert %s to str: %s", type(text), exc)
+                return ""
+
+        try:
+            text = unicodedata.normalize("NFKC", text)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Unicode normalization failed: %s", exc)
+
+        try:
+            text = _SURROGATE_RE.sub(replacement, text)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Surrogate removal failed: %s", exc)
+            text = "".join(
+                ch
+                for ch in text
+                if not (0xD800 <= ord(ch) <= 0xDFFF)
+            )
+
+        text = _CONTROL_RE.sub("", text)
+        text = _drop_dangerous_prefix(text)
+
+        try:
+            text.encode("utf-8")
+        except UnicodeEncodeError as exc:  # pragma: no cover - best effort
+            logger.error("Unencodable characters removed: %s", exc)
+            text = text.encode("utf-8", "ignore").decode("utf-8", "ignore")
+
+        return text
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def safe_decode(data: bytes, encoding: str = "utf-8") -> str:
+        """Safely decode ``data`` using ``encoding`` with surrogate handling."""
+
+        try:
+            text = data.decode(encoding, errors="surrogatepass")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Primary decode failed: %s", exc)
+            try:
+                text = data.decode(encoding, errors="ignore")
+            except Exception:
+                return ""
+
+        return UnicodeProcessor.clean_text(text)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def safe_encode(value: Any) -> str:
+        """Convert ``value`` to a safe UTF-8 string."""
+
+        if isinstance(value, bytes):
+            return UnicodeProcessor.safe_decode(value)
+
+        return UnicodeProcessor.clean_text(value)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+        """Return ``df`` with all columns and object data sanitized."""
+
+        try:
+            df_clean = df.copy()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to copy dataframe: %s", exc)
+            return df
+
+        new_columns: list[str] = []
+        used: set[str] = set()
+        for col in df_clean.columns:
+            safe_col = UnicodeProcessor.safe_encode(col)
+            safe_col = _drop_dangerous_prefix(safe_col) or "col"
+            base = safe_col
+            count = 1
+            while safe_col in used:
+                safe_col = f"{base}_{count}"
+                count += 1
+            used.add(safe_col)
+            new_columns.append(safe_col)
+
+        df_clean.columns = new_columns
+
+        obj_cols = df_clean.select_dtypes(include=["object"]).columns
+        for col in obj_cols:
+            df_clean[col] = (
+                df_clean[col]
+                .apply(UnicodeProcessor.safe_encode)
+                .apply(_drop_dangerous_prefix)
+            )
+
+        return df_clean
+
+
+class ChunkedUnicodeProcessor:
+    """Process byte content in manageable chunks."""
+
+    DEFAULT_CHUNK_SIZE: int = 1024 * 1024  # 1MB
+
+    @staticmethod
+    def process_large_content(
+        content: bytes,
+        encoding: str = "utf-8",
+        chunk_size: Optional[int] = None,
+    ) -> str:
+        """Decode and sanitize large byte ``content`` in chunks."""
+
+        if chunk_size is None:
+            chunk_size = ChunkedUnicodeProcessor.DEFAULT_CHUNK_SIZE
+
+        parts: list[str] = []
+        view = memoryview(content)
+        for start in range(0, len(view), chunk_size):
+            chunk = view[start : start + chunk_size].tobytes()
+            parts.append(UnicodeProcessor.safe_decode(chunk, encoding))
+        return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Preferred public API
+
+
+def clean_unicode_text(text: str) -> str:
+    """Clean ``text`` of surrogates, controls and dangerous prefixes."""
+
+    return UnicodeProcessor.clean_text(text)
+
+
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    """Decode bytes safely, removing unsafe Unicode characters."""
+
+    return UnicodeProcessor.safe_decode(data, encoding)
+
+
+def safe_encode_text(value: Any) -> str:
+    """Return a UTF-8 safe string representation of ``value``."""
+
+    return UnicodeProcessor.safe_encode(value)
+
+
+def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Sanitize a :class:`~pandas.DataFrame` for unsafe Unicode."""
+
+    return UnicodeProcessor.sanitize_dataframe(df)
+
+
+# ---------------------------------------------------------------------------
+# Deprecation helpers
+
+
+def deprecated(replacement: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to mark legacy helpers as deprecated."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(
+                f"{func.__name__} is deprecated; use {replacement}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@deprecated("safe_encode_text")
+def safe_unicode_encode(value: Any) -> str:
+    return safe_encode_text(value)
+
+
+@deprecated("safe_encode_text")
+def safe_encode(value: Any) -> str:
+    return safe_encode_text(value)
+
+
+@deprecated("safe_decode_bytes")
+def safe_decode(data: bytes, encoding: str = "utf-8") -> str:
+    return safe_decode_bytes(data, encoding)
+
+
+@deprecated("clean_unicode_text")
+def handle_surrogate_characters(text: str) -> str:
+    return UnicodeProcessor.clean_text(text, replacement=UnicodeProcessor.REPLACEMENT_CHAR)
+
+
+@deprecated("clean_unicode_text")
+def clean_unicode_surrogates(text: Any) -> str:
+    return clean_unicode_text(str(text))
+
+
+@deprecated("safe_encode_text")
+def sanitize_unicode_input(text: Any) -> str:
+    return safe_encode_text(text)
+
+
+@deprecated("sanitize_dataframe")
+def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
+    return sanitize_dataframe(df)
+
+
+__all__ = [
+    # Preferred helpers
+    "clean_unicode_text",
+    "safe_decode_bytes",
+    "safe_encode_text",
+    "sanitize_dataframe",
+    # Classes
+    "UnicodeProcessor",
+    "ChunkedUnicodeProcessor",
+    # Deprecated
+    "safe_unicode_encode",
+    "safe_encode",
+    "safe_decode",
+    "handle_surrogate_characters",
+    "clean_unicode_surrogates",
+    "sanitize_unicode_input",
+    "sanitize_data_frame",
+]
 


### PR DESCRIPTION
## Summary
- add new enterprise Unicode utility functions with deprecations
- update utils package exports with migration aliases
- introduce test suite for new unicode utilities
- provide helper script for updating old imports

## Testing
- `python -m py_compile utils/unicode_utils.py`
- `python -m py_compile utils/__init__.py`
- `python -m py_compile scripts/update_unicode_imports.py`
- `pytest -q tests/test_unicode_migration.py` *(fails: ModuleNotFoundError: CallbackEvent)*

------
https://chatgpt.com/codex/tasks/task_e_68689c1f96fc8320a639ce367c11d951