### PR TITLE
Enhance Unicode sanitization

### DIFF
--- a/utils/unicode_utils.py
+++ b/utils/unicode_utils.py
@@ -8,7 +8,7 @@ Calling these functions will emit :class:`DeprecationWarning` directing you
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Callable, Union
 
 import pandas as pd
 
@@ -42,9 +42,13 @@ def safe_encode_text(value: Any) -> str:
     return _u.safe_encode(value)
 
 
-def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+def sanitize_dataframe(
+    df: pd.DataFrame,
+    *,
+    progress: Union[bool, Callable[[int, int], None], None] = None,
+) -> pd.DataFrame:
     _warn("sanitize_dataframe")
-    return _u.sanitize_dataframe(df)
+    return _u.sanitize_dataframe(df, progress=progress)
 
 
 def safe_unicode_encode(value: Any) -> str:


### PR DESCRIPTION
## Summary
- support string columns and nested structures in `sanitize_dataframe`
- expose optional progress callback in Unicode helpers
- test recursive sanitization and progress handling

## Testing
- `pre-commit run --files core/unicode_processor.py utils/unicode_utils.py tests/test_unicode_handler_full.py`
- `flake8 core/unicode_processor.py utils/unicode_utils.py tests/test_unicode_handler_full.py`
- `pytest tests/test_unicode_handler_full.py::TestUnicodeProcessor::test_sanitize_dataframe_string_dtype -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_68699071fa408320848a60ee42dbc3e7