### PR TITLE
Implement role-based session timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,18 @@ All secrets can be provided via the `SecretManager` which supports `env`,
 Docker secrets. See the [architecture diagram](docs/auth_flow.png) for
 implementation details.
 
+Session cookies are marked as permanent on login. The default lifetime is
+configured via `security.session_timeout` in seconds. You can override the
+timeout for specific roles using `security.session_timeout_by_role`:
+
+```yaml
+security:
+  session_timeout: 3600
+  session_timeout_by_role:
+    admin: 7200
+    basic: 1800
+```
+
 The configuration loader performs a validation step on startup to ensure
 required secrets are set. See
 [docs/secret_management.md](docs/secret_management.md) for rotation

--- a/config/config.py
+++ b/config/config.py
@@ -75,6 +75,7 @@ class SecurityConfig:
 
     secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
     session_timeout: int = 3600
+    session_timeout_by_role: Dict[str, int] = field(default_factory=dict)
     cors_origins: List[str] = field(default_factory=list)
     csrf_enabled: bool = True
     max_failed_attempts: int = 5
@@ -274,6 +275,11 @@ class ConfigManager(ConfigProviderProtocol):
             self.config.security.session_timeout = sec_data.get(
                 "session_timeout", self.config.security.session_timeout
             )
+            if "session_timeout_by_role" in sec_data:
+                self.config.security.session_timeout_by_role = sec_data.get(
+                    "session_timeout_by_role",
+                    self.config.security.session_timeout_by_role,
+                )
             self.config.security.cors_origins = sec_data.get(
                 "cors_origins", self.config.security.cors_origins
             )

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,6 +15,9 @@ database:
 
 security:
   session_timeout: 3600
+  session_timeout_by_role:
+    admin: 7200
+    basic: 1800
   csrf_enabled: false
 
 sample_files:

--- a/tests/session_tests/test_session_lifetime.py
+++ b/tests/session_tests/test_session_lifetime.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import types
+from dataclasses import dataclass, field
+from typing import Dict
+from flask import Flask, session
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+@dataclass
+class SecurityConfig:
+    session_timeout: int = 3600
+    session_timeout_by_role: Dict[str, int] = field(default_factory=dict)
+
+def _setup_fake_config(cfg):
+    pkg = types.ModuleType("config")
+    sub = types.ModuleType("config.config")
+    sub.get_security_config = lambda: cfg
+    pkg.config = sub
+    sys.modules["config"] = pkg
+    sys.modules["config.config"] = sub
+
+_setup_fake_config(SecurityConfig())
+from core.auth import User, _determine_session_timeout, _apply_session_timeout
+
+
+def test_determine_session_timeout(monkeypatch):
+    cfg = SecurityConfig(session_timeout=3600,
+                         session_timeout_by_role={"admin": 7200, "basic": 1800})
+    monkeypatch.setattr("core.auth.get_security_config", lambda: cfg)
+    assert _determine_session_timeout(["basic"]) == 1800
+    assert _determine_session_timeout(["unknown"]) == 3600
+    assert _determine_session_timeout(["admin", "basic"]) == 7200
+
+
+def test_apply_session_timeout_sets_flask_values(monkeypatch):
+    cfg = SecurityConfig(session_timeout=3600,
+                         session_timeout_by_role={"admin": 7200})
+    monkeypatch.setattr("core.auth.get_security_config", lambda: cfg)
+    app = Flask(__name__)
+    app.secret_key = "x"
+    user = User("1", "Admin", "a@b.com", ["admin"])
+    with app.app_context():
+        with app.test_request_context():
+            _apply_session_timeout(user)
+            assert session.permanent is True
+            assert app.permanent_session_lifetime.total_seconds() == 7200


### PR DESCRIPTION
## Summary
- set session as permanent during login
- configure session lifetime using SecurityConfig
- support per-role session timeouts
- document session timeout options
- test session timeout logic

## Testing
- `pytest tests/session_tests/test_session_lifetime.py -q --confcutdir=tests/session_tests`

------
https://chatgpt.com/codex/tasks/task_e_686a2441fcd88320aff9e5199f702d9f