### PR TITLE
Add thread-safe plugin manager

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -2,7 +2,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    from .manager import PluginManager
+    from .manager import ThreadSafePluginManager as PluginManager
     from .auto_config import PluginAutoConfiguration
     PLUGINS_AVAILABLE = True
 except ImportError as e:

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -6,7 +6,7 @@ import logging
 from dash import Dash
 
 from core.callback_manager import CallbackManager
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager
 from services.data_processing.core.protocols import PluginProtocol
 from core.container import Container as DIContainer
 from config.config import ConfigManager
@@ -37,7 +37,9 @@ class UnifiedPluginRegistry:
         from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
         self.coordinator = TrulyUnifiedCallbacks(app)
-        self.plugin_manager = PluginManager(container, config_manager, package=package)
+        self.plugin_manager = ThreadSafePluginManager(
+            container, config_manager, package=package
+        )
         # Register health endpoint immediately
         try:
             self.plugin_manager.register_health_endpoint(app)

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -1,5 +1,5 @@
 import sys
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -20,7 +20,7 @@ from core.json_serialization_plugin import (
     JsonSerializationService,
     JsonCallbackService,
 )
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2,7 +2,7 @@ import sys
 import time
 from pathlib import Path
 
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 from services.data_processing.core.protocols import PluginMetadata

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -3,7 +3,7 @@ import sys
 import types
 from pathlib import Path
 
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 from services.data_processing.core.protocols import PluginStatus, PluginMetadata

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -1,5 +1,5 @@
 import time
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.container import Container as DIContainer
 from config.config import ConfigManager
 

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -1,5 +1,5 @@
 import sys
-from core.plugins.manager import PluginManager
+from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginPriority
 from core.container import Container as DIContainer
 from config.config import ConfigManager

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -1,0 +1,83 @@
+import time
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from core.plugins.manager import ThreadSafePluginManager
+from core.container import Container as DIContainer
+from config.config import ConfigManager
+from services.data_processing.core.protocols import PluginMetadata
+
+
+for var in [
+    "SECRET_KEY",
+    "DB_PASSWORD",
+    "AUTH0_CLIENT_ID",
+    "AUTH0_CLIENT_SECRET",
+    "AUTH0_DOMAIN",
+    "AUTH0_AUDIENCE",
+]:
+    os.environ.setdefault(var, "test")
+
+
+class ConcurrencyPlugin:
+    metadata = PluginMetadata(
+        name="concurrent",
+        version="0.1",
+        description="concurrency test",
+        author="tester",
+    )
+
+    def __init__(self):
+        self.start_count = 0
+
+    def load(self, container, config):
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        self.start_count += 1
+        return True
+
+    def stop(self):
+        return True
+
+    def health_check(self):
+        return {"healthy": True}
+
+
+def test_concurrent_load_plugin():
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["concurrent"] = {"enabled": True}
+    manager = ThreadSafePluginManager(DIContainer(), cfg, health_check_interval=0.1)
+    plugin = ConcurrencyPlugin()
+
+    with ThreadPoolExecutor(max_workers=5) as exe:
+        futures = [exe.submit(manager.load_plugin, plugin) for _ in range(5)]
+        results = [f.result() for f in futures]
+
+    assert results.count(True) == 1
+    assert plugin.start_count == 1
+    manager.stop_health_monitor()
+
+
+def test_concurrent_health_checks():
+    cfg = ConfigManager()
+    cfg.config.plugin_settings["concurrent"] = {"enabled": True}
+    manager = ThreadSafePluginManager(DIContainer(), cfg, health_check_interval=0.1)
+    plugin = ConcurrencyPlugin()
+    manager.load_plugin(plugin)
+
+    time.sleep(0.3)
+
+    with ThreadPoolExecutor(max_workers=5) as exe:
+        futures = [exe.submit(manager.get_plugin_health) for _ in range(10)]
+        results = [f.result() for f in futures]
+
+    for res in results:
+        assert res["concurrent"]["health"]["healthy"] is True
+
+    assert manager.health_snapshot["concurrent"]["health"]["healthy"] is True
+    manager.stop_health_monitor()
+


### PR DESCRIPTION
## Summary
- implement `ThreadSafePluginManager` using a reentrant lock
- use it in `UnifiedPluginRegistry` and expose in package init
- update all tests to reference `ThreadSafePluginManager`
- add concurrency tests for loading and health checks

## Testing
- `pytest tests/test_thread_safe_plugin_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686997b914e48320b8146aa23a6a55d6