### PR TITLE
Update lint commands line length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
 
       # ----- Lint & static analysis -----
       - name: 🧹 Black (format check)
-        run: black --check --diff .
+        run: black --line-length=88 --check --diff .
 
       - name: 🔀 Isort (import order)
-        run: isort --profile=black --check --diff .
+        run: isort --profile=black --line-length=88 --check --diff .
 
       - name: 🔍 Flake8
         run: flake8 .


### PR DESCRIPTION
## Summary
- configure CI Black and isort with `--line-length=88`

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869c7ed753083208b70e17b715962a9