### PR TITLE
Fix production SECRET_KEY validation and staging CORS defaults

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -18,6 +18,14 @@ from core.exceptions import ConfigurationError
 logger = logging.getLogger(__name__)
 
 
+def _validate_production_secrets() -> None:
+    """Ensure required secrets are set when running in production."""
+    if os.getenv("YOSAI_ENV") == "production":
+        secret = os.getenv("SECRET_KEY")
+        if not secret:
+            raise ConfigurationError("SECRET_KEY required in production")
+
+
 @dataclass
 class AppConfig:
     """Application configuration"""
@@ -157,6 +165,7 @@ class ConfigManager:
     def _load_config(self) -> None:
         """Load configuration from YAML file and environment"""
         self.config.environment = get_environment()
+        _validate_production_secrets()
         # Load from YAML file
         yaml_config = self._load_yaml_config()
 

--- a/core/plugins/config/production.yaml
+++ b/core/plugins/config/production.yaml
@@ -106,7 +106,7 @@ security:
   max_file_size_mb: 100
   cors_enabled: true
   cors_origins:
-    - ${FRONTEND_URL:https://staging-dashboard.yourdomain.com}
+    - ${FRONTEND_URL:https://dashboard.yourdomain.com}
   rate_limiting_enabled: true
   rate_limit_per_minute: 200
 

--- a/core/plugins/config/staging.yaml
+++ b/core/plugins/config/staging.yaml
@@ -78,8 +78,8 @@ security:
   # CORS Configuration
   cors_enabled: ${CORS_ENABLED:true}
   cors_origins:
-    - ${FRONTEND_URL:https://staging-dashboard.yourdomain.com}
-    - ${ADDITIONAL_CORS_ORIGIN:https://staging-admin.yourdomain.com}
+    - ${FRONTEND_URL}
+    - ${ADDITIONAL_CORS_ORIGIN}
   cors_methods:
     - GET
     - POST


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY presence when YOSAI_ENV=production
- remove hardcoded staging URL defaults in plugin config
- correct production plugin CORS default

## Testing
- `pip install --quiet -r requirements.txt`
- `pip install --quiet -r requirements-dev.txt`
- `pytest -k config_production_secrets -q` *(fails: numpy dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_6869ac441500832084c2179d3bdde371