### PR TITLE
Add simple CSV parsing utility

### DIFF
--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,2 +1,25 @@
-from ..unicode_processor import *  # re-export
+from ..unicode_processor import *
+from .processor import (
+    UnicodeTextProcessor,
+    UnicodeSQLProcessor,
+    UnicodeSecurityProcessor,
+)
 
+__all__ = [
+    "UnicodeProcessor",
+    "ChunkedUnicodeProcessor",
+    "clean_unicode_text",
+    "safe_decode",
+    "safe_encode",
+    "sanitize_dataframe",
+    "sanitize_data_frame",
+    "safe_unicode_encode",
+    "handle_surrogate_characters",
+    "clean_unicode_surrogates",
+    "sanitize_unicode_input",
+    "process_large_csv_content",
+    "safe_format_number",
+    "UnicodeTextProcessor",
+    "UnicodeSQLProcessor",
+    "UnicodeSecurityProcessor",
+]

--- a/security/validation_exceptions.py
+++ b/security/validation_exceptions.py
@@ -1,5 +1,11 @@
-"""Custom security-related exceptions."""
+"""Custom security-related exceptions and helpers."""
+
+from core.exceptions import ValidationError as CoreValidationError
 
 
 class SecurityViolation(Exception):
     """Raised for detected attacks."""
+
+
+class ValidationError(CoreValidationError):  # pragma: no cover - thin alias
+    """Alias for :class:`core.exceptions.ValidationError`."""

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -13,6 +13,8 @@ from services.input_validator import InputValidator, ValidationResult
 from security.file_validator import SecureFileValidator
 from security.dataframe_validator import DataFrameSecurityValidator
 from core.exceptions import ValidationError
+from .file_handler import process_file_simple
+from .core.exceptions import FileProcessingError
 
 logger = logging.getLogger(__name__)
 
@@ -128,4 +130,4 @@ class FileProcessor:
         return {"status": "ok"}
 
 
-__all__ = ["FileProcessor", "UnifiedFileValidator"]
+__all__ = ["FileProcessor", "UnifiedFileValidator", "process_file_simple", "FileProcessingError"]


### PR DESCRIPTION
## Summary
- implement `process_file_simple` to decode bytes and load CSV
- expose `process_file_simple` and errors via `file_processor`
- fix security validation exceptions
- correct unicode package exports

## Testing
- `pytest tests/test_file_processor.py::TestFileProcessorUtilities::test_process_file_simple_function -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_6868b41249f0832098132f13685f9830