### PR TITLE
Remove progress event emission in upload service

### DIFF
--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -169,7 +169,6 @@ class UploadProcessingService:
 
             try:
                 def _cb(pct: int) -> None:
-                    progress_manager.emit(filename, pct)
                     if task_progress:
                         overall = int(((processed_files + pct / 100) / total_files) * 100)
                         task_progress(overall)


### PR DESCRIPTION
## Summary
- simplify file processing callback

## Testing
- `pytest -k process_uploaded_files -q` *(fails: No module named 'dash')*
- `python quick_test.py` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686a67c672b083208be2db27bdc51f2b