### PR TITLE
Add max_display_rows config option

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -14,6 +14,7 @@ try:
     from config.dynamic_config import dynamic_config
 except Exception:  # pragma: no cover - optional config
     dynamic_config = None
+from services.analytics_service import MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +273,8 @@ def create_data_preview(df: pd.DataFrame, filename: str = "") -> html.Div:
         return dbc.Alert("No data to preview", color="info")
 
     # Clamp to avoid huge previews
-    df = df.head(99)
+    df_limited = df.head(MAX_DISPLAY_ROWS) if len(df) > MAX_DISPLAY_ROWS else df
+    df = df_limited.head(99)
     num_rows, num_cols = df.shape
 
     return dbc.Card(
@@ -295,7 +297,7 @@ def create_data_preview(df: pd.DataFrame, filename: str = "") -> html.Div:
                     # Data preview table
                     html.H6("Sample Data:", className="mt-3"),
                     dbc.Table.from_dataframe(
-                        df.head(5),
+                        df_limited.head(5),
                         striped=True,
                         bordered=True,
                         hover=True,

--- a/config/config.py
+++ b/config/config.py
@@ -93,6 +93,7 @@ class AnalyticsConfig:
     data_retention_days: int = 30
     query_timeout_seconds: int = 600
     force_full_dataset_analysis: bool = True
+    max_display_rows: int = 10000
 
 
 @dataclass

--- a/config/constants.py
+++ b/config/constants.py
@@ -116,6 +116,7 @@ class AnalyticsConstants:
     data_retention_days: int = 30
     max_workers: int = 4
     query_timeout_seconds: int = 300
+    max_display_rows: int = 10000
 
 
 @dataclass

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -60,6 +60,7 @@ analytics:
   data_retention_days: ${DATA_RETENTION_DAYS:365}
   query_timeout_seconds: ${QUERY_TIMEOUT_SECONDS:600}
   force_full_dataset_analysis: ${FORCE_FULL_DATASET:true}
+  max_display_rows: ${MAX_DISPLAY_ROWS:10000}
 
 monitoring:
   health_check_enabled: true

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -47,6 +47,7 @@ analytics:
   data_retention_days: 30
   query_timeout_seconds: 600
   force_full_dataset_analysis: true
+  max_display_rows: 10000
 
 monitoring:
   health_check_interval: 30

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -28,6 +28,7 @@ analytics:
   chunk_size: 50000
   force_full_dataset_analysis: true
   query_timeout_seconds: 300
+  max_display_rows: 10000
 
 monitoring:
   health_check_interval: 30

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -39,6 +39,10 @@ ensure_analytics_config()
 
 logger = logging.getLogger(__name__)
 
+from config.dynamic_config import dynamic_config
+
+MAX_DISPLAY_ROWS = dynamic_config.analytics.max_display_rows
+
 
 class AnalyticsService:
     """Complete analytics service that integrates all data sources"""

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -14,6 +14,7 @@ from pathlib import Path
 # Core processing imports only - NO UI COMPONENTS
 from security.unicode_security_processor import sanitize_unicode_input
 from core.unicode_processor import safe_format_number
+from services.analytics_service import MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,8 @@ def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 def create_file_preview(df: pd.DataFrame, max_rows: int = 10) -> Dict[str, Any]:
     """Create safe preview data without UI components"""
     try:
-        preview_df = df.head(max_rows)
+        df_limited = df.head(MAX_DISPLAY_ROWS) if len(df) > MAX_DISPLAY_ROWS else df
+        preview_df = df_limited.head(max_rows)
         # Ensure all data is JSON serializable and Unicode-safe
         preview_data = []
         for _, row in preview_df.iterrows():

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from services.analytics_service import MAX_DISPLAY_ROWS
 
 from services.data_processing.file_processor import UnicodeFileProcessor
 
@@ -32,7 +33,8 @@ class AsyncUploadProcessor:
     async def preview_from_parquet(self, path: str | Path, *, rows: int = 10) -> pd.DataFrame:
         """Return the first ``rows`` of a parquet file asynchronously."""
         df = await self.read_parquet(path)
-        return df.head(rows)
+        df_limited = df.head(MAX_DISPLAY_ROWS) if len(df) > MAX_DISPLAY_ROWS else df
+        return df_limited.head(rows)
 
 
 __all__ = ["AsyncUploadProcessor"]

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from config.config import ConfigManager
+from config.dynamic_config import dynamic_config
+from services.data_processing.file_processor import create_file_preview
+from services.analytics_service import MAX_DISPLAY_ROWS
+
+
+def test_dynamic_config_default_display_rows():
+    assert dynamic_config.analytics.max_display_rows == 10000
+
+
+def test_config_manager_loads_max_display_rows(tmp_path, monkeypatch):
+    yaml = """
+app:
+  title: Test
+database:
+  name: test.db
+security:
+  secret_key: test
+analytics:
+  max_display_rows: 123
+"""
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml)
+    envs = {
+        "SECRET_KEY": "x",
+        "DB_PASSWORD": "x",
+        "AUTH0_CLIENT_ID": "x",
+        "AUTH0_CLIENT_SECRET": "x",
+        "AUTH0_DOMAIN": "x",
+        "AUTH0_AUDIENCE": "x",
+    }
+    for k, v in envs.items():
+        monkeypatch.setenv(k, v)
+    cfg = ConfigManager(str(path))
+    assert cfg.get_analytics_config().max_display_rows == 123
+
+
+def test_create_file_preview_respects_limit():
+    df = pd.DataFrame({"a": range(MAX_DISPLAY_ROWS + 50)})
+    preview = create_file_preview(df, max_rows=MAX_DISPLAY_ROWS + 20)
+    assert len(preview["preview_data"]) == MAX_DISPLAY_ROWS

--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -4,6 +4,7 @@ from typing import Any, List, Dict
 import pandas as pd
 
 from security.unicode_security_processor import sanitize_unicode_input
+from services.analytics_service import MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,8 @@ def serialize_dataframe_preview(df: pd.DataFrame) -> List[Dict[str, Any]]:
     returned.
     """
     try:
-        limited_df = df.head(99)  # clamp DataFrame to <100 rows
+        df_limited = df.head(MAX_DISPLAY_ROWS) if len(df) > MAX_DISPLAY_ROWS else df
+        limited_df = df_limited.head(99)  # clamp DataFrame to <100 rows
         preview = limited_df.head(5).to_dict("records")
         preview = [
             {k: sanitize_unicode_input(v) for k, v in row.items()}


### PR DESCRIPTION
## Summary
- support configurable display row limit
- apply MAX_DISPLAY_ROWS across preview helpers
- expose new config via `AnalyticsConfig`
- test the display row configuration logic

## Testing
- `pytest -q tests/test_max_display_rows.py`

------
https://chatgpt.com/codex/tasks/task_e_6869ac4e5e3c83208c8fcd5100d36469