### PR TITLE
Fix lazy imports for services

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -31,15 +31,19 @@ from .database_exceptions import (
 from .dynamic_config import dynamic_config, DynamicConfigManager
 from .constants import SecurityConstants, PerformanceConstants, CSSConstants
 import logging
-from services.registry import get_service
+
+def _lazy_get_service(name: str):
+    """Import ``get_service`` lazily to avoid early registry imports."""
+    from services.registry import get_service
+    return get_service(name)
 
 logger = logging.getLogger(__name__)
 
 # Resolve optional database manager via registry
-DatabaseManager = get_service("DatabaseManager")
-DatabaseConnection = get_service("DatabaseConnection")
-MockConnection = get_service("MockConnection")
-EnhancedPostgreSQLManager = get_service("EnhancedPostgreSQLManager")
+DatabaseManager = _lazy_get_service("DatabaseManager")
+DatabaseConnection = _lazy_get_service("DatabaseConnection")
+MockConnection = _lazy_get_service("MockConnection")
+EnhancedPostgreSQLManager = _lazy_get_service("EnhancedPostgreSQLManager")
 DATABASE_MANAGER_AVAILABLE = DatabaseManager is not None
 
 __all__ = [

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -19,8 +19,13 @@ from core.unicode import (
     sanitize_dataframe,
     sanitize_unicode_input,
 )
-from core.security import InputValidator as StringValidator
 from services.input_validator import InputValidator, ValidationResult
+
+
+def _lazy_string_validator() -> "StringValidator":
+    """Import ``InputValidator`` from :mod:`core.security` lazily."""
+    from core.security import InputValidator as StringValidator
+    return StringValidator()
 from core.exceptions import ValidationError
 
 
@@ -174,7 +179,7 @@ class UnifiedFileValidator:
 
     def __init__(self, max_size_mb: Optional[int] = None) -> None:
         self.max_size_mb = max_size_mb or dynamic_config.security.max_upload_mb
-        self._string_validator = StringValidator()
+        self._string_validator = _lazy_string_validator()
         self._basic_validator = InputValidator(self.max_size_mb)
 
     def _sanitize_string(self, value: str) -> str:


### PR DESCRIPTION
## Summary
- avoid eager import of get_service in `config/__init__`
- lazily import `InputValidator` in unified file validator

## Testing
- `pytest tests/test_input_validator.py::test_none_upload_rejected -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686929c123e883208d7964265e579f86