### PR TITLE
Implement contains_surrogates checker

### DIFF
--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,9 +1,9 @@
 from ..unicode_processor import *
 from ..unicode_processor import safe_decode_bytes, safe_encode_text
 from .processor import (
-    UnicodeTextProcessor,
-    UnicodeSQLProcessor,
     UnicodeSecurityProcessor,
+    UnicodeSQLProcessor,
+    UnicodeTextProcessor,
 )
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
     "handle_surrogate_characters",
     "clean_unicode_surrogates",
     "sanitize_unicode_input",
+    "contains_surrogates",
     "process_large_csv_content",
     "safe_format_number",
     "UnicodeTextProcessor",

--- a/core/unicode_processor.py
+++ b/core/unicode_processor.py
@@ -8,7 +8,6 @@ import re
 import unicodedata
 from typing import Any, Optional, Union
 
-
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -21,6 +20,12 @@ _BOM_RE = re.compile("\ufeff")
 # Leading characters that may trigger dangerous behaviour when interpreted by
 # spreadsheet applications (e.g. Excel formula injection)
 _DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
+
+# Match unpaired surrogate code points (high not followed by low or
+# low not preceded by high)
+_UNPAIRED_SURROGATE_RE = re.compile(
+    r"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])"
+)
 
 
 class UnicodeProcessor:
@@ -214,6 +219,18 @@ def clean_unicode_surrogates(text: Any) -> str:
     return UnicodeProcessor.clean_surrogate_chars(str(text))
 
 
+def contains_surrogates(text: str) -> bool:
+    """Return ``True`` if ``text`` contains any unpaired surrogate code points."""
+
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    return bool(_UNPAIRED_SURROGATE_RE.search(text))
+
+
 def sanitize_unicode_input(text: Union[str, Any]) -> str:
     """Return ``text`` stripped of surrogate pairs and BOM characters."""
 
@@ -272,6 +289,7 @@ __all__ = [
     "handle_surrogate_characters",
     "clean_unicode_surrogates",
     "sanitize_unicode_input",
+    "contains_surrogates",
     "process_large_csv_content",
     "safe_format_number",
 ]

--- a/tests/test_contains_surrogates.py
+++ b/tests/test_contains_surrogates.py
@@ -1,0 +1,16 @@
+import pytest
+
+from core.unicode_processor import contains_surrogates
+
+
+def test_contains_surrogates_detects_unpaired_high():
+    assert contains_surrogates("A\ud800B")
+
+
+def test_contains_surrogates_detects_unpaired_low():
+    assert contains_surrogates("\udc00")
+
+
+def test_contains_surrogates_ignores_valid_pair():
+    assert not contains_surrogates("\ud800\udc00")
+


### PR DESCRIPTION
## Summary
- add helper to detect unpaired surrogate code points
- expose the helper in `core.unicode` exports
- test the new function

## Testing
- `isort core/unicode_processor.py core/unicode/__init__.py tests/test_contains_surrogates.py`
- `pytest -q tests/test_contains_surrogates.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869907133b08320b15ca5a8f540c667