### PR TITLE
Sanitize dataframe preview output

### DIFF
--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -3,6 +3,8 @@ import logging
 from typing import Any, List, Dict
 import pandas as pd
 
+from security.unicode_security_processor import sanitize_unicode_input
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,6 +18,10 @@ def serialize_dataframe_preview(df: pd.DataFrame) -> List[Dict[str, Any]]:
     try:
         limited_df = df.head(99)  # clamp DataFrame to <100 rows
         preview = limited_df.head(5).to_dict("records")
+        preview = [
+            {k: sanitize_unicode_input(v) for k, v in row.items()}
+            for row in preview
+        ]
         serialized = json.dumps(preview, ensure_ascii=False)
         if len(serialized.encode("utf-8")) >= 5 * 1024 * 1024:
             logger.warning("Serialized preview exceeds 5MB; omitting preview")


### PR DESCRIPTION
## Summary
- handle unicode sanitation for dataframe previews

## Testing
- `pytest -k preview_utils -q` *(fails: cannot import name 'FileProcessor' from 'services.data_processing.file_processor')*

------
https://chatgpt.com/codex/tasks/task_e_6868d2134b908320bf813848b4d0cff4