### PR TITLE
Improve plugin cycle detection

### DIFF
--- a/core/plugins/dependency_resolver.py
+++ b/core/plugins/dependency_resolver.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
-from typing import List, Dict, Set, DefaultDict
+from typing import List, Dict, Set, DefaultDict, Iterable
 
 from services.data_processing.core.protocols import PluginProtocol
+
+
+class CircularDependencyError(ValueError):
+    """Raised when a dependency cycle is detected."""
+
+    def __init__(self, nodes: Iterable[str]):
+        self.nodes = list(nodes)
+        super().__init__(
+            "Circular dependency detected among: " + ", ".join(sorted(self.nodes))
+        )
 
 
 class PluginDependencyResolver:
@@ -47,9 +57,7 @@ class PluginDependencyResolver:
 
         if len(ordered) != len(plugins_with_meta):
             unresolved = set(name_map) - {p.metadata.name for p in ordered}
-            raise ValueError(
-                "Circular dependency detected among: " + ", ".join(sorted(unresolved))
-            )
+            raise CircularDependencyError(unresolved)
 
         ordered.extend(plugins_without_meta)
         return ordered

--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -102,6 +102,12 @@ class PluginManager:
 
         try:
             ordered = self._resolver.resolve(discovered)
+        except ValueError as exc:
+            if "Circular dependency" in str(exc):
+                logger.error("Plugin dependency cycle detected: %s", exc)
+                return []
+            logger.error("Failed to resolve plugin dependencies: %s", exc)
+            return []
         except Exception as exc:
             logger.error("Failed to resolve plugin dependencies: %s", exc)
             return []

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -68,3 +68,13 @@ This loads every enabled plugin, registers callbacks, exposes `/health/plugins`
 and attaches the plugin manager as `app._yosai_plugin_manager`.
 
 For a visual overview of discovery, dependency resolution and the lifecycle calls see [plugin_lifecycle.md](plugin_lifecycle.md).
+
+## Circular dependencies
+
+Plugins should avoid depending on each other in a cycle. If the dependency resolver detects such a cycle the manager logs a message like:
+
+```
+ERROR - Plugin dependency cycle detected: Circular dependency detected among: a, b
+```
+
+None of the involved plugins will be loaded. Check the logged plugin names and update their `dependencies` lists to remove the cycle.


### PR DESCRIPTION
## Summary
- add `CircularDependencyError` for cycle info
- log special message in `PluginManager` when cycles are detected
- document how circular plugin dependencies are reported
- test new cycle logging behaviour

## Testing
- `pytest tests/test_dependency_resolver.py::test_manager_cycle_logging -q` *(fails: ModuleNotFoundError: No module named 'bleach')*
- `pytest tests/test_dependency_resolver.py::test_manager_unknown_dependency_logging -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_6869f2d4f3a88320b62a7757e7d8929e