### PR TITLE
Add memory usage safeguards

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -3,17 +3,19 @@
 Simplified Configuration System
 Replaces: config/yaml_config.py, config/unified_config.py, config/validator.py
 """
-import os
-import yaml
 import logging
+import os
 from dataclasses import dataclass, field
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, List, Optional
 
+import yaml
+
+from core.exceptions import ConfigurationError
+from core.secrets_validator import SecretsValidator
+
+from .config_validator import ConfigValidator
 from .dynamic_config import dynamic_config
 from .environment import get_environment, select_config_file
-from .config_validator import ConfigValidator
-from core.secrets_validator import SecretsValidator
-from core.exceptions import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +95,7 @@ class AnalyticsConfig:
     data_retention_days: int = 30
     query_timeout_seconds: int = 600
     force_full_dataset_analysis: bool = True
+    max_memory_mb: int = 1024
 
 
 @dataclass

--- a/config/constants.py
+++ b/config/constants.py
@@ -116,6 +116,7 @@ class AnalyticsConstants:
     data_retention_days: int = 30
     max_workers: int = 4
     query_timeout_seconds: int = 300
+    max_memory_mb: int = 1024
 
 
 @dataclass

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,15 +1,15 @@
-import os
 import logging
-from typing import Dict, Any
+import os
+from typing import Any, Dict
 
-from .environment import select_config_file
 from .constants import (
-    SecurityConstants,
-    PerformanceConstants,
-    CSSConstants,
     AnalyticsConstants,
+    CSSConstants,
+    PerformanceConstants,
+    SecurityConstants,
     UploadLimits,
 )
+from .environment import select_config_file
 
 
 class DynamicConfigManager:
@@ -122,6 +122,10 @@ class DynamicConfigManager:
         if batch_size is not None:
             self.analytics.batch_size = int(batch_size)
 
+        max_memory = os.getenv("ANALYTICS_MAX_MEMORY_MB")
+        if max_memory is not None:
+            self.analytics.max_memory_mb = int(max_memory)
+
         upload_chunk = os.getenv("UPLOAD_CHUNK_SIZE")
         if upload_chunk is not None:
             self.uploads.DEFAULT_CHUNK_SIZE = int(upload_chunk)
@@ -195,8 +199,9 @@ dynamic_config = DynamicConfigManager()
 
 def diagnose_upload_config():
     """Diagnostic function to check upload configuration"""
-    from config.dynamic_config import dynamic_config
     import os
+
+    from config.dynamic_config import dynamic_config
 
     print("=== Upload Configuration Diagnosis ===")
     print(f"Environment MAX_UPLOAD_MB: {os.getenv('MAX_UPLOAD_MB', 'Not Set')}")

--- a/services/data_processing/no_limit_processor.py
+++ b/services/data_processing/no_limit_processor.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Iterable
+from typing import Iterable, List
 
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
+from utils.memory_utils import check_memory_limit
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class UnlimitedFileProcessor:
 
     def __init__(self, chunk_size: int | None = None) -> None:
         self.chunk_size = chunk_size or dynamic_config.analytics.chunk_size
+        self.max_memory_mb = dynamic_config.analytics.max_memory_mb
 
     def read_csv_chunks(
         self, file_path: str | Path, encoding: str = "utf-8"
@@ -28,6 +30,7 @@ class UnlimitedFileProcessor:
         rows = 0
         for chunk in pd.read_csv(path, chunksize=self.chunk_size, encoding=encoding):
             rows += len(chunk)
+            check_memory_limit(self.max_memory_mb, logger)
             logger.debug("Processed %s rows from %s", rows, path.name)
             yield chunk
         logger.info("Finished processing %s rows from %s", rows, path.name)

--- a/tests/test_memory_abort.py
+++ b/tests/test_memory_abort.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+
+from core.performance_file_processor import PerformanceFileProcessor
+
+
+class FakeProcess:
+    def __init__(self, rss_values):
+        self._rss = rss_values
+        self.calls = 0
+
+    def memory_info(self):
+        class Mem:
+            def __init__(self, rss):
+                self.rss = rss
+        rss = self._rss[min(self.calls, len(self._rss) - 1)]
+        self.calls += 1
+        return Mem(rss)
+
+def test_abort_on_memory_limit(monkeypatch, tmp_path):
+    df = pd.DataFrame({'a': range(10)})
+    path = tmp_path / 'data.csv'
+    df.to_csv(path, index=False)
+
+    fake_proc = FakeProcess([10 * 1024 * 1024, 200 * 1024 * 1024])
+    monkeypatch.setattr('core.performance_file_processor.psutil.Process', lambda: fake_proc)
+
+    processor = PerformanceFileProcessor(chunk_size=5, max_memory_mb=50)
+    with pytest.raises(MemoryError):
+        processor.process_large_csv(path)

--- a/utils/memory_utils.py
+++ b/utils/memory_utils.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Utility helpers for monitoring process memory usage."""
+
+import logging
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - optional dependency
+    psutil = None  # type: ignore
+
+
+def check_memory_limit(max_mb: int, logger: logging.Logger) -> None:
+    """Raise ``MemoryError`` if RSS memory exceeds ``max_mb``."""
+    if not psutil:
+        return
+    mem_mb = psutil.Process().memory_info().rss / (1024 * 1024)
+    if mem_mb > max_mb:
+        logger.error(
+            "Memory usage %.1f MB exceeds limit %s MB", mem_mb, max_mb
+        )
+        raise MemoryError(
+            f"Memory usage {mem_mb:.1f} MB exceeds limit {max_mb} MB"
+        )


### PR DESCRIPTION
## Summary
- cap memory usage via `max_memory_mb` in analytics config
- enforce limit in performance file processors
- expose helper `check_memory_limit`
- test aborting when memory limit is exceeded

## Testing
- `pre-commit run --files config/constants.py config/config.py config/dynamic_config.py core/performance_file_processor.py services/data_processing/async_file_processor.py services/data_processing/no_limit_processor.py utils/memory_utils.py tests/test_memory_abort.py`
- `pytest tests/test_memory_abort.py -q`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869ac50e184832091f0fe186bd1e2e6