### PR TITLE
Implement ConfigProviderProtocol

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -9,6 +9,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List
 
+from core.protocols import ConfigProviderProtocol
+
 from .dynamic_config import dynamic_config
 from .environment import get_environment, select_config_file
 from .config_validator import ConfigValidator
@@ -145,7 +147,7 @@ class Config:
     plugin_settings: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
 
-class ConfigManager:
+class ConfigManager(ConfigProviderProtocol):
     """Simple configuration manager"""
 
     def __init__(self, config_path: Optional[str] = None):

--- a/core/protocols.py
+++ b/core/protocols.py
@@ -111,3 +111,22 @@ class CallbackProtocol(Protocol):
     def validate_callback_output(self, output: Any) -> Any:
         """Validate and sanitize callback output"""
         ...
+
+
+class ConfigProviderProtocol(Protocol):
+    """Protocol for objects that supply configuration sections."""
+
+    @abstractmethod
+    def get_analytics_config(self) -> Dict[str, Any]:
+        """Return analytics configuration."""
+        ...
+
+    @abstractmethod
+    def get_database_config(self) -> Dict[str, Any]:
+        """Return database configuration."""
+        ...
+
+    @abstractmethod
+    def get_security_config(self) -> Dict[str, Any]:
+        """Return security configuration."""
+        ...


### PR DESCRIPTION
## Summary
- add `ConfigProviderProtocol` to `core/protocols`
- implement the protocol in `ConfigManager`

## Testing
- `python -m py_compile core/protocols.py config/config.py`
- `pytest -k "plugin_manager" -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa9351888320921e2cfeebeaa9ab