### PR TITLE
Implement drag-drop upload area and queue progress

### DIFF
--- a/components/advanced_upload.py
+++ b/components/advanced_upload.py
@@ -1,0 +1,39 @@
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+from services.upload.validators import ClientSideValidator
+
+class DragDropUploadArea:
+    """Simple drag-and-drop upload component with client-side validation."""
+
+    def __init__(self, id: str = "upload-data", *, max_size: int | None = None) -> None:
+        self.id = id
+        self.max_size = max_size
+        self.validator = ClientSideValidator(max_size=max_size)
+
+    def render(self) -> dcc.Upload:
+        return dcc.Upload(
+            id=self.id,
+            max_size=self.max_size,
+            multiple=True,
+            children=html.Div(
+                [
+                    html.Span(
+                        [
+                            html.I(
+                                className="fas fa-cloud-upload-alt fa-4x mb-3 text-primary",
+                                **{"aria-hidden": "true"},
+                            ),
+                            html.Span("Upload icon", className="sr-only"),
+                        ]
+                    ),
+                    html.H5("Drag and Drop or Click to Upload", className="text-primary"),
+                    html.P(
+                        "Supports CSV, Excel (.xlsx, .xls), and JSON files",
+                        className="text-muted mb-0",
+                    ),
+                ]
+            ),
+            className="file-upload-area",
+        )
+
+__all__ = ["DragDropUploadArea"]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -38,6 +38,8 @@ from services.upload import (
     get_trigger_id,
     save_ai_training_data,
 )
+from services.upload import ChunkedUploadManager, UploadQueueManager, ClientSideValidator
+from components.advanced_upload import DragDropUploadArea
 from services.task_queue import create_task, get_status, clear_task
 
 
@@ -61,38 +63,10 @@ def layout():
                                     ),
                                     dbc.CardBody(
                                         [
-                                            dcc.Upload(
+                                            DragDropUploadArea(
                                                 id="upload-data",
-                                                max_size=dynamic_config.get_max_upload_size_bytes(),  # Updated to use new method
-                                                children=html.Div(
-                                                    [
-                                                        html.Span(
-                                                            [
-                                                                html.I(
-                                                                    className="fas fa-cloud-upload-alt fa-4x mb-3 text-primary",
-                                                                    **{
-                                                                        "aria-hidden": "true"
-                                                                    },
-                                                                ),
-                                                                html.Span(
-                                                                    "Upload icon",
-                                                                    className="sr-only",
-                                                                ),
-                                                            ]
-                                                        ),
-                                                        html.H5(
-                                                            "Drag and Drop or Click to Upload",
-                                                            className="text-primary",
-                                                        ),
-                                                        html.P(
-                                                            "Supports CSV, Excel (.xlsx, .xls), and JSON files",
-                                                            className="text-muted mb-0",
-                                                        ),
-                                                    ]
-                                                ),
-                                                className="file-upload-area",
-                                                multiple=True,
-                                            )
+                                                max_size=dynamic_config.get_max_upload_size_bytes(),
+                                            ).render()
                                         ]
                                     ),
                                 ]
@@ -113,7 +87,9 @@ def layout():
                                 label="0%",
                                 striped=True,
                                 animated=True,
-                            )
+                                **{"aria-label": "Overall upload progress"},
+                            ),
+                            html.Ul(id="file-progress-list", className="list-unstyled mt-2")
                         ]
                     )
                 ],
@@ -234,6 +210,9 @@ class Callbacks:
         self.preview_processor = self.processing.async_processor
         self.ai = AISuggestionService()
         self.modal = ModalService()
+        self.chunked = ChunkedUploadManager()
+        self.queue = UploadQueueManager()
+        self.validator = ClientSideValidator(max_size=dynamic_config.get_max_upload_size_bytes())
 
     def highlight_upload_area(self, n_clicks):
         """Highlight upload area when 'upload more' is clicked."""
