### PR TITLE
Add adhoc HTTPS support

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,7 +182,12 @@ def main():
 
         # Run the application
         try:
-            app.run(debug=app_config.debug, host=app_config.host, port=app_config.port)
+            app.run_server(
+                host=app_config.host,
+                port=app_config.port,
+                debug=app_config.debug,
+                ssl_context='adhoc'
+            )
         except KeyboardInterrupt:
             logger.info("\n👋 Application stopped by user")
         except Exception as e:


### PR DESCRIPTION
## Summary
- run the Dash server with adhoc SSL context

## Testing
- `black app.py`
- `flake8 app.py` *(fails: module level import not at top of file, line too long)*
- `pytest -q` *(fails: missing packages and test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869871f01f8832091eafa3c752d7866