### PR TITLE
Add psutil dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,13 @@ dashboard. Key entry points include `tests/test_integration.py`,
 - **Hardened SQL Injection Prevention**: Uses `sqlparse` and `bleach` to validate queries
 - **Centralized Unicode Processing**: Normalize text with `core.unicode`.
 - **Event Driven Callbacks**: Plugins react to `core.callback_controller` events.
-- **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance.
+- **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance
+  using `psutil`.
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run
 `pip install -r requirements.txt` to install all dependencies.
+`PerformanceMonitor` also requires `psutil` for CPU and memory metrics.
 
 ## 🔧 Configuration
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest
 pytest-cov
 safety==2.3.5
 PyYAML==6.0.1
+psutil>=5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ cssutils==2.8.0
 scipy>=1.13.0
 scikit-learn==1.3.0
 joblib==1.3.2
+psutil>=5.9.0
 psycopg2-binary==2.9.7
 requests>=2.32.0
 


### PR DESCRIPTION
## Summary
- add `psutil` to requirements files
- note requirement in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868c52201148320a4fb423461e864f8