### PR TITLE
Add unicode processor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ dashboard. Key entry points include `tests/test_integration.py`,
 - **CSRF Protection Plugin**: Optional production-ready CSRF middleware for Dash
 - **Machine-Learned Column Mapping**: Trainable model for smarter CSV header recognition
 - **Hardened SQL Injection Prevention**: Uses `sqlparse` and `bleach` to validate queries
-- **Centralized Unicode Processing**: Normalize text with `core.unicode_processor`.
+- **Centralized Unicode Processing**: Normalize text with `core.unicode`.
 - **Event Driven Callbacks**: Plugins react to `core.callback_controller` events.
 - **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance.
 
@@ -468,9 +468,10 @@ Update the spec by running `python tools/generate_openapi.py` which writes `docs
 
 ### Cleaning text
 ```python
-from core.unicode_processor import UnicodeProcessor
+from core.unicode import get_text_processor
 raw = "Bad\uD83DText"
-clean = UnicodeProcessor.safe_encode_text(raw)
+processor = get_text_processor()
+clean = processor.safe_encode_text(raw)
 ```
 
 ### Firing events

--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,0 +1,59 @@
+"""Unified Unicode processing helpers.
+
+This subpackage bundles text, SQL and security utilities.  Use the
+factory helpers to obtain the appropriate processor:
+
+>>> from core.unicode import get_text_processor
+>>> processor = get_text_processor()
+>>> safe = processor.safe_encode_text("example")
+
+Simple class aliases (:class:`TextProcessor`, :class:`SQLProcessor`,
+and :class:`SecurityProcessor`) remain available for backward
+compatibility.
+"""
+
+from utils.unicode_utils import (
+    UnicodeProcessor,
+    ChunkedUnicodeProcessor,
+)
+from config.unicode_handler import UnicodeQueryHandler
+from security.unicode_security_handler import UnicodeSecurityHandler
+
+# ---------------------------------------------------------------------------
+# Backward compatible aliases
+# ---------------------------------------------------------------------------
+TextProcessor = UnicodeProcessor
+SQLProcessor = UnicodeQueryHandler
+SecurityProcessor = UnicodeSecurityHandler
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+def get_text_processor() -> type[TextProcessor]:
+    """Return the Unicode text processor class."""
+    return TextProcessor
+
+
+def get_sql_processor() -> type[SQLProcessor]:
+    """Return the SQL Unicode processor class."""
+    return SQLProcessor
+
+
+def get_security_processor() -> type[SecurityProcessor]:
+    """Return the security Unicode processor class."""
+    return SecurityProcessor
+
+
+__all__ = [
+    "UnicodeProcessor",
+    "ChunkedUnicodeProcessor",
+    "UnicodeQueryHandler",
+    "UnicodeSecurityHandler",
+    "TextProcessor",
+    "SQLProcessor",
+    "SecurityProcessor",
+    "get_text_processor",
+    "get_sql_processor",
+    "get_security_processor",
+]

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -50,6 +50,7 @@ in a future release.
 
 Example usage of the processor:
 ```python
-from core.unicode_processor import UnicodeProcessor
-cleaned = UnicodeProcessor.safe_encode_text(user_input)
+from core.unicode import get_text_processor
+processor = get_text_processor()
+cleaned = processor.safe_encode_text(user_input)
 ```


### PR DESCRIPTION
## Summary
- add `core/unicode` package exposing unified processors
- document factory usage in README and validation docs

## Testing
- `pytest -k unicode -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6868abdd77a083209d2c140446b42bde