### PR TITLE
Refactor Unicode query handling

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -19,6 +19,7 @@ from .config import (
 from .connection_pool import DatabaseConnectionPool
 from .connection_retry import ConnectionRetryManager, RetryConfig
 from .unicode_handler import UnicodeQueryHandler
+from .unicode_sql_processor import UnicodeSQLProcessor
 from .database_exceptions import (
     DatabaseError,
     ConnectionRetryExhausted,
@@ -57,6 +58,7 @@ __all__ = [
     "ConnectionRetryManager",
     "RetryConfig",
     "UnicodeQueryHandler",
+    "UnicodeSQLProcessor",
     "DatabaseError",
     "ConnectionRetryExhausted",
     "ConnectionValidationFailed",

--- a/config/unicode_handler.py
+++ b/config/unicode_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .database_exceptions import UnicodeEncodingError
+from .unicode_sql_processor import UnicodeSQLProcessor
 
 
 class UnicodeQueryHandler:
@@ -12,9 +13,10 @@ class UnicodeQueryHandler:
     def _encode(value: Any) -> Any:
         if isinstance(value, str):
             try:
-                data = value.encode("utf-8", "surrogateescape")
-                return data.decode("utf-8", "replace")
-            except Exception as exc:
+                return UnicodeSQLProcessor.encode_query(value)
+            except UnicodeEncodingError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive
                 raise UnicodeEncodingError(str(exc)) from exc
         if isinstance(value, dict):
             return {k: UnicodeQueryHandler._encode(v) for k, v in value.items()}

--- a/config/unicode_sql_processor.py
+++ b/config/unicode_sql_processor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Utilities for safely encoding SQL queries."""
+
+from typing import Any
+
+from .database_exceptions import UnicodeEncodingError
+
+
+class UnicodeSQLProcessor:
+    """Encode SQL queries while handling surrogate escapes."""
+
+    @staticmethod
+    def encode_query(query: Any) -> str:
+        """Return ``query`` encoded for safe SQL execution."""
+        if not isinstance(query, str):
+            query = str(query)
+        try:
+            data = query.encode("utf-8", "surrogateescape")
+            return data.decode("utf-8", "replace")
+        except Exception as exc:  # pragma: no cover - defensive
+            raise UnicodeEncodingError(str(exc)) from exc
+
+
+__all__ = ["UnicodeSQLProcessor"]


### PR DESCRIPTION
## Summary
- add `UnicodeSQLProcessor` for SQL string sanitisation
- delegate `UnicodeQueryHandler` encoding to new processor
- export processor in `config.__init__`

## Testing
- `pytest tests/test_unicode_handler.py -q` *(fails: ImportError: cannot import name 'CallbackEvent' from 'callback_controller')*

------
https://chatgpt.com/codex/tasks/task_e_6868abdf4eec8320bf0b478941d96acd