### PR TITLE
Implement safe Unicode helpers

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -29,7 +29,7 @@ from core.security_patterns import (
     SQL_INJECTION_PATTERNS,
     XSS_PATTERNS,
 )
-from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_utils import sanitize_for_utf8
 
 
 class SecurityLevel(Enum):
@@ -110,7 +110,7 @@ class InputValidator:
         """Comprehensive input validation"""
         if not isinstance(input_data, str):
             input_data = str(input_data)
-        input_data = sanitize_unicode_input(input_data)
+        input_data = sanitize_for_utf8(input_data)
 
         result = {
             "field": field_name,
@@ -176,7 +176,7 @@ class InputValidator:
 
     def _sanitize_input(self, data: str) -> str:
         """Sanitize input data"""
-        data = sanitize_unicode_input(data)
+        data = sanitize_for_utf8(data)
         # Remove null bytes
         sanitized = data.replace("\x00", "")
 
@@ -281,10 +281,8 @@ class InputValidator:
         """Check file content for security issues"""
         # Convert to string for pattern matching (first 1KB)
         try:
-            from security.unicode_security_handler import UnicodeSecurityHandler
-
             text_content = content[:1024].decode("utf-8", errors="ignore")
-            text_content = UnicodeSecurityHandler.sanitize_unicode_input(text_content).lower()
+            text_content = sanitize_for_utf8(text_content).lower()
         except Exception:
             return False
 

--- a/core/unicode_utils.py
+++ b/core/unicode_utils.py
@@ -1,6 +1,71 @@
-"""Re-export core unicode functionality for backward compatibility."""
-from core.unicode import *
+"""Simplified Unicode helpers used across the code base."""
 
-# This module exists only for backward compatibility
-# All new code should import directly from core.unicode
+from __future__ import annotations
+
+import logging
+import unicodedata
+from typing import Any
+
+from .unicode_processor import sanitize_unicode_input as _sanitize_unicode_input
+
+
+logger = logging.getLogger(__name__)
+
+
+class UnicodeNormalizationError(Exception):
+    """Raised when Unicode normalization fails."""
+
+
+def normalize_unicode_safely(text: Any, form: str = "NFKC") -> str:
+    """Return ``text`` normalised using ``form`` with robust error handling."""
+
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to convert %r to str: %s", text, exc)
+            raise UnicodeNormalizationError(str(exc)) from exc
+
+    try:
+        return unicodedata.normalize(form, text)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Unicode normalization failed: %s", exc)
+        raise UnicodeNormalizationError(str(exc)) from exc
+
+
+def detect_surrogate_pairs(text: Any) -> bool:
+    """Return ``True`` if ``text`` contains any UTF-16 surrogate pair."""
+
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    for idx in range(len(text) - 1):
+        first = ord(text[idx])
+        second = ord(text[idx + 1])
+        if 0xD800 <= first <= 0xDBFF and 0xDC00 <= second <= 0xDFFF:
+            return True
+    return False
+
+
+def sanitize_for_utf8(value: Any) -> str:
+    """Return ``value`` cleaned of surrogates and normalised for UTF-8."""
+
+    cleaned = _sanitize_unicode_input(value)
+    try:
+        return normalize_unicode_safely(cleaned)
+    except UnicodeNormalizationError as exc:  # pragma: no cover - best effort
+        logger.warning("Returning unnormalised text due to error: %s", exc)
+        return cleaned
+
+
+__all__ = [
+    "normalize_unicode_safely",
+    "detect_surrogate_pairs",
+    "sanitize_for_utf8",
+    "UnicodeNormalizationError",
+]
+
 

--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -63,10 +63,10 @@ class ValidationMiddleware:
                 return None
             try:
                 from core.unicode_decode import safe_unicode_decode
-                from security.unicode_security_handler import UnicodeSecurityHandler
+                from core.unicode_utils import sanitize_for_utf8
 
                 raw_text = safe_unicode_decode(request.data, "utf-8")
-                sanitized = UnicodeSecurityHandler.sanitize_unicode_input(raw_text)
+                sanitized = sanitize_for_utf8(raw_text)
                 request._cached_data = self.orchestrator.validate(sanitized).encode(
                     "utf-8"
                 )

--- a/services/analytics_processing.py
+++ b/services/analytics_processing.py
@@ -6,7 +6,7 @@ import pandas as pd
 from dash import html
 
 from core.unicode_processor import safe_format_number
-from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_utils import sanitize_for_utf8
 from services import get_analytics_service
 from services.ai_suggestions import generate_column_suggestions
 from services.upload_data_service import get_uploaded_data
@@ -446,7 +446,7 @@ def create_analysis_results_display(results: Dict[str, Any], analysis_type: str)
             specific_content = [html.P("Standard analysis completed")]
             color = "info"
 
-        title_safe = sanitize_unicode_input(analysis_type.title() + " Results")
+        title_safe = sanitize_for_utf8(analysis_type.title() + " Results")
         events_safe = safe_format_number(total_events)
         users_safe = safe_format_number(unique_users)
         doors_safe = safe_format_number(unique_doors)

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -8,10 +8,8 @@ import pandas as pd
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from core.unicode_processor import process_large_csv_content
-from security.unicode_security_processor import (
-    sanitize_dataframe,
-    sanitize_unicode_input,
-)
+from core.unicode_utils import sanitize_for_utf8
+from security.unicode_security_processor import sanitize_dataframe
 from services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,
@@ -47,7 +45,7 @@ def process_file_simple(
         else:
             text = safe_decode_with_unicode_handling(content, encoding)
 
-        text = sanitize_unicode_input(text)
+        text = sanitize_for_utf8(text)
 
         from io import StringIO
 

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -17,7 +17,7 @@ from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 
 # Core processing imports only - NO UI COMPONENTS
-from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_utils import sanitize_for_utf8
 
 
 def _get_max_display_rows() -> int:
@@ -51,7 +51,7 @@ class UnicodeFileProcessor:
         """Remove Unicode surrogate characters from DataFrame"""
         for col in df.select_dtypes(include=['object']).columns:
             df[col] = df[col].astype(str).apply(
-                lambda x: sanitize_unicode_input(x) if isinstance(x, str) else x
+                lambda x: sanitize_for_utf8(x) if isinstance(x, str) else x
             )
         return df
 
@@ -125,7 +125,7 @@ def create_file_preview(df: pd.DataFrame, max_rows: int | None = None) -> Dict[s
                 elif isinstance(val, (int, float)):
                     safe_row[col] = safe_format_number(val)
                 else:
-                    safe_row[col] = sanitize_unicode_input(str(val))
+                    safe_row[col] = sanitize_for_utf8(str(val))
             preview_data.append(safe_row)
 
         return {

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -15,11 +15,8 @@ import pandas as pd
 
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
-from core.unicode import (
-    UnicodeProcessor,
-    sanitize_dataframe,
-    sanitize_unicode_input,
-)
+from core.unicode import UnicodeProcessor, sanitize_dataframe
+from core.unicode_utils import sanitize_for_utf8
 from upload_types import ValidationResult
 from upload_validator import UploadValidator
 
@@ -45,9 +42,7 @@ def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
 
     text = safe_unicode_decode(data, enc)
 
-    from security.unicode_security_handler import UnicodeSecurityHandler
-
-    cleaned = UnicodeSecurityHandler.sanitize_unicode_input(text)
+    cleaned = sanitize_for_utf8(text)
     return cleaned.replace("\ufffd", "")
 
 
@@ -216,7 +211,7 @@ class UnifiedFileValidator:
         self._basic_validator = UploadValidator(self.max_size_mb)
 
     def _sanitize_string(self, value: str) -> str:
-        cleaned = sanitize_unicode_input(str(value))
+        cleaned = sanitize_for_utf8(str(value))
         if re.search(
             r"(<script.*?>.*?</script>|<.*?on\w+\s*=|javascript:|data:text/html|[<>])",
             cleaned,

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -14,11 +14,8 @@ import pandas as pd
 
 from config.dynamic_config import dynamic_config
 from core.performance_file_processor import PerformanceFileProcessor
-from core.unicode import (
-    process_large_csv_content,
-    sanitize_data_frame,
-    sanitize_unicode_input,
-)
+from core.unicode import process_large_csv_content, sanitize_data_frame
+from core.unicode_utils import sanitize_for_utf8
 from services.data_processing.core.protocols import FileProcessorProtocol
 from utils.file_validator import safe_decode_with_unicode_handling
 
@@ -64,7 +61,7 @@ class FileProcessorService(BaseService):
 
     def validate_file(self, filename: str, content: bytes) -> Dict[str, Any]:
         """Validate uploaded file"""
-        filename = sanitize_unicode_input(filename)
+        filename = sanitize_for_utf8(filename)
         issues = []
 
         # Check file extension
@@ -95,7 +92,7 @@ class FileProcessorService(BaseService):
     def process_file(self, file_content: bytes, filename: str) -> pd.DataFrame:
         """Process uploaded file and return DataFrame"""
         try:
-            filename = sanitize_unicode_input(filename)
+            filename = sanitize_for_utf8(filename)
             file_ext = Path(filename).suffix.lower()
 
             if file_ext == ".csv":
@@ -216,7 +213,7 @@ class FileProcessorService(BaseService):
             text = data.decode(encoding, errors="surrogatepass")
         except Exception:
             text = data.decode(encoding, errors="replace")
-        return sanitize_unicode_input(text)
+        return sanitize_for_utf8(text)
 
     def _is_reasonable_text(self, text: str) -> bool:
         """Basic check to ensure decoded text looks valid."""

--- a/tests/test_unicode_utils.py
+++ b/tests/test_unicode_utils.py
@@ -1,0 +1,23 @@
+import pytest
+
+from core.unicode_utils import (
+    normalize_unicode_safely,
+    detect_surrogate_pairs,
+    sanitize_for_utf8,
+    UnicodeNormalizationError,
+)
+
+
+def test_normalize_unicode_safely_nfkc():
+    text = "ＡＢＣ"
+    assert normalize_unicode_safely(text) == "ABC"
+
+
+def test_detect_surrogate_pairs():
+    assert detect_surrogate_pairs("\ud83d\ude00")
+    assert not detect_surrogate_pairs("hello")
+
+
+def test_sanitize_for_utf8_removes_surrogates_and_normalizes():
+    text = "A" + "\ud800" + "B" + "\ufeff" + "Ｃ"
+    assert sanitize_for_utf8(text) == "ABC"

--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from config.config import get_analytics_config
-from security.unicode_security_processor import sanitize_unicode_input
+from core.unicode_utils import sanitize_for_utf8
 from services.analytics_service import MAX_DISPLAY_ROWS
 
 
@@ -27,7 +27,7 @@ def serialize_dataframe_preview(df: pd.DataFrame) -> List[Dict[str, Any]]:
 
         preview = limited_df.head(5).to_dict("records")
         preview = [
-            {k: sanitize_unicode_input(v) for k, v in row.items()}
+            {k: sanitize_for_utf8(v) for k, v in row.items()}
             for row in preview
         ]
         serialized = json.dumps(preview, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- add new Unicode utilities for normalization, surrogate detection and sanitization
- update security validator and middleware to use them
- migrate upload processing modules to the new helpers
- extend input validation with UTF‑8 sanitization
- add unit tests for the utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ae12873108320a1a58326587e19b1