### PR TITLE
Update unicode wrapper test imports

### DIFF
--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -2,9 +2,23 @@ import importlib
 import time
 import pandas as pd
 import pytest
+import warnings
 
 from core.unicode_processor import UnicodeProcessor as UnicodeTextProcessor
-from utils.unicode_utils import UnicodeProcessor as UtilsProcessor, sanitize_dataframe
+from core.unicode import (
+    clean_unicode_text,
+    safe_encode_text,
+    sanitize_dataframe,
+    UnicodeProcessor as UtilsProcessor,
+    # Test deprecated functions
+    safe_unicode_encode,
+    safe_encode,
+    safe_decode,
+    handle_surrogate_characters,
+    clean_unicode_surrogates,
+    sanitize_unicode_input,
+    sanitize_data_frame,
+)
 from config.unicode_handler import UnicodeQueryHandler
 from security.unicode_security_handler import UnicodeSecurityHandler as UnicodeSecurityProcessor
 


### PR DESCRIPTION
## Summary
- update import block in `test_unicode_wrappers`

## Testing
- `pytest tests/test_unicode_wrappers.py::test_wrapper_compatibility_and_imports -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_68690040a15c8320a9de0913fab27d54