### PR TITLE
Implement chunked upload manager

### DIFF
--- a/services/upload/chunked_upload_manager.py
+++ b/services/upload/chunked_upload_manager.py
@@ -1,0 +1,145 @@
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from config.connection_retry import ConnectionRetryManager, RetryConfig
+from utils.upload_store import UploadedDataStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UploadMetadata:
+    """Persistent state for an in-progress upload."""
+
+    filename: str
+    total_rows: int
+    chunk_size: int
+    uploaded_chunks: int = 0
+    uploaded_rows: int = 0
+    completed: bool = False
+
+
+class ChunkedUploadManager:
+    """Manage large file uploads in chunks with resume capability."""
+
+    def __init__(
+        self,
+        store: UploadedDataStore,
+        metadata_dir: Optional[Path | str] = None,
+        *,
+        initial_chunk_size: int = 50000,
+    ) -> None:
+        self.store = store
+        self.metadata_dir = Path(metadata_dir or "temp/upload_metadata")
+        self.metadata_dir.mkdir(parents=True, exist_ok=True)
+        self.initial_chunk_size = initial_chunk_size
+        self.min_chunk_size = 1000
+        self.max_chunk_size = 100_000
+        self.retry_config = RetryConfig(max_attempts=3, base_delay=0.2, jitter=False)
+
+    # ------------------------------------------------------------------
+    def _metadata_path(self, filename: str) -> Path:
+        return self.metadata_dir / f"{Path(filename).name}.json"
+
+    def _load_metadata(self, filename: str) -> Optional[UploadMetadata]:
+        path = self._metadata_path(filename)
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return UploadMetadata(**data)
+        return None
+
+    def _save_metadata(self, meta: UploadMetadata) -> None:
+        path = self._metadata_path(meta.filename)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(asdict(meta), fh, indent=2)
+
+    @staticmethod
+    def _count_rows(path: Path) -> int:
+        with open(path, "rb") as fh:
+            return max(sum(1 for _ in fh) - 1, 0)
+
+    def _adjust_chunk_size(self, size: int, elapsed: float) -> int:
+        if elapsed < 0.5:
+            size = min(size * 2, self.max_chunk_size)
+        elif elapsed > 2:
+            size = max(int(size / 2), self.min_chunk_size)
+        return size
+
+    def _persist_chunk(self, name: str, df: pd.DataFrame) -> None:
+        def _save() -> None:
+            self.store.add_file(name, df)
+
+        ConnectionRetryManager(self.retry_config).run_with_retry(_save)
+
+    # ------------------------------------------------------------------
+    def upload_file(self, file_path: str | Path, *, encoding: str = "utf-8") -> None:
+        """Upload a file in chunks with adaptive sizing."""
+        path = Path(file_path)
+        meta = self._load_metadata(path.name)
+        if meta is None:
+            total_rows = self._count_rows(path)
+            meta = UploadMetadata(
+                filename=path.name,
+                total_rows=total_rows,
+                chunk_size=self.initial_chunk_size,
+            )
+            self._save_metadata(meta)
+        if meta.completed:
+            logger.info("Upload already completed for %s", path.name)
+            return
+
+        chunk_size = meta.chunk_size
+        skip = meta.uploaded_rows
+        reader = pd.read_csv(
+            path,
+            chunksize=chunk_size,
+            encoding=encoding,
+            skiprows=range(1, skip + 1) if skip else None,
+        )
+        idx = meta.uploaded_chunks
+        for chunk in reader:
+            start = time.monotonic()
+            part_name = f"{meta.filename}.part{idx}"
+            self._persist_chunk(part_name, chunk)
+            elapsed = time.monotonic() - start
+            chunk_size = self._adjust_chunk_size(chunk_size, elapsed)
+            meta.uploaded_chunks = idx + 1
+            meta.uploaded_rows += len(chunk)
+            meta.chunk_size = chunk_size
+            self._save_metadata(meta)
+            idx += 1
+        # Finalize upload by concatenating parts
+        parts: list[pd.DataFrame] = []
+        for i in range(meta.uploaded_chunks):
+            part_name = f"{meta.filename}.part{i}"
+            parts.append(self.store.load_dataframe(part_name))
+        full_df = pd.concat(parts, ignore_index=True) if parts else pd.DataFrame()
+        self.store.add_file(meta.filename, full_df)
+        meta.completed = True
+        self._save_metadata(meta)
+
+    def resume_upload(self, file_path: str | Path, *, encoding: str = "utf-8") -> None:
+        """Resume an interrupted upload using stored metadata."""
+        self.upload_file(file_path, encoding=encoding)
+
+    def get_upload_progress(self, filename: str) -> float:
+        """Return upload progress between 0 and 1."""
+        meta = self._load_metadata(filename)
+        if meta is None:
+            return 0.0
+        if meta.completed:
+            return 1.0
+        if meta.total_rows == 0:
+            return 0.0
+        progress = meta.uploaded_rows / meta.total_rows
+        return max(0.0, min(progress, 1.0))
+
+
+__all__ = ["ChunkedUploadManager", "UploadMetadata"]

