### PR TITLE
Handle optional psutil import

### DIFF
--- a/core/performance_file_processor.py
+++ b/core/performance_file_processor.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Callable, Optional, List
 
 import pandas as pd
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - optional dependency
+    psutil = None  # type: ignore
 
 
 class PerformanceFileProcessor:
@@ -45,7 +48,10 @@ class PerformanceFileProcessor:
         for chunk in pd.read_csv(path, chunksize=self.chunk_size, encoding=encoding):
             dfs.append(chunk)
             rows += len(chunk)
-            mem_mb = psutil.Process().memory_info().rss / (1024 * 1024)
+            mem_mb = (
+                psutil.Process().memory_info().rss / (1024 * 1024)
+                if psutil else 0
+            )
             if progress_callback:
                 try:
                     progress_callback(rows, mem_mb)


### PR DESCRIPTION
## Summary
- allow performance file processor to run without psutil
- guard psutil import with try/except
- fall back to zero memory usage when psutil is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6868d7790a4c8320aa5f156e6350ae8d