### PR TITLE
Add max_display_rows constant

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -118,6 +118,7 @@ class AnalyticsConstants:
     max_workers: int = 4
     query_timeout_seconds: int = 300
     max_memory_mb: int = 1024
+    max_display_rows: int = 10000
 
 
 


### PR DESCRIPTION
## Summary
- add `max_display_rows` to `AnalyticsConstants` so dynamic config exposes this option

## Testing
- `pytest tests/test_max_display_rows.py::test_dynamic_config_default_display_rows -q`


------
https://chatgpt.com/codex/tasks/task_e_6869d139505083209187c3801ff5699f