### PR TITLE
Update Unicode sanitization and add numeric formatting tests

### DIFF
--- a/tests/security/test_unicode_utils.py
+++ b/tests/security/test_unicode_utils.py
@@ -11,6 +11,11 @@ def test_sanitize_unicode_removes_surrogates():
     assert "A" in result and "B" in result
 
 
+def test_sanitize_unicode_removes_bom():
+    text = "\ufeffHello"
+    assert sanitize_unicode_input(text) == "Hello"
+
+
 def test_sanitize_unicode_handles_bad_str():
     class Bad:
         def __str__(self):

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -1,7 +1,11 @@
 import pandas as pd
 from concurrent.futures import ThreadPoolExecutor
 
-from core.unicode_processor import safe_unicode_encode, sanitize_data_frame
+from core.unicode_processor import (
+    safe_unicode_encode,
+    sanitize_data_frame,
+    safe_format_number,
+)
 
 
 
@@ -58,6 +62,12 @@ def test_safe_decode_encode_no_errors():
     encoded = safe_encode(decoded + chr(0xDFFF))
     assert isinstance(decoded, str) and isinstance(encoded, str)
     assert "\ud800" not in decoded and "\udfff" not in encoded
+
+
+def test_safe_format_number_handles_special_values():
+    assert safe_format_number(float("nan")) is None
+    assert safe_format_number(float("inf")) is None
+    assert safe_format_number(12345) == "12,345"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- improve regex definitions in unicode_processor
- drop surrogate pairs and BOM in `sanitize_unicode_input`
- return `None` for NaN/inf in `safe_format_number`
- test BOM removal
- test numeric formatting

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt` *(fails: ResolutionImpossible)*
- `pytest -q tests/security/test_unicode_utils.py tests/test_unicode_processor.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868cd4b869483209fe44bfa7faa80d1