### PR TITLE
Enhance drag-drop upload UI

### DIFF
--- a/assets/css/03-components/_upload.css
+++ b/assets/css/03-components/_upload.css
@@ -83,3 +83,65 @@
 [data-theme="high-contrast"] .upload-progress__bar {
   background: var(--color-white);
 }
+
+/* -------------------------------------------------- */
+/* Accessible Drag & Drop Upload Area                 */
+/* -------------------------------------------------- */
+.drag-drop-upload {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--color-accent);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  background: var(--surface-tertiary);
+  transition: background var(--duration-normal) var(--ease-out),
+              border-color var(--duration-normal) var(--ease-out);
+  cursor: pointer;
+}
+
+.drag-drop-upload--hover {
+  background: var(--color-accent-subtle);
+}
+
+.drag-drop-upload--dragging {
+  border-color: var(--color-accent-hover);
+  animation: upload-pulse 1.2s ease-out infinite;
+}
+
+.drag-drop-upload--uploading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+.drag-drop-upload__previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: 0;
+  list-style: none;
+}
+
+.drag-drop-upload__preview {
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--color-gray-600);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--surface-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.drag-drop-upload__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/assets/js/upload-handlers.js
+++ b/assets/js/upload-handlers.js
@@ -2,6 +2,10 @@
   const STORE_ID = 'client-validation-store';
   const UPLOAD_ID = 'upload-data';
 
+  function byId(id){
+    return document.getElementById(id);
+  }
+
   function bytesToHex(bytes){
     return Array.from(bytes).map(b=>b.toString(16).padStart(2,'0')).join('');
   }
@@ -56,24 +60,86 @@
   }
 
   document.addEventListener('DOMContentLoaded', function(){
-    const upload = document.getElementById(UPLOAD_ID);
+    const upload = byId(UPLOAD_ID);
     if(!upload){ return; }
+    const area = byId(`${UPLOAD_ID}-area`);
+    const previewList = byId(`${UPLOAD_ID}-previews`);
+    const cameraBtn = byId(`${UPLOAD_ID}-camera`);
     const input = upload.querySelector('input[type="file"]');
     if(!input){ return; }
     const maxBytes = parseInt(upload.getAttribute('data-max-size') || '0', 10);
 
+    if(area){
+      ['dragenter','dragover'].forEach(evt=>{
+        area.addEventListener(evt, e=>{
+          e.preventDefault();
+          area.classList.add('drag-drop-upload--hover');
+          if(evt==='dragover'){ area.classList.add('drag-drop-upload--dragging'); }
+        });
+      });
+      ['dragleave','drop'].forEach(evt=>{
+        area.addEventListener(evt, e=>{
+          area.classList.remove('drag-drop-upload--hover','drag-drop-upload--dragging');
+        });
+      });
+    }
+
+    if(cameraBtn){
+      cameraBtn.addEventListener('click', ()=>{
+        const camInput = document.createElement('input');
+        camInput.type = 'file';
+        camInput.accept = 'image/*';
+        camInput.capture = 'environment';
+        camInput.addEventListener('change', ()=>{
+          if(camInput.files.length){
+            const dt = new DataTransfer();
+            Array.from(input.files).forEach(f=>dt.items.add(f));
+            Array.from(camInput.files).forEach(f=>dt.items.add(f));
+            input.files = dt.files;
+            input.dispatchEvent(new Event('change', {bubbles:true}));
+          }
+        });
+        camInput.click();
+      });
+    }
+
     input.addEventListener('change', async function(e){
       e.stopImmediatePropagation();
       e.preventDefault();
+      if(area){ area.classList.add('drag-drop-upload--uploading'); }
       const files = Array.from(input.files);
       const {results, valid} = await validateFiles(files, maxBytes);
       updateStore(results);
       const dt = new DataTransfer();
       valid.forEach(f => dt.items.add(f));
       input.files = dt.files;
+      if(previewList){
+        previewList.innerHTML = '';
+        valid.forEach(file => {
+          const li = document.createElement('li');
+          li.className = 'drag-drop-upload__preview';
+          if(file.type.startsWith('image/')){
+            const reader = new FileReader();
+            reader.onload = () => {
+              const img = document.createElement('img');
+              img.src = reader.result;
+              img.alt = file.name;
+              li.appendChild(img);
+            };
+            reader.readAsDataURL(file);
+          } else {
+            const icon = document.createElement('span');
+            icon.className = 'fa fa-file';
+            icon.setAttribute('aria-hidden','true');
+            li.appendChild(icon);
+          }
+          previewList.appendChild(li);
+        });
+      }
       if(valid.length){
         input.dispatchEvent(new Event('change', {bubbles:true}));
       }
+      if(area){ setTimeout(()=>area.classList.remove('drag-drop-upload--uploading'),500); }
     }, true);
 
   });

