### PR TITLE
Add drag drop upload area component

### DIFF
--- a/assets/js/upload-handlers.js
+++ b/assets/js/upload-handlers.js
@@ -1,0 +1,48 @@
+(function(){
+  function byId(id){ return document.getElementById(id); }
+  function setState(area, state){
+    var states = ['idle','hover','dragging','uploading','success','error'];
+    states.forEach(function(s){ area.classList.remove('drag-drop-upload--'+s); });
+    area.classList.add('drag-drop-upload--'+state);
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    var area = byId('drag-drop-upload-area') || byId('drag-drop-upload-area');
+    if(!area){
+      area = document.querySelector('.drag-drop-upload');
+    }
+    if(!area){ return; }
+    var input = area.querySelector('input[type="file"]');
+    var cameraBtn = byId('drag-drop-upload-camera') || area.querySelector('[id$="-camera"]');
+
+    area.addEventListener('dragover', function(e){
+      e.preventDefault();
+      setState(area, 'dragging');
+    });
+    area.addEventListener('dragleave', function(){
+      setState(area, 'hover');
+    });
+    area.addEventListener('drop', function(){
+      setState(area, 'uploading');
+    });
+    area.addEventListener('mouseover', function(){ setState(area, 'hover'); });
+    area.addEventListener('mouseout', function(){ setState(area, 'idle'); });
+    area.addEventListener('touchstart', function(){ setState(area, 'dragging'); });
+    area.addEventListener('touchend', function(){ setState(area, 'idle'); });
+    area.addEventListener('keyup', function(e){
+      if(e.key === 'Enter' || e.key === ' '){
+        if(input){ input.click(); }
+      }
+    });
+    if(input){
+      input.addEventListener('change', function(){ setState(area, 'uploading'); });
+    }
+    if(cameraBtn && input){
+      cameraBtn.addEventListener('click', function(){
+        input.setAttribute('capture', 'environment');
+        input.click();
+        setTimeout(function(){ input.removeAttribute('capture'); }, 1000);
+      });
+    }
+  });
+})();

--- a/components/upload/__init__.py
+++ b/components/upload/__init__.py
@@ -1,0 +1,5 @@
+"""Upload UI components."""
+
+from .drag_drop_upload_area import DragDropUploadArea
+
+__all__ = ["DragDropUploadArea"]

--- a/components/upload/drag_drop_upload_area.py
+++ b/components/upload/drag_drop_upload_area.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Accessible drag and drop upload area component."""
+from __future__ import annotations
+
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+
+def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
+    """Return an accessible drag and drop upload area.
+
+    The component exposes different state classes that can be toggled via
+    JavaScript: ``--idle``, ``--hover``, ``--dragging``, ``--uploading``,
+    ``--success`` and ``--error``.
+    """
+
+    status_id = f"{upload_id}-status"
+    camera_id = f"{upload_id}-camera"
+
+    return html.Div(
+        [
+            dcc.Upload(
+                id=upload_id,
+                className="drag-drop-upload__input",
+                multiple=True,
+                children=html.Div(
+                    [
+                        html.Div(
+                            [
+                                html.I(
+                                    className="fas fa-cloud-upload-alt fa-3x",
+                                    **{"aria-hidden": "true"},
+                                ),
+                                html.Span("Upload icon", className="sr-only"),
+                            ]
+                        ),
+                        html.P(
+                            "Drag and drop files or press Enter to select",
+                            id=f"{upload_id}-label",
+                            className="mb-1",
+                        ),
+                        dbc.Button(
+                            "Use Camera",
+                            id=camera_id,
+                            color="secondary",
+                            size="sm",
+                            className="mt-2",
+                            **{"aria-label": "Use camera to capture"},
+                        ),
+                    ],
+                    className="drag-drop-upload__inner",
+                ),
+            ),
+            html.Div(id=status_id, className="drag-drop-upload__status", role="status"),
+        ],
+        id=f"{upload_id}-area",
+        className="drag-drop-upload drag-drop-upload--idle",
+        tabIndex=0,
+        role="button",
+        **{"aria-describedby": f"{upload_id}-label"},
+    )
+
+
+__all__ = ["DragDropUploadArea"]


### PR DESCRIPTION
## Summary
- add drag & drop upload area component
- expose DragDropUploadArea in new upload package
- add client-side handlers for drag/drop, touch gestures and camera capture

## Testing
- `pre-commit run --files components/upload/drag_drop_upload_area.py components/upload/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869a938949883209a7dbd3503e932a7