### PR TITLE
Fix Dash version for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dash-leaflet==1.1.3
 dash-extensions==2.0.4
 Flask>=2.2.5
 dash-bootstrap-components==1.6.0
-dash==3.0.0
+dash>=2,<3
 plotly==5.15.0
 pandas==2.1.1
 numpy>=1.24.0

--- a/requirements_ui.txt
+++ b/requirements_ui.txt
@@ -1,4 +1,4 @@
-dash==3.0.0
+dash>=2,<3
 dash-bootstrap-components==1.6.0
 plotly==5.15.0
 pandas==2.1.1


### PR DESCRIPTION
## Summary
- pin Dash <3 for compatibility with dash-bootstrap-components

## Testing
- `pip install "dash>=2,<3" dash-bootstrap-components==1.6.0`
- `python wsgi.py --dev` *(fails: numpy dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_6868bf7afb348320bbba4b9edaebded6