### PR TITLE
Expand unicode sanitization tests

### DIFF
--- a/core/unicode.py
+++ b/core/unicode.py
@@ -263,6 +263,15 @@ def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
     return sanitize_dataframe(df)
 
 
+def contains_surrogates(text: Any) -> bool:
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return False
+    return bool(_SURROGATE_RE.search(text))
+
+
 __all__ = [
     # Preferred helpers
     "clean_unicode_text",
@@ -279,6 +288,7 @@ __all__ = [
     "handle_surrogate_characters",
     "clean_unicode_surrogates",
     "sanitize_unicode_input",
+    "contains_surrogates",
     "sanitize_data_frame",
 ]
 

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -16,6 +16,7 @@ from .validation_middleware import ValidationMiddleware, ValidationOrchestrator
 from .attack_detection import AttackDetection
 from core.exceptions import ValidationError
 from .validation_exceptions import SecurityViolation
+from .unicode_security_validator import UnicodeSecurityValidator
 from .secrets_validator import SecretsValidator, register_health_endpoint
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "AttackDetection",
     "ValidationError",
     "SecurityViolation",
+    "UnicodeSecurityValidator",
     "SecretsValidator",
     "register_health_endpoint",
 ]

--- a/security/unicode_security_validator.py
+++ b/security/unicode_security_validator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .unicode_security_processor import UnicodeSecurityProcessor
+from .validation_exceptions import ValidationError
+from core.unicode_processor import contains_surrogates
+
+
+class UnicodeSecurityValidator:
+    """Validate and sanitize text or DataFrames for surrogate characters."""
+
+    @staticmethod
+    def validate_text(text: Any) -> str:
+        sanitized = UnicodeSecurityProcessor.sanitize_unicode_input(text)
+        if contains_surrogates(sanitized):
+            raise ValidationError("Surrogate characters detected")
+        return sanitized
+
+    @staticmethod
+    def validate_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+        sanitized = UnicodeSecurityProcessor.sanitize_dataframe(df)
+        if sanitized.select_dtypes(include=["object"]).applymap(
+            lambda x: contains_surrogates(str(x))
+        ).any().any():
+            raise ValidationError("Surrogate characters detected")
+        return sanitized
+
+
+__all__ = ["UnicodeSecurityValidator"]


### PR DESCRIPTION
## Summary
- ensure emojis survive sanitization
- validate new `contains_surrogates` helper and `UnicodeSecurityValidator`
- handle nested values when sanitizing DataFrames

## Testing
- `pytest tests/test_unicode_processor.py tests/test_unicode_wrappers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68699076738883209eb7df05ff5f59bd