### PR TITLE
Apply Black 88 to file_processing_utils

### DIFF
--- a/analytics/file_processing_utils.py
+++ b/analytics/file_processing_utils.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from datetime import datetime
 from typing import Any, Dict, Iterable, Tuple
-from collections import Counter
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- run isort and black on `file_processing_utils.py`

## Testing
- `isort --check analytics/file_processing_utils.py`
- `black --check analytics/file_processing_utils.py -l 88`
- `flake8 analytics/file_processing_utils.py`
- `mypy analytics/file_processing_utils.py` *(fails: hundreds of unrelated type errors)*
- `bandit -r analytics/file_processing_utils.py`
- `pytest` *(fails: numpy/pandas binary compatibility error)*

------
https://chatgpt.com/codex/tasks/task_e_6869e03c8da88320b9d4c6c1f65d27a5