### PR TITLE
Add gitleaks scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
       - name: 📚 Safety (dependency CVE scan)
         run: python scripts/audit_dependencies.py
 
+      - name: 🔎 Gitleaks (secret scan)
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: "--source=."
+
       # ----- Tests -----
       - name: ✅ Run PyTest
         run: pytest -q --cov=.


### PR DESCRIPTION
## Summary
- run `gitleaks` secret scanning in CI to fail builds on leaked secrets

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad467b7c83208c2434d62791edbb