--- a/tests/test_chunked_upload_manager.py
+++ b/tests/test_chunked_upload_manager.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import pytest
+
+from services.upload.chunked_upload_manager import ChunkedUploadManager
+from utils.upload_store import UploadedDataStore
+
+
+def _create_csv(path, rows=30):
+    df = pd.DataFrame({"a": range(rows)})
+    df.to_csv(path, index=False)
+    return df
+
+
+def test_chunked_upload_manager_basic(tmp_path):
+    data_file = tmp_path / "sample.csv"
+    df = _create_csv(data_file, rows=25)
+    store = UploadedDataStore(storage_dir=tmp_path / "store")
+    mgr = ChunkedUploadManager(
+        store, metadata_dir=tmp_path / "meta", initial_chunk_size=10
+    )
+
+    mgr.upload_file(data_file)
+    store.wait_for_pending_saves()
+
+    assert mgr.get_upload_progress("sample.csv") == pytest.approx(1.0)
+    saved = store.load_dataframe("sample.csv")
+    pd.testing.assert_frame_equal(saved, df)
+
+
+def test_chunked_upload_manager_resume(tmp_path, monkeypatch):
+    data_file = tmp_path / "resume.csv"
+    df = _create_csv(data_file, rows=30)
+    store = UploadedDataStore(storage_dir=tmp_path / "store")
+    mgr = ChunkedUploadManager(
+        store, metadata_dir=tmp_path / "meta", initial_chunk_size=10
+    )
+
+    call_count = 0
+    original_add_file = store.add_file
+
+    def fail_second(name, chunk_df):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise RuntimeError("fail")
+        original_add_file(name, chunk_df)
+
+    monkeypatch.setattr(store, "add_file", fail_second)
+    from config.connection_retry import ConnectionRetryExhausted
+
+    with pytest.raises(ConnectionRetryExhausted):
+        mgr.upload_file(data_file)
+
+    # progress should show first chunk uploaded
+    progress = mgr.get_upload_progress("resume.csv")
+    assert 0 < progress < 1
+
+    monkeypatch.setattr(store, "add_file", original_add_file)
+    mgr.resume_upload(data_file)
+    store.wait_for_pending_saves()
+
+    assert mgr.get_upload_progress("resume.csv") == pytest.approx(1.0)
+    saved = store.load_dataframe("resume.csv")
+    pd.testing.assert_frame_equal(saved, df)


### PR DESCRIPTION
## Summary
- add `ChunkedUploadManager` for resumable chunked uploads
- store progress metadata and implement adaptive chunk sizing
- retry chunk persistence with exponential backoff
- test chunked upload and resume functionality

## Testing
- `pytest tests/test_chunked_upload_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a9377d808320828178d6e7f9e433