### PR TITLE
Format upload modules and add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     hooks:
       - id: isort
         args: ["--profile=black"]
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: ["--line-length=88"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ known_first_party = [
     "utils",
 ]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+
+[tool.black]
+line-length = 88

--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -1,11 +1,10 @@
-from .processing import UploadProcessingService
-from .async_processor import AsyncUploadProcessor
 from .ai import AISuggestionService, analyze_device_name_with_ai
-from .modal import ModalService
+from .async_processor import AsyncUploadProcessor
 from .helpers import get_trigger_id, save_ai_training_data
 from .managers import ChunkedUploadManager, UploadQueueManager
+from .modal import ModalService
+from .processing import UploadProcessingService
 from .validators import ClientSideValidator
-
 
 __all__ = [
     "AsyncUploadProcessor",
@@ -18,5 +17,4 @@ __all__ = [
     "ChunkedUploadManager",
     "UploadQueueManager",
     "ClientSideValidator",
-
 ]

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from services.analytics_service import MAX_DISPLAY_ROWS
 
-from services.data_processing.file_processor import UnicodeFileProcessor
 from config.config import get_analytics_config
+from services.analytics_service import MAX_DISPLAY_ROWS
+from services.data_processing.file_processor import UnicodeFileProcessor
+
 
 def _get_max_display_rows() -> int:
     return get_analytics_config().max_display_rows or 10000
@@ -34,10 +35,13 @@ class AsyncUploadProcessor:
         df = await asyncio.to_thread(pd.read_parquet, path, **kwargs)
         return self.unicode_processor.sanitize_dataframe_unicode(df)
 
-    async def preview_from_parquet(self, path: str | Path, *, rows: int | None = None) -> pd.DataFrame:
+    async def preview_from_parquet(
+        self, path: str | Path, *, rows: int | None = None
+    ) -> pd.DataFrame:
         """Return the first ``rows`` of a parquet file asynchronously."""
         df = await self.read_parquet(path)
         limit = rows or _get_max_display_rows()
         return df.head(limit)
+
 
 __all__ = ["AsyncUploadProcessor"]

--- a/services/upload/managers.py
+++ b/services/upload/managers.py
@@ -38,4 +38,5 @@ class UploadQueueManager:
         pct = int(len(self.completed) / total * 100)
         return max(0, min(100, pct))
 
+
 __all__ = ["ChunkedUploadManager", "UploadQueueManager"]

--- a/services/upload/modal.py
+++ b/services/upload/modal.py
@@ -1,5 +1,6 @@
-from typing import Any, Tuple
 import logging
+from typing import Any, Tuple
+
 from dash.dash import no_update
 
 logger = logging.getLogger(__name__)

--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -10,10 +10,11 @@ from components.file_preview import create_file_preview_ui
 from services.data_enhancer import get_ai_column_suggestions
 from services.data_processing.async_file_processor import AsyncFileProcessor
 from services.data_processing.file_processor import create_file_preview
-from .async_processor import AsyncUploadProcessor
 from services.device_learning_service import get_device_learning_service
 from services.progress_event_manager import progress_manager
 from utils.upload_store import UploadedDataStore
+
+from .async_processor import AsyncUploadProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -168,9 +169,7 @@ class UploadProcessingService:
                 cols = len(df.columns)
 
                 self.store.add_file(filename, df)
-                upload_results.append(
-                    self.build_success_alert(filename, rows, cols)
-                )
+                upload_results.append(self.build_success_alert(filename, rows, cols))
                 file_preview_components.append(
                     self.build_file_preview_component(df, filename)
                 )
@@ -188,9 +187,7 @@ class UploadProcessingService:
 
                 try:
                     learning_service = get_device_learning_service()
-                    user_mappings = learning_service.get_user_device_mappings(
-                        filename
-                    )
+                    user_mappings = learning_service.get_user_device_mappings(filename)
                     if user_mappings:
                         from services.ai_mapping_store import ai_mapping_store
 
@@ -212,9 +209,7 @@ class UploadProcessingService:
                     logger.info("⚠️ Error: %s", exc)
             except Exception as exc:  # pragma: no cover - best effort
                 upload_results.append(
-                    self.build_failure_alert(
-                        f"Error processing {filename}: {str(exc)}"
-                    )
+                    self.build_failure_alert(f"Error processing {filename}: {str(exc)}")
                 )
 
         upload_nav = []

--- a/services/upload/upload_queue_manager.py
+++ b/services/upload/upload_queue_manager.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 class UploadQueueManager:
     """Manage prioritized upload tasks with concurrency control."""
 
-    def __init__(self, state: Dict[str, Any] | None = None, *, max_concurrent: int = 3) -> None:
+    def __init__(
+        self, state: Dict[str, Any] | None = None, *, max_concurrent: int = 3
+    ) -> None:
         self.max_concurrent = max_concurrent
         self._lock = threading.Lock()
         self._queue: List[Tuple[int, float, Any]] = []
@@ -54,7 +56,9 @@ class UploadQueueManager:
             }
         return status
 
-    async def process_queue(self, handler: Callable[[Any], asyncio.Future | Any]) -> List[Tuple[str, Any]]:
+    async def process_queue(
+        self, handler: Callable[[Any], asyncio.Future | Any]
+    ) -> List[Tuple[str, Any]]:
         """Process queued items using ``handler`` respecting concurrency.
 
         ``handler`` should be a coroutine function accepting a single queued

--- a/services/upload/validators.py
+++ b/services/upload/validators.py
@@ -5,8 +5,12 @@ from typing import Iterable
 class ClientSideValidator:
     """Validate uploaded file name and size before processing."""
 
-    def __init__(self, allowed_ext: Iterable[str] | None = None, max_size: int | None = None) -> None:
-        self.allowed_ext = {e.lower() for e in (allowed_ext or [".csv", ".xlsx", ".xls", ".json"])}
+    def __init__(
+        self, allowed_ext: Iterable[str] | None = None, max_size: int | None = None
+    ) -> None:
+        self.allowed_ext = {
+            e.lower() for e in (allowed_ext or [".csv", ".xlsx", ".xls", ".json"])
+        }
         self.max_size = max_size
 
     def validate(self, filename: str, content: str) -> tuple[bool, str]:
@@ -15,12 +19,13 @@ class ClientSideValidator:
             return False, f"Unsupported file type: {filename}"
         if self.max_size is not None:
             try:
-                data = content.split(',', 1)[1]
+                data = content.split(",", 1)[1]
                 size = len(base64.b64decode(data))
                 if size > self.max_size:
                     return False, f"{filename} exceeds maximum size"
             except Exception:
                 return False, "Failed to decode uploaded content"
         return True, ""
+
 
 __all__ = ["ClientSideValidator"]

--- a/utils/mapping_helpers.py
+++ b/utils/mapping_helpers.py
@@ -1,6 +1,7 @@
 """Utility functions for mapping uploaded data columns."""
 
 from typing import Dict, Optional
+
 import pandas as pd
 
 # Standard column mapping used across the project

--- a/utils/memory_store.py
+++ b/utils/memory_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 
 @dataclass

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -3,12 +3,13 @@
 import json
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor, Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
+
 from file_conversion.file_converter import FileConverter
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add black step to pre-commit config
- configure line length in pyproject
- format upload-related modules with black and sort imports

## Testing
- `black --check services/upload/*.py components/upload/*.py utils/upload_store.py utils/memory_store.py utils/mapping_helpers.py`
- `isort --profile=black utils/upload_store.py utils/memory_store.py utils/mapping_helpers.py components/upload/*.py services/upload/*.py --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869defc68c8832095e4fa2f5b53b202