### PR TITLE
Add multi-stage production Dockerfile

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,35 @@
+FROM python:3.11-slim as builder
+WORKDIR /app
+
+# install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# install python dependencies into a virtual env
+COPY requirements.txt .
+RUN python -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
+
+# copy application source
+COPY . .
+
+FROM python:3.11-slim
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+
+# copy virtual env and built artifacts from builder
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app /app
+
+# create non-root user
+RUN groupadd --system app && useradd --system --gid app app
+USER app
+
+ENV YOSAI_ENV=production
+EXPOSE 8050
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 CMD curl -f http://localhost:8050/ || exit 1
+
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "wsgi:server"]


### PR DESCRIPTION
## Summary
- create `Dockerfile.production` with builder and runtime stages
- run app under a non-root user
- include healthcheck and use Gunicorn config

## Testing
- `pytest -k test_ai_device_generator -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*
- `pip install -r requirements.txt --quiet` *(failed: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6869a0d8fc7883208dd54bc0a2356183