### PR TITLE
Add explicit mypy package bases

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 python_version = 3.11
+explicit_package_bases = True
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True
@@ -20,4 +21,40 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-joblib.*]
+ignore_missing_imports = True
+
+[mypy-dash_bootstrap_components.*]
+ignore_missing_imports = True
+
+[mypy-flask.*]
+ignore_missing_imports = True
+
+[mypy-flask_babel.*]
+ignore_missing_imports = True
+
+[mypy-babel.*]
+ignore_missing_imports = True
+
+[mypy-babel.messages.*]
+ignore_missing_imports = True
+
+[mypy-yaml.*]
+ignore_missing_imports = True
+
+[mypy-psycopg2.*]
+ignore_missing_imports = True
+
+[mypy-authlib.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.mypy]
+python_version = "3.11"
+explicit_package_bases = true
+mypy_path = ["."]


### PR DESCRIPTION
## Summary
- add pyproject configuration for mypy
- enable explicit package bases in mypy.ini
- ignore missing imports for optional dependencies
- make `tests` a package to avoid duplicate module paths

## Testing
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868a4a5b190832088670d66a69bdfc1