### PR TITLE
Add contributing guide and install dev deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements_ui.txt
-          pip install black flake8 mypy bandit pytest pytest-cov safety==2.3.5
+          pip install -r requirements-dev.txt
 
       - name: 🔤 Extract translations
         run: pybabel extract -F babel.cfg -o messages.pot .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to Yōsai Intel Dashboard
+
+Thank you for considering a contribution! Follow these steps to get the development environment ready.
+
+## Setup
+
+Install the core and development dependencies:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+These additional packages provide linting, type checking, security scanning and testing tools used in our CI pipeline.
+
+## Running Tests
+
+After installing the dependencies you can run the tests and code quality checks:
+
+```bash
+pytest
+mypy --strict .
+flake8 .
+black --check .
+bandit -r .
+```
+
+Please ensure tests and linters pass before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ mappings have been saved, otherwise the mapping step will fail.
 
 ## 🤝 Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines. In short:
+
 1. Install dependencies:
    ```bash
    pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- document how to install development requirements in `CONTRIBUTING.md`
- link to the new guide from the README
- install dev requirements in CI

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868a4a45ed083208b0969b97ee94b1b