### PR TITLE
Update docs for container usage

### DIFF
--- a/docs/analytics_service.md
+++ b/docs/analytics_service.md
@@ -46,3 +46,21 @@ parameter. The yielded chunks are passed to `_aggregate_counts` to update user
 and door statistics.  The final dictionary is assembled by `_build_result`.
 This incremental approach prevents excessive memory usage when processing very
 large CSV uploads.
+
+## Using the DI Container
+
+The analytics service can be registered with `core.container` so other modules
+resolve it without direct imports:
+
+```python
+from core.container import Container
+from services.analytics_service import create_analytics_service
+
+container = Container()
+container.register("analytics", create_analytics_service())
+
+analytics = container.get("analytics")
+```
+
+`AnalyticsService` implements `AnalyticsServiceProtocol`, allowing alternative
+implementations for testing or future extensions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,3 +27,25 @@ generation while controllers manage UI callbacks.
 Developers still using the legacy `DataLoader` or `DataLoadingService` should
 migrate to `services.data_processing.processor.Processor` and update imports
 accordingly.
+
+## Service Lookup
+
+Common services like configuration and analytics are obtained from the DI
+container. Register them during application startup and retrieve them where
+needed:
+
+```python
+from core.container import Container
+from config.config import ConfigManager
+from services.analytics_service import create_analytics_service
+
+container = Container()
+container.register("config", ConfigManager())
+container.register("analytics", create_analytics_service())
+
+config_manager = container.get("config")  # ConfigurationProtocol
+analytics_service = container.get("analytics")  # AnalyticsServiceProtocol
+```
+
+Both services implement protocols so alternative implementations can be swapped
+in for tests or future extensions.


### PR DESCRIPTION
## Summary
- document container-based configuration lookup
- explain analytics service via `core.container`
- note protocols allow alternate implementations
- clean up old `config_manager.py` references

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa98fe148320b7d364a0f580babf