### PR TITLE
Introduce UnicodeSecurityProcessor wrapper

### DIFF
--- a/core/input_validation.py
+++ b/core/input_validation.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, Dict
 
 import bleach
 
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 from security.validation_exceptions import ValidationError
 from core.security import InputValidator as _ComprehensiveValidator
 

--- a/core/security.py
+++ b/core/security.py
@@ -27,7 +27,7 @@ from core.security_patterns import (
     PATH_TRAVERSAL_PATTERNS,
 )
 
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 from config.dynamic_config import dynamic_config
 
 

--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, List, Callable
 
 from config.constants import FileProcessingLimits
 
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 from dataclasses import dataclass
 from enum import Enum
 from .security_patterns import (

--- a/core/serialization/safe_json.py
+++ b/core/serialization/safe_json.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from core.unicode_processor import UnicodeProcessor
+from security.unicode_security_processor import UnicodeSecurityProcessor
 
 try:  # Optional Flask-Babel
     from flask_babel import LazyString
@@ -47,16 +47,16 @@ class SafeJSONSerializer:
                 return obj
 
             if isinstance(obj, bytes):
-                return UnicodeProcessor.safe_decode(obj).text
+                return UnicodeSecurityProcessor.sanitize_unicode_input(obj)
 
             if isinstance(obj, str):
-                return UnicodeProcessor.clean_text(obj).text
+                return UnicodeSecurityProcessor.sanitize_unicode_input(obj)
 
             if MARKUP_AVAILABLE and isinstance(obj, Markup):
-                return UnicodeProcessor.clean_text(str(obj)).text
+                return UnicodeSecurityProcessor.sanitize_unicode_input(str(obj))
 
             if BABEL_AVAILABLE and LazyString and isinstance(obj, LazyString):
-                return UnicodeProcessor.clean_text(str(obj)).text
+                return UnicodeSecurityProcessor.sanitize_unicode_input(str(obj))
 
             if isinstance(obj, dict):
                 return {self._sanitize(k): self._sanitize(v) for k, v in obj.items()}
@@ -74,6 +74,6 @@ class SafeJSONSerializer:
                 return {k: self._sanitize(v) for k, v in vars(obj).items()}
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning("SafeJSONSerializer failed: %s", exc)
-            return UnicodeProcessor.clean_text(str(obj)).text
+            return UnicodeSecurityProcessor.sanitize_unicode_input(str(obj))
 
         return obj

--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Set
 
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 
 logger = logging.getLogger(__name__)
 

--- a/file_conversion/file_converter.py
+++ b/file_conversion/file_converter.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 import pandas as pd
 
-from core.unicode_processor import sanitize_dataframe
+from security.unicode_security_processor import sanitize_dataframe
 
 _logger = logging.getLogger(__name__)
 

--- a/file_conversion/storage_manager.py
+++ b/file_conversion/storage_manager.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Tuple
 import pandas as pd
 
 from .file_converter import FileConverter
-from core.unicode_processor import sanitize_dataframe
+from security.unicode_security_processor import sanitize_dataframe
 
 _logger = logging.getLogger(__name__)
 

--- a/pages/deep_analytics/__init__.py
+++ b/pages/deep_analytics/__init__.py
@@ -28,7 +28,7 @@ from services.data_processing.analytics_engine import (
     process_suggests_analysis,
     process_suggests_analysis_safe,
 )
-from core.unicode_processor import sanitize_dataframe
+from security.unicode_security_processor import sanitize_dataframe
 
 from core.callback_controller import CallbackController
 

--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -19,7 +19,8 @@ import plotly.graph_objects as go
 
 # Add this import
 from services import AnalyticsService
-from core.unicode_processor import sanitize_unicode_input, safe_format_number
+from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_processor import safe_format_number
 from utils.preview_utils import serialize_dataframe_preview
 from security.unicode_security_handler import UnicodeSecurityHandler
 

--- a/pages/export.py
+++ b/pages/export.py
@@ -3,7 +3,7 @@
 
 from dash import html, dcc
 import dash_bootstrap_components as dbc
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 
 
 def _instructions() -> dbc.Card:

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -3,7 +3,7 @@
 
 from dash import html, dcc
 import dash_bootstrap_components as dbc
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 from services.analytics_summary import create_sample_data
 from analytics.interactive_charts import create_charts_generator
 from core.cache import cache

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -3,7 +3,7 @@
 
 from dash import html
 import dash_bootstrap_components as dbc
-from core.unicode_processor import sanitize_unicode_input
+from security.unicode_security_processor import sanitize_unicode_input
 
 
 def _settings_section(title: str) -> dbc.Card:

--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from services.data_processing.core.protocols import PluginMetadata
 
-from core.unicode_processor import UnicodeProcessor
+from security.unicode_security_processor import UnicodeSecurityProcessor
 from core.serialization import SafeJSONSerializer
 
 # Optional Babel import
@@ -64,8 +64,8 @@ def _is_lazy_string(obj: Any) -> bool:
 
 
 def _sanitize_text(text: str) -> str:
-    result = UnicodeProcessor.clean_text(text)
-    return result.text
+    """Return sanitized text using :class:`UnicodeSecurityProcessor`."""
+    return UnicodeSecurityProcessor.sanitize_unicode_input(text)
 
 
 def sanitize_lazystring(obj: Any) -> Any:

--- a/security/unicode_security_handler.py
+++ b/security/unicode_security_handler.py
@@ -6,21 +6,19 @@ from typing import Any
 
 import pandas as pd
 
-from core.unicode_processor import UnicodeProcessor
+from .unicode_security_processor import UnicodeSecurityProcessor
 
 
 class UnicodeSecurityHandler:
-    """Centralized Unicode sanitization for security modules."""
+    """Backward compatibility wrapper for :class:`UnicodeSecurityProcessor`."""
 
     @staticmethod
     def sanitize_unicode_input(text: Any) -> str:
-        """Sanitize input text for unsafe Unicode characters."""
-        return UnicodeProcessor.safe_encode(text).text
+        return UnicodeSecurityProcessor.sanitize_unicode_input(text)
 
     @staticmethod
     def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
-        """Sanitize all string data within a DataFrame."""
-        return UnicodeProcessor.sanitize_dataframe(df)
+        return UnicodeSecurityProcessor.sanitize_dataframe(df)
 
 
 __all__ = ["UnicodeSecurityHandler"]

--- a/security/unicode_security_processor.py
+++ b/security/unicode_security_processor.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Security-focused wrapper around core Unicode utilities."""
+
+from typing import Any
+
+import pandas as pd
+
+from core.unicode_processor import UnicodeProcessor
+
+
+class UnicodeSecurityProcessor:
+    """Expose safe Unicode helpers used by the security modules."""
+
+    @staticmethod
+    def sanitize_unicode_input(text: Any) -> str:
+        """Return ``text`` with unsafe characters removed."""
+        return UnicodeProcessor.safe_encode_text(text)
+
+    @staticmethod
+    def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+        """Sanitize all string data within ``df``."""
+        return UnicodeProcessor.sanitize_dataframe(df)
+
+
+# Module-level helpers for convenience ---------------------------------
+
+def sanitize_unicode_input(text: Any) -> str:
+    return UnicodeSecurityProcessor.sanitize_unicode_input(text)
+
+
+def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    return UnicodeSecurityProcessor.sanitize_dataframe(df)
+
+
+__all__ = [
+    "UnicodeSecurityProcessor",
+    "sanitize_unicode_input",
+    "sanitize_dataframe",
+]

--- a/services/analytics_processing.py
+++ b/services/analytics_processing.py
@@ -8,7 +8,8 @@ from services import get_analytics_service
 from services.ai_suggestions import generate_column_suggestions
 from services.upload_data_service import get_uploaded_data
 from utils.preview_utils import serialize_dataframe_preview
-from core.unicode_processor import sanitize_unicode_input, safe_format_number
+from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_processor import safe_format_number
 
 logger = logging.getLogger(__name__)
 

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -6,11 +6,11 @@ from typing import Any, Optional
 import pandas as pd
 
 from utils.file_validator import safe_decode_with_unicode_handling
-from core.unicode_processor import (
+from security.unicode_security_processor import (
     sanitize_unicode_input,
     sanitize_dataframe,
-    process_large_csv_content,
 )
+from core.unicode_processor import process_large_csv_content
 from core.callback_controller import (
     CallbackController,
     CallbackEvent,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -32,18 +32,19 @@ try:  # pragma: no cover - graceful import fallback
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
 except Exception:  # pragma: no cover - fallback when unicode_utils unavailable
-    from core.unicode_processor import (
+    from security.unicode_security_processor import (
         sanitize_dataframe as sanitize_data_frame,
-        UnicodeProcessor,
-        safe_encode as safe_unicode_encode,
+        UnicodeSecurityProcessor,
+        sanitize_unicode_input,
+    )
+    from core.unicode_processor import (
         process_large_csv_content,
         safe_format_number,
     )
-    handle_surrogate_characters = UnicodeProcessor.clean_surrogate_chars
-    sanitize_unicode_input = UnicodeProcessor.safe_encode_text
-    clean_unicode_surrogates = UnicodeProcessor.clean_surrogate_chars
-    unicode_clean_text = UnicodeProcessor.clean_surrogate_chars
-    unicode_safe_encode = UnicodeProcessor.safe_encode_text
+    handle_surrogate_characters = UnicodeSecurityProcessor.sanitize_unicode_input
+    clean_unicode_surrogates = UnicodeSecurityProcessor.sanitize_unicode_input
+    unicode_clean_text = UnicodeSecurityProcessor.sanitize_unicode_input
+    unicode_safe_encode = UnicodeSecurityProcessor.sanitize_unicode_input
     unicode_sanitize_df = sanitize_data_frame
 
     from .assets_debug import (


### PR DESCRIPTION
## Summary
- add `UnicodeSecurityProcessor` with helper functions
- use `UnicodeSecurityProcessor` across the codebase
- fix `.text` attribute usage in security utilities

## Testing
- `pytest -q` *(fails: ImportError - CallbackEvent from callback_controller)*

------
https://chatgpt.com/codex/tasks/task_e_6868abdfab848320a600c33268947285