### PR TITLE
Add dependency checker utility

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,8 +12,8 @@ logging.basicConfig(
 )
 import os
 import sys
-import importlib
 from flask import request
+from utils.dependency_checker import verify_requirements
 
 try:
     from dotenv import load_dotenv
@@ -63,21 +63,7 @@ def check_learning_status():
 
 
 def verify_dependencies() -> None:
-    """Ensure critical third-party libraries are available."""
-    required = ["bleach", "pandas", "dash", "flask", "dotenv"]
-    missing = []
-    for pkg in required:
-        try:
-            importlib.import_module(pkg)
-        except ImportError:
-            missing.append(pkg)
-
-    if missing:
-        logger.error("Missing required dependencies: %s", ", ".join(missing))
-        logger.info(
-            "\n💡 Run `pip install -r requirements.txt` or `./scripts/setup.sh` to install them"
-        )
-        sys.exit(1)
+    verify_requirements("requirements.txt")
 
 
 def print_startup_info(app_config):

--- a/utils/dependency_checker.py
+++ b/utils/dependency_checker.py
@@ -1,0 +1,30 @@
+import importlib
+import logging
+from pathlib import Path
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+
+def check_dependencies(packages: Iterable[str]) -> List[str]:
+    missing = []
+    for pkg in packages:
+        try:
+            importlib.import_module(pkg)
+        except ImportError:
+            missing.append(pkg)
+    return missing
+
+
+def verify_requirements(path: str = "requirements.txt") -> None:
+    reqs: List[str] = []
+    with open(Path(path), "r", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                reqs.append(line.split("==")[0].split(">=")[0].split("~=")[0])
+    missing = check_dependencies(reqs)
+    if missing:
+        logger.error("Missing required dependencies: %s", ", ".join(sorted(missing)))
+        logger.info("Run `pip install -r %s`", path)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add new `utils/dependency_checker.py` utility for verifying packages
- update `app.py` to use `verify_requirements` instead of a custom check

## Testing
- `pip install -q pandas pytest` *(fails: ModuleNotFoundError due to network restrictions)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_6868d210955c83209247035aebbb7685