### PR TITLE
Remove obsolete Poetry environment setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VERSION: 1.8.2
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
## Summary
- clean up CI env variables

## Testing
- `pytest -q` *(fails: `numpy.dtype size changed, may indicate binary incompatibility`)*

------
https://chatgpt.com/codex/tasks/task_e_6869ad4b256083208aeaa4db639e2c79