### PR TITLE
Fix encoding detection default

### DIFF
--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -27,7 +27,7 @@ class UnicodeFileProcessor:
         try:
             # Detect encoding
             detected = chardet.detect(content)
-            encoding = detected.get('encoding', 'utf-8')
+            encoding = detected.get('encoding') or 'utf-8'
 
             # Try detected encoding first
             try:


### PR DESCRIPTION
## Summary
- update unicode file processor encoding detection to avoid `None`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6868fcdff6e083208a289d720b96a1d4