### PR TITLE
Fix docstring spacing for migration helpers

### DIFF
--- a/scripts/migrate_plugin_system.py
+++ b/scripts/migrate_plugin_system.py
@@ -12,7 +12,6 @@ This tool assists migrating to the new plugin architecture:
 
 Pass ``--dry-run`` to preview file modifications without applying them.
 """
-
 from __future__ import annotations
 
 import ast

--- a/tools/migrate_pickle_mappings.py
+++ b/tools/migrate_pickle_mappings.py
@@ -14,7 +14,6 @@ Usage::
 The JSON output will be written next to the pickle file using the
 ``.json`` extension.
 """
-
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- remove blank line before `from __future__ import annotations` in migration helpers

## Testing
- `pytest` *(fails: numpy dtype size mismatch)*
- `mypy --strict .` *(fails: many errors)*
- `python -m flake8 .` *(fails: various style issues)*
- `black --check .` *(fails: would reformat many files)*
- `python -m bandit -r .`

------
https://chatgpt.com/codex/tasks/task_e_686929aecc1c83208191c902f50f4cef