### PR TITLE
Fix plugin config imports

### DIFF
--- a/core/plugins/config/__init__.py
+++ b/core/plugins/config/__init__.py
@@ -1,27 +1,19 @@
 """Minimal plugin config compatibility"""
 
-# Re-export from unified configuration for compatibility
-try:
-    from config.unified_config import (
-        UnifiedConfig,
-        get_config,
-    )
-    from config.database_manager import DatabaseManager
+# Import configuration manager from the new configuration module
+from config.config import ConfigManager, get_config
+from config.database_manager import DatabaseManager
 
-    def get_service_locator():
-        """Return configuration object for plugins"""
-        return get_config()
 
-    __all__ = [
-        "UnifiedConfig",
-        "get_config",
-        "get_service_locator",
-        "DatabaseManager",
-    ]
+def get_service_locator() -> ConfigManager:
+    """Return configuration object for plugins"""
 
-except Exception:
+    return get_config()
 
-    def get_service_locator():  # pragma: no cover - fallback
-        return None
 
-    __all__ = ["get_service_locator"]
+__all__ = [
+    "ConfigManager",
+    "get_config",
+    "get_service_locator",
+    "DatabaseManager",
+]


### PR DESCRIPTION
## Summary
- clean up `core/plugins/config/__init__.py`
- drop fallback to `UnifiedConfig`

## Testing
- `pytest -q` *(fails: 45 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6869f2dbd5ec8320aca4180f70903a55