### PR TITLE
Refactor tests to use unified validator API

### DIFF
--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -17,6 +17,7 @@ from services.analytics import (
     analyze_with_chunking,
     map_and_clean,
 )
+from utils.unicode_utils import sanitize_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -192,18 +193,18 @@ class UploadAnalyticsProcessor:
             all_data = []
             if os.path.exists(csv_file):
                 df_csv = pd.read_csv(csv_file)
-                result = processor._validate_data(df_csv)
-                if result["valid"]:
-                    processed_df = result["data"]
+                metrics = processor.validate_dataframe(df_csv)
+                if metrics.get("valid"):
+                    processed_df = sanitize_dataframe(df_csv)
                     processed_df["source_file"] = "csv"
                     all_data.append(processed_df)
             if os.path.exists(json_file):
                 with open(json_file, "r", encoding="utf-8", errors="replace") as f:
                     json_data = json.load(f)
                 df_json = pd.DataFrame(json_data)
-                result = processor._validate_data(df_json)
-                if result["valid"]:
-                    processed_df = result["data"]
+                metrics = processor.validate_dataframe(df_json)
+                if metrics.get("valid"):
+                    processed_df = sanitize_dataframe(df_json)
                     processed_df["source_file"] = "json"
                     all_data.append(processed_df)
             if all_data:

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-
+import base64
 
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
@@ -19,8 +19,9 @@ def test_parse_csv_with_various_delimiters(tmp_path, sep):
 
     processor = UnifiedFileValidator()
     with open(csv_path, "rb") as f:
-        text, _ = processor.validate_and_decode(str(csv_path), f.read())
-    parsed = processor._parse_csv(text)
+        data_b64 = base64.b64encode(f.read()).decode()
+    contents = f"data:text/csv;base64,{data_b64}"
+    parsed = processor.validate_file(contents, "sample.csv")
 
     expected = df.copy()
     expected["timestamp"] = pd.to_datetime(expected["timestamp"])


### PR DESCRIPTION
## Summary
- update `upload_processing` and `file_processing_service` to call `validate_dataframe`
- adjust CSV parsing and enhanced processor tests to use the new API
- sanitize dataframes when validating files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868b41114a08320888698dc00b5037e