@@ -315,7 +294,46 @@ class Callbacks:
     async def process_uploaded_files(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
     ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
-        return await self.processing.process_files(contents_list, filenames_list)
+        if not contents_list:
+            return (
+                [],
+                [],
+                {},
+                [],
+                {},
+                no_update,
+                no_update,
+            )
+
+        if not isinstance(contents_list, list):
+            contents_list = [contents_list]
+            filenames_list = [filenames_list]
+
+        valid_contents: list[str] = []
+        valid_filenames: list[str] = []
+        alerts: list[Any] = []
+        for content, fname in zip(contents_list, filenames_list):
+            ok, msg = self.validator.validate(fname, content)
+            if not ok:
+                alerts.append(self.processing.build_failure_alert(msg))
+            else:
+                valid_contents.append(content)
+                valid_filenames.append(fname)
+                self.chunked.start_file(fname)
+                self.queue.add_file(fname)
+
+        if not valid_contents:
+            return alerts, [], {}, [], {}, no_update, no_update
+
+        result = await self.processing.process_files(valid_contents, valid_filenames)
+
+        for fname in valid_filenames:
+            self.chunked.finish_file(fname)
+            self.queue.mark_complete(fname)
+
+        result = list(result)
+        result[0] = alerts + result[0]
+        return tuple(result)
 
     def schedule_upload_task(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
@@ -342,12 +360,25 @@ class Callbacks:
             return 0, "0%", True
         return 0, "0%", False
 
-    def update_progress_bar(self, _n: int, task_id: str) -> Tuple[int, str]:
-        """Update the progress bar based on current task status."""
+    def update_progress_bar(self, _n: int, task_id: str) -> Tuple[int, str, Any]:
+        """Update the progress bar and per-file indicators."""
 
         status = get_status(task_id)
         progress = int(status.get("progress", 0))
-        return progress, f"{progress}%"
+        file_items = [
+            html.Li(
+                dbc.Progress(
+                    value=self.chunked.get_progress(fname),
+                    label=f"{fname} {self.chunked.get_progress(fname)}%",
+                    striped=True,
+                    animated=True,
+                    id={"type": "file-progress", "name": fname},
+                    **{"aria-label": f"Upload progress for {fname}"},
+                )
+            )
+            for fname in self.queue.files
+        ]
+        return progress, f"{progress}%", file_items
 
     def finalize_upload_results(
         self, _n: int, task_id: str
@@ -1235,6 +1266,7 @@ def register_callbacks(
             [
                 Output("upload-progress", "value", allow_duplicate=True),
                 Output("upload-progress", "label", allow_duplicate=True),
+                Output("file-progress-list", "children", allow_duplicate=True),
             ],
             Input("upload-progress-interval", "n_intervals"),
             State("upload-task-id", "data"),

--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -3,6 +3,8 @@ from .async_processor import AsyncUploadProcessor
 from .ai import AISuggestionService, analyze_device_name_with_ai
 from .modal import ModalService
 from .helpers import get_trigger_id, save_ai_training_data
+from .managers import ChunkedUploadManager, UploadQueueManager
+from .validators import ClientSideValidator
 
 __all__ = [
     "AsyncUploadProcessor",
@@ -12,4 +14,7 @@ __all__ = [
     "analyze_device_name_with_ai",
     "get_trigger_id",
     "save_ai_training_data",
+    "ChunkedUploadManager",
+    "UploadQueueManager",
+    "ClientSideValidator",
 ]

--- a/services/upload/managers.py
+++ b/services/upload/managers.py
@@ -1,0 +1,41 @@
+class ChunkedUploadManager:
+    """Track progress for chunked file uploads."""
+
+    def __init__(self) -> None:
+        self._progress = {}
+
+    def start_file(self, filename: str) -> None:
+        self._progress[filename] = 0
+
+    def update_file(self, filename: str, pct: int) -> None:
+        self._progress[filename] = max(0, min(100, int(pct)))
+
+    def finish_file(self, filename: str) -> None:
+        self._progress[filename] = 100
+
+    def get_progress(self, filename: str) -> int:
+        return int(self._progress.get(filename, 0))
+
+
+class UploadQueueManager:
+    """Manage queue of uploads and overall progress."""
+
+    def __init__(self) -> None:
+        self.files: list[str] = []
+        self.completed: set[str] = set()
+
+    def add_file(self, filename: str) -> None:
+        if filename not in self.files:
+            self.files.append(filename)
+
+    def mark_complete(self, filename: str) -> None:
+        self.completed.add(filename)
+
+    def overall_progress(self) -> int:
+        total = len(self.files)
+        if total == 0:
+            return 0
+        pct = int(len(self.completed) / total * 100)
+        return max(0, min(100, pct))
+
+__all__ = ["ChunkedUploadManager", "UploadQueueManager"]

--- a/services/upload/validators.py
+++ b/services/upload/validators.py
@@ -1,0 +1,26 @@
+import base64
+from typing import Iterable
+
+
+class ClientSideValidator:
+    """Validate uploaded file name and size before processing."""
+
+    def __init__(self, allowed_ext: Iterable[str] | None = None, max_size: int | None = None) -> None:
+        self.allowed_ext = {e.lower() for e in (allowed_ext or [".csv", ".xlsx", ".xls", ".json"])}
+        self.max_size = max_size
+
+    def validate(self, filename: str, content: str) -> tuple[bool, str]:
+        ext_ok = any(filename.lower().endswith(ext) for ext in self.allowed_ext)
+        if not ext_ok:
+            return False, f"Unsupported file type: {filename}"
+        if self.max_size is not None:
+            try:
+                data = content.split(',', 1)[1]
+                size = len(base64.b64decode(data))
+                if size > self.max_size:
+                    return False, f"{filename} exceeds maximum size"
+            except Exception:
+                return False, "Failed to decode uploaded content"
+        return True, ""
+
+__all__ = ["ClientSideValidator"]


### PR DESCRIPTION
## Summary
- add `DragDropUploadArea` component
- expose new upload managers and validator
- validate uploads and display progress per file
- show accessible progress markup on upload page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869a93d573483209a2c2cb97faa35f7