### PR TITLE
Add placeholders for infra test scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,19 +83,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Run security audit
-        run: ./security_audit.sh
+        run: ./scripts/security_audit.sh
 
       - name: 📊 Run load test
-        run: ./load_test.sh
+        run: ./scripts/load_test.sh
 
       - name: 🛡️ Run failover test
-        run: ./failover_test.sh
+        run: ./scripts/failover_test.sh
 
       - name: ♻️ Run recovery test
-        run: ./recovery_test.sh
+        run: ./scripts/recovery_test.sh
 
       - name: 🗄️ Run compliance audit
-        run: ./compliance_audit.sh
+        run: ./scripts/compliance_audit.sh
 
       - name: 🏗️  Build & push image
         uses: docker/build-push-action@v5

--- a/scripts/compliance_audit.sh
+++ b/scripts/compliance_audit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🗄️  Running compliance audit..."
+echo "No compliance audit defined. Skipping."
+
+exit 0

--- a/scripts/failover_test.sh
+++ b/scripts/failover_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🛡️  Running failover test..."
+echo "No failover test defined. Skipping."
+
+exit 0

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "📊 Running load tests..."
+echo "No load tests defined. Skipping."
+
+exit 0

--- a/scripts/recovery_test.sh
+++ b/scripts/recovery_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "♻️  Running recovery test..."
+echo "No recovery test defined. Skipping."
+
+exit 0

--- a/scripts/security_audit.sh
+++ b/scripts/security_audit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🔐 Running security audit..."
+echo "No security audit implemented. Skipping."
+
+exit 0


### PR DESCRIPTION
## Summary
- add placeholder security, load, failover, recovery, and compliance scripts
- invoke these scripts from CI workflow under `scripts/`

## Testing
- `pre-commit run --files .github/workflows/ci.yml scripts/security_audit.sh scripts/load_test.sh scripts/failover_test.sh scripts/recovery_test.sh scripts/compliance_audit.sh`
- `python quick_check.py`

------
https://chatgpt.com/codex/tasks/task_e_6869ad41f49083208b1a7d0047a60700