### PR TITLE
Add UnlimitedFileProcessor

### DIFF
--- a/services/data_processing/no_limit_processor.py
+++ b/services/data_processing/no_limit_processor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""File processor that streams CSV data without imposing row limits."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Iterable
+
+import pandas as pd
+
+from config.dynamic_config import dynamic_config
+
+logger = logging.getLogger(__name__)
+
+
+class UnlimitedFileProcessor:
+    """Read CSV files in chunks and log progress."""
+
+    def __init__(self, chunk_size: int | None = None) -> None:
+        self.chunk_size = chunk_size or dynamic_config.analytics.chunk_size
+
+    def read_csv_chunks(
+        self, file_path: str | Path, encoding: str = "utf-8"
+    ) -> Iterable[pd.DataFrame]:
+        """Yield ``DataFrame`` chunks from ``file_path``."""
+        path = Path(file_path)
+        rows = 0
+        for chunk in pd.read_csv(path, chunksize=self.chunk_size, encoding=encoding):
+            rows += len(chunk)
+            logger.debug("Processed %s rows from %s", rows, path.name)
+            yield chunk
+        logger.info("Finished processing %s rows from %s", rows, path.name)
+
+    def load_csv(self, file_path: str | Path, encoding: str = "utf-8") -> pd.DataFrame:
+        """Return the combined dataframe from all chunks."""
+        chunks: List[pd.DataFrame] = list(self.read_csv_chunks(file_path, encoding))
+        if chunks:
+            df = pd.concat(chunks, ignore_index=True)
+        else:
+            df = pd.DataFrame()
+        self.validate_no_truncation(file_path, len(df))
+        return df
+
+    def validate_no_truncation(
+        self, file_path: str | Path, processed_rows: int
+    ) -> bool:
+        """Check ``file_path`` line count matches ``processed_rows``."""
+        try:
+            with open(file_path, "rb") as fh:
+                total_lines = sum(1 for _ in fh)
+            # subtract header line
+            expected = max(total_lines - 1, 0)
+            if expected != processed_rows:
+                logger.warning(
+                    "Possible truncation reading %s: expected %s rows, got %s",
+                    file_path,
+                    expected,
+                    processed_rows,
+                )
+                return False
+            return True
+        except Exception as exc:  # pragma: no cover - validation best effort
+            logger.error("Validation failed for %s: %s", file_path, exc)
+            return False
+
+
+unlimited_processor = UnlimitedFileProcessor()
+
+__all__ = ["UnlimitedFileProcessor", "unlimited_processor"]


### PR DESCRIPTION
## Summary
- add `UnlimitedFileProcessor` that streams CSV files without imposing row limits
- expose an instance as `unlimited_processor`

## Testing
- `pytest -q tests/test_file_processor.py::test_unicode_processor_isolation tests/test_file_processor.py::test_preview_without_ui` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6868cd4ad8608320be0ff1b7c8d3c774