### PR TITLE
Implement memory efficient uploaded data store

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -58,7 +58,6 @@ from services.task_queue import create_task, get_status, clear_task
 logger = logging.getLogger(__name__)
 
 
-
 def layout():
     """File upload page layout with persistent storage"""
     return dbc.Container(
@@ -271,10 +270,16 @@ class Callbacks:
         file_preview_components: List[Any] = []
         current_file_info: Dict[str, Any] = {}
 
-        for filename in _uploaded_data_store.get_filenames():
-            df = _uploaded_data_store.load_dataframe(filename)
-            rows = len(df)
-            cols = len(df.columns)
+        file_infos = _uploaded_data_store.get_file_info()
+
+        for filename, info in file_infos.items():
+            path = info.get("path") or str(_uploaded_data_store.get_file_path(filename))
+            try:
+                df_preview = pd.read_parquet(path).head(10)
+            except Exception:
+                df_preview = _uploaded_data_store.load_dataframe(filename).head(10)
+            rows = info.get("rows", len(df_preview))
+            cols = info.get("columns", len(df_preview.columns))
 
             upload_results.append(
                 self.processing.build_success_alert(
@@ -287,15 +292,15 @@ class Callbacks:
             )
 
             file_preview_components.append(
-                self.processing.build_file_preview_component(df, filename)
+                self.processing.build_file_preview_component(df_preview, filename)
             )
 
             current_file_info = {
                 "filename": filename,
                 "rows": rows,
                 "columns": cols,
-                "column_names": df.columns.tolist(),
-                "ai_suggestions": get_ai_column_suggestions(df.columns.tolist()),
+                "path": path,
+                "ai_suggestions": info.get("ai_suggestions", {}),
             }
 
         upload_nav = html.Div(
@@ -763,7 +768,16 @@ class Callbacks:
             .replace("🔧", "")
             .replace("❌", "")
         )
-        columns = file_info.get("column_names", []) or file_info.get("columns", [])
+        columns = file_info.get("columns", [])
+        if not columns:
+            path = file_info.get("path") or str(
+                _uploaded_data_store.get_file_path(filename)
+            )
+            try:
+                columns = pd.read_parquet(path, nrows=0).columns.tolist()
+            except Exception:
+                df_tmp = _uploaded_data_store.load_dataframe(filename)
+                columns = df_tmp.columns.tolist()
         ai_suggestions = file_info.get("ai_suggestions", {})
 
         # ADD THIS BLOCK HERE - Check for saved column mappings
@@ -787,9 +801,7 @@ class Callbacks:
                             "confidence": 1.0,
                             "source": "saved",
                         }
-                    logger.info(
-                        f"📋 Pre-filled saved mappings: {saved_column_mappings}"
-                    )
+                    logger.info(f"📋 Pre-filled saved mappings: {saved_column_mappings}")
         except Exception as e:
             logger.debug(f"No saved mappings: {e}")
         # END OF ADDITION
@@ -1058,7 +1070,9 @@ class Callbacks:
                         )
                         storage_dir = _uploaded_data_store.storage_dir
                         logger.error(f"📁 Storage directory: {storage_dir}")
-                        logger.error(f"📁 Storage directory exists: {storage_dir.exists()}")
+                        logger.error(
+                            f"📁 Storage directory exists: {storage_dir.exists()}"
+                        )
                         if storage_dir.exists():
                             disk_files = list(storage_dir.glob("*.parquet"))
                             logger.error(
@@ -1123,9 +1137,7 @@ class Callbacks:
         logger.info(f"🔍 DEBUG - confirm_clicks: {confirm_clicks}")
         logger.info(f"🔍 DEBUG - values: {values}")
         logger.info(f"🔍 DEBUG - ids: {ids}")
-        logger.info(
-            f"🔍 DEBUG - file_info filename: {file_info.get('filename', 'N/A')}"
-        )
+        logger.info(f"🔍 DEBUG - file_info filename: {file_info.get('filename', 'N/A')}")
 
         try:
             filename = file_info.get("filename", "")
@@ -1165,8 +1177,6 @@ class Callbacks:
                 dismissable=True,
                 duration=5000,
             )
-
-
 
 
 # ------------------------------------------------------------

--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -178,7 +178,7 @@ class UploadProcessingService:
                         "filename": filename,
                         "rows": rows,
                         "columns": cols,
-                        "column_names": column_names,
+                        "path": str(self.store.get_file_path(filename)),
                         "upload_time": pd.Timestamp.now().isoformat(),
                         "ai_suggestions": get_ai_column_suggestions(column_names),
                     }

--- a/tests/test_memory_efficient_store.py
+++ b/tests/test_memory_efficient_store.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from utils.upload_store import UploadedDataStore
+
+
+def test_memory_cleanup_after_save(tmp_path):
+    store = UploadedDataStore(storage_dir=tmp_path)
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    store.add_file("sample.csv", df)
+    store.wait_for_pending_saves()
+
+    assert store._data_store == {}
+
+    info = store.get_file_info()["sample.csv"]
+    assert info["rows"] == 2
+    assert "path" in info
+
+    df_loaded = store.load_dataframe("sample.csv")
+    assert len(df_loaded) == 2
+    # loading the dataframe should not keep it cached
+    assert store._data_store == {}
+
+    # re-load store from disk
+    store2 = UploadedDataStore(storage_dir=tmp_path)
+    info2 = store2.get_file_info()["sample.csv"]
+    assert info2["rows"] == 2
+    assert "path" in info2

--- a/utils/memory_store.py
+++ b/utils/memory_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any
+
+
+@dataclass
+class FileMeta:
+    filename: str
+    path: Path
+    rows: int
+    columns: int
+
+
+class MemoryEfficientStore:
+    """In-memory metadata store for uploaded files."""
+
+    def __init__(self) -> None:
+        self._meta: Dict[str, FileMeta] = {}
+
+    def add(self, filename: str, rows: int, columns: int, path: Path) -> None:
+        self._meta[filename] = FileMeta(filename, path, rows, columns)
+
+    def get(self, filename: str) -> FileMeta | None:
+        return self._meta.get(filename)
+
+    def all(self) -> Dict[str, Any]:
+        return {name: meta.__dict__ for name, meta in self._meta.items()}
+
+    def clear(self) -> None:
+        self._meta.clear()
+
+
+__all__ = ["MemoryEfficientStore", "FileMeta"]


### PR DESCRIPTION
## Summary
- create `MemoryEfficientStore` for storing only parquet metadata
- update `UploadedDataStore` to drop dataframes after saving and expose file paths
- return metadata from upload processing
- load previews directly from cached parquet files
- test memory cleanup and metadata correctness

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869876fd0a08320ae0f79fec85ea3f8