### PR TITLE
Fix duplicate logger import

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -15,14 +15,12 @@ from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any
 import pandas as pd
-import logging
 
 # ADD after existing imports
 from services.door_mapping_service import door_mapping_service
 from services.ai_mapping_store import ai_mapping_store
 from services.device_learning_service import get_device_learning_service
 
-logger = logging.getLogger(__name__)
 
 # Options for special device areas shared with verification component
 special_areas_options = [


### PR DESCRIPTION
## Summary
- clean up `simple_device_mapping` logging setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868f64ed3b0832096a78368a774134d