### PR TITLE
Fix unicode import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ files while maintaining backwards compatible helper functions like
 - Supports PostgreSQL, SQLite, and Mock databases
 - Type-safe connection management
 - Retry logic via `connection_retry.py` with exponential backoff
-- Safe Unicode handling with `unicode_utils.py`
+- Safe Unicode handling with `core.unicode`
 - Connection pooling through `connection_pool.py`
 ```python
 from config.database_manager import EnhancedPostgreSQLManager, DatabaseConfig

--- a/core/unicode_utils.py
+++ b/core/unicode_utils.py
@@ -1,2 +1,6 @@
-from utils.unicode_utils import *  # re-export for backward compatibility
+"""Re-export core unicode functionality for backward compatibility."""
+from core.unicode import *
+
+# This module exists only for backward compatibility
+# All new code should import directly from core.unicode
 

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional, Tuple
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
-from utils.unicode_utils import (
+from core.unicode import (
     UnicodeProcessor,
     sanitize_dataframe,
     sanitize_unicode_input,

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from .base import BaseService
 from services.data_processing.core.protocols import FileProcessorProtocol
 from utils.file_validator import safe_decode_with_unicode_handling
-from utils.unicode_utils import (
+from core.unicode import (
     sanitize_unicode_input,
     sanitize_data_frame,
     process_large_csv_content,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,7 +7,7 @@ except Exception:  # pragma: no cover - fallback when dependencies fail
     process_large_csv_content = None  # type: ignore
 
 try:  # pragma: no cover - graceful import fallback
-    from .unicode_utils import (
+    from core.unicode import (
         # Preferred API
         clean_unicode_text,
         safe_decode_bytes,
@@ -37,7 +37,7 @@ try:  # pragma: no cover - graceful import fallback
     )
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
-except Exception:  # pragma: no cover - fallback when unicode_utils unavailable
+except Exception:  # pragma: no cover - fallback when core.unicode unavailable
     from security.unicode_security_processor import (
         sanitize_dataframe as sanitize_data_frame,
         UnicodeSecurityProcessor,

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from typing import Iterable, Dict, Any
-from .unicode_utils import safe_unicode_encode
+from core.unicode import safe_unicode_encode
 
 from dash import html  # type: ignore
 


### PR DESCRIPTION
## Summary
- re-export unicode helpers directly from `core.unicode`
- point services and utilities at the new core unicode module
- adjust readme mention of unicode utils

## Testing
- `pytest tests/test_unicode_migration.py tests/test_unicode_wrappers.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869003f933c8320843268b25c73f7c5