### PR TITLE
Add line length constant and metrics to StyleAnalyzer

### DIFF
--- a/analyzers/style_analyzer.py
+++ b/analyzers/style_analyzer.py
@@ -2,9 +2,14 @@ from typing import List
 from pathlib import Path
 from .base_analyzer import BaseAnalyzer, QualityIssue, IssueType
 
+MAX_LINE_LENGTH = 88
+
 
 class StyleAnalyzer(BaseAnalyzer):
     """Analyzes code style and formatting"""
+
+    def __init__(self) -> None:
+        self.metrics = {"max_line_length": 0}
 
     def analyze(self, file_path: Path) -> List[QualityIssue]:
         issues = []
@@ -13,16 +18,20 @@ class StyleAnalyzer(BaseAnalyzer):
                 lines = f.readlines()
 
             for i, line in enumerate(lines, 1):
-                if len(line.rstrip()) > 120:
+                line_length = len(line.rstrip())
+                if line_length > self.metrics["max_line_length"]:
+                    self.metrics["max_line_length"] = line_length
+
+                if line_length > MAX_LINE_LENGTH:
                     issues.append(
                         QualityIssue(
                             file_path=str(file_path),
                             line_number=i,
                             issue_type=IssueType.STYLE,
                             severity="info",
-                            message=f"Line too long: {len(line.rstrip())} chars",
+                            message=f"Line too long: {line_length} chars",
                             rule="line_length",
-                            suggestion="Break long lines (max: 120 chars)",
+                            suggestion=f"Break long lines (max: {MAX_LINE_LENGTH} chars)",
                         )
                     )
 
@@ -44,4 +53,4 @@ class StyleAnalyzer(BaseAnalyzer):
         return issues
 
     def get_metrics(self):
-        return {}
+        return self.metrics.copy()

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -57,7 +57,7 @@ class TestStyleAnalyzer:
 
     def test_detects_long_lines(self, tmp_path):
         test_file = tmp_path / "long_line.py"
-        long_line = "x = " + "a" * 130
+        long_line = "x = " + "a" * 90
         test_file.write_text(long_line)
 
         analyzer = StyleAnalyzer()
@@ -65,3 +65,14 @@ class TestStyleAnalyzer:
 
         line_length_issues = [i for i in issues if i.rule == "line_length"]
         assert len(line_length_issues) == 1
+
+    def test_metrics_max_line_length(self, tmp_path):
+        test_file = tmp_path / "metrics.py"
+        long_line = "y = " + "b" * 95
+        test_file.write_text("short\n" + long_line)
+
+        analyzer = StyleAnalyzer()
+        analyzer.analyze(test_file)
+        metrics = analyzer.get_metrics()
+
+        assert metrics["max_line_length"] == len(long_line)


### PR DESCRIPTION
## Summary
- introduce `MAX_LINE_LENGTH` constant in `StyleAnalyzer`
- track `max_line_length` metric
- update style analyzer suggestions to use new constant
- adjust tests for new limit and verify metrics

## Testing
- `pip install pandas`
- `pip install pyyaml`
- `pip install bleach`
- `pip install sqlparse`
- `pytest tests/test_analyzers.py::TestStyleAnalyzer::test_detects_long_lines -q` *(fails: ConfigManager not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6869c7ec2b3083208a4465d0b0cf2964