### PR TITLE
Document dependency setup for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ Thank you for considering a contribution! Follow these steps to get the developm
 Install the core and development dependencies:
 
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
+./scripts/setup.sh
 pip install pre-commit
 pre-commit install
 ```

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ with this Python release and newer.
    ```bash
    ./scripts/setup.sh
    ```
-   The script installs requirements from PyPI or a local `packages/` directory if
-   present. Ensure dependencies are installed **before** running Pyright or using
-   the Pylance extension. Missing packages will otherwise appear as unresolved
-   imports.
+   The script installs both `requirements.txt` and `requirements-dev.txt` from
+   PyPI or a local `packages/` directory if present. Ensure dependencies are
+   installed **before** running Pyright or using the Pylance extension. Missing
+   packages will otherwise appear as unresolved imports.
 
 4. **Set up environment:**
    ```bash
@@ -142,7 +142,8 @@ following steps:
    ```bash
    ./scripts/setup.sh
    ```
-   If you encounter errors like `module 'flask' has no attribute 'helpers'`,
+   The script installs both requirement files. If you encounter errors like
+   `module 'flask' has no attribute 'helpers'`,
    ensure there are no local directories named `flask`, `pandas`, or `yaml`
    in the project root. These placeholder packages can shadow the real
    libraries installed from `requirements.txt`. Delete them before running
@@ -153,7 +154,9 @@ following steps:
 4. If the dashboard starts with a blank page, required packages are
    likely missing. Install them before launching the app:
    ```bash
-   pip install -r requirements.txt  # or ./scripts/setup.sh
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   # or simply run ./scripts/setup.sh
    ```
 5. If Dash packages behave unexpectedly, reinstall them with pinned versions:
    ```bash
@@ -213,7 +216,7 @@ Install dependencies before running the tests:
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-# or use ./scripts/setup.sh which installs requirements.txt
+# or simply run ./scripts/setup.sh
 ```
 Detailed instructions are provided in
 [docs/test_setup.md](docs/test_setup.md).
@@ -257,7 +260,8 @@ dashboard. Key entry points include `tests/test_integration.py`,
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run
-`pip install -r requirements.txt` to install all dependencies.
+`pip install -r requirements.txt` and `pip install -r requirements-dev.txt` to
+install all dependencies (or execute `./scripts/setup.sh`).
 `PerformanceMonitor` requires `psutil` for CPU and memory metrics, and the
 file processing utilities depend on `chardet` to detect text encoding.
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     logging.error("Required package 'python-dotenv' is missing.")
     logging.error(
-        "Run `pip install -r requirements.txt` or `./scripts/setup.sh` to install dependencies."
+        "Run `pip install -r requirements.txt && pip install -r requirements-dev.txt` or `./scripts/setup.sh` to install dependencies."
     )
     sys.exit(1)
 

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -25,10 +25,10 @@ This guide walks new contributors through setting up a local development environ
 3. **Install dependencies:**
    ```bash
    ./scripts/setup.sh
-   pip install -r requirements-dev.txt
    ```
-   The development requirements include additional packages such as
-   **PyYAML** that are necessary when running the test suite.
+   This installs both `requirements.txt` and `requirements-dev.txt`. The
+   development requirements include additional packages such as **PyYAML** that
+   are necessary when running the test suite.
 
 4. **Compile translations:**
    ```bash

--- a/docs/developer_setup_checklist.md
+++ b/docs/developer_setup_checklist.md
@@ -18,8 +18,7 @@ This checklist summarizes the basic steps required to prepare a development envi
 ## Pre‑commit Hooks
 1. Install the dependencies and `pre-commit`:
    ```bash
-   pip install -r requirements.txt
-   pip install -r requirements-dev.txt
+   ./scripts/setup.sh
    pip install pre-commit
    ```
 2. Install the hooks:

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -16,6 +16,7 @@ Install the application and development requirements:
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
 ```
+Alternatively you can run `./scripts/setup.sh` to install both files at once.
 `requirements-dev.txt` includes additional packages such as **PyYAML** that are
 required by the tests but not needed in production.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
 if [ -d "$ROOT_DIR/packages" ]; then
     pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements.txt"
+    pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements-dev.txt"
 else
     pip install -r "$ROOT_DIR/requirements.txt"
+    pip install -r "$ROOT_DIR/requirements-dev.txt"
 fi


### PR DESCRIPTION
## Summary
- update setup script to install both requirements files
- clarify dependency installation steps in README
- link to setup script in test setup docs
- adjust developer docs and CONTRIBUTING instructions
- update error message about missing deps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a2eb63b588320ab619aaf93d70706