### PR TITLE
Fix imports and dependency checks

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -7,7 +7,10 @@ Feeds back to AI training data
 
 import pandas as pd
 from dash import html, dcc, callback, Input, Output, State, ALL, MATCH
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -647,7 +650,7 @@ def toggle_custom_field(selected_value):
 
 
 def register_callbacks(
-    manager: TrulyUnifiedCallbacks,
+    manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the coordinator."""

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -3,7 +3,10 @@
 import pandas as pd
 from dash import html, dcc
 from dash.dependencies import Input, Output, State, ALL, MATCH
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -275,7 +278,7 @@ def mark_device_as_edited(floor, access, special, security):
 
 
 def register_callbacks(
-    manager: TrulyUnifiedCallbacks,
+    manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the provided coordinator."""

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -3,7 +3,10 @@
 from dash import html, dcc
 from dash._callback_context import callback_context
 import dash
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 import logging
 
@@ -540,7 +543,7 @@ def populate_simple_device_modal(is_open):
 
 
 def register_callbacks(
-    manager: TrulyUnifiedCallbacks,
+    manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Register component callbacks using the provided coordinator."""

--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -4,7 +4,9 @@ Navigation bar component with grid layout using existing framework
 
 import datetime
 from typing import TYPE_CHECKING, Optional, Any, Union
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from flask_babel import lazy_gettext as _l, refresh
 from flask import session
 from core.plugins.decorators import safe_callback

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -19,14 +19,28 @@ def create_app(mode: str | None = None):
     return _create_app(mode)
 
 
+from typing import TYPE_CHECKING
+
 from .unicode_processor import sanitize_unicode_input
-from .truly_unified_callbacks import TrulyUnifiedCallbacks
 from .unicode import (
     UnicodeTextProcessor,
     UnicodeSQLProcessor,
     UnicodeSecurityProcessor,
 )
 from .performance_file_processor import PerformanceFileProcessor
+
+if TYPE_CHECKING:  # pragma: no cover - avoid circular import at runtime
+    from .truly_unified_callbacks import TrulyUnifiedCallbacks
+
+
+def __getattr__(name: str):
+    """Lazily import heavy modules on demand."""
+    if name == "TrulyUnifiedCallbacks":
+        from .truly_unified_callbacks import TrulyUnifiedCallbacks as _tuc
+
+        globals()[name] = _tuc
+        return _tuc
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 __all__ = [
     "create_app",

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Complete application factory integration."""
+from __future__ import annotations
 import dash
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Any
+from typing import Optional, Any, TYPE_CHECKING
 from flasgger import Swagger
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Input, Output
 from components.ui.navbar import create_navbar_layout
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from core.container import Container as DIContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.secret_manager import validate_secrets
@@ -21,6 +21,9 @@ from flask_talisman import Talisman
 from core.theme_manager import apply_theme_settings, DEFAULT_THEME, sanitize_theme
 from config.config import get_config
 from .cache import cache
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 BUNDLE = "/assets/dist/main.min.css"
@@ -184,6 +187,8 @@ def _create_full_app() -> dash.Dash:
         app.layout = _serve_layout
 
         # Register all callbacks using TrulyUnifiedCallbacks
+        from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
         coordinator = TrulyUnifiedCallbacks(app)
         _register_router_callbacks(coordinator)
         _register_global_callbacks(coordinator)
@@ -553,7 +558,7 @@ def _create_placeholder_page(title: str, subtitle: str, message: str) -> html.Di
     )
 
 
-def _register_router_callbacks(manager: TrulyUnifiedCallbacks) -> None:
+def _register_router_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
     """Register page routing callbacks."""
 
     @manager.register_callback(
@@ -669,7 +674,7 @@ def _get_upload_page() -> Any:
         )
 
 
-def _register_global_callbacks(manager: TrulyUnifiedCallbacks) -> None:
+def _register_global_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
     """Register global application callbacks"""
 
     # Register device learning callbacks

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -78,6 +78,8 @@ def setup_logging(config: Dict[str, Any]) -> None:
                 "maxBytes": 10485760,
                 "backupCount": 5,
                 "formatter": "json",
+                "encoding": "utf-8",
+                "errors": "backslashreplace",
             },
         },
         "loggers": {

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TYPE_CHECKING
 import logging
 
 from dash import Dash
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from core.callback_manager import CallbackManager
 from core.plugins.manager import PluginManager
 from services.data_processing.core.protocols import PluginProtocol
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 from services.registry import registry as service_registry
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,10 @@ class UnifiedPluginRegistry:
         self.app = app
         self.container = container
         self.callback_manager = callback_manager or CallbackManager()
+
+        # Import lazily to avoid circular dependency during module import
+        from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
         self.coordinator = TrulyUnifiedCallbacks(app)
         self.plugin_manager = PluginManager(container, config_manager, package=package)
         # Register health endpoint immediately

--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 """Truly unified callback system combining registry and coordinator."""
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from dash import Dash
 
-from .plugins.callback_unifier import CallbackUnifier
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .plugins.callback_unifier import CallbackUnifier
 
 
 class TrulyUnifiedCallbacks:
@@ -18,6 +19,8 @@ class TrulyUnifiedCallbacks:
 
     def callback(self, *args: Any, **kwargs: Any):
         """Unified callback decorator."""
+        from .plugins.callback_unifier import CallbackUnifier
+
         return CallbackUnifier(self)(*args, **kwargs)
 
     unified_callback = callback

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -2,7 +2,10 @@
 
 from dash import Input, Output, State, callback_context, html
 from dash.exceptions import PreventUpdate
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 from core.dash_profile import profile_callback
 import logging
@@ -502,7 +505,7 @@ class Callbacks:
 
 
 def register_callbacks(
-    manager: TrulyUnifiedCallbacks,
+    manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Instantiate :class:`Callbacks` and register its methods."""

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -14,7 +14,10 @@ from typing import Optional, Dict, Any, List, Tuple
 from dash import html, dcc
 from dash.dash import no_update
 from dash._callback_context import callback_context
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 from core.dash_profile import profile_callback
 import logging
@@ -1172,7 +1175,7 @@ class Callbacks:
 
 
 def register_callbacks(
-    manager: TrulyUnifiedCallbacks,
+    manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
 ) -> None:
     """Instantiate :class:`Callbacks` and register its methods."""

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -9,7 +9,10 @@ from datetime import datetime
 import pandas as pd
 from dash import html
 from dash.dependencies import Input, Output
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from services.consolidated_learning_service import get_learning_service
 from dash._callback_context import callback_context
 
@@ -344,7 +347,7 @@ def get_device_learning_service() -> DeviceLearningService:
     return _device_learning_service
 
 
-def create_learning_callbacks(manager: TrulyUnifiedCallbacks) -> None:
+def create_learning_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
     """Register device learning callback with coordinator."""
 
     @manager.unified_callback(

--- a/utils/dependency_checker.py
+++ b/utils/dependency_checker.py
@@ -1,9 +1,26 @@
 import importlib
 import logging
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Dict
 
 logger = logging.getLogger(__name__)
+
+# Map pip package names to their corresponding Python import names. This ensures
+# that dependency checks use the correct module names even when they differ from
+# the package identifier used in ``requirements.txt``.
+PACKAGE_MODULE_MAP: Dict[str, str] = {
+    "flask-babel": "flask_babel",
+    "flask-caching": "flask_caching",
+    "flask-login": "flask_login",
+    "dash-bootstrap-components": "dash_bootstrap_components",
+    "dash-extensions": "dash_extensions",
+    "dash-leaflet": "dash_leaflet",
+    "psycopg2-binary": "psycopg2",
+    "python-dotenv": "dotenv",
+    "python-jose": "jose",
+    "scikit-learn": "sklearn",
+    "pyyaml": "yaml",
+}
 
 
 def check_dependencies(packages: Iterable[str]) -> List[str]:
@@ -17,12 +34,19 @@ def check_dependencies(packages: Iterable[str]) -> List[str]:
 
 
 def verify_requirements(path: str = "requirements.txt") -> None:
+    """Validate that all packages listed in ``path`` are importable."""
+
     reqs: List[str] = []
     with open(Path(path), "r", encoding="utf-8", errors="ignore") as fh:
         for line in fh:
             line = line.strip()
-            if line and not line.startswith("#"):
-                reqs.append(line.split("==")[0].split(">=")[0].split("~=")[0])
+            if not line or line.startswith("#"):
+                continue
+
+            pkg = line.split("==")[0].split(">=")[0].split("~=")[0]
+            module_name = PACKAGE_MODULE_MAP.get(pkg.lower(), pkg.replace("-", "_"))
+            reqs.append(module_name)
+
     missing = check_dependencies(reqs)
     if missing:
         logger.error("Missing required dependencies: %s", ", ".join(sorted(missing)))


### PR DESCRIPTION
## Summary
- avoid circular imports in unified callbacks and plugins
- defer TrulyUnifiedCallbacks imports where only used for type hints
- map pip package names to module names when verifying requirements
- ensure RotatingFileHandler uses UTF-8 with fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python -m py_compile utils/dependency_checker.py core/logging_config.py core/truly_unified_callbacks.py core/__init__.py core/plugins/unified_registry.py core/app_factory.py pages/deep_analytics/callbacks.py pages/file_upload.py services/device_learning_service.py components/ui/navbar.py components/device_verification.py components/simple_device_mapping.py components/column_verification.py`

------
https://chatgpt.com/codex/tasks/task_e_6868e07425d883209ad73ae80c5834dd