### PR TITLE
Add Prometheus and Logstash configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ switch themes at runtime.
 
 See the [data model diagram](docs/data_model.md) for an overview of key entities.
 The running application exposes Swagger-based API docs at `http://<host>:<port>/api/docs`.
-- Performance metrics: [docs/performance_monitoring.md](docs/performance_monitoring.md)
+- Performance & log monitoring: [docs/performance_monitoring.md](docs/performance_monitoring.md)
 - Large file processing: [docs/performance_file_processor.md](docs/performance_file_processor.md)
 - Upload progress SSE: `/upload/progress/<task_id>` streams `data: <progress>` events roughly 60 times per second.
 

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -12,3 +12,31 @@ summary = get_performance_monitor().get_metrics_summary()
 Snapshots are taken automatically in the background and can be visualized or exported
 for further analysis.
 
+
+## External Metrics Collection
+
+Prometheus and Logstash can aggregate metrics and logs from all containers.
+
+### Prometheus
+
+The sample configuration `monitoring/prometheus.yml` scrapes metrics from the
+application itself, a PostgreSQL exporter and a Redis exporter. Launch it with:
+
+```bash
+docker run -p 9090:9090 \
+  -v $(pwd)/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml \
+  prom/prometheus
+```
+
+### Logstash
+
+`logging/logstash.conf` reads the application, Postgres and Redis logs and can
+forward them to Elasticsearch. Start a Logstash container with:
+
+```bash
+docker run -p 5044:5044 \
+  -v $(pwd)/logging/logstash.conf:/usr/share/logstash/pipeline/logstash.conf \
+  docker.elastic.co/logstash/logstash:8
+```
+
+Adjust the `elasticsearch` output section if you have a different destination.

--- a/logging/logstash.conf
+++ b/logging/logstash.conf
@@ -1,0 +1,29 @@
+input {
+  file {
+    path => "/app/logs/app.log"
+    start_position => "beginning"
+    sincedb_path => "/tmp/logstash-app"
+    type => "app"
+  }
+  file {
+    path => "/var/log/postgresql/*.log"
+    start_position => "beginning"
+    sincedb_path => "/tmp/logstash-postgres"
+    type => "postgres"
+  }
+  file {
+    path => "/var/log/redis/*.log"
+    start_position => "beginning"
+    sincedb_path => "/tmp/logstash-redis"
+    type => "redis"
+  }
+}
+
+output {
+  stdout { codec => rubydebug }
+  # Forward to Elasticsearch if available
+  elasticsearch {
+    hosts => ["elasticsearch:9200"]
+    index => "dashboard-%{type}-%{+YYYY.MM.dd}"
+  }
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: 'app'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['app:8050']
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres:9187']
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis:9121']


### PR DESCRIPTION
## Summary
- add Prometheus scraping config
- add Logstash pipeline config
- document external monitoring setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869a0ddabf8832096f8a40bb49e31be