### PR TITLE
Add docs for mobile upload workflow and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,29 @@ install all dependencies (or execute `./scripts/setup.sh`).
 `PerformanceMonitor` requires `psutil` for CPU and memory metrics, and the
 file processing utilities depend on `chardet` to detect text encoding.
 
+## 🔄 Upload Workflow
+
+The upload page now streams files directly to a background task. Progress is
+reported via Server‑Sent Events at `/upload/progress/<task_id>`. Once the server
+finishes processing a file it updates the `file-info-store` so analytics pages
+pick up the new dataset automatically. Mobile users can collapse the queue to
+free up space and the workflow adjusts for touch interactions.
+
+## 📱 Mobile Support
+
+The layout is responsive down to narrow phone screens. Navigation collapses into
+a hamburger menu and the drag‑and‑drop region expands to full width. All touch
+targets meet the 44&nbsp;px guideline and alerts reposition so they remain
+readable on mobile devices.
+
+## 🛠️ Monitoring Setup
+
+Runtime metrics are exposed at `/metrics` for Prometheus. A sample configuration
+is provided in `monitoring/prometheus.yml`. Logstash support is available via
+`logging/logstash.conf`. Dashboards can be built in Grafana or Kibana using
+these data sources. See [performance_monitoring.md](docs/performance_monitoring.md)
+for details.
+
 ## 🔧 Configuration
 
 This project uses **`config/config.py`** for all application settings. The
@@ -572,6 +595,9 @@ The running application exposes Swagger-based API docs at `http://<host>:<port>/
 - Performance & log monitoring: [docs/performance_monitoring.md](docs/performance_monitoring.md)
 - Large file processing: [docs/performance_file_processor.md](docs/performance_file_processor.md)
 - Upload progress SSE: `/upload/progress/<task_id>` streams `data: <progress>` events roughly 60 times per second.
+- Callback design: [docs/callback_architecture.md](docs/callback_architecture.md)
+- State stores: [docs/state_management.md](docs/state_management.md)
+- Ops reference: [docs/operations_guide.md](docs/operations_guide.md)
 
 Update the spec by running `python tools/generate_openapi.py` which writes `docs/openapi.json` for the UI.
 ## Usage Examples

--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -1,0 +1,23 @@
+# Callback Architecture
+
+The dashboard routes events through a unified callback layer. `TrulyUnifiedCallbacks`
+wraps the Dash app and exposes a single `.callback` decorator. This decorator
+behaves like `app.callback` but also registers the function with the internal
+`CallbackManager`.
+
+## Registering Callbacks
+
+```python
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from core.callback_events import CallbackEvent
+
+callbacks = TrulyUnifiedCallbacks(app)
+
+@callbacks.callback(Output('output', 'children'), Input('btn', 'n_clicks'))
+def handle_click(n):
+    return f"Clicked {n} times"
+```
+
+Plugins can register their own hooks by implementing `register_callbacks(manager, container)`.
+The manager dispatches events defined in `CallbackEvent` so separate modules can
+react to analytics completion, file uploads and security incidents.

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -1,0 +1,25 @@
+# Operations Guide
+
+This document outlines how to monitor the dashboard and configure alerts.
+
+## Alert Configuration
+
+Alerts are emitted when background tasks fail or exceed the configured
+threshold. Set the notification email and severity level in your YAML
+configuration:
+
+```yaml
+alerts:
+  email: ops@example.com
+  severity_threshold: warning
+```
+
+The application sends messages to this address using the SMTP settings defined in
+`config`. You can override these values via environment variables in production.
+
+## Performance Dashboards
+
+Prometheus scrapes metrics from `/metrics` using the sample
+`monitoring/prometheus.yml`. Import this data source into Grafana to build CPU,
+memory and request charts. Logs can be forwarded to Elasticsearch through
+`logging/logstash.conf` and visualized with Kibana.

--- a/docs/state_management.md
+++ b/docs/state_management.md
@@ -1,0 +1,21 @@
+# State Management
+
+State is stored in several `dcc.Store` components placed in the base layout.
+These stores keep the client in sync across pages without relying on global
+variables.
+
+- **global-store** – application wide state shared by all users.
+- **session-store** – data scoped to the current user session.
+- **app-state-store** – cross page flags such as the initial load marker.
+- **theme-store** – remembers the selected color theme.
+
+Callbacks read and write to these stores via the `data` property. Example:
+
+```python
+@app.callback(Output('session-store', 'data'), Input('logout-btn', 'n_clicks'))
+def clear_session(_):
+    return {}
+```
+
+Use these stores instead of hidden inputs to avoid race conditions during
+multiple callback updates.

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -4,6 +4,12 @@
 
 The dashboard exposes a simple drag-and-drop area on the **Upload** page. Either drag files onto the drop zone or click the region to open the file dialog. Selected files appear in a queue where you can remove entries prior to starting the upload. Once you press **Upload**, each file is sent to the server and a progress indicator shows completion status.
 
+Behind the scenes the upload is handled by a background worker. A task ID is
+returned immediately and progress events are streamed over Server‑Sent Events at
+`/upload/progress/<task_id>`. When processing completes the UI refreshes the
+`file-info-store` so analytics pages can use the new data without reloading the
+entire app.
+
 Supported file types are CSV and JSON. Large files are streamed to avoid exhausting browser memory. You may upload multiple files at once; they will be processed sequentially.
 
 ## Configuration Options
@@ -18,7 +24,9 @@ variable `UPLOAD_CHUNK_SIZE`.
 
 Background tasks such as analytics processing and file saves run in a thread
 pool. The worker count comes from `uploads.max_parallel_uploads` (default `4`).
-Use the `MAX_PARALLEL_UPLOADS` environment variable to adjust this value.
+Use the `MAX_PARALLEL_UPLOADS` environment variable to adjust this value. When a
+file takes too long the worker emits a warning which appears in the alert panel
+and is also sent to any connected monitoring systems.
 
 ## Mobile & Accessibility Guidelines
 
@@ -26,4 +34,10 @@ Use the `MAX_PARALLEL_UPLOADS` environment variable to adjust this value.
 - Provide an `aria-label` on the drop zone so screen readers announce its purpose.
 - Ensure contrast ratios meet WCAG AA guidelines and that keyboard focus is visible.
 - Touch targets, including the Upload button and remove icons, should be at least 44&times;44&nbsp;px.
+
+## Monitoring
+
+Metrics for file uploads are exposed at `/metrics`. Import the sample
+`prometheus.yml` from the `monitoring/` directory to scrape these statistics.
+Logstash integration is also available via `logging/logstash.conf`.
 


### PR DESCRIPTION
## Summary
- document upload workflow and monitoring in README
- expand upload interface docs
- add dev docs on callback architecture and state stores
- create operations guide

## Testing
- `pytest -q` *(fails: ImportError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a833d2f548320879c4079617c21f2