### PR TITLE
Add production setup utility script

### DIFF
--- a/scripts/production_setup.py
+++ b/scripts/production_setup.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+from config.config import ConfigManager
+from database.connection import create_database_connection
+
+
+def validate_environment() -> ConfigManager:
+    """Validate required environment variables and secrets."""
+    config = ConfigManager()
+    return config
+
+
+def ensure_ssl_certificates(cert_file: str = "localhost+1.pem", key_file: str = "localhost+1-key.pem") -> None:
+    """Ensure SSL certificate files exist."""
+    if not (Path(cert_file).exists() and Path(key_file).exists()):
+        raise FileNotFoundError(
+            f"SSL certificates not found: {cert_file}, {key_file}. "
+            "Generate them using mkcert or update paths."
+        )
+
+
+def setup_schema(sql_path: str = "deployment/database_setup.sql") -> None:
+    """Create database schema using the provided SQL file."""
+    conn = create_database_connection()
+    if not Path(sql_path).exists():
+        raise FileNotFoundError(sql_path)
+    with open(sql_path, "r", encoding="utf-8") as fh:
+        sql = fh.read()
+    for statement in sql.split(";"):
+        stmt = statement.strip()
+        if stmt:
+            conn.execute_command(stmt + ";")
+
+
+def create_performance_settings_table() -> None:
+    """Create the performance_settings table if missing."""
+    conn = create_database_connection()
+    conn.execute_command(
+        """
+        CREATE TABLE IF NOT EXISTS performance_settings (
+            setting_name VARCHAR(50) PRIMARY KEY,
+            value VARCHAR(200) NOT NULL
+        )
+        """
+    )
+
+
+def provision_admin_account(person_id: str = "admin", password_env: str = "ADMIN_PASSWORD") -> None:
+    """Insert an initial admin account into the people table."""
+    password = os.getenv(password_env)
+    if not password:
+        raise ValueError(f"{password_env} environment variable required")
+    conn = create_database_connection()
+    conn.execute_command(
+        """
+        INSERT INTO people (person_id, name, department, clearance_level, access_groups, is_visitor)
+        VALUES (%s, 'Administrator', 'IT', 10, 'admin', false)
+        ON CONFLICT (person_id) DO NOTHING
+        """,
+        (person_id,),
+    )
+
+
+__all__ = [
+    "validate_environment",
+    "ensure_ssl_certificates",
+    "setup_schema",
+    "create_performance_settings_table",
+    "provision_admin_account",
+]
+


### PR DESCRIPTION
## Summary
- add `scripts/production_setup.py` to help deploy a production instance

## Testing
- `python -m py_compile scripts/production_setup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869a0ded5ec83209da77bd69569ace8