### PR TITLE
Refactor upload file handling

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ Centralized analytics service for dashboard operations.
 
 - `get_dashboard_summary() -> Dict[str, Any]`: Get dashboard overview
 - `get_access_patterns_analysis(days) -> Dict[str, Any]`: Analyze access patterns
-- `process_uploaded_file(df, filename) -> Dict[str, Any]`: Process uploaded data
+- `FileProcessor.read_uploaded_file(contents, filename) -> DataFrame`: Decode uploaded data
 
 ## Models
 

--- a/services/analytics/__init__.py
+++ b/services/analytics/__init__.py
@@ -9,6 +9,7 @@ from ..result_formatting import (
     regular_analysis,
 )
 from utils.mapping_helpers import map_and_clean
+from .preparation import prepare_dataframe
 
 __all__ = [
     "generate_basic_analytics",
@@ -19,5 +20,6 @@ __all__ = [
     "calculate_temporal_stats_safe",
     "regular_analysis",
     "map_and_clean",
+    "prepare_dataframe",
 ]
 

--- a/services/analytics/preparation.py
+++ b/services/analytics/preparation.py
@@ -1,0 +1,16 @@
+"""Helpers for preparing uploaded data for analytics."""
+
+from __future__ import annotations
+
+import pandas as pd
+from services.data_validation import DataValidationService
+from utils.mapping_helpers import map_and_clean
+
+
+def prepare_dataframe(df: pd.DataFrame, validator: DataValidationService | None = None) -> pd.DataFrame:
+    """Validate and clean ``df`` for analytics."""
+    validator = validator or DataValidationService()
+    df = validator.validate(df)
+    return map_and_clean(df)
+
+__all__ = ["prepare_dataframe"]

--- a/tests/test_read_uploaded_file.py
+++ b/tests/test_read_uploaded_file.py
@@ -1,0 +1,14 @@
+import base64
+import pandas as pd
+
+from services.data_processing.file_processor import FileProcessor
+
+
+def test_read_uploaded_file_basic():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    encoded = base64.b64encode(df.to_csv(index=False).encode()).decode()
+    contents = f"data:text/csv;base64,{encoded}"
+    processor = FileProcessor()
+    loaded, size = processor.read_uploaded_file(contents, "sample.csv")
+    assert len(loaded) == len(df)
+    assert size > 0


### PR DESCRIPTION
## Summary
- delegate file parsing to data_processing.file_processor
- add analytics.preparation for DataFrame cleanup
- use new helpers in upload_service
- document new file processor API
- test basic read_uploaded_file helper

## Testing
- `pip install pandas dash dash-bootstrap-components`
- `pip install pyyaml`
- `pip install bleach`
- `pip install sqlparse`
- `pip install flask_caching`
- `pytest -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac7c685c8320a30ff357f4ce6f64