### PR TITLE
Update plugin config imports

### DIFF
--- a/core/plugins/config/__init__.py
+++ b/core/plugins/config/__init__.py
@@ -1,27 +1,18 @@
 """Minimal plugin config compatibility"""
 
-# Re-export from unified configuration for compatibility
-try:
-    from config.unified_config import (
-        UnifiedConfig,
-        get_config,
-    )
-    from config.database_manager import DatabaseManager
+# Import the primary configuration manager and database manager
+from config.config import ConfigManager, get_config
+from config.database_manager import DatabaseManager
 
-    def get_service_locator():
-        """Return configuration object for plugins"""
-        return get_config()
 
-    __all__ = [
-        "UnifiedConfig",
-        "get_config",
-        "get_service_locator",
-        "DatabaseManager",
-    ]
+def get_service_locator():
+    """Return configuration object for plugins"""
+    return get_config()
 
-except Exception:
 
-    def get_service_locator():  # pragma: no cover - fallback
-        return None
-
-    __all__ = ["get_service_locator"]
+__all__ = [
+    "ConfigManager",
+    "get_config",
+    "get_service_locator",
+    "DatabaseManager",
+]


### PR DESCRIPTION
## Summary
- simplify config plugin initialization
- export ConfigManager and DatabaseManager

## Testing
- `pytest tests/test_auto_configuration.py tests/test_config_validator.py tests/test_config_production_secrets.py -q` *(fails: numpy.dtype size changed, may indicate binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_6869f281760883208d4403dee56bc2c5