### PR TITLE
Clarify ConfigManager usage in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,12 +263,22 @@ file processing utilities depend on `chardet` to detect text encoding.
 
 ## 🔧 Configuration
 
-This project uses **`config/config.py`** for application settings. It
-loads defaults from `config/config.yaml` and allows environment variables to
-override any value. Earlier versions used separate modules like
-`app_config.py`, `simple_config.py` and `config_manager.py`; these have been
-replaced by the unified `ConfigManager` in `config/config.py`. Register the
-configuration with the DI container so it can be resolved from anywhere:
+Configuration is managed by **`config.config.ConfigManager`**. The loader
+selects a YAML file based on the `YOSAI_ENV` or `YOSAI_CONFIG_FILE`
+environment variables and applies environment overrides. Earlier versions used
+separate modules like `app_config.py`, `simple_config.py` and
+`config_manager.py`; these have been replaced by this unified manager. Register
+the configuration with the DI container so it can be resolved from anywhere:
+
+```python
+from config.config import ConfigManager
+
+config = ConfigManager()
+db_cfg = config.get_database_config()
+```
+
+To share the configuration across the application, register the manager with
+the dependency injection container:
 
 ```python
 from core.container import Container
@@ -362,8 +372,8 @@ YOSAI_APP_MODE=simple python app.py
 
 #### Dynamic Constants
 
-The new `DynamicConfigManager` reads several optional environment variables to
-override security and performance defaults:
+`ConfigManager` integrates with the dynamic configuration helper to read a few
+optional environment variables that tweak security and performance settings:
 
 - `PBKDF2_ITERATIONS` – password hashing iterations
 - `RATE_LIMIT_API` – number of requests allowed per window

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,5 +47,18 @@ config_manager = container.get("config")  # ConfigurationProtocol
 analytics_service = container.get("analytics")  # AnalyticsServiceProtocol
 ```
 
+`ConfigManager` automatically loads the YAML file specified by
+`YOSAI_CONFIG_FILE` or chosen according to `YOSAI_ENV` (development,
+staging, production or test).
+
+Minimal usage without the container:
+
+```python
+from config.config import ConfigManager
+
+config = ConfigManager()
+db_cfg = config.get_database_config()
+```
+
 Both services implement protocols so alternative implementations can be swapped
 in for tests or future extensions.

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -10,11 +10,15 @@ Supported file types are CSV and JSON. Large files are streamed to avoid exhaust
 
 ### Chunk Size
 
-Large CSV files are processed in chunks. The default chunk size is 50,000 rows and is configured via `dynamic_config.analytics.chunk_size`. You can override it at runtime by setting the environment variable `ANALYTICS_CHUNK_SIZE`.
+Large CSV files are processed in chunks. The default chunk size is configured
+under `uploads.chunk_size` and can be overridden by setting the environment
+variable `UPLOAD_CHUNK_SIZE`.
 
 ### Queue Limits
 
-Background tasks such as analytics processing and file saves run in a thread pool. The number of concurrent workers is controlled by `dynamic_config.analytics.max_workers` (default `4`). Adjust the `MAX_WORKERS` environment variable to increase or decrease the processing queue.
+Background tasks such as analytics processing and file saves run in a thread
+pool. The worker count comes from `uploads.max_parallel_uploads` (default `4`).
+Use the `MAX_PARALLEL_UPLOADS` environment variable to adjust this value.
 
 ## Mobile & Accessibility Guidelines
 


### PR DESCRIPTION
## Summary
- explain that configuration is provided by `config.config.ConfigManager`
- document how `YOSAI_ENV` and `YOSAI_CONFIG_FILE` select the YAML file
- show example usage of ConfigManager
- avoid implying multiple config systems
- note new env vars for upload configuration

## Testing
- `pytest -k ConfigManager -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_6869f2841d0c8320868ed153e61ee2c1