### PR TITLE
Fix ConfigProviderProtocol import

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,34 +3,38 @@
 Simplified configuration package - Fixed imports
 """
 
+import logging
+
 # Import the main configuration system
+from core.protocols import ConfigProviderProtocol
+
 from .config import (
-    Config,
     AppConfig,
+    Config,
+    ConfigManager,
     DatabaseConfig,
     SecurityConfig,
-    ConfigManager,
-    get_config,
-    reload_config,
     get_app_config,
+    get_config,
     get_database_config,
     get_security_config,
+    reload_config,
 )
 from .connection_pool import DatabaseConnectionPool
 from .connection_retry import ConnectionRetryManager, RetryConfig
-from .unicode_handler import UnicodeQueryHandler
-from .unicode_sql_processor import UnicodeSQLProcessor
+from .constants import CSSConstants, PerformanceConstants, SecurityConstants
 from .database_exceptions import (
-    DatabaseError,
     ConnectionRetryExhausted,
     ConnectionValidationFailed,
+    DatabaseError,
     UnicodeEncodingError,
 )
 
 # Import dynamic configuration helpers
-from .dynamic_config import dynamic_config, DynamicConfigManager
-from .constants import SecurityConstants, PerformanceConstants, CSSConstants
-import logging
+from .dynamic_config import DynamicConfigManager, dynamic_config
+from .unicode_handler import UnicodeQueryHandler
+from .unicode_sql_processor import UnicodeSQLProcessor
+
 
 def _lazy_get_service(name: str):
     """Import ``get_service`` lazily to avoid early registry imports."""
@@ -52,6 +56,7 @@ __all__ = [
     "DatabaseConfig",
     "SecurityConfig",
     "ConfigManager",
+    "ConfigProviderProtocol",
     "get_config",
     "reload_config",
     "get_app_config",

--- a/config/config.py
+++ b/config/config.py
@@ -11,10 +11,10 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from core.exceptions import ConfigurationError
+from core.protocols import ConfigProviderProtocol
 from core.secrets_validator import SecretsValidator
 
 from .config_validator import ConfigValidator
-
 from .dynamic_config import dynamic_config
 from .environment import get_environment, select_config_file
 


### PR DESCRIPTION
## Summary
- import `ConfigProviderProtocol` to satisfy `ConfigManager`
- re-export `ConfigProviderProtocol` in `config.__init__`

## Testing
- `pre-commit run --files config/config.py config/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_6869c7c9b3588320a6fe27ac2752f47e