### PR TITLE
Apply Black formatting to analytics service

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -92,6 +92,7 @@ class AnalyticsService(AnalyticsProviderProtocol):
                 DatabaseManager,
                 DatabaseConfig as ManagerConfig,
             )
+
             if self._config_provider is not None:
                 cfg = self._config_provider.get_database_config()
             else:


### PR DESCRIPTION
## Summary
- reformat `services/analytics_service.py` using Black with 88-char line length

## Testing
- `black -l 88 services/analytics_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6869e02b06c08320a5bf6fa16191d1f3