### PR TITLE
Add callback events and metadata tracking to StorageManager

### DIFF
--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -1,6 +1,11 @@
 import json
 import pandas as pd
 from datetime import datetime
+from core.callback_controller import (
+    CallbackController,
+    CallbackEvent,
+    TemporaryCallback,
+)
 from file_conversion.storage_manager import StorageManager
 
 
@@ -9,9 +14,32 @@ def test_migrate_pkl_to_parquet(tmp_path):
     pkl_path = tmp_path / "sample.pkl"
     df.to_pickle(pkl_path)
 
-    storage = StorageManager(base_dir=tmp_path / "converted")
-    success, msg = storage.migrate_pkl_to_parquet(pkl_path)
+    controller = CallbackController()
+    controller.clear_all_callbacks()
+    events = []
+
+    def record(ctx):
+        events.append(ctx.event_type)
+
+    with TemporaryCallback(
+        CallbackEvent.FILE_PROCESSING_START,
+        record,
+        controller,
+    ), TemporaryCallback(
+        CallbackEvent.FILE_PROCESSING_COMPLETE,
+        record,
+        controller,
+    ), TemporaryCallback(
+        CallbackEvent.FILE_PROCESSING_ERROR,
+        record,
+        controller,
+    ):
+        storage = StorageManager(base_dir=tmp_path / "converted")
+        success, msg = storage.migrate_pkl_to_parquet(pkl_path)
     assert success, msg
+
+    assert events[0] == CallbackEvent.FILE_PROCESSING_START
+    assert CallbackEvent.FILE_PROCESSING_COMPLETE in events
 
     parquet_path = storage.base_dir / "sample.parquet"
     assert parquet_path.exists()
@@ -24,6 +52,8 @@ def test_migrate_pkl_to_parquet(tmp_path):
     assert "sample.parquet" in metadata
     entry = metadata["sample.parquet"]
     assert entry["original_file"] == str(pkl_path)
+    assert entry["rows"] == len(df)
+    assert entry["columns"] == len(df.columns)
     assert "converted_at" in entry
     # ensure ISO format timestamp
     datetime.fromisoformat(entry["converted_at"])


### PR DESCRIPTION
## Summary
- integrate `CallbackController` into `StorageManager`
- sanitize data with `UnicodeProcessor`
- fire processing events during pickle migration
- store row/column counts in metadata
- update related unit test to check events and metadata

## Testing
- `flake8 file_conversion/storage_manager.py tests/test_storage_manager.py`
- `pytest tests/test_storage_manager.py -q` *(fails: ModuleNotFoundError: No module named 'services.upload_processing')*

------
https://chatgpt.com/codex/tasks/task_e_6868c51dede48320bc138ac672ca8d7a