### PR TITLE
Fix bare excepts

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -260,7 +260,7 @@ class InputValidator:
 
             text_content = content[:1024].decode("utf-8", errors="ignore")
             text_content = UnicodeSecurityHandler.sanitize_unicode_input(text_content).lower()
-        except:
+        except Exception:
             return False
 
         # Check for suspicious patterns

--- a/dash_csrf_plugin/__init__.py
+++ b/dash_csrf_plugin/__init__.py
@@ -283,7 +283,7 @@ class EnhancedCSRFManager:
             from flask_wtf.csrf import generate_csrf
 
             return generate_csrf()
-        except:
+        except Exception:
             return ""
 
     def validate_csrf(self) -> bool:
@@ -298,7 +298,7 @@ class EnhancedCSRFManager:
             if token:
                 validate_csrf(token)
                 return True
-        except:
+        except Exception:
             pass
         return False
 

--- a/investigate_data.py
+++ b/investigate_data.py
@@ -80,7 +80,7 @@ def investigate_data():
             try:
                 if filepath.stat().st_size > 5 * 1024 * 1024:  # 5MB
                     large_files.append(filepath)
-            except:
+            except OSError:
                 pass
 
     if large_files:

--- a/models/base.py
+++ b/models/base.py
@@ -124,7 +124,7 @@ class AccessEventModel(BaseModel):
                         patterns["hourly_distribution"][hour] = (
                             patterns["hourly_distribution"].get(hour, 0) + 1
                         )
-                    except:
+                    except Exception:
                         pass
 
             return patterns

--- a/persistence_diagnostics.py
+++ b/persistence_diagnostics.py
@@ -145,7 +145,7 @@ def test_save_load_cycle():
                         if data.get("filename") == test_filename:
                             our_file = file_path
                             break
-                except:
+                except Exception:
                     continue
 
             if our_file:

--- a/quick_check.py
+++ b/quick_check.py
@@ -91,7 +91,7 @@ def quick_check():
 
             store_data = ai_mapping_store.all()
             print(f"   Global store items: {len(store_data)}")
-        except:
+        except Exception:
             print(f"   Global store: Not available")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- specify expected exception types
- preserve existing log/fallback behavior

## Testing
- `flake8 .` *(fails: imported but unused, style errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686929b0a0a08320870319ef9f78142f