### PR TITLE
Add isort config, dependency, and usage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ After installing the dependencies you can run the tests and code quality checks:
 pytest
 mypy --strict .
 flake8 .
+isort --check .
 black --check .
 bandit -r .
 ```
+
+Run `isort .` to automatically sort imports before committing changes.
 
 Please ensure tests and linters pass before opening a pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,17 @@
 python_version = "3.11"
 explicit_package_bases = true
 mypy_path = ["."]
+
+[tool.isort]
+profile = "black"
+known_first_party = [
+    "core",
+    "models",
+    "services",
+    "analytics",
+    "analyzers",
+    "components",
+    "pages",
+    "utils",
+]
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black
+isort
 flake8
 mypy
 bandit


### PR DESCRIPTION
## Summary
- configure `isort` in pyproject with black profile
- add `isort` to development requirements
- document running `isort` in CONTRIBUTING guide

## Testing
- `isort --check .` *(fails: imports not sorted)*
- `black --check .` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*
- `mypy --strict .` *(fails: 1 error in services/upload/processing.py)*
- `bandit -r .` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68698c5ad0508320876f2dc7c1e37699