### PR TITLE
Reorder imports in analytics_service

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -5,9 +5,11 @@ Uploaded files are validated with :class:`services.data_processing.unified_file_
 before processing to ensure they are present, non-empty and within the configured
 size limits.
 """
-import pandas as pd
 import logging
-from typing import Dict, Any, List, Optional, Tuple
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
 
 from services.data_loader import DataLoader
 from services.analytics_summary import generate_sample_analytics
@@ -17,7 +19,6 @@ from services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.db_analytics_helper import DatabaseAnalyticsHelper
 from services.summary_reporting import SummaryReporter
 
-from datetime import datetime
 
 
 def ensure_analytics_config():
@@ -374,8 +375,6 @@ class AnalyticsService:
 
     def get_unique_patterns_analysis(self, data_source: str | None = None):
         """Get unique patterns analysis for the requested source."""
-        import logging
-
         logger = logging.getLogger(__name__)
 
         try:


### PR DESCRIPTION
## Summary
- reorder imports in `analytics_service.py` so standard library imports come first
- remove duplicate runtime `import logging`

## Testing
- `pytest tests/test_analytics_service.py -q` *(fails: ModuleNotFoundError or failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68698d25a3f08320b5eb530120a7ccc2