### PR TITLE
Add SSE-based upload progress events

### DIFF
--- a/assets/upload_progress_sse.js
+++ b/assets/upload_progress_sse.js
@@ -1,0 +1,21 @@
+(function(){
+  var source;
+  window.startUploadProgress = function(taskId){
+    if(!taskId){return;}
+    if(source){source.close();}
+    var progressBar = document.getElementById('upload-progress');
+    source = new EventSource('/upload/progress/' + taskId);
+    source.onmessage = function(e){
+      var val = parseInt(e.data);
+      if(progressBar){
+        progressBar.setAttribute('value', val);
+        progressBar.textContent = val + '%';
+      }
+      if(val >= 100){
+        source.close();
+        var btn = document.getElementById('progress-done-trigger');
+        if(btn){btn.click();}
+      }
+    };
+  };
+})();

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -250,6 +250,8 @@ def _create_full_app() -> dash.Dash:
         # Expose basic health check endpoint and Swagger docs
         server = app.server
         _configure_swagger(server)
+        from services.progress_events import ProgressEventManager
+        progress_events = ProgressEventManager()
 
         @server.route("/health", methods=["GET"])
         def health():
@@ -275,6 +277,11 @@ def _create_full_app() -> dash.Dash:
         def health_secrets():
             """Return validation summary for required secrets"""
             return validate_secrets(), 200
+
+        @server.route("/upload/progress/<task_id>")
+        def upload_progress(task_id: str):
+            """Stream task progress updates as Server-Sent Events."""
+            return progress_events.stream(task_id)
 
         @app.server.before_request
         def filter_noisy_requests():

--- a/services/progress_events.py
+++ b/services/progress_events.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import time
+from typing import Iterator
+from flask import Response, stream_with_context
+from services.task_queue import get_status
+
+
+class ProgressEventManager:
+    """Simple manager streaming task progress via Server-Sent Events."""
+
+    def __init__(self, interval: float = 0.5) -> None:
+        self.interval = interval
+
+    def generator(self, task_id: str) -> Iterator[str]:
+        """Yield progress values for ``task_id`` until completion."""
+        last = None
+        while True:
+            status = get_status(task_id)
+            progress = int(status.get("progress", 0))
+            if progress != last:
+                yield str(progress)
+                last = progress
+            if status.get("done"):
+                break
+            time.sleep(self.interval)
+
+    def stream(self, task_id: str) -> Response:
+        """Return an SSE ``Response`` streaming progress for ``task_id``."""
+        def _wrap():
+            for value in self.generator(task_id):
+                yield f"data: {value}\n\n"
+        return Response(stream_with_context(_wrap()), mimetype="text/event-stream")
+
+
+__all__ = ["ProgressEventManager"]

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import dash
+import dash_bootstrap_components as dbc
+from dash import html, dcc
+
+from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from pages import file_upload
+
+
+def _create_upload_app():
+    app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    coord = UnifiedCallbackCoordinator(app)
+    file_upload.register_callbacks(coord)
+    app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
+    return app
+
+
+def test_upload_progress_sse(dash_duo, tmp_path):
+    csv = tmp_path / "sample.csv"
+    pd.DataFrame({"a": [1, 2]}).to_csv(csv, index=False)
+    app = _create_upload_app()
+    dash_duo.start_server(app)
+    assert not dash_duo.find_elements("#upload-progress-interval")
+    file_input = dash_duo.find_element("#upload-data input")
+    file_input.send_keys(str(csv))
+    dash_duo.wait_for_text_to_equal("#upload-progress", "100%", timeout=10)

--- a/tests/test_progress_events.py
+++ b/tests/test_progress_events.py
@@ -1,0 +1,17 @@
+import asyncio
+from services.progress_events import ProgressEventManager
+from services.task_queue import create_task, clear_task
+
+
+def test_progress_event_generator():
+    manager = ProgressEventManager(interval=0.01)
+
+    async def sample():
+        await asyncio.sleep(0.02)
+        return "ok"
+
+    tid = create_task(sample())
+    events = list(manager.generator(tid))
+    clear_task(tid)
+    assert events[0] == "0"
+    assert events[-1] == "100"


### PR DESCRIPTION
## Summary
- introduce `ProgressEventManager` for SSE streaming
- add `/upload/progress/<task_id>` endpoint
- enable SSE progress updates on the file upload page
- clientside callback opens SSE connection
- remove old polling interval
- test `ProgressEventManager` and SSE integration

## Testing
- `pytest tests/test_progress_events.py -q` *(fails: ModuleNotFoundError: No module named 'chardet')*


------
https://chatgpt.com/codex/tasks/task_e_68698767c884832097ae36499a8acd79