### PR TITLE
Update Unicode migration test imports

### DIFF
--- a/tests/test_unicode_migration.py
+++ b/tests/test_unicode_migration.py
@@ -1,13 +1,14 @@
 import pandas as pd
 import pytest
 
-from utils.unicode_utils import (
+from core.unicode import (
     UnicodeProcessor,
     ChunkedUnicodeProcessor,
     clean_unicode_text,
     safe_decode_bytes,
     safe_encode_text,
     sanitize_dataframe,
+    # Deprecated functions for testing
     safe_unicode_encode,
     safe_encode,
     safe_decode,


### PR DESCRIPTION
## Summary
- switch unicode migration tests to use imports from `core.unicode`

## Testing
- `pytest -q tests/test_unicode_migration.py` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6869003f87f88320b81bebfed749633d