### PR TITLE
Update docs on unified configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,5 +47,15 @@ config_manager = container.get("config")  # ConfigurationProtocol
 analytics_service = container.get("analytics")  # AnalyticsServiceProtocol
 ```
 
+`ConfigManager` automatically selects the YAML file to load based on
+`YOSAI_ENV` or `YOSAI_CONFIG_FILE`. It can also be used directly:
+
+```python
+from config.config import ConfigManager
+
+config = ConfigManager()
+db_cfg = config.get_database_config()
+```
+
 Both services implement protocols so alternative implementations can be swapped
 in for tests or future extensions.


### PR DESCRIPTION
## Summary
- document ConfigManager as the single configuration loader
- show how `YOSAI_ENV` and `YOSAI_CONFIG_FILE` select the YAML file
- add direct usage example in docs

## Testing
- `pre-commit run --files README.md docs/architecture.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6869f2df04d48320bbed086140a7333b