### PR TITLE
Fix data_processing exports

### DIFF
--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,6 +1,8 @@
 """Data processing utilities."""
 
 from .file_handler import FileHandler, process_file_simple
+from .file_processor import FileProcessor
+from .unified_file_validator import UnifiedFileValidator
 from .core.exceptions import (
     FileProcessingError,
     FileValidationError,


### PR DESCRIPTION
## Summary
- expose `FileProcessor` and `UnifiedFileValidator` directly from `services.data_processing`

## Testing
- `flake8 services/data_processing/__init__.py`
- `black services/data_processing/__init__.py`
- `pytest tests/test_file_processor.py::TestRobustFileProcessor::test_process_simple_csv -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6868a4a194408320b7884d6ef53f3e7f