### PR TITLE
Add provider protocols

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -1,0 +1,38 @@
+# core/interfaces.py
+"""Protocol definitions for configuration and analytics providers."""
+
+from typing import Protocol, Any, Dict
+from abc import abstractmethod
+
+
+class ConfigurationProviderProtocol(Protocol):
+    """Provide configuration sections for various subsystems."""
+
+    @abstractmethod
+    def get_analytics_config(self) -> Dict[str, Any]:
+        """Return analytics configuration section."""
+        ...
+
+    @abstractmethod
+    def get_database_config(self) -> Dict[str, Any]:
+        """Return database configuration section."""
+        ...
+
+    @abstractmethod
+    def get_security_config(self) -> Dict[str, Any]:
+        """Return security configuration section."""
+        ...
+
+
+class AnalyticsProviderProtocol(Protocol):
+    """Perform analytics operations and retrieve metrics."""
+
+    @abstractmethod
+    def process_data(self, data: Any) -> Any:
+        """Process raw analytics data and return a result."""
+        ...
+
+    @abstractmethod
+    def get_metrics(self) -> Dict[str, Any]:
+        """Return computed analytics metrics."""
+        ...


### PR DESCRIPTION
## Summary
- add protocols for configuration and analytics providers

## Testing
- `flake8 core/interfaces.py`
- `black core/interfaces.py --line-length 88`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa9248488320bfd5904c24ebf4c7