### PR TITLE
Add async file processing progress reporting

### DIFF
--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -1,6 +1,7 @@
 """Data processing utilities."""
 
 from .file_handler import FileHandler, process_file_simple
+from .async_file_processor import AsyncFileProcessor
 # ``FileProcessor`` was removed in favor of ``UnicodeFileProcessor``.  Import
 # the new class here and optionally expose it under the old name for backward
 # compatibility.
@@ -62,6 +63,7 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
 
 __all__ = [
     "FileHandler",
+    "AsyncFileProcessor",
     "UnifiedFileValidator",
     "process_file_simple",
     "FileProcessingError",

--- a/services/data_processing/async_file_processor.py
+++ b/services/data_processing/async_file_processor.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Asynchronous CSV processing helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator, Callable, List, Optional
+
+import pandas as pd
+
+from config.dynamic_config import dynamic_config
+
+
+class AsyncFileProcessor:
+    """Read CSV files asynchronously in chunks with progress reporting."""
+
+    def __init__(self, chunk_size: int | None = None) -> None:
+        self.chunk_size = chunk_size or dynamic_config.analytics.chunk_size
+
+    async def read_csv_chunks(
+        self,
+        file_path: str | Path,
+        *,
+        encoding: str = "utf-8",
+        progress_callback: Optional[Callable[[int], None]] = None,
+    ) -> AsyncIterator[pd.DataFrame]:
+        path = Path(file_path)
+        total_lines = await asyncio.to_thread(self._count_lines, path)
+        processed = 0
+        reader = pd.read_csv(path, chunksize=self.chunk_size, encoding=encoding)
+
+        def _next_chunk() -> pd.DataFrame | None:
+            try:
+                return next(reader)
+            except StopIteration:
+                return None
+
+        while True:
+            chunk = await asyncio.to_thread(_next_chunk)
+            if chunk is None:
+                break
+            processed += len(chunk)
+            if progress_callback and total_lines:
+                pct = int(processed / total_lines * 100)
+                pct = max(0, min(100, pct))
+                try:
+                    progress_callback(pct)
+                except Exception:  # pragma: no cover - best effort
+                    pass
+            yield chunk
+        if progress_callback:
+            try:
+                progress_callback(100)
+            except Exception:  # pragma: no cover - best effort
+                pass
+
+    async def load_csv(
+        self,
+        file_path: str | Path,
+        *,
+        encoding: str = "utf-8",
+        progress_callback: Optional[Callable[[int], None]] = None,
+    ) -> pd.DataFrame:
+        chunks: List[pd.DataFrame] = []
+        async for chunk in self.read_csv_chunks(
+            file_path, encoding=encoding, progress_callback=progress_callback
+        ):
+            chunks.append(chunk)
+        return pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+
+    @staticmethod
+    def _count_lines(path: Path) -> int:
+        with open(path, "rb") as fh:
+            return max(sum(1 for _ in fh) - 1, 0)
+
+
+__all__ = ["AsyncFileProcessor"]

--- a/services/task_queue.py
+++ b/services/task_queue.py
@@ -1,7 +1,8 @@
 import asyncio
+import inspect
 import threading
 import uuid
-from typing import Any, Dict, Coroutine
+from typing import Any, Dict, Coroutine, Callable, Awaitable
 
 # Simple in-memory async task tracker
 _tasks: Dict[str, Dict[str, Any]] = {}
@@ -12,14 +13,30 @@ _thread = threading.Thread(target=_loop.run_forever, daemon=True)
 _thread.start()
 
 
-def create_task(coro: Coroutine[Any, Any, Any]) -> str:
-    """Schedule ``coro`` and return a task ID."""
+def create_task(
+    func: Callable[[Callable[[int], None]], Awaitable[Any]] | Awaitable[Any]
+) -> str:
+    """Schedule ``func`` and return a task ID.
+
+    ``func`` may be either a coroutine object or a callable that accepts a
+    progress callback and returns a coroutine.  The callback will update
+    the internal progress state and may be used by the task to report
+    incremental progress.
+    """
+
     task_id = str(uuid.uuid4())
     _tasks[task_id] = {"progress": 0, "result": None, "done": False}
 
+    def _update(pct: int) -> None:
+        pct = max(0, min(100, int(pct)))
+        _tasks[task_id]["progress"] = pct
+
     async def _runner() -> None:
-        _tasks[task_id]["progress"] = 50
         try:
+            if inspect.iscoroutine(func):
+                coro = func
+            else:
+                coro = func(_update)
             result = await coro
             _tasks[task_id]["result"] = result
         except Exception as exc:  # pragma: no cover - best effort
@@ -34,7 +51,10 @@ def create_task(coro: Coroutine[Any, Any, Any]) -> str:
 
 def get_status(task_id: str) -> Dict[str, Any]:
     """Return the status dictionary for ``task_id``."""
-    return _tasks.get(task_id, {"progress": 100, "result": None, "done": True})
+    status = _tasks.get(task_id)
+    if status is None:
+        return {"progress": 100, "result": None, "done": True}
+    return dict(status)
 
 
 def clear_task(task_id: str) -> None:

--- a/tests/test_async_file_processor.py
+++ b/tests/test_async_file_processor.py
@@ -1,0 +1,34 @@
+import asyncio
+import pandas as pd
+import time
+
+from services.data_processing.async_file_processor import AsyncFileProcessor
+from services.task_queue import create_task, get_status, clear_task
+
+
+def test_async_file_processor_progress(tmp_path):
+    df = pd.DataFrame({"a": range(5)})
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+
+    processor = AsyncFileProcessor(chunk_size=2)
+
+    async def job(progress):
+        return await processor.load_csv(path, progress_callback=progress)
+
+    tid = create_task(job)
+    last = 0
+    while True:
+        status = get_status(tid)
+        cur = status["progress"]
+        assert cur >= last
+        last = cur
+        if status.get("done"):
+            break
+        time.sleep(0.01)
+
+    result = status["result"]
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == len(df)
+    assert last == 100
+    clear_task(tid)

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -18,3 +18,26 @@ def test_task_queue_basic():
     assert status.get("done") is True
     assert status.get("result") == "ok"
     clear_task(tid)
+
+
+def test_task_queue_progress():
+    async def sample(progress):
+        for i in range(5):
+            await asyncio.sleep(0.01)
+            progress((i + 1) * 20)
+        return "ok"
+
+    tid = create_task(sample)
+    last = 0
+    for _ in range(200):
+        status = get_status(tid)
+        assert status["progress"] >= last
+        last = status["progress"]
+        if status.get("done"):
+            break
+        time.sleep(0.01)
+    status = get_status(tid)
+    assert status.get("done") is True
+    assert status.get("result") == "ok"
+    assert status["progress"] == 100
+    clear_task(tid)


### PR DESCRIPTION
## Summary
- extend `create_task` to support a progress callback and return intermediate progress values
- implement `AsyncFileProcessor` for reading CSV files asynchronously while reporting progress
- expose `AsyncFileProcessor` from `services.data_processing`
- add unit tests for task queue and asynchronous file processor progress reporting

## Testing
- `pytest tests/test_task_queue.py tests/test_async_file_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68698771a9a08320a48836c4148ba696