### PR TITLE
Add Kubernetes deployment and autoscaler configs

### DIFF
--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yosai-dashboard
+  labels:
+    app: yosai-dashboard
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: yosai-dashboard
+  template:
+    metadata:
+      labels:
+        app: yosai-dashboard
+    spec:
+      containers:
+        - name: yosai-dashboard
+          image: yosai-intel-dashboard:latest
+          ports:
+            - containerPort: 8050
+          env:
+            - name: YOSAI_ENV
+              value: "production"
+            - name: DB_TYPE
+              value: "postgresql"
+            - name: DB_HOST
+              value: "db"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "yosai_intel"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: DB_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: SECRET_KEY
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/production/hpa.yaml
+++ b/k8s/production/hpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: yosai-dashboard-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: yosai-dashboard
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75


### PR DESCRIPTION
## Summary
- add Kubernetes deployment with rolling update strategy
- add HorizontalPodAutoscaler config for CPU and memory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy --strict .` *(fails with type errors)*
- `flake8 .` *(fails: command not found)*
- `isort --check .` *(fails with import order errors)*
- `black --check .` *(fails with formatting errors)*
- `bandit -r .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a0dc8f888320b9c2bf928e84757b