### PR TITLE
Implement asynchronous upload processing

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -318,10 +318,10 @@ class Callbacks:
             False,
         )
 
-    def process_uploaded_files(
+    async def process_uploaded_files(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
     ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
-        return self.processing.process_files(contents_list, filenames_list)
+        return await self.processing.process_files(contents_list, filenames_list)
 
     def start_upload_background(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
@@ -347,9 +347,7 @@ class Callbacks:
         if not isinstance(filenames_list, list):
             filenames_list = [filenames_list]
 
-        async_coro = asyncio.to_thread(
-            self.processing.process_files, contents_list, filenames_list
-        )
+        async_coro = self.processing.process_files(contents_list, filenames_list)
         task_id = create_task(async_coro)
 
         return (

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -20,6 +20,7 @@ from .analytics.upload_analytics import UploadAnalyticsProcessor
 from .db_analytics_helper import DatabaseAnalyticsHelper
 from .summary_reporting import SummaryReporter
 from .data_processing.unified_file_validator import UnifiedFileValidator
+from .progress_event_manager import progress_manager
 
 logger = logging.getLogger(__name__)
 
@@ -54,5 +55,5 @@ __all__ = [
     "UploadAnalyticsProcessor",
     "DatabaseAnalyticsHelper",
     "SummaryReporter",
-
+    "progress_manager",
 ]

--- a/services/data_processing/async_file_processor.py
+++ b/services/data_processing/async_file_processor.py
@@ -1,0 +1,79 @@
+"""Asynchronous file processor using aiofiles."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Callable, Awaitable, Optional
+
+import aiofiles
+import pandas as pd
+
+from .file_processor import UnicodeFileProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncFileProcessor:
+    """Process uploaded files asynchronously in chunks."""
+
+    def __init__(self, chunk_size: int = 1024 * 1024) -> None:
+        self.chunk_size = chunk_size
+
+    async def _notify(
+        self,
+        callback: Optional[Callable[[str, int], Awaitable[None] | None]],
+        filename: str,
+        processed: int,
+        total: int,
+    ) -> None:
+        if not callback:
+            return
+        percent = int(processed / total * 100) if total else 100
+        try:
+            if asyncio.iscoroutinefunction(callback):
+                await callback(filename, percent)
+            else:
+                callback(filename, percent)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("Progress callback failed: %s", exc)
+
+    async def process_file(
+        self,
+        contents: str,
+        filename: str,
+        progress_callback: Optional[Callable[[str, int], Awaitable[None] | None]] = None,
+    ) -> pd.DataFrame:
+        """Return DataFrame parsed from ``contents``."""
+        prefix, data = contents.split(",", 1)
+        raw = base64.b64decode(data)
+        total = len(raw)
+        async with aiofiles.tempfile.NamedTemporaryFile(
+            "wb", delete=False, suffix=Path(filename).suffix
+        ) as tmp:
+            path = tmp.name
+            for offset in range(0, total, self.chunk_size):
+                chunk = raw[offset : offset + self.chunk_size]
+                await tmp.write(chunk)
+                await self._notify(progress_callback, filename, offset + len(chunk), total)
+        try:
+            if filename.endswith(".csv"):
+                df = await asyncio.to_thread(pd.read_csv, path)
+            elif filename.endswith((".xlsx", ".xls")):
+                df = await asyncio.to_thread(pd.read_excel, path)
+            else:
+                raise ValueError(f"Unsupported file type: {filename}")
+        finally:
+            try:
+                os.unlink(path)
+            except Exception:  # pragma: no cover - cleanup best effort
+                pass
+        df = UnicodeFileProcessor.sanitize_dataframe_unicode(df)
+        await self._notify(progress_callback, filename, total, total)
+        return df
+
+
+__all__ = ["AsyncFileProcessor"]

--- a/services/progress_event_manager.py
+++ b/services/progress_event_manager.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Callable, List, Any
+
+logger = logging.getLogger(__name__)
+
+class ProgressEventManager:
+    """Lightweight manager for upload progress events."""
+
+    def __init__(self) -> None:
+        self._callbacks: List[Callable[[str, int], Any]] = []
+
+    def register(self, callback: Callable[[str, int], Any]) -> None:
+        """Register a progress callback."""
+        self._callbacks.append(callback)
+
+    def unregister(self, callback: Callable[[str, int], Any]) -> None:
+        """Unregister a callback."""
+        self._callbacks = [cb for cb in self._callbacks if cb != callback]
+
+    def emit(self, filename: str, progress: int) -> None:
+        """Emit a progress update to all callbacks."""
+        for cb in list(self._callbacks):
+            try:
+                cb(filename, progress)
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Progress callback failed: %s", exc)
+
+progress_manager = ProgressEventManager()
+
+__all__ = ["ProgressEventManager", "progress_manager"]

--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -6,10 +6,9 @@ from dash import html
 from dash.dash import no_update
 import dash_bootstrap_components as dbc
 
-from services.data_processing.file_processor import (
-    process_uploaded_file,
-    create_file_preview,
-)
+from services.data_processing.file_processor import create_file_preview
+from services.data_processing.async_file_processor import AsyncFileProcessor
+from services.progress_event_manager import progress_manager
 from components.file_preview import create_file_preview_ui
 from services.device_learning_service import get_device_learning_service
 from services.data_enhancer import get_ai_column_suggestions
@@ -23,6 +22,7 @@ class UploadProcessingService:
 
     def __init__(self, store: UploadedDataStore):
         self.store = store
+        self.processor = AsyncFileProcessor()
 
     def build_success_alert(
         self,
@@ -117,7 +117,7 @@ class UploadProcessingService:
             ]
         )
 
-    def process_files(
+    async def process_files(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
     ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
         if not contents_list:
@@ -159,60 +159,60 @@ class UploadProcessingService:
                 content = parts[0]
 
             try:
-                result = process_uploaded_file(content, filename)
-                if result["status"] == "success":
-                    df = result["data"]
-                    rows = len(df)
-                    cols = len(df.columns)
+                df = await self.processor.process_file(
+                    content, filename, progress_manager.emit
+                )
+                rows = len(df)
+                cols = len(df.columns)
 
-                    self.store.add_file(filename, df)
-                    upload_results.append(
-                        self.build_success_alert(filename, rows, cols)
+                self.store.add_file(filename, df)
+                upload_results.append(
+                    self.build_success_alert(filename, rows, cols)
+                )
+                file_preview_components.append(
+                    self.build_file_preview_component(df, filename)
+                )
+
+                column_names = df.columns.tolist()
+                file_info_dict[filename] = {
+                    "filename": filename,
+                    "rows": rows,
+                    "columns": cols,
+                    "column_names": column_names,
+                    "upload_time": pd.Timestamp.now().isoformat(),
+                    "ai_suggestions": get_ai_column_suggestions(column_names),
+                }
+                current_file_info = file_info_dict[filename]
+
+                try:
+                    learning_service = get_device_learning_service()
+                    user_mappings = learning_service.get_user_device_mappings(
+                        filename
                     )
-                    file_preview_components.append(
-                        self.build_file_preview_component(df, filename)
-                    )
+                    if user_mappings:
+                        from services.ai_mapping_store import ai_mapping_store
 
-                    column_names = df.columns.tolist()
-                    file_info_dict[filename] = {
-                        "filename": filename,
-                        "rows": rows,
-                        "columns": cols,
-                        "column_names": column_names,
-                        "upload_time": pd.Timestamp.now().isoformat(),
-                        "ai_suggestions": get_ai_column_suggestions(column_names),
-                    }
-                    current_file_info = file_info_dict[filename]
-
-                    try:
-                        learning_service = get_device_learning_service()
-                        user_mappings = learning_service.get_user_device_mappings(
-                            filename
+                        ai_mapping_store.clear()
+                        for device, mapping in user_mappings.items():
+                            mapping["source"] = "user_confirmed"
+                            ai_mapping_store.set(device, mapping)
+                        logger.info(
+                            "✅ Loaded %s saved mappings - AI SKIPPED",
+                            len(user_mappings),
                         )
-                        if user_mappings:
-                            from services.ai_mapping_store import ai_mapping_store
+                    else:
+                        logger.info("🆕 First upload - AI will be used")
+                        from services.ai_mapping_store import ai_mapping_store
 
-                            ai_mapping_store.clear()
-                            for device, mapping in user_mappings.items():
-                                mapping["source"] = "user_confirmed"
-                                ai_mapping_store.set(device, mapping)
-                            logger.info(
-                                "✅ Loaded %s saved mappings - AI SKIPPED",
-                                len(user_mappings),
-                            )
-                        else:
-                            logger.info("🆕 First upload - AI will be used")
-                            from services.ai_mapping_store import ai_mapping_store
-
-                            ai_mapping_store.clear()
-                            self.auto_apply_learned_mappings(df, filename)
-                    except Exception as exc:  # pragma: no cover - best effort
-                        logger.info("⚠️ Error: %s", exc)
-                else:
-                    upload_results.append(self.build_failure_alert(result["error"]))
+                        ai_mapping_store.clear()
+                        self.auto_apply_learned_mappings(df, filename)
+                except Exception as exc:  # pragma: no cover - best effort
+                    logger.info("⚠️ Error: %s", exc)
             except Exception as exc:  # pragma: no cover - best effort
                 upload_results.append(
-                    self.build_failure_alert(f"Error processing {filename}: {str(exc)}")
+                    self.build_failure_alert(
+                        f"Error processing {filename}: {str(exc)}"
+                    )
                 )
 
         upload_nav = []

--- a/tests/test_async_file_processor.py
+++ b/tests/test_async_file_processor.py
@@ -1,0 +1,48 @@
+import base64
+import asyncio
+import pandas as pd
+
+from services.data_processing.async_file_processor import AsyncFileProcessor
+from services.progress_event_manager import progress_manager
+from services.upload.processing import UploadProcessingService
+from utils.upload_store import UploadedDataStore
+
+
+def _encode_df(df: pd.DataFrame) -> str:
+    data = df.to_csv(index=False).encode("utf-8", "surrogatepass")
+    b64 = base64.b64encode(data).decode()
+    return f"data:text/csv;base64,{b64}"
+
+
+def test_async_processor_progress_and_surrogates():
+    df = pd.DataFrame({"col": ["A\ud83d", "B"]})
+    content = _encode_df(df)
+    prog: list[int] = []
+    proc = AsyncFileProcessor(chunk_size=5)
+    out = asyncio.run(
+        proc.process_file(content, "t.csv", lambda f, p: prog.append(p))
+    )
+    assert prog and prog[-1] == 100
+    assert "\ud83d" not in out["col"].iloc[0]
+
+
+def test_upload_processing_async(tmp_path):
+    df = pd.DataFrame({"x": ["A\ud83d"], "y": [1]})
+    content = _encode_df(df)
+    store = UploadedDataStore(storage_dir=tmp_path)
+    service = UploadProcessingService(store)
+
+    progress: list[int] = []
+    cb = lambda f, p: progress.append(p)
+    progress_manager.register(cb)
+    try:
+        res = asyncio.run(service.process_files([content], ["data.csv"]))
+    finally:
+        progress_manager.unregister(cb)
+
+    assert progress and progress[-1] == 100
+    info = res[2]
+    assert info["data.csv"]["rows"] == 1
+    stored = store.get_all_data()["data.csv"]
+    assert "\ud83d" not in str(stored.iloc[0, 0])
+

--- a/tests/test_device_mapping_save.py
+++ b/tests/test_device_mapping_save.py
@@ -1,6 +1,7 @@
 import base64
 import pandas as pd
 import dash_bootstrap_components as dbc
+import asyncio
 from services.upload import UploadProcessingService
 from utils.upload_store import UploadedDataStore
 
@@ -32,7 +33,7 @@ def test_immediate_confirm_after_upload(monkeypatch, tmp_path):
     content = _encode_df(df)
 
     # Simulate upload which triggers async disk save
-    cb.process_uploaded_files(content, "data.csv")
+    asyncio.run(cb.process_uploaded_files(content, "data.csv"))
 
     file_info = {"filename": "data.csv", "devices": ["Door1"]}
     alert, _, _ = cb.save_confirmed_device_mappings(

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -1,5 +1,6 @@
 import base64
 import pandas as pd
+import asyncio
 
 from pages.file_upload import Callbacks, _uploaded_data_store
 from services.upload import UploadProcessingService
@@ -21,7 +22,9 @@ def test_multi_part_upload_row_count():
 
     cb = Callbacks()
     cb.processing = UploadProcessingService(_uploaded_data_store)
-    res = cb.process_uploaded_files([part1, part2], ["sample.csv", "sample.csv"])
+    res = asyncio.run(
+        cb.process_uploaded_files([part1, part2], ["sample.csv", "sample.csv"])
+    )
     info = res[2]
     assert info["sample.csv"]["rows"] == len(df)
     stored = _uploaded_data_store.get_all_data()["sample.csv"]

--- a/tests/test_process_uploaded_files_split.py
+++ b/tests/test_process_uploaded_files_split.py
@@ -1,5 +1,6 @@
 import base64
 import pandas as pd
+import asyncio
 
 from pages import file_upload
 from pages.file_upload import Callbacks
@@ -27,7 +28,7 @@ def test_process_uploaded_files_split(monkeypatch, tmp_path):
 
     cb = Callbacks()
     cb.processing = UploadProcessingService(store)
-    result = cb.process_uploaded_files(contents_list, filenames_list)
+    result = asyncio.run(cb.process_uploaded_files(contents_list, filenames_list))
     info = result[2]
 
     assert info["big.csv"]["rows"] == len(df)

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -8,7 +8,7 @@ def test_task_queue_basic():
         await asyncio.sleep(0.01)
         return "ok"
 
-    tid = create_task(sample())
+    tid = create_task(sample)
     for _ in range(100):
         status = get_status(tid)
         if status.get("done"):


### PR DESCRIPTION
## Summary
- add `AsyncFileProcessor` for chunked async file handling
- emit progress events via new `ProgressEventManager`
- integrate async processor into `UploadProcessingService`
- allow `create_task` to take coroutine functions
- update callbacks and tests for async workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', ...)*

------
https://chatgpt.com/codex/tasks/task_e_6869876d0f5c8320a430bbb4407b8a58