### PR TITLE
Improve analytics service thread safety

### DIFF
--- a/tests/test_analytics_service_threadsafe.py
+++ b/tests/test_analytics_service_threadsafe.py
@@ -1,0 +1,18 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from services import analytics_service
+
+
+def test_get_analytics_service_threadsafe(monkeypatch):
+    # Reset global instance before test
+    analytics_service._analytics_service = None
+
+    def worker(_: int):
+        return analytics_service.get_analytics_service()
+
+    with ThreadPoolExecutor(max_workers=5) as exc:
+        results = list(exc.map(worker, range(10)))
+
+    first = results[0]
+    for result in results:
+        assert result is first


### PR DESCRIPTION
## Summary
- guard global analytics service instance with a threading lock
- add regression test for concurrent get_analytics_service calls

## Testing
- `flake8 services/analytics_service.py tests/test_analytics_service_threadsafe.py`
- `mypy services/analytics_service.py tests/test_analytics_service_threadsafe.py` *(fails: multiple unrelated type errors)*
- `pytest tests/test_analytics_service_threadsafe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686997be5fe883208c61054d5781b49d