### PR TITLE
Add safe_unicode_decode utility

### DIFF
--- a/core/unicode_decode.py
+++ b/core/unicode_decode.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Lightweight Unicode decoding helpers."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _remove_invalid_surrogates(text: str) -> str:
+    """Return ``text`` without lone surrogate code points."""
+    out = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        code = ord(ch)
+        if 0xD800 <= code <= 0xDBFF:
+            if i + 1 < len(text) and 0xDC00 <= ord(text[i + 1]) <= 0xDFFF:
+                out.append(ch)
+                out.append(text[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        if 0xDC00 <= code <= 0xDFFF:
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def safe_unicode_decode(data: Any, encoding: str = "utf-8") -> str:
+    """Decode ``data`` safely removing invalid surrogates."""
+    if isinstance(data, str):
+        return _remove_invalid_surrogates(data)
+
+    try:
+        text = data.decode(encoding, errors="surrogatepass")
+    except UnicodeError as exc:
+        logger.warning("Primary decode failed: %s", exc)
+        try:
+            text = data.decode(encoding, errors="replace")
+        except Exception:
+            text = data.decode("utf-8", errors="ignore")
+    return _remove_invalid_surrogates(text)
+
+
+__all__ = ["safe_unicode_decode"]

--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -66,7 +66,9 @@ class ValidationMiddleware:
             try:
                 from security.unicode_security_handler import UnicodeSecurityHandler
 
-                raw_text = request.data.decode("utf-8", errors="ignore")
+                from core.unicode_decode import safe_unicode_decode
+
+                raw_text = safe_unicode_decode(request.data, "utf-8")
                 sanitized = UnicodeSecurityHandler.sanitize_unicode_input(raw_text)
                 request._cached_data = self.orchestrator.validate(sanitized).encode(
                     "utf-8"

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -36,16 +36,12 @@ class UnicodeFileProcessor:
             detected = chardet.detect(content)
             encoding = detected.get('encoding') or 'utf-8'
 
-            # Try detected encoding first
-            try:
-                return content.decode(encoding)
-            except UnicodeDecodeError:
-                # Fallback to utf-8 with error handling
-                return content.decode('utf-8', errors='replace')
+            from core.unicode_decode import safe_unicode_decode
+
+            return safe_unicode_decode(content, encoding)
         except Exception as e:
             logger.warning(f"Unicode decode error: {e}")
-            # Last resort: latin-1 can decode any byte sequence
-            return content.decode('latin-1')
+            return safe_unicode_decode(content, "latin-1")
 
     @staticmethod
     def sanitize_dataframe_unicode(df: pd.DataFrame) -> pd.DataFrame:

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -38,12 +38,9 @@ logger = logging.getLogger(__name__)
 
 
 def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
-    try:
-        text = data.decode(enc, errors="surrogatepass")
-    except UnicodeDecodeError:
-        text = data.decode(enc, errors="replace")
+    from core.unicode_decode import safe_unicode_decode
 
-    text = UnicodeProcessor.clean_surrogate_chars(text)
+    text = safe_unicode_decode(data, enc)
 
     from security.unicode_security_handler import UnicodeSecurityHandler
 

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -199,8 +199,10 @@ class FileProcessorService(BaseService):
                     return text
             except Exception:
                 continue
+        from core.unicode_decode import safe_unicode_decode
+
         logger.warning("All encodings failed, using replacement characters")
-        return content.decode("utf-8", errors="replace")
+        return safe_unicode_decode(content, "utf-8")
 
     def _is_reasonable_text(self, text: str) -> bool:
         """Basic check to ensure decoded text looks valid."""

--- a/tests/test_unicode_decode.py
+++ b/tests/test_unicode_decode.py
@@ -1,0 +1,15 @@
+import pytest
+
+from core.unicode_decode import safe_unicode_decode
+
+
+def test_removes_invalid_surrogates():
+    data = b"A\xed\xa0\x80B"  # contains lone high surrogate D800
+    assert safe_unicode_decode(data) == "AB"
+
+
+def test_fallback_on_unicode_error():
+    latin = "café".encode("latin-1")
+    out = safe_unicode_decode(latin, "ascii")
+    assert isinstance(out, str)
+    assert out.startswith("caf")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,7 @@ try:  # pragma: no cover - graceful import fallback
         # Preferred API
         clean_unicode_text,
         safe_decode_bytes,
+        safe_unicode_decode,
         safe_encode,
         sanitize_dataframe,
         UnicodeProcessor,
@@ -63,6 +64,7 @@ __all__: list[str] = [
     # Preferred API
     "clean_unicode_text",
     "safe_decode_bytes",
+    "safe_unicode_decode",
     "safe_encode",
     "sanitize_dataframe",
     "UnicodeProcessor",


### PR DESCRIPTION
## Summary
- provide safe_unicode_decode utility for robust text decoding
- cover invalid surrogate handling with dedicated tests
- use safe_unicode_decode in request validation and file processing modules
- export safe_unicode_decode via utils package

## Testing
- `pytest -q tests/test_unicode_decode.py`

------
https://chatgpt.com/codex/tasks/task_e_6869def7e34c83209942622e2f8efc7c