### PR TITLE
Update docs API references

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ Centralized analytics service for dashboard operations.
 
 - `get_dashboard_summary() -> Dict[str, Any]`: Get dashboard overview
 - `get_access_patterns_analysis(days) -> Dict[str, Any]`: Analyze access patterns
-- `FileProcessor.read_uploaded_file(contents, filename) -> DataFrame`: Decode uploaded data
+ - `process_uploaded_file(contents, filename) -> Dict[str, Any]`: Validate and parse an uploaded file using `UnifiedFileValidator.validate_file`
 
 ## Models
 


### PR DESCRIPTION
## Summary
- fix outdated API reference in docs/api.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868dd66d248832091bfe162b0c60341