### PR TITLE
Add unicode processor utilities

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -21,5 +21,18 @@ def create_app(mode: str | None = None):
 
 from .unicode_processor import sanitize_unicode_input
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
+from .unicode import (
+    UnicodeTextProcessor,
+    UnicodeSQLProcessor,
+    UnicodeSecurityProcessor,
+)
 
-__all__ = ["create_app", "profile_callback", "sanitize_unicode_input", "TrulyUnifiedCallbacks"]
+__all__ = [
+    "create_app",
+    "profile_callback",
+    "sanitize_unicode_input",
+    "TrulyUnifiedCallbacks",
+    "UnicodeTextProcessor",
+    "UnicodeSQLProcessor",
+    "UnicodeSecurityProcessor",
+]

--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,0 +1,13 @@
+"""Unicode processing helpers."""
+
+from .processor import (
+    UnicodeTextProcessor,
+    UnicodeSQLProcessor,
+    UnicodeSecurityProcessor,
+)
+
+__all__ = [
+    "UnicodeTextProcessor",
+    "UnicodeSQLProcessor",
+    "UnicodeSecurityProcessor",
+]

--- a/core/unicode/processor.py
+++ b/core/unicode/processor.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Unicode handling utilities specialized for text, SQL and security."""
+
+import logging
+import re
+import unicodedata
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Precompiled regular expressions for performance
+_CONTROL_RE = re.compile(r"[\x00-\x1F\x7F]")
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+
+
+class UnicodeTextProcessor:
+    """Clean and normalize arbitrary text."""
+
+    @staticmethod
+    def clean_text(text: Any) -> str:
+        """Return ``text`` stripped of control codes and surrogates."""
+        if not isinstance(text, str):
+            try:
+                text = str(text)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to convert text to str: %s", exc)
+                return ""
+
+        try:
+            text = unicodedata.normalize("NFKC", text)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("Unicode normalization failed: %s", exc)
+
+        try:
+            text = _SURROGATE_RE.sub("", text)
+            text = _CONTROL_RE.sub("", text)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Regex cleanup failed: %s", exc)
+            text = "".join(
+                ch
+                for ch in text
+                if not (0xD800 <= ord(ch) <= 0xDFFF or ord(ch) < 32 or ord(ch) == 0x7F)
+            )
+
+        return text
+
+
+class UnicodeSQLProcessor:
+    """Safely encode SQL queries with Unicode handling."""
+
+    @staticmethod
+    def encode_query(query: Any) -> str:
+        """Return ``query`` encoded for safe SQL execution."""
+        cleaned = UnicodeTextProcessor.clean_text(query)
+        try:
+            cleaned.encode("utf-8")
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Unicode encode failed: %s", exc)
+            cleaned = cleaned.encode("utf-8", "ignore").decode("utf-8", "ignore")
+        return cleaned
+
+
+class UnicodeSecurityProcessor:
+    """Sanitize input for security sensitive contexts."""
+
+    _HTML_REPLACEMENTS = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#x27;",
+        "/": "&#x2F;",
+    }
+
+    @staticmethod
+    def sanitize_input(text: Any) -> str:
+        """Return ``text`` sanitized for safe handling."""
+        sanitized = UnicodeTextProcessor.clean_text(text)
+        for char, repl in UnicodeSecurityProcessor._HTML_REPLACEMENTS.items():
+            sanitized = sanitized.replace(char, repl)
+        return sanitized
+
+
+__all__ = [
+    "UnicodeTextProcessor",
+    "UnicodeSQLProcessor",
+    "UnicodeSecurityProcessor",
+]


### PR DESCRIPTION
## Summary
- add `core/unicode` package with text, SQL and security processors
- export processors from the core package

## Testing
- `pytest -q` *(fails: ImportError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6868abda7adc8320bd15146a5024dab2