### PR TITLE
Add chunked streaming with memory monitoring

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -87,6 +87,7 @@ class PerformanceConstants:
 
     db_pool_size: int = 10
     ai_confidence_threshold: int = 75
+    memory_usage_threshold_mb: int = 1024
 
 
 @dataclass

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -98,6 +98,10 @@ class DynamicConfigManager:
         if ai_threshold is not None:
             self.performance.ai_confidence_threshold = int(ai_threshold)
 
+        mem_thresh = os.getenv("MEMORY_THRESHOLD_MB")
+        if mem_thresh is not None:
+            self.performance.memory_usage_threshold_mb = int(mem_thresh)
+
         css_threshold = os.getenv("CSS_BUNDLE_THRESHOLD")
         if css_threshold is not None:
             self.css.bundle_threshold_kb = int(css_threshold)

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -66,6 +66,7 @@ monitoring:
   metrics_enabled: true
   health_check_interval: ${HEALTH_CHECK_INTERVAL:30}
   performance_monitoring: ${ENABLE_PERFORMANCE_MONITORING:true}
+  memory_threshold_mb: ${MEMORY_THRESHOLD_MB:1024}
   error_reporting_enabled: ${ENABLE_ERROR_REPORTING:true}
   sentry_dsn: ${SENTRY_DSN}
   log_retention_days: ${LOG_RETENTION_DAYS:90}

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -8,6 +8,8 @@ import pandas as pd
 import json
 import io
 import chardet
+from config.dynamic_config import dynamic_config
+from core.performance import get_performance_monitor
 from typing import Optional, Dict, Any, List, Tuple, Union
 from pathlib import Path
 
@@ -63,9 +65,17 @@ def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
         # Safe Unicode processing
         text_content = UnicodeFileProcessor.safe_decode_content(decoded)
 
+        chunk_size = getattr(dynamic_config.analytics, "chunk_size", 50000)
+        monitor = get_performance_monitor()
+
         # Process based on file type
         if filename.endswith('.csv'):
-            df = pd.read_csv(io.StringIO(text_content))
+            reader = pd.read_csv(io.StringIO(text_content), chunksize=chunk_size)
+            chunks = []
+            for chunk in reader:
+                monitor.throttle_if_needed()
+                chunks.append(chunk)
+            df = pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
         elif filename.endswith(('.xlsx', '.xls')):
             df = pd.read_excel(io.BytesIO(decoded))
         else:

--- a/services/data_processing/no_limit_processor.py
+++ b/services/data_processing/no_limit_processor.py
@@ -10,6 +10,7 @@ from typing import List, Iterable
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
+from core.performance import get_performance_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,9 @@ class UnlimitedFileProcessor:
         """Yield ``DataFrame`` chunks from ``file_path``."""
         path = Path(file_path)
         rows = 0
+        monitor = get_performance_monitor()
         for chunk in pd.read_csv(path, chunksize=self.chunk_size, encoding=encoding):
+            monitor.throttle_if_needed()
             rows += len(chunk)
             logger.debug("Processed %s rows from %s", rows, path.name)
             yield chunk


### PR DESCRIPTION
## Summary
- add memory threshold config
- monitor memory usage in `PerformanceMonitor`
- stream CSV/JSON reading in several data processing modules
- enforce limits when memory exceeds threshold
- test memory-limit behavior

## Testing
- `pip install pandas psutil --quiet`
- `pip install PyYAML --quiet`
- `pytest tests/test_memory_limit.py -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad3883d08320b299e8ac49ad8982