### PR TITLE
Remove file handler wrappers

### DIFF
--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -1,7 +1,0 @@
-from services.data_processing.file_handler import (
-    FileHandler as FileProcessor,
-    FileProcessingError,
-    process_file_simple,
-)
-
-__all__ = ["FileProcessor", "FileProcessingError", "process_file_simple"]

--- a/core/unified_file_validator.py
+++ b/core/unified_file_validator.py
@@ -1,3 +1,0 @@
-from services.data_processing.unified_file_validator import UnifiedFileValidator
-
-__all__ = ["UnifiedFileValidator"]

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -24,7 +24,7 @@ import pandas as pd
 
 from security.file_validator import SecureFileValidator
 from services.input_validator import InputValidator, ValidationResult
-from services.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_file_validator import UnifiedFileValidator
 from services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from core.file_processor import FileProcessor as FileHandler
+from services.data_processing.file_handler import FileHandler
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 @pytest.mark.parametrize("sep", [";", "\t"])

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -10,8 +10,8 @@ import json
 from pathlib import Path
 import tempfile
 
-from core.file_processor import (
-    FileProcessor as RobustFileProcessor,
+from services.data_processing.file_handler import (
+    FileHandler as RobustFileProcessor,
     FileProcessingError,
     process_file_simple,
 )

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import base64
 
-from core.file_processor import FileProcessor as FileHandler
+from services.data_processing.file_handler import FileHandler
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 from services.upload_service import process_uploaded_file

--- a/tests/test_process_and_analyze.py
+++ b/tests/test_process_and_analyze.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from core.file_processor import FileProcessor
+from services.data_processing.file_handler import FileHandler as FileProcessor
 from analytics.upload_processor import UploadAnalyticsProcessor
 from services.file_processing_service import FileProcessingService
 from services.data_validation import DataValidationService

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -17,8 +17,8 @@ from core.callback_controller import (
     fire_event,
     callback_handler,
 )
-from core.file_processor import (
-    FileProcessor as RobustFileProcessor,
+from services.data_processing.file_handler import (
+    FileHandler as RobustFileProcessor,
     process_file_simple,
     FileProcessingError,
 )


### PR DESCRIPTION
## Summary
- remove deprecated `core` wrappers
- fix `file_handler` imports
- update tests to import from `services.data_processing`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'CallbackEvent')*

------
https://chatgpt.com/codex/tasks/task_e_6868ac7645c88320aedd56dfad67d303