### PR TITLE
Add InputValidator.validate

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -29,6 +29,7 @@ from core.security_patterns import (
 
 from security.unicode_security_processor import sanitize_unicode_input
 from config.dynamic_config import dynamic_config
+from core.exceptions import ValidationError
 
 
 class SecurityLevel(Enum):
@@ -78,6 +79,30 @@ class InputValidator:
                 for pattern in PATH_TRAVERSAL_PATTERNS
             ],
         }
+
+    def validate(self, value: str) -> str:
+        """Validate a single value and return the sanitized result.
+
+        Parameters
+        ----------
+        value: str
+            The input value to validate.
+
+        Returns
+        -------
+        str
+            The sanitized form of ``value``.
+
+        Raises
+        ------
+        ValidationError
+            If the input fails validation checks.
+        """
+
+        result = self.validate_input(value)
+        if not result.get("valid", False):
+            raise ValidationError("Invalid input", result)
+        return result.get("sanitized", value)
 
     def validate_input(
         self, input_data: str, field_name: str = "unknown"


### PR DESCRIPTION
## Summary
- add InputValidator.validate and import ValidationError
- use ValidationError when validation fails

## Testing
- `pip install pandas flask bleach sqlparse pytest dash-bootstrap-components==1.6.0 dash==2.10.2 pandas numpy requests`
- `pip install setuptools`
- `pip install pyyaml`
- `pip install psutil`
- `pip install chardet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869edf08718832086abd426bb5e64ff