### PR TITLE
Add unified file controller with integration tests

### DIFF
--- a/services/unified_file_controller.py
+++ b/services/unified_file_controller.py
@@ -1,0 +1,114 @@
+import logging
+import time
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from core.callback_controller import fire_event
+from core.callback_events import CallbackEvent
+from core.unicode import UnicodeProcessor
+from services.data_processing.unified_file_validator import UnifiedFileValidator
+from file_conversion.storage_manager import StorageManager
+
+_logger = logging.getLogger(__name__)
+
+# Simple in-memory metrics
+_metrics = {
+    "uploaded_files": 0,
+    "migrated_files": 0,
+    "total_rows": 0,
+    "bytes_saved": 0,
+    "total_time": 0.0,
+}
+
+
+def process_file_upload(
+    contents: str,
+    filename: str,
+    *,
+    storage: Optional[StorageManager] = None,
+) -> dict:
+    """Validate ``contents``, sanitize with :class:`UnicodeProcessor` and save.
+
+    Parameters
+    ----------
+    contents:
+        Base64 encoded file contents.
+    filename:
+        Name of the uploaded file.
+    storage:
+        Optional :class:`StorageManager` instance.
+
+    Returns
+    -------
+    dict
+        Information about the processed file.
+    """
+    storage = storage or StorageManager()
+    validator = UnifiedFileValidator()
+    start = time.perf_counter()
+
+    df = validator.validate_file(contents, filename)
+    df = UnicodeProcessor.sanitize_dataframe(df)
+
+    base = Path(filename).stem
+    ok, msg = storage.save_dataframe(df, base)
+    if not ok:
+        raise RuntimeError(msg)
+
+    fire_event(
+        CallbackEvent.DATA_PROCESSED,
+        "unified_file_controller",
+        {"filename": filename, "rows": len(df)},
+    )
+
+    _metrics["uploaded_files"] += 1
+    _metrics["total_rows"] += len(df)
+    _metrics["bytes_saved"] += df.memory_usage(deep=True).sum()
+    _metrics["total_time"] += time.perf_counter() - start
+
+    return {
+        "rows": len(df),
+        "columns": list(df.columns),
+        "saved_as": f"{base}.parquet",
+    }
+
+
+def batch_migrate_legacy_files(
+    paths: Sequence[str | Path] | Path,
+    *,
+    storage: Optional[StorageManager] = None,
+    progress: Optional[Callable[[int, int, str], None]] = None,
+) -> None:
+    """Migrate pickled files to Parquet using :class:`StorageManager`.
+
+    ``paths`` may be a directory or iterable of files. ``progress`` is called
+    after each file with ``(index, total, filename)``.
+    """
+    storage = storage or StorageManager()
+    if isinstance(paths, (str, Path)):
+        pkl_files = sorted(Path(paths).glob("*.pkl"))
+    else:
+        pkl_files = [Path(p) for p in paths]
+
+    total = len(pkl_files)
+    for idx, pkl in enumerate(pkl_files, 1):
+        success, _ = storage.migrate_pkl_to_parquet(pkl)
+        if success:
+            _metrics["migrated_files"] += 1
+        if progress:
+            try:
+                progress(idx, total, pkl.name)
+            except Exception as exc:  # pragma: no cover - best effort
+                _logger.error("Progress callback failed: %s", exc)
+
+
+def get_processing_metrics() -> dict:
+    """Return a copy of internal processing metrics."""
+    return dict(_metrics)
+
+
+__all__ = [
+    "process_file_upload",
+    "batch_migrate_legacy_files",
+    "get_processing_metrics",
+]

--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -1,0 +1,18 @@
+class UploadAnalyticsProcessor:
+    """Minimal stub for tests."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def _process_uploaded_data_directly(self, data):
+        return {
+            "total_events": sum(len(df) for df in data.values()),
+            "active_users": len({row['Person ID'] for df in data.values() for row in df.to_dict('records')}),
+            "active_doors": len({row['Device name'] for df in data.values() for row in df.to_dict('records')}),
+        }
+
+    def analyze_uploaded_data(self):
+        return {"status": "success"}
+
+    def load_uploaded_data(self):  # pragma: no cover - simple stub
+        return {}

--- a/tests/test_unified_file_system_integration.py
+++ b/tests/test_unified_file_system_integration.py
@@ -1,0 +1,73 @@
+import base64
+import pandas as pd
+import pytest
+
+from core.callback_events import CallbackEvent
+from core.callback_controller import TemporaryCallback
+from file_conversion.storage_manager import StorageManager
+from services.unified_file_controller import (
+    process_file_upload,
+    batch_migrate_legacy_files,
+    get_processing_metrics,
+)
+
+
+def _encode_df(df: pd.DataFrame) -> str:
+    header = ",".join(df.columns)
+    rows = [",".join(map(str, r)) for r in df.to_numpy()]
+    csv_text = "\n".join([header] + rows)
+    data = base64.b64encode(csv_text.encode("utf-8", "surrogatepass")).decode()
+    return f"data:text/csv;base64,{data}"
+
+
+def test_upload_workflow_and_metrics(tmp_path):
+    events = []
+    df = pd.DataFrame({"na\ud83dme": [1], "<script>": ["x"]})
+    contents = _encode_df(df)
+
+    storage = StorageManager(base_dir=tmp_path)
+    with TemporaryCallback(
+        CallbackEvent.DATA_PROCESSED,
+        lambda ctx: events.append(ctx.data),
+    ):
+        _ = process_file_upload(contents, "test.csv", storage=storage)
+
+    loaded, err = storage.load_dataframe("test")
+    assert err == ""
+    assert "script" not in loaded.columns[0].lower()
+    assert events and events[0]["filename"].endswith(".csv")
+
+    metrics = get_processing_metrics()
+    assert metrics["uploaded_files"] == 1
+    assert metrics["total_rows"] == 1
+
+
+def test_batch_migration_and_progress(tmp_path):
+    df = pd.DataFrame({"a": [1]})
+    p1 = tmp_path / "one.pkl"
+    p2 = tmp_path / "two.pkl"
+    df.to_pickle(p1)
+    df.to_pickle(p2)
+
+    storage = StorageManager(base_dir=tmp_path / "conv")
+    progress = []
+    batch_migrate_legacy_files(
+        [p1, p2],
+        storage=storage,
+        progress=lambda i, t, n: progress.append((i, t, n)),
+    )
+
+    assert (tmp_path / "conv" / "one.parquet").exists()
+    assert (tmp_path / "conv" / "two.parquet").exists()
+    assert progress == [(1, 2, "one.pkl"), (2, 2, "two.pkl")]
+
+    metrics = get_processing_metrics()
+    assert metrics["migrated_files"] == 2
+
+
+def test_security_validation_blocks_bad_file(tmp_path):
+    bad_df = pd.DataFrame({"=cmd": ["=1"]})
+    contents = _encode_df(bad_df)
+    storage = StorageManager(base_dir=tmp_path)
+    with pytest.raises(Exception):
+        process_file_upload(contents, "bad.csv", storage=storage)


### PR DESCRIPTION
## Summary
- implement `services/unified_file_controller.py` with upload handling, batch migration and metrics
- provide stub `services/upload_processing.py` for optional analytics imports
- add integration tests for unified file controller

## Testing
- `flake8 services/unified_file_controller.py tests/test_unified_file_system_integration.py`
- `pytest -q tests/test_unified_file_system_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_6868c52127048320aa4dbb5b01644e18