### PR TITLE
Add performance marker and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,36 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  performance-test:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: ⚙️  Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: 📦 Install deps
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_ui.txt
+          pip install -r requirements-dev.txt
+
+      - name: 🚀 Run performance tests
+        run: pytest -m performance -q | tee performance-results.log
+
+      - name: 📊 Upload performance results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: performance-results
+          path: performance-results.log
+
   docker:
     needs: build-test
     if: github.ref == 'refs/heads/main'

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,4 @@ markers =
     integration: Integration tests
     slow: Slow running tests
     database: Tests requiring database
+    performance: Performance benchmarks

--- a/tests/security/test_sql_validator.py
+++ b/tests/security/test_sql_validator.py
@@ -32,6 +32,7 @@ def test_legitimate_inputs():
     assert validator.validate_query_parameter(123) == "123"
 
 
+@pytest.mark.performance
 def test_performance_large_batch():
     validator = SQLInjectionPrevention()
     for _ in range(10000):

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,8 +1,10 @@
 import pandas as pd
+import pytest
 from core.performance_file_processor import PerformanceFileProcessor as UnlimitedFileProcessor
 from core.unicode_processor import sanitize_unicode_input, safe_format_number
 
 
+@pytest.mark.performance
 def test_unlimited_file_processor_handles_large_csv(tmp_path):
     df = pd.DataFrame({'A': range(200)})
     path = tmp_path / "big.csv"

--- a/tests/test_lazystring_fix.py
+++ b/tests/test_lazystring_fix.py
@@ -46,6 +46,7 @@ def test_nested_structures_and_types():
     assert sanitized["items"][0] == 1
 
 
+@pytest.mark.performance
 def test_long_string_performance():
     text = "a" * SecurityLimits.MAX_INPUT_STRING_LENGTH_CHARACTERS
     result = serializer.serialize(text)

--- a/tests/test_migration_and_plugin_performance.py
+++ b/tests/test_migration_and_plugin_performance.py
@@ -1,3 +1,4 @@
+import pytest
 from core.plugins.performance_manager import PluginPerformanceManager
 from tools.migration_validator import (
     MigrationValidator,
@@ -7,6 +8,7 @@ from tools.migration_validator import (
 )
 
 
+@pytest.mark.performance
 def test_plugin_performance_tracking():
     mgr = PluginPerformanceManager()
     mgr.record_plugin_metric('plug', 'load_time', 1.0)
@@ -19,6 +21,7 @@ def test_migration_detection():
     assert validator.generate_validation_report()['status'] == 'ok'
 
 
+@pytest.mark.performance
 def test_performance_alerts():
     mgr = PluginPerformanceManager()
     mgr.performance_thresholds['load_time'] = 0.5

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -95,6 +95,7 @@ def test_dataframe_nested_values_cleaned():
 
 
 @pytest.mark.slow
+@pytest.mark.performance
 def test_sanitize_dataframe_benchmark():
     df = pd.DataFrame({"=col": ["=1"] * 100})
     start = time.time()

--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -53,6 +53,7 @@ def test_wrapper_compatibility_and_imports():
 
 
 @pytest.mark.slow
+@pytest.mark.performance
 def test_large_dataframe_performance():
     df = pd.DataFrame({"col": ["=bad" + chr(0xD800)] * 1_000_000})
     start = time.time()


### PR DESCRIPTION
## Summary
- add new `performance` pytest marker
- mark performance-focused tests
- run `pytest -m performance` in a new workflow job

## Testing
- `pytest -m performance -q` *(fails: ImportError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad47a7348320a305f4df951f94dc