### PR TITLE
Fix __future__ import position

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -2,6 +2,8 @@
 Navigation bar component with grid layout using existing framework
 """
 
+from __future__ import annotations
+
 import datetime
 from typing import TYPE_CHECKING, Optional, Any, Union
 
@@ -13,7 +15,6 @@ from core.plugins.decorators import safe_callback
 from core.theme_manager import DEFAULT_THEME, sanitize_theme
 from utils.assets_utils import get_nav_icon
 from utils.assets_debug import check_navbar_assets
-from __future__ import annotations
 
 import logging
 


### PR DESCRIPTION
## Summary
- move `from __future__ import annotations` to top of `components/ui/navbar.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869896f5d1c832082c7720e8b800ffc