### PR TITLE
Add configurable client-side validator

### DIFF
--- a/assets/js/upload-handlers.js
+++ b/assets/js/upload-handlers.js
@@ -6,39 +6,62 @@
     return Array.from(bytes).map(b=>b.toString(16).padStart(2,'0')).join('');
   }
 
-  function checkMagic(file){
+  function getConfig(upload){
+    const attr = upload.getAttribute('data-validator-config');
+    if(attr){
+      try{ return JSON.parse(attr); }catch(e){ }
+    }
+    if(window.uploadValidatorConfig){ return window.uploadValidatorConfig; }
+    return {};
+  }
+
+  function checkMagic(file, expected){
+    if(!expected || !expected.length){ return Promise.resolve(true); }
+    const maxLen = Math.max.apply(null, expected.map(h=>h.length/2));
     return new Promise((resolve)=>{
       const reader = new FileReader();
       reader.onloadend = function(){
         const arr = new Uint8Array(reader.result || []);
-        const hex = bytesToHex(arr.slice(0,4));
-        let ok = false;
-        if(hex.startsWith('504b0304')){ // zip based XLSX
-          ok = true;
-        } else if(hex.startsWith('d0cf11e0')){ // legacy XLS
-          ok = true;
-        } else {
-          const text = new TextDecoder('utf-8').decode(arr.slice(0,4));
-          ok = /^[\x20-\x7E\r\n]+$/.test(text);
-        }
+        const hex = bytesToHex(arr.slice(0,maxLen));
+        const ok = expected.some(h => hex.startsWith(h.toLowerCase()));
         resolve(ok);
       };
       reader.onerror = function(){ resolve(false); };
-      reader.readAsArrayBuffer(file.slice(0,8));
+      reader.readAsArrayBuffer(file.slice(0,maxLen));
     });
   }
 
-  async function validateFiles(files, maxBytes){
+  async function validateFiles(files, config){
     const results = [];
     const valid = [];
     const seen = new Set();
     for(const file of files){
       const issues = [];
-      if(maxBytes && file.size > maxBytes){ issues.push('too_large'); }
-      if(seen.has(file.name)){ issues.push('duplicate'); }
-      seen.add(file.name);
-      const magicOk = await checkMagic(file);
+      const ext = file.name.toLowerCase().split('.').pop();
+      const dotExt = '.' + ext;
+      if(config.allowed_ext && config.allowed_ext.length && !config.allowed_ext.includes(dotExt)){
+        issues.push('unsupported_type');
+      }
+      const limit = (config.size_limits && config.size_limits[dotExt]) || config.max_size;
+      if(limit && file.size > limit){ issues.push('too_large'); }
+      if(config.track_duplicates !== false){
+        if(seen.has(file.name)){ issues.push('duplicate'); }
+        seen.add(file.name);
+      }
+      const magicOk = await checkMagic(file, (config.magic_numbers && config.magic_numbers[dotExt]) || []);
       if(!magicOk){ issues.push('bad_magic'); }
+      if(Array.isArray(config.hooks)){
+        for(const fnName of config.hooks){
+          const fn = window[fnName];
+          if(typeof fn === 'function'){
+            try{
+              const res = await fn(file);
+              if(res === false){ issues.push('custom_error'); }
+              else if(typeof res === 'string' && res){ issues.push(res); }
+            }catch(err){ issues.push('custom_error'); }
+          }
+        }
+      }
       results.push({filename: file.name, valid: issues.length===0, issues: issues});
       if(issues.length===0){ valid.push(file); }
     }
@@ -60,13 +83,13 @@
     if(!upload){ return; }
     const input = upload.querySelector('input[type="file"]');
     if(!input){ return; }
-    const maxBytes = parseInt(upload.getAttribute('data-max-size') || '0', 10);
+    const config = getConfig(upload);
 
     input.addEventListener('change', async function(e){
       e.stopImmediatePropagation();
       e.preventDefault();
       const files = Array.from(input.files);
-      const {results, valid} = await validateFiles(files, maxBytes);
+      const {results, valid} = await validateFiles(files, config);
       updateStore(results);
       const dt = new DataTransfer();
       valid.forEach(f => dt.items.add(f));

--- a/components/upload/client_side_validator.py
+++ b/components/upload/client_side_validator.py
@@ -11,13 +11,25 @@ from dash import html
 class ClientSideValidator:
     """Utility for handling client-side upload validation results."""
 
+    ISSUE_MESSAGES = {
+        "too_large": "File exceeds size limit",
+        "duplicate": "Duplicate file",
+        "bad_magic": "File contents do not match type",
+        "unsupported_type": "Unsupported file type",
+        "decode_error": "Failed to decode data",
+        "custom_error": "Custom validation failed",
+    }
+
     def build_error_alerts(self, results: List[Dict[str, Any]]) -> List[Any]:
         """Convert validation results from the browser into alert components."""
         alerts: List[Any] = []
         for res in results:
             if res.get("valid", False):
                 continue
-            issues = ", ".join(res.get("issues", [])) or "Failed validation"
+            raw = res.get("issues", [])
+            issues = ", ".join(
+                self.ISSUE_MESSAGES.get(code, str(code)) for code in raw
+            ) or "Failed validation"
             alerts.append(
                 dbc.Alert(
                     [html.Strong(res.get("filename", "Unknown")), f": {issues}"],

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -55,3 +55,19 @@ from core.unicode import get_text_processor
 processor = get_text_processor()
 cleaned = processor.safe_encode_text(user_input)
 ```
+
+## ClientSideValidator
+
+Uploads are checked in the browser before being sent to the server.  The
+`ClientSideValidator` mirrors these rules on the server so behaviour is
+consistent regardless of where validation occurs.
+
+Key rules enforced:
+
+- **Magic number checks** – file headers must match their extension.
+- **Size limits** – configurable per file type with a global fallback.
+- **Duplicate detection** – repeated filenames are rejected in a single batch.
+- **Custom hooks** – optional callbacks allow bespoke validation logic.
+
+The validator exposes a JSON configuration via `to_json()` used by the
+`upload-handlers.js` script to apply the same checks client-side.

--- a/services/upload/validators.py
+++ b/services/upload/validators.py
@@ -1,31 +1,111 @@
 import base64
-from typing import Iterable
+import json
+from typing import Any, Callable, Iterable, List, Mapping
 
 
 class ClientSideValidator:
-    """Validate uploaded file name and size before processing."""
+    """Validate uploaded file name and size before processing.
+
+    The validator mirrors the behaviour of the client side checks shipped in the
+    accompanying JavaScript.  Instances can be configured with per-extension size
+    limits, magic number expectations, duplicate tracking and arbitrary rule
+    hooks.
+    """
 
     def __init__(
-        self, allowed_ext: Iterable[str] | None = None, max_size: int | None = None
+        self,
+        allowed_ext: Iterable[str] | None = None,
+        *,
+        max_size: int | None = None,
+        size_limits: Mapping[str, int] | None = None,
+        magic_numbers: Mapping[str, Iterable[bytes | str]] | None = None,
+        track_duplicates: bool = True,
+        hooks: Iterable[Callable[[str, bytes], Any]] | None = None,
     ) -> None:
         self.allowed_ext = {
             e.lower() for e in (allowed_ext or [".csv", ".xlsx", ".xls", ".json"])
         }
         self.max_size = max_size
+        self.size_limits = {k.lower(): v for k, v in (size_limits or {}).items()}
+        self.magic_numbers: dict[str, List[bytes]] = {}
+        for ext, vals in (magic_numbers or {}).items():
+            self.magic_numbers[ext.lower()] = [
+                v if isinstance(v, bytes) else bytes.fromhex(v)
+                for v in vals
+            ]
+        self.track_duplicates = track_duplicates
+        self.hooks = list(hooks or [])
+        self._seen: set[str] = set()
 
+    # ------------------------------------------------------------------
+    def _decode_content(self, content: str) -> bytes:
+        try:
+            data = content.split(",", 1)[1]
+            return base64.b64decode(data)
+        except Exception:
+            return b""
+
+    # ------------------------------------------------------------------
     def validate(self, filename: str, content: str) -> tuple[bool, str]:
-        ext_ok = any(filename.lower().endswith(ext) for ext in self.allowed_ext)
-        if not ext_ok:
-            return False, f"Unsupported file type: {filename}"
-        if self.max_size is not None:
+        """Validate a single uploaded file."""
+
+        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        issues: List[str] = []
+
+        if self.allowed_ext and ext not in self.allowed_ext:
+            issues.append("unsupported_type")
+
+        data = self._decode_content(content)
+        if not data:
+            issues.append("decode_error")
+
+        limit = self.size_limits.get(ext, self.max_size)
+        if limit is not None and len(data) > limit:
+            issues.append("too_large")
+
+        magics = self.magic_numbers.get(ext)
+        if magics:
+            header = data[: max(len(m) for m in magics)]
+            if not any(header.startswith(m) for m in magics):
+                issues.append("bad_magic")
+
+        if self.track_duplicates:
+            if filename in self._seen:
+                issues.append("duplicate")
+            self._seen.add(filename)
+
+        for hook in self.hooks:
             try:
-                data = content.split(",", 1)[1]
-                size = len(base64.b64decode(data))
-                if size > self.max_size:
-                    return False, f"{filename} exceeds maximum size"
-            except Exception:
-                return False, "Failed to decode uploaded content"
-        return True, ""
+                result = hook(filename, data)
+                if isinstance(result, tuple):
+                    valid, msg = result
+                    if not valid:
+                        issues.append(msg or "custom_error")
+                elif result is False:
+                    issues.append("custom_error")
+                elif isinstance(result, str) and result:
+                    issues.append(result)
+            except Exception as exc:  # pragma: no cover - hook error handling
+                issues.append(f"hook_error:{exc}")
+
+        return len(issues) == 0, ", ".join(issues)
+
+    # ------------------------------------------------------------------
+    def to_json(self) -> str:
+        """Return a JSON configuration for the browser validator."""
+
+        return json.dumps(
+            {
+                "allowed_ext": sorted(self.allowed_ext),
+                "max_size": self.max_size,
+                "size_limits": self.size_limits,
+                "magic_numbers": {
+                    k: [m.hex() for m in v]
+                    for k, v in self.magic_numbers.items()
+                },
+                "track_duplicates": self.track_duplicates,
+            }
+        )
 
 
 __all__ = ["ClientSideValidator"]


### PR DESCRIPTION
## Summary
- extend `ClientSideValidator` with magic checks, per-extension size limits,
  duplicate detection and hooks
- enforce rules in `upload-handlers.js`
- improve alert helper for client-side validation
- document validation behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a8338a4908320939069d840fa3c94