### PR TITLE
Add DI container tests

### DIFF
--- a/di_tests/test_container_core.py
+++ b/di_tests/test_container_core.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("container", ROOT / "core" / "container.py")
+module = importlib.util.module_from_spec(spec)
+sys.modules["container"] = module
+spec.loader.exec_module(module)  # type: ignore
+Container = module.Container
+
+
+def test_container_initialization():
+    container = Container()
+    assert isinstance(container._services, dict)
+    assert container._services == {}
+
+
+def test_service_registration_and_retrieval():
+    container = Container()
+    service = Mock()
+    container.register("svc", service)
+
+    assert container.has("svc") is True
+    assert container.get("svc") is service
+
+
+def test_get_missing_service_returns_none():
+    container = Container()
+    assert container.get("missing") is None
+    assert container.has("missing") is False

--- a/di_tests/test_di_container_integration.py
+++ b/di_tests/test_di_container_integration.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("container", ROOT / "core" / "container.py")
+container_module = importlib.util.module_from_spec(spec)
+sys.modules["container"] = container_module
+spec.loader.exec_module(container_module)  # type: ignore
+Container = container_module.Container
+
+sys.path.append(str(ROOT))
+
+sys.modules.setdefault("pandas", SimpleNamespace(DataFrame=object))
+
+from config.config import ConfigManager
+from services.analytics_service import AnalyticsService
+
+
+def test_container_initializes_without_circular_dependencies():
+    for var in [
+        "SECRET_KEY",
+        "DB_PASSWORD",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_CLIENT_SECRET",
+        "AUTH0_DOMAIN",
+        "AUTH0_AUDIENCE",
+    ]:
+        os.environ.setdefault(var, "test")
+    container = Container()
+    cfg = ConfigManager()
+    analytics = AnalyticsService()
+
+    container.register("config", cfg)
+    container.register("analytics", analytics)
+
+    assert container.get("config") is cfg
+    assert container.get("analytics") is analytics

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [tool:pytest]
-testpaths = tests
+testpaths = tests di_tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary
- add unit tests for simple service container
- add integration test ensuring ConfigManager and AnalyticsService work in DI container
- include new test folder in pytest configuration

## Testing
- `pytest di_tests/test_container_core.py di_tests/test_di_container_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869aa9a306883208be0b766dde6d295