### PR TITLE
Update upload progress callback

### DIFF
--- a/services/upload/processing.py
+++ b/services/upload/processing.py
@@ -168,8 +168,7 @@ class UploadProcessingService:
                 content = parts[0]
 
             try:
-                def _cb(pct: int) -> None:
-                    progress_manager.emit(filename, pct)
+                def _cb(name: str, pct: int) -> None:
                     if task_progress:
                         overall = int(((processed_files + pct / 100) / total_files) * 100)
                         task_progress(overall)


### PR DESCRIPTION
## Summary
- adjust the local progress callback to accept filename and pct
- remove obsolete reference to `progress_manager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_686a67c821e88320a2f65060ef87884d