### PR TITLE
Streamlined upload store metadata handling

### DIFF
--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -26,9 +26,15 @@ def get_file_info() -> Dict[str, Dict[str, Any]]:
     """Return metadata for uploaded files."""
     return uploaded_data_store.get_file_info()
 
+
+def load_dataframe(filename: str) -> pd.DataFrame:
+    """Load a single uploaded file on demand."""
+    return uploaded_data_store.load_dataframe(filename)
+
 __all__ = [
     "get_uploaded_data",
     "get_uploaded_filenames",
     "clear_uploaded_data",
     "get_file_info",
+    "load_dataframe",
 ]

--- a/tests/test_memory_efficient_store.py
+++ b/tests/test_memory_efficient_store.py
@@ -9,6 +9,8 @@ def test_memory_cleanup_after_save(tmp_path):
     store.wait_for_pending_saves()
 
     assert store._data_store == {}
+    # ensure no stray DataFrame objects remain referenced
+    assert not any(isinstance(v, pd.DataFrame) for v in store.__dict__.values())
 
     info = store.get_file_info()["sample.csv"]
     assert info["rows"] == 2
@@ -18,6 +20,7 @@ def test_memory_cleanup_after_save(tmp_path):
     assert len(df_loaded) == 2
     # loading the dataframe should not keep it cached
     assert store._data_store == {}
+    assert not any(isinstance(v, pd.DataFrame) for v in store.__dict__.values())
 
     # re-load store from disk
     store2 = UploadedDataStore(storage_dir=tmp_path)


### PR DESCRIPTION
## Summary
- save uploaded DataFrames directly to parquet and drop in-memory cache
- expose `load_dataframe` in `upload_data_service`
- ensure no DataFrame objects linger after saving

## Testing
- `pytest tests/test_memory_efficient_store.py tests/test_upload_store_threading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68699e2fa9048320a4969ce456df8cf0