### PR TITLE
Add graceful fallback for plugin imports

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -1,0 +1,24 @@
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    from .manager import PluginManager
+    from .auto_config import PluginAutoConfiguration
+    PLUGINS_AVAILABLE = True
+except ImportError as e:
+    logger.warning(f"Plugin system not available: {e}")
+    PLUGINS_AVAILABLE = False
+    class PluginManager:
+        def __init__(self, *args, **kwargs):
+            pass
+        def discover_plugins(self):
+            return []
+        def load_plugin(self, plugin):
+            return False
+    class PluginAutoConfiguration:
+        def __init__(self, *args, **kwargs):
+            pass
+        def scan_and_configure(self, *args):
+            pass
+
+__all__ = ["PluginManager", "PluginAutoConfiguration", "PLUGINS_AVAILABLE"]


### PR DESCRIPTION
## Summary
- implement fallback loader for plugins

## Testing
- `pytest -q` *(fails: cannot import name 'FileProcessor')*

------
https://chatgpt.com/codex/tasks/task_e_6868cd4bf1ec83209523a4e16189907e