### PR TITLE
Refactor tests to unified modules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,9 +20,9 @@ The factory builds the container, which then instantiates services. Services ope
   `DataFrameSecurityValidator` classes.
 - **Separated Analytics Modules** – The previously monolithic
   `AnalyticsService` has been broken into smaller modules under
-  `services/data_processing/` and `analytics/`.  `FileHandler`, `DataProcessor`
-  and `AnalyticsEngine` handle file loading, cleaning and metric generation
-  while controllers manage UI callbacks.
+`services/data_processing/` and `analytics/`.  `UnifiedFileValidator`,
+`Processor` and `AnalyticsEngine` handle file loading, cleaning and metric
+generation while controllers manage UI callbacks.
 
 Developers still using the legacy `DataLoader` or `DataLoadingService` should
 migrate to `services.data_processing.processor.Processor` and update imports

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -7,17 +7,17 @@ The `services/data_processing/` directory contains the building blocks for uploa
 ```
 services/
   data_processing/
-      file_handler.py       # Validate and parse uploads
+      file_processor.py     # Validate and parse uploads
+      processor.py          # Coordinate validation and enhancement
       data_enhancer.py      # Enrich DataFrame columns
-      data_processor.py     # Coordinate file handling and enhancement
       analytics_engine.py   # Produce charts and metrics
 ```
 
 ## Core Classes
 
-- **`FileHandler`** – Reads CSV/JSON/Excel files and performs validation.
+- **`UnifiedFileValidator`** – Reads CSV/JSON/Excel files and performs validation.
 - **`DataEnhancer`** – Applies normalisation and adds computed columns.
-- **`DataProcessor`** – High level wrapper that uses `FileHandler` and `DataEnhancer` to produce a clean dataframe.
+- **`Processor`** – High level wrapper that uses `UnifiedFileValidator` and `DataEnhancer` to produce a clean dataframe.
 - **`AnalyticsEngine`** – Generates statistics from the processed dataframe.
 - **``core.callback_controller.CallbackController``** – Emits events throughout the pipeline so plugins can react.
 
@@ -25,9 +25,9 @@ services/
 
 ```mermaid
 classDiagram
-    FileHandler <|-- DataProcessor
-    DataEnhancer <|-- DataProcessor
-    DataProcessor --> AnalyticsEngine
+    UnifiedFileValidator <|-- Processor
+    DataEnhancer <|-- Processor
+    Processor --> AnalyticsEngine
     AnalyticsEngine --> CallbackController
 ```
 

--- a/examples/debug_live_upload.py
+++ b/examples/debug_live_upload.py
@@ -72,26 +72,26 @@ def add_debug_hooks():
 
     file_validator.process_dataframe = debug_process_dataframe
 
-    # Hook 4: Patch FileHandler._validate_data if it exists
+    # Hook 4: Patch FileProcessor.process_uploaded_contents if available
     try:
-        from services.data_processing.file_handler import FileHandler as FileProcessor
+        from services.data_processing.file_processor import FileProcessor
 
-        original_validate_data = FileProcessor._validate_data
+        original_process = FileProcessor.process_uploaded_contents
 
         def debug_validate_data(self, df):
             input_rows = len(df)
             logger.info(
-                f"🧹 HOOK 4: FileProcessor._validate_data() input: {input_rows} rows"
+                f"🧹 HOOK 4: FileProcessor.process_uploaded_contents() input: {input_rows} rows"
             )
-            result = original_validate_data(self, df)
+            result = original_process(self, df)
             if result.get("valid") and result.get("data") is not None:
                 output_rows = len(result["data"])
                 logger.info(
-                    f"🎯 HOOK 4: FileProcessor._validate_data() output: {output_rows} rows"
+                    f"🎯 HOOK 4: FileProcessor.process_uploaded_contents() output: {output_rows} rows"
                 )
                 if output_rows == 150:
                     logger.error(
-                        f"🚨 FOUND 150 ROW LIMIT in FileProcessor._validate_data!"
+                        f"🚨 FOUND 150 ROW LIMIT in FileProcessor.process_uploaded_contents!"
                     )
                 if output_rows != input_rows:
                     logger.warning(
@@ -99,7 +99,7 @@ def add_debug_hooks():
                     )
             return result
 
-        FileProcessor._validate_data = debug_validate_data
+        FileProcessor.process_uploaded_contents = debug_validate_data
         logger.info("✅ Added FileProcessor debugging hook")
     except ImportError:
         logger.info("⏭️ FileProcessor not available for debugging")

--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from core.input_validation import InputValidator
+from core.security_validator import SecurityValidator
 from security.dataframe_validator import DataFrameSecurityValidator
 from security.sql_validator import SQLInjectionPrevention
 from security.xss_validator import XSSPrevention
@@ -9,26 +9,26 @@ from security.validation_exceptions import ValidationError
 
 
 def test_unicode_normalization():
-    validator = InputValidator()
+    validator = SecurityValidator()
     with pytest.raises(ValidationError):
-        validator.validate("<bad>")
+        validator.validate_input("<bad>")
 
 
 def test_html_js_injection_attempts():
-    validator = InputValidator()
+    validator = SecurityValidator()
     payloads = [
         "<script>alert('xss')</script>",
         "<img src=x onerror=alert(1)>",
     ]
     for payload in payloads:
         with pytest.raises(ValidationError):
-            validator.validate(payload)
+            validator.validate_input(payload)
 
 
 def test_json_input_allowed():
-    validator = InputValidator()
+    validator = SecurityValidator()
     # Should not raise ValidationError for quotes within JSON structures
-    validator.validate('{"key":"val"}')
+    validator.validate_input('{"key":"val"}')
 
 
 def test_sql_injection_detection():

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 
-from core.file_processor import FileProcessor as FileHandler
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 @pytest.mark.parametrize("sep", [";", "\t"])

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 import tempfile
 
-from core.file_processor import (
+from services.data_processing.file_processor import (
     FileProcessor as RobustFileProcessor,
     FileProcessingError,
     process_file_simple,

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import base64
 
-from core.file_processor import FileProcessor as FileHandler
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 from services.upload_service import process_uploaded_file

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from services.data_processing.unified_file_validator import UnifiedFileValidator as FileHandler
+from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 
 

--- a/tests/test_process_and_analyze.py
+++ b/tests/test_process_and_analyze.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from core.file_processor import FileProcessor
+from services.data_processing.file_processor import FileProcessor
 from analytics.upload_processor import UploadAnalyticsProcessor
 from services.file_processing_service import FileProcessingService
 from services.data_validation import DataValidationService

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -17,7 +17,7 @@ from core.callback_controller import (
     fire_event,
     callback_handler,
 )
-from core.file_processor import (
+from services.data_processing.file_processor import (
     FileProcessor as RobustFileProcessor,
     process_file_simple,
     FileProcessingError,


### PR DESCRIPTION
## Summary
- point tests to consolidated validator and processor modules
- update architecture and data processing docs
- patch debugging example to use new FileProcessor

## Testing
- `pip install pandas==2.1.1 numpy==1.24.0` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest tests/test_csv_parsing.py::test_parse_csv_with_various_delimiters -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868ac8182b48320ae9542ba2dc09aec