### PR TITLE
Fix theme switching

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -329,6 +329,7 @@ def create_navbar_layout() -> Optional[Any]:
                                                                         },
                                                                     ),
                                                                     className="px-2",
+                                                                    toggle=False,
                                                                 ),
                                                             ],
                                                             nav=True,

--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -37,15 +37,24 @@ def generate_theme_script() -> str:
         const saved = sanitize(localStorage.getItem('app-theme'));
         const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         const initial = saved || sanitize(system);
-        const target = document.querySelector("[data-theme]") || document.documentElement;
-        target.dataset.theme = initial;
-        document.dispatchEvent(new CustomEvent('themeChange', {{ detail: initial }}));
-        window.setAppTheme = function(theme) {{
+
+        function applyTheme(theme) {{
             const clean = sanitize(theme);
-            target.dataset.theme = clean;
+            document.documentElement.dataset.theme = clean;
+            document.querySelectorAll('[data-theme]').forEach(el => {{
+                el.dataset.theme = clean;
+            }});
             localStorage.setItem('app-theme', clean);
             document.dispatchEvent(new CustomEvent('themeChange', {{ detail: clean }}));
-        }};
+        }}
+
+        if (document.readyState !== 'loading') {{
+            applyTheme(initial);
+        }} else {{
+            document.addEventListener('DOMContentLoaded', function(){{ applyTheme(initial); }});
+        }}
+
+        window.setAppTheme = applyTheme;
     }})();
     </script>
     """


### PR DESCRIPTION
## Summary
- fix theme dropdown from closing by toggling drop-down behaviour
- ensure JS applies theme to all data-theme elements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a2a3788d48320ba36cd06be91ac69