### PR TITLE
Add upload interface guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Roadmap](docs/roadmap.md)
 - [Sequence Diagrams](docs/sequence_diagrams.md)
 - [UI Flows](docs/ui_flows.md)
+- [Upload Interface Guide](docs/upload_interface.md)
 - [UI Design Assets](docs/ui_design/README.md)
 - [Validation Overview](docs/validation_overview.md)
 - [Model Cards](docs/model_cards.md)

--- a/docs/analytics_sequence.md
+++ b/docs/analytics_sequence.md
@@ -10,7 +10,7 @@ sequenceDiagram
     participant V as Validator
     participant AS as AnalyticsService
 
-    U->>B: Select file & click upload
+    U->>B: Drag or select file, click Upload
     B->>S: POST /upload
     S->>V: Validate file
     V-->>S: Clean data

--- a/docs/architecture_diagrams.md
+++ b/docs/architecture_diagrams.md
@@ -23,7 +23,7 @@ sequenceDiagram
     participant S as Service layer
     participant DB as Database
 
-    U->>FE: Upload file
+    U->>FE: Drag or select file
     FE->>BE: POST /upload
     BE->>S: Validate and parse
     S->>DB: Store records

--- a/docs/sequence_diagrams.md
+++ b/docs/sequence_diagrams.md
@@ -28,7 +28,7 @@ sequenceDiagram
     participant S as Server
     participant FS as FileStorage
 
-    U->>B: Choose file
+    U->>B: Drag or select file
     B->>S: POST /files
     S->>FS: Save
     FS-->>S: Path

--- a/docs/ui_flows.md
+++ b/docs/ui_flows.md
@@ -12,7 +12,7 @@ sequenceDiagram
     participant S as Server
     participant AS as AnalyticsService
 
-    U->>B: Select file
+    U->>B: Drag or select file
     B->>S: POST /upload
     S->>AS: validate_and_store()
     AS-->>S: confirmation

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -1,0 +1,25 @@
+# Upload Interface Guide
+
+## Drag-and-Drop Usage
+
+The dashboard exposes a simple drag-and-drop area on the **Upload** page. Either drag files onto the drop zone or click the region to open the file dialog. Selected files appear in a queue where you can remove entries prior to starting the upload. Once you press **Upload**, each file is sent to the server and a progress indicator shows completion status.
+
+Supported file types are CSV and JSON. Large files are streamed to avoid exhausting browser memory. You may upload multiple files at once; they will be processed sequentially.
+
+## Configuration Options
+
+### Chunk Size
+
+Large CSV files are processed in chunks. The default chunk size is 50,000 rows and is configured via `dynamic_config.analytics.chunk_size`. You can override it at runtime by setting the environment variable `ANALYTICS_CHUNK_SIZE`.
+
+### Queue Limits
+
+Background tasks such as analytics processing and file saves run in a thread pool. The number of concurrent workers is controlled by `dynamic_config.analytics.max_workers` (default `4`). Adjust the `MAX_WORKERS` environment variable to increase or decrease the processing queue.
+
+## Mobile & Accessibility Guidelines
+
+- The drop zone expands to full width on small screens and falls back to a standard file input when drag events are not supported.
+- Provide an `aria-label` on the drop zone so screen readers announce its purpose.
+- Ensure contrast ratios meet WCAG AA guidelines and that keyboard focus is visible.
+- Touch targets, including the Upload button and remove icons, should be at least 44&times;44&nbsp;px.
+


### PR DESCRIPTION
## Summary
- document drag-and-drop usage and configuration
- update README docs list
- revise upload sequences in diagrams

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `flake8` *(fails: various style errors)*
- `black --check .` *(fails: 114 files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_6869a940401c8320b81dbe170c6b8ca5