### PR TITLE
Add surrogate validator

### DIFF
--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -3,18 +3,14 @@ Enhanced Security Validation for Yōsai Intel Dashboard
 Implements comprehensive input validation and security checks
 """
 
-from dataclasses import dataclass
-from enum import Enum
 import logging
 import os
 import re
 import secrets
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Dict, List
 
-from .security_patterns import (
-    PATH_TRAVERSAL_PATTERNS as RAW_PATH_PATTERNS,
-    XSS_PATTERNS as RAW_XSS_PATTERNS,
-)
 from config.constants import FileProcessingLimits
 from core.exceptions import ValidationError
 from security.sql_validator import SQLInjectionPrevention
@@ -23,6 +19,9 @@ from security_callback_controller import (
     SecurityEvent,
     emit_security_event,
 )
+
+from .security_patterns import PATH_TRAVERSAL_PATTERNS as RAW_PATH_PATTERNS
+from .security_patterns import XSS_PATTERNS as RAW_XSS_PATTERNS
 
 
 class SecurityLevel(Enum):
@@ -81,6 +80,10 @@ class SecurityValidator:
 
     def _sanitize_input(self, value: str) -> str:
         """Sanitize input by encoding dangerous characters"""
+        from security.unicode_surrogate_validator import UnicodeSurrogateValidator
+
+        validator = UnicodeSurrogateValidator()
+        value = validator.sanitize(value)
         value = sanitize_unicode_input(value)
         # HTML entity encoding
         replacements = {

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,22 +1,28 @@
 """Security package exposing validation utilities."""
 
-from core.security import InputValidator
 from typing import Protocol
+
+from core.security import InputValidator
 
 
 class Validator(Protocol):
     def validate(self, data: str) -> str:
         ...
 
-from .dataframe_validator import DataFrameSecurityValidator
-from .sql_validator import SQLInjectionPrevention, SQLSecurityConfig
-from .xss_validator import XSSPrevention
-from .business_logic_validator import BusinessLogicValidator
-from .validation_middleware import ValidationMiddleware, ValidationOrchestrator
-from .attack_detection import AttackDetection
 from core.exceptions import ValidationError
-from .validation_exceptions import SecurityViolation
+
+from .attack_detection import AttackDetection
+from .business_logic_validator import BusinessLogicValidator
+from .dataframe_validator import DataFrameSecurityValidator
 from .secrets_validator import SecretsValidator, register_health_endpoint
+from .sql_validator import SQLInjectionPrevention, SQLSecurityConfig
+from .unicode_surrogate_validator import (
+    SurrogateHandlingConfig,
+    UnicodeSurrogateValidator,
+)
+from .validation_exceptions import SecurityViolation
+from .validation_middleware import ValidationMiddleware, ValidationOrchestrator
+from .xss_validator import XSSPrevention
 
 __all__ = [
     "InputValidator",
@@ -33,4 +39,6 @@ __all__ = [
     "SecurityViolation",
     "SecretsValidator",
     "register_health_endpoint",
+    "UnicodeSurrogateValidator",
+    "SurrogateHandlingConfig",
 ]

--- a/security/unicode_surrogate_validator.py
+++ b/security/unicode_surrogate_validator.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Validator for Unicode surrogate characters."""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from core.exceptions import ValidationError
+from security_callback_controller import SecurityEvent, emit_security_event
+
+
+def contains_surrogates(text: str) -> bool:
+    """Return ``True`` if ``text`` contains any surrogate codepoints."""
+    return any(0xD800 <= ord(ch) <= 0xDFFF for ch in text)
+
+
+@dataclass
+class SurrogateHandlingConfig:
+    """Configuration for :class:`UnicodeSurrogateValidator`."""
+
+    mode: str = "remove"
+    replacement: str = ""
+
+
+class UnicodeSurrogateValidator:
+    """Validate or sanitize text for surrogate characters."""
+
+    def __init__(self, config: SurrogateHandlingConfig | None = None) -> None:
+        self.config = config or SurrogateHandlingConfig()
+        self.logger = logging.getLogger(__name__)
+
+    def sanitize(self, value: Any) -> str:
+        """Return ``value`` with surrogates handled according to configuration."""
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not contains_surrogates(value):
+            return value
+
+        emit_security_event(SecurityEvent.VALIDATION_FAILED, {"issue": "unicode_surrogates"})
+
+        if self.config.mode == "strict":
+            raise ValidationError("Surrogate characters not allowed")
+
+        replacement = self.config.replacement if self.config.mode == "replace" else ""
+        cleaned = "".join(ch if not (0xD800 <= ord(ch) <= 0xDFFF) else replacement for ch in value)
+        return cleaned
+
+
+__all__ = ["UnicodeSurrogateValidator", "SurrogateHandlingConfig", "contains_surrogates"]

--- a/security_callback_controller.py
+++ b/security_callback_controller.py
@@ -1,7 +1,7 @@
 """Compatibility wrapper exposing security-specific callback names."""
 
+from core.callback_controller import CallbackEvent
 from core.callback_manager import CallbackManager
-from core.callback_events import CallbackEvent
 
 SecurityEvent = CallbackEvent
 SecurityCallbackController = CallbackManager

--- a/tests/security/test_surrogate_validator.py
+++ b/tests/security/test_surrogate_validator.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+import types
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "security.unicode_surrogate_validator",
+    "security/unicode_surrogate_validator.py",
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+UnicodeSurrogateValidator = module.UnicodeSurrogateValidator
+SurrogateHandlingConfig = module.SurrogateHandlingConfig
+contains_surrogates = module.contains_surrogates
+from security_callback_controller import SecurityEvent
+
+
+def test_contains_surrogates_detects():
+    assert contains_surrogates("a\ud800b")
+    assert not contains_surrogates("abc")
+
+
+def test_remove_mode(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        module,
+        "emit_security_event",
+        lambda event, data=None: events.append(event),
+    )
+    validator = UnicodeSurrogateValidator()
+    result = validator.sanitize("A\ud800B")
+    assert result == "AB"
+    assert events and events[0] == SecurityEvent.VALIDATION_FAILED
+
+
+def test_replace_mode():
+    cfg = SurrogateHandlingConfig(mode="replace", replacement="?")
+    validator = UnicodeSurrogateValidator(cfg)
+    assert validator.sanitize("x\ud800y") == "x?y"
+
+
+def test_strict_mode():
+    cfg = SurrogateHandlingConfig(mode="strict")
+    validator = UnicodeSurrogateValidator(cfg)
+    with pytest.raises(Exception):
+        validator.sanitize("bad\ud800")


### PR DESCRIPTION
## Summary
- implement `UnicodeSurrogateValidator` to detect surrogate characters
- expose new validator in `security`
- delegate surrogate cleaning in `SecurityValidator`
- fix callback controller import
- add unit tests for surrogate validator

## Testing
- `pre-commit run --files security/unicode_surrogate_validator.py security/__init__.py core/security_validator.py tests/security/test_surrogate_validator.py security_callback_controller.py`
- `PYTHONPATH=. pytest -q tests/security/test_surrogate_validator.py --confcutdir=tests/security`

------
https://chatgpt.com/codex/tasks/task_e_68699074ee288320b1923c712bca5abc