### PR TITLE
Add upload manager unit and integration tests

### DIFF
--- a/new_tests/test_upload_integration.py
+++ b/new_tests/test_upload_integration.py
@@ -1,0 +1,151 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# provide minimal stubs for config dependencies
+import types
+conn_mod = types.ModuleType("config.connection_retry")
+class RetryConfig:
+    def __init__(self, max_attempts=3, base_delay=0.2, jitter=False):
+        self.max_attempts = max_attempts
+        self.base_delay = base_delay
+        self.jitter = jitter
+class ConnectionRetryManager:
+    def __init__(self, cfg=None):
+        self.cfg = cfg or RetryConfig()
+    def run_with_retry(self, func):
+        return func()
+conn_mod.RetryConfig = RetryConfig
+conn_mod.ConnectionRetryManager = ConnectionRetryManager
+sys.modules["config.connection_retry"] = conn_mod
+spec_queue = importlib.util.spec_from_file_location(
+    "upload_queue_manager", ROOT / "services" / "upload" / "upload_queue_manager.py"
+)
+queue_mod = importlib.util.module_from_spec(spec_queue)
+
+class SimpleStore:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.data: dict[str, pd.DataFrame] = {}
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def add_file(self, name: str, df: pd.DataFrame) -> None:
+        self.data[name] = df
+
+    def load_dataframe(self, name: str) -> pd.DataFrame:
+        return self.data[name]
+
+    def wait_for_pending_saves(self) -> None:
+        pass
+
+upload_store_mod = types.ModuleType("utils.upload_store")
+upload_store_mod.UploadedDataStore = SimpleStore
+sys.modules["utils.upload_store"] = upload_store_mod
+
+class CallbackEvent:
+    ANALYSIS_ERROR = "ANALYSIS_ERROR"
+
+class CallbackContext:
+    def __init__(self, event_type, source_id, timestamp, data=None):
+        self.event_type = event_type
+        self.source_id = source_id
+        self.timestamp = timestamp
+        self.data = data or {}
+
+class CallbackManager:
+    def __init__(self):
+        self.callbacks = []
+
+    def register_callback(self, event, func, priority=50):
+        self.callbacks.append(func)
+
+    def trigger(self, event, ctx):
+        for cb in list(self.callbacks):
+            cb(ctx)
+
+sys.modules["upload_queue_manager"] = queue_mod
+spec_queue.loader.exec_module(queue_mod)  # type: ignore
+UploadQueueManager = queue_mod.UploadQueueManager
+
+spec_chunk = importlib.util.spec_from_file_location(
+    "chunked_upload_manager", ROOT / "services" / "upload" / "chunked_upload_manager.py"
+)
+chunk_mod = importlib.util.module_from_spec(spec_chunk)
+sys.modules["chunked_upload_manager"] = chunk_mod
+spec_chunk.loader.exec_module(chunk_mod)  # type: ignore
+ChunkedUploadManager = chunk_mod.ChunkedUploadManager
+
+
+
+def test_resumable_upload_and_error_callback(tmp_path, monkeypatch):
+    data_file = tmp_path / "sample.csv"
+    df = pd.DataFrame({"a": range(15)})
+    df.to_csv(data_file, index=False)
+
+    store = SimpleStore(tmp_path / "store")
+    cmgr = ChunkedUploadManager(store, metadata_dir=tmp_path / "meta", initial_chunk_size=5)
+    queue = UploadQueueManager(max_concurrent=1)
+    queue.add_files([data_file])
+
+    cb_manager = CallbackManager()
+    errors: list[str] = []
+    cb_manager.register_callback(
+        CallbackEvent.ANALYSIS_ERROR,
+        lambda ctx: errors.append(ctx.data.get("err")),
+    )
+
+    call_count = 0
+    original_add = store.add_file
+
+    def flaky(name: str, chunk_df: pd.DataFrame):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("fail")
+        original_add(name, chunk_df)
+
+    monkeypatch.setattr(store, "add_file", flaky)
+
+    async def handler(path: Path):
+        try:
+            cmgr.upload_file(path)
+        except Exception as exc:  # first attempt fails
+            cb_manager.trigger(
+                CallbackEvent.ANALYSIS_ERROR,
+                CallbackContext(
+                    CallbackEvent.ANALYSIS_ERROR,
+                    "uploader",
+                    datetime.now(),
+                    {"err": str(exc)},
+                ),
+            )
+            raise
+
+    async def _run():
+        results = []
+        for _ in range(3):
+            results.extend(await queue.process_queue(handler))
+            if results:
+                break
+            await asyncio.sleep(0.01)
+        return results
+
+    results = asyncio.run(_run())
+
+    assert results and isinstance(results[0][1], Exception)
+    assert errors  # callback captured error
+
+    monkeypatch.setattr(store, "add_file", original_add)
+    cmgr.resume_upload(data_file)
+    store.wait_for_pending_saves()
+    assert cmgr.get_upload_progress("sample.csv") == pytest.approx(1.0)
+    saved = store.load_dataframe("sample.csv")
+    pd.testing.assert_frame_equal(saved, df)

--- a/new_tests/test_upload_queue_manager.py
+++ b/new_tests/test_upload_queue_manager.py
@@ -1,0 +1,54 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "upload_queue_manager", ROOT / "services" / "upload" / "upload_queue_manager.py"
+)
+upload_queue_manager = importlib.util.module_from_spec(spec)
+sys.modules["upload_queue_manager"] = upload_queue_manager
+spec.loader.exec_module(upload_queue_manager)  # type: ignore
+UploadQueueManager = upload_queue_manager.UploadQueueManager
+
+
+async def _dummy_handler(item):
+    await asyncio.sleep(0.01)
+    return item * 2
+
+
+def test_add_and_status():
+    state = {}
+    q = UploadQueueManager(state, max_concurrent=2)
+    q.add_files([1, 2, 3], priority=1)
+    assert q.get_queue_status()["pending"] == 3
+    assert state["queue_state"]["queue"]
+
+
+def test_persistence_between_instances():
+    state = {}
+    q1 = UploadQueueManager(state)
+    q1.add_files(["a", "b"])
+
+    q2 = UploadQueueManager(state)
+    status = q2.get_queue_status()
+    assert status["pending"] == 2
+
+
+def test_process_queue_executes_tasks():
+    async def _run():
+        q = UploadQueueManager(max_concurrent=2)
+        q.add_files([1, 2, 3])
+
+        results = []
+        for _ in range(10):
+            results.extend(await q.process_queue(_dummy_handler))
+            if not q.get_queue_status()["pending"] and not q.get_queue_status()["active"]:
+                break
+            await asyncio.sleep(0.02)
+        processed = [r for _, r in results]
+        return processed
+
+    processed = asyncio.run(_run())
+    assert sorted(processed) == [2, 4, 6]


### PR DESCRIPTION
## Summary
- add standalone tests for UploadQueueManager
- add resumable upload integration test covering callback errors

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest new_tests -q --confcutdir=new_tests`

------
https://chatgpt.com/codex/tasks/task_e_686a833b957c8320acb34a84568f2b87