### PR TITLE
Remove deprecated FileProcessor import

### DIFF
--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,7 +1,14 @@
 """Data processing utilities."""
 
 from .file_handler import FileHandler, process_file_simple
-from .file_processor import FileProcessor
+# ``FileProcessor`` was removed in favor of ``UnicodeFileProcessor``.  Import
+# the new class here and optionally expose it under the old name for backward
+# compatibility.
+from .file_processor import UnicodeFileProcessor
+
+# Provide the legacy name ``FileProcessor`` for callers that still import it
+# from ``services.data_processing``.
+FileProcessor = UnicodeFileProcessor
 from .unified_file_validator import UnifiedFileValidator
 from .core.exceptions import (
     FileProcessingError,
@@ -55,7 +62,6 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
 
 __all__ = [
     "FileHandler",
-    "FileProcessor",
     "UnifiedFileValidator",
     "process_file_simple",
     "FileProcessingError",

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -127,3 +127,13 @@ def create_file_preview(df: pd.DataFrame, max_rows: int = 10) -> Dict[str, Any]:
             'dtypes': {}
         }
 
+# For backwards compatibility expose ``UnicodeFileProcessor`` as ``FileProcessor``
+FileProcessor = UnicodeFileProcessor
+
+__all__ = [
+    "UnicodeFileProcessor",
+    "FileProcessor",
+    "process_uploaded_file",
+    "create_file_preview",
+]
+


### PR DESCRIPTION
## Summary
- stop importing FileProcessor from services.data_processing
- keep compatibility by aliasing UnicodeFileProcessor
- export alias from file_processor module

## Testing
- `pytest tests/test_file_processor.py::test_unicode_processor_isolation -q`
- `pytest tests/test_process_and_analyze.py::test_process_then_analyze -q` *(fails: AttributeError - UnicodeFileProcessor has no attribute 'read_uploaded_file')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6868dd6487648320bc763f7c8aafc6e4