### PR TITLE
Add PyYAML to dev deps and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ pip install -r requirements.txt
 pip install -r requirements-dev.txt
 # or use ./scripts/setup.sh which installs requirements.txt
 ```
+Detailed instructions are provided in
+[docs/test_setup.md](docs/test_setup.md).
 
 Run the complete test suite:
 ```bash

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -25,7 +25,10 @@ This guide walks new contributors through setting up a local development environ
 3. **Install dependencies:**
    ```bash
    ./scripts/setup.sh
+   pip install -r requirements-dev.txt
    ```
+   The development requirements include additional packages such as
+   **PyYAML** that are necessary when running the test suite.
 
 4. **Compile translations:**
    ```bash
@@ -44,8 +47,11 @@ This guide walks new contributors through setting up a local development environ
 7. **Run the test suite:**
    ```bash
    pytest --cov
+   mypy .
+   flake8 .
+   black --check .
    ```
-
+   
 8. **Start the application:**
    ```bash
    python app.py

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -1,0 +1,54 @@
+# Running the Test Suite
+
+This project includes a fairly extensive set of unit and integration tests. The
+steps below outline how to set up your environment and execute the entire suite.
+
+## 1. Install Dependencies
+
+Create and activate a virtual environment if you have not already:
+```bash
+python -m venv venv
+source venv/bin/activate
+```
+
+Install the application and development requirements:
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+`requirements-dev.txt` includes additional packages such as **PyYAML** that are
+required by the tests but not needed in production.
+
+## 2. Prepare the Environment
+
+Compile the translation files (needed for some integration tests):
+```bash
+pybabel compile -d translations
+```
+
+Copy the sample environment file and adjust any values you need:
+```bash
+cp .env.example .env
+```
+
+If the CSS bundle has not been built yet, generate it:
+```bash
+npm run build-css  # or python tools/build_css.py
+```
+
+## 3. Run the Tests
+
+Execute the full suite with coverage reporting:
+```bash
+pytest --cov
+```
+
+Static analysis and linting checks can be run as well:
+```bash
+mypy .
+flake8 .
+black --check .
+```
+
+All tests are located under the `tests/` directory. Running `pytest` from the
+repository root will automatically discover them.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ bandit
 pytest
 pytest-cov
 safety==2.3.5
+PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- update developer docs with test-suite setup steps
- add PyYAML to `requirements-dev.txt`
- describe the full testing setup in new documentation
- mention test setup doc in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868b7a28aac8320bc0073ee16a42f3e