### PR TITLE
Group upload callbacks and add debounce helper

### DIFF
--- a/core/callback_registry.py
+++ b/core/callback_registry.py
@@ -3,10 +3,31 @@ Centralized Callback Registry for Dash Application
 Manages all callbacks in a modular, organized way
 """
 
-from dash import callback, Input, Output, State, callback_context, clientside_callback
-import dash
-from typing import Dict, List, Callable, Any
+from dash import no_update
+from typing import List, Callable
+from functools import wraps
+import time
 import logging
+
+
+def debounce(wait_ms: int = 300):
+    """Return decorator to suppress rapid callback invocations."""
+
+    def decorator(func: Callable):
+        last_call = 0.0
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            nonlocal last_call
+            now = time.monotonic() * 1000
+            if now - last_call < wait_ms:
+                return no_update
+            last_call = now
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 logger = logging.getLogger(__name__)
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -4,36 +4,23 @@ Complete File Upload Page - Missing piece for consolidation
 Integrates with analytics system
 """
 import logging
-import json
 from datetime import datetime
-import asyncio
 import time
 
 import pandas as pd
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple
 from dash import html, dcc
 from dash.dash import no_update
-from dash._callback_context import callback_context
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from analytics.controllers import UnifiedAnalyticsController
 from core.dash_profile import profile_callback
-import logging
-
-logger = logging.getLogger(__name__)
+from core.callback_registry import debounce
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
-from services.device_learning_service import (
-    DeviceLearningService,
-    get_device_learning_service,
-)
-from services.data_processing.file_processor import (
-    process_uploaded_file,
-    create_file_preview,
-)
-from components.file_preview import create_file_preview_ui
+from services.device_learning_service import get_device_learning_service
 from utils.upload_store import uploaded_data_store as _uploaded_data_store
 from services.upload_data_service import (
     get_uploaded_data as service_get_uploaded_data,
@@ -44,7 +31,6 @@ from services.upload_data_service import (
 from config.dynamic_config import dynamic_config
 
 from components.column_verification import save_verified_mappings
-from services.data_enhancer import get_ai_column_suggestions
 from services.upload import (
     UploadProcessingService,
     AISuggestionService,
@@ -1181,7 +1167,19 @@ def register_callbacks(
     """Instantiate :class:`Callbacks` and register its methods."""
 
     cb = Callbacks()
-    callback_defs = [
+
+    def _register(defs: List[tuple]):
+        for func, outputs, inputs, states, cid, extra in defs:
+            manager.unified_callback(
+                outputs,
+                inputs,
+                states,
+                callback_id=cid,
+                component_name="file_upload",
+                **extra,
+            )(debounce()(profile_callback(cid)(func)))
+
+    upload_callbacks = [
         (
             cb.highlight_upload_area,
             Output("upload-data", "className"),
@@ -1227,6 +1225,9 @@ def register_callbacks(
             "restore_upload_state",
             {"prevent_initial_call": "initial_duplicate", "allow_duplicate": True},
         ),
+    ]
+
+    progress_callbacks = [
         (
             cb.update_progress_bar,
             [
@@ -1256,6 +1257,9 @@ def register_callbacks(
             "finalize_upload_results",
             {"prevent_initial_call": True, "allow_duplicate": True},
         ),
+    ]
+
+    modal_callbacks = [
         (
             cb.handle_modal_dialogs,
             [
@@ -1336,15 +1340,9 @@ def register_callbacks(
         ),
     ]
 
-    for func, outputs, inputs, states, cid, extra in callback_defs:
-        manager.unified_callback(
-            outputs,
-            inputs,
-            states,
-            callback_id=cid,
-            component_name="file_upload",
-            **extra,
-        )(profile_callback(cid)(func))
+    _register(upload_callbacks)
+    _register(progress_callbacks)
+    _register(modal_callbacks)
 
     manager.app.clientside_callback(
         "function(tid){if(window.startUploadProgress){window.startUploadProgress(tid);} return '';}",


### PR DESCRIPTION
## Summary
- add a `debounce` decorator to `core.callback_registry`
- group file upload callbacks into upload, progress, and modal sets
- use the new helper when registering callbacks

## Testing
- `pytest -k upload_progress_sse -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68699e31fcc083209f8359193876a76e