--- a/components/upload/drag_drop_upload_area.py
+++ b/components/upload/drag_drop_upload_area.py
@@ -16,6 +16,7 @@ def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
 
     status_id = f"{upload_id}-status"
     camera_id = f"{upload_id}-camera"
+    preview_id = f"{upload_id}-previews"
 
     return html.Div(
         [
@@ -51,7 +52,13 @@ def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
                     className="drag-drop-upload__inner",
                 ),
             ),
-            html.Div(id=status_id, className="drag-drop-upload__status", role="status"),
+            html.Ul(id=preview_id, className="drag-drop-upload__previews", role="list"),
+            html.Div(
+                id=status_id,
+                className="drag-drop-upload__status",
+                role="status",
+                **{"aria-live": "polite"},
+            ),
         ],
         id=f"{upload_id}-area",
         className="drag-drop-upload drag-drop-upload--idle",

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -2,7 +2,18 @@
 
 ## Drag-and-Drop Usage
 
-The dashboard exposes a simple drag-and-drop area on the **Upload** page. Either drag files onto the drop zone or click the region to open the file dialog. Selected files appear in a queue where you can remove entries prior to starting the upload. Once you press **Upload**, each file is sent to the server and a progress indicator shows completion status.
+The dashboard exposes a simple drag-and-drop area on the **Upload** page. Either drag files onto the drop zone or click the region to open the file dialog. Selected files appear in a preview list where you can remove entries prior to starting the upload. Once you press **Upload**, each file is sent to the server and a progress indicator shows completion status.
+
+The component toggles state classes so you can style hover, dragging and uploading transitions. These classes are:
+
+- `drag-drop-upload--idle`
+- `drag-drop-upload--hover`
+- `drag-drop-upload--dragging`
+- `drag-drop-upload--uploading`
+
+File previews are rendered as thumbnails for images or with a generic file icon for other types.
+
+On mobile devices a **Use Camera** button activates the device camera and inserts the captured photo into the file list.
 
 Supported file types are CSV and JSON. Large files are streamed to avoid exhausting browser memory. You may upload multiple files at once; they will be processed sequentially.
 
@@ -25,5 +36,7 @@ Use the `MAX_PARALLEL_UPLOADS` environment variable to adjust this value.
 - The drop zone expands to full width on small screens and falls back to a standard file input when drag events are not supported.
 - Provide an `aria-label` on the drop zone so screen readers announce its purpose.
 - Ensure contrast ratios meet WCAG AA guidelines and that keyboard focus is visible.
+- The area exposes `role="button"` and supports keyboard activation via the Enter key.
 - Touch targets, including the Upload button and remove icons, should be at least 44&times;44&nbsp;px.
+- The **Use Camera** button invokes the mobile camera when available.
 


### PR DESCRIPTION
## Summary
- extend `DragDropUploadArea` to expose preview list and status region
- add styling and states for hover, dragging and uploading
- support drag events, previews and camera capture on the client
- document new behaviour in the upload guide

## Testing
- `pytest tests/integration/test_upload_progress_sse.py::test_upload_progress_sse -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a83356d808320b43bf44134929a94