### PR TITLE
Add common pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,20 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: ["--line-length=88"]
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
       - id: isort
-        args: ["--profile=black"]
+        args: ["--profile=black", "--line-length=88"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=88"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.1
+    hooks:
+      - id: mypy


### PR DESCRIPTION
## Summary
- add standard linters and type checker to the pre-commit configuration

## Testing
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6869c7e7a9948320a17ed3171954aede