### PR TITLE
Fix dash import to avoid removed module

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any
-from dash.development.base_component import Component
 import pandas as pd
 import logging
 
@@ -207,7 +206,7 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
     )
     status_div = html.Div(id="device-save-status")
 
-    modal_children: List[Component] = [
+    modal_children: List[Any] = [
         device_store,
         suggestions_store,
         status_div,


### PR DESCRIPTION
## Summary
- remove `dash.development` import from device mapping component
- adjust list typing to `List[Any]`

## Testing
- `black --check components/simple_device_mapping.py`
- `flake8 components/simple_device_mapping.py` *(fails: E402, E501)*
- `mypy components/simple_device_mapping.py` *(fails: several missing stubs)*
- `bandit -r components/simple_device_mapping.py`
- `pytest -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868f3425280832085d000ff26df0a54