### PR TITLE
Fix indentation error in file_upload

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -321,7 +321,6 @@ class Callbacks:
             False,
             False,
         )
-            )
         
         if not isinstance(contents_list, list):
             contents_list = [contents_list]


### PR DESCRIPTION
## Summary
- fix stray closing paren in `file_upload.py`

## Testing
- `python3 -m py_compile pages/file_upload.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a6952ebe88320ae709ae3571f1b2b