### PR TITLE
Add VSCode settings for Black and flake8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": ["--line-length=88"],
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": true,
+  "editor.rulers": [88],
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
## Summary
- add `.vscode/settings.json` to configure VS Code
  - enable Black formatting with 88 char lines
  - enable flake8 linting
  - show ruler at column 88
  - run formatting on save

## Testing
- `pre-commit run --files .vscode/settings.json`

------
https://chatgpt.com/codex/tasks/task_e_6869c7e9add483208f188f24f4a73b95