### PR TITLE
Add unicode helper wrappers

### DIFF
--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,4 +1,5 @@
 from ..unicode_processor import *
+from ..unicode_processor import safe_decode_bytes, safe_encode_text
 from .processor import (
     UnicodeTextProcessor,
     UnicodeSQLProcessor,
@@ -9,6 +10,8 @@ __all__ = [
     "UnicodeProcessor",
     "ChunkedUnicodeProcessor",
     "clean_unicode_text",
+    "safe_decode_bytes",
+    "safe_encode_text",
     "safe_decode",
     "safe_encode",
     "sanitize_dataframe",

--- a/core/unicode_processor.py
+++ b/core/unicode_processor.py
@@ -155,6 +155,18 @@ def clean_unicode_text(text: str) -> str:
     return UnicodeProcessor.clean_surrogate_chars(text)
 
 
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    """Safely decode bytes with Unicode handling."""
+
+    return UnicodeProcessor.safe_decode_bytes(data, encoding)
+
+
+def safe_encode_text(value: Any) -> str:
+    """Convert any value to a safe UTF-8 string."""
+
+    return UnicodeProcessor.safe_encode_text(value)
+
+
 def safe_decode(data: bytes, encoding: str = "utf-8") -> str:
     """Safely decode bytes with Unicode handling."""
 
@@ -249,6 +261,8 @@ __all__ = [
     "UnicodeProcessor",
     "ChunkedUnicodeProcessor",
     "clean_unicode_text",
+    "safe_decode_bytes",
+    "safe_encode_text",
     "safe_decode",
     "safe_encode",
     "sanitize_dataframe",


### PR DESCRIPTION
## Summary
- expose `safe_decode_bytes` and `safe_encode_text` wrappers in `core.unicode_processor`
- re-export wrappers from `core.unicode`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686929bf178c8320a9c6e2c5893169a2