### PR TITLE
Add chardet & gunicorn dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,7 @@ python-dotenv==1.0.0
 pytest==7.4.0
 pyarrow>=10.0.0
 polars>=0.19.0  # optional, for enhanced CSV processing
+
+# Deployment
+gunicorn>=21.0.0
+chardet>=5.0.0


### PR DESCRIPTION
## Summary
- add `gunicorn` and `chardet` near deployment section in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868cd4a11fc8320a48d9da324f80804