### PR TITLE
Update dash-extensions version

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ following steps:
    pip uninstall -y dash dash-leaflet dash-extensions dash-bootstrap-components
    pip install dash==2.14.1
    pip install dash-bootstrap-components==1.6.0
-   pip install dash-extensions==1.0.4
+   pip install dash-extensions==1.0.11
    pip install dash-leaflet==0.1.28
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-dash==2.14.1
+dash==2.15.0
 dash-bootstrap-components==1.6.0
-dash-extensions==1.0.4
+dash-extensions==1.0.11
 dash-leaflet==0.1.28
 Flask>=2.2.5
 plotly==5.15.0


### PR DESCRIPTION
## Summary
- upgrade `dash` to 2.15.0
- upgrade `dash-extensions` to 1.0.11
- keep `Flask-Caching` pinned
- update README to mention new `dash-extensions` version

## Testing
- `pip install -r requirements.txt` *(fails: Building wheel for scikit-learn... canceled)*
- `pip install -r requirements.txt --dry-run` *(fails: Preparing metadata for scikit-learn canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6868e69dfc8883209499489263560785