### PR TITLE
Improve SSE progress updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ See the [data model diagram](docs/data_model.md) for an overview of key entities
 The running application exposes Swagger-based API docs at `http://<host>:<port>/api/docs`.
 - Performance metrics: [docs/performance_monitoring.md](docs/performance_monitoring.md)
 - Large file processing: [docs/performance_file_processor.md](docs/performance_file_processor.md)
+- Upload progress SSE: `/upload/progress/<task_id>` streams `data: <progress>` events roughly 60 times per second.
 
 Update the spec by running `python tools/generate_openapi.py` which writes `docs/openapi.json` for the UI.
 ## Usage Examples

--- a/assets/upload_progress_sse.js
+++ b/assets/upload_progress_sse.js
@@ -1,5 +1,7 @@
 (function(){
   var source;
+  var lastVal = -1;
+  window.uploadProgressLog = [];
   window.startUploadProgress = function(taskId){
     if(!taskId){return;}
     if(source){source.close();}
@@ -7,9 +9,11 @@
     source = new EventSource('/upload/progress/' + taskId);
     source.onmessage = function(e){
       var val = parseInt(e.data);
-      if(progressBar){
+      window.uploadProgressLog.push(val);
+      if(progressBar && val !== lastVal){
         progressBar.setAttribute('value', val);
         progressBar.textContent = val + '%';
+        lastVal = val;
       }
       if(val >= 100){
         source.close();

--- a/services/progress_events.py
+++ b/services/progress_events.py
@@ -1,35 +1,35 @@
 from __future__ import annotations
-import time
+
+import asyncio
 from typing import Iterator
+
 from flask import Response, stream_with_context
+
 from services.task_queue import get_status
 
 
 class ProgressEventManager:
     """Simple manager streaming task progress via Server-Sent Events."""
 
-    def __init__(self, interval: float = 0.5) -> None:
+    def __init__(self, interval: float = 0.016) -> None:
         self.interval = interval
 
     def generator(self, task_id: str) -> Iterator[str]:
-        """Yield progress values for ``task_id`` until completion."""
-        last = None
+        """Yield SSE formatted progress updates for ``task_id`` until completion."""
         while True:
             status = get_status(task_id)
             progress = int(status.get("progress", 0))
-            if progress != last:
-                yield str(progress)
-                last = progress
+            yield f"data: {progress}\n\n"
             if status.get("done"):
                 break
-            time.sleep(self.interval)
+            asyncio.run(asyncio.sleep(self.interval))
 
     def stream(self, task_id: str) -> Response:
         """Return an SSE ``Response`` streaming progress for ``task_id``."""
-        def _wrap():
-            for value in self.generator(task_id):
-                yield f"data: {value}\n\n"
-        return Response(stream_with_context(_wrap()), mimetype="text/event-stream")
+        return Response(
+            stream_with_context(self.generator(task_id)),
+            mimetype="text/event-stream",
+        )
 
 
 __all__ = ["ProgressEventManager"]

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -1,7 +1,7 @@
-import pandas as pd
 import dash
 import dash_bootstrap_components as dbc
-from dash import html, dcc
+import pandas as pd
+from dash import dcc, html
 
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from pages import file_upload
@@ -24,3 +24,5 @@ def test_upload_progress_sse(dash_duo, tmp_path):
     file_input = dash_duo.find_element("#upload-data input")
     file_input.send_keys(str(csv))
     dash_duo.wait_for_text_to_equal("#upload-progress", "100%", timeout=10)
+    logs = dash_duo.driver.execute_script("return window.uploadProgressLog.length")
+    assert logs and logs > 3

--- a/tests/test_progress_events.py
+++ b/tests/test_progress_events.py
@@ -1,6 +1,7 @@
 import asyncio
+
 from services.progress_events import ProgressEventManager
-from services.task_queue import create_task, clear_task
+from services.task_queue import clear_task, create_task
 
 
 def test_progress_event_generator():
@@ -13,5 +14,5 @@ def test_progress_event_generator():
     tid = create_task(sample())
     events = list(manager.generator(tid))
     clear_task(tid)
-    assert events[0] == "0"
-    assert events[-1] == "100"
+    assert events[0] == "data: 0\n\n"
+    assert events[-1] == "data: 100\n\n"


### PR DESCRIPTION
## Summary
- rework `ProgressEventManager` to stream SSE data every ~16ms using `asyncio.sleep`
- only update the DOM on value change and log events in `upload_progress_sse.js`
- mention `/upload/progress/<task_id>` SSE endpoint in the README
- adjust tests for new SSE format and verify event count

## Testing
- `pre-commit run --files services/progress_events.py assets/upload_progress_sse.js README.md tests/test_progress_events.py tests/integration/test_upload_progress_sse.py`
- `pytest tests/test_progress_events.py`
- `pytest tests/test_progress_events.py tests/integration/test_upload_progress_sse.py` *(fails: AttributeError: 'Cache' object has no attribute 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68699e2dec148320b76793e16bfd2e99