### PR TITLE
Add Unicode normalization to security processor

### DIFF
--- a/security/unicode_security_processor.py
+++ b/security/unicode_security_processor.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import unicodedata
 from typing import Any
 
 import pandas as pd
 
 from core.unicode_processor import UnicodeProcessor
+
+logger = logging.getLogger(__name__)
 
 
 class UnicodeSecurityProcessor:
@@ -14,8 +18,32 @@ class UnicodeSecurityProcessor:
 
     @staticmethod
     def sanitize_unicode_input(text: Any) -> str:
-        """Return ``text`` with unsafe characters removed."""
-        return UnicodeProcessor.safe_encode_text(text)
+        """Return ``text`` normalized and stripped of surrogate codepoints."""
+
+        if not isinstance(text, str):
+            try:
+                text = str(text)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to convert %r to str: %s", text, exc)
+                return ""
+
+        try:
+            sanitized = UnicodeProcessor.sanitize_unicode_input(text)
+            return unicodedata.normalize("NFKC", sanitized)
+        except UnicodeError as exc:
+            logger.warning("Unicode sanitization failed: %s", exc)
+            cleaned = UnicodeProcessor.clean_surrogate_chars(text)
+            try:
+                cleaned = UnicodeProcessor.sanitize_unicode_input(cleaned)
+                return unicodedata.normalize("NFKC", cleaned)
+            except Exception as inner:
+                logger.error("Normalization retry failed: %s", inner)
+                return cleaned
+        except Exception as exc:  # pragma: no cover - extreme defensive
+            logger.error("sanitize_unicode_input failed: %s", exc)
+            return "".join(
+                ch for ch in str(text) if not (0xD800 <= ord(ch) <= 0xDFFF)
+            )
 
     @staticmethod
     def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/security/test_unicode_security_processor.py
+++ b/tests/security/test_unicode_security_processor.py
@@ -1,0 +1,17 @@
+from security.unicode_security_processor import UnicodeSecurityProcessor
+
+
+def test_sanitize_unicode_removes_surrogates_and_normalizes():
+    text = "test" + "\ud83d\ude00"  # 😀 surrogate pair
+    result = UnicodeSecurityProcessor.sanitize_unicode_input(text)
+    assert result == "test"  # emoji removed
+
+    # normalization example - fullwidth digits
+    fullwidth = "１２３"
+    assert UnicodeSecurityProcessor.sanitize_unicode_input(fullwidth) == "123"
+
+
+def test_sanitize_unicode_handles_unpaired_surrogate():
+    text = "bad" + "\ud800"
+    result = UnicodeSecurityProcessor.sanitize_unicode_input(text)
+    assert result == "bad"

--- a/tests/stubs/flask_caching/__init__.py
+++ b/tests/stubs/flask_caching/__init__.py
@@ -1,0 +1,13 @@
+class Cache:
+    def __init__(self, config=None):
+        self.config = config or {}
+
+    def __getattr__(self, name):
+        def decorator(*args, **kwargs):
+            if name in {"memoize", "cached"}:
+                def wrapper(fn):
+                    return fn
+                return wrapper
+            return lambda *a, **kw: None
+
+        return decorator


### PR DESCRIPTION
## Summary
- normalize text after removing surrogates in `UnicodeSecurityProcessor`
- add stub for `flask_caching` used in tests
- test surrogate handling and normalization

## Testing
- `pre-commit run --files security/unicode_security_processor.py tests/security/test_unicode_security_processor.py tests/stubs/flask_caching/__init__.py`
- `pytest tests/security/test_unicode_security_processor.py` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad37795083208ee68a3be317dfd4