### PR TITLE
Update prod compose to use Docker secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,10 @@ Desktop.ini
 .env.development
 .env.staging
 *.key
-secrets/
+secrets/*
+!secrets/
+!secrets/*.txt
+!secrets/README.md
 
 # Training data
 data/training/

--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ Using Docker Compose:
 docker-compose -f docker-compose.prod.yml up -d
 ```
 Whenever you modify the code, rebuild the Docker image with `docker-compose build` (or `docker-compose up --build`) so the running container picks up your changes.
-Docker Compose reads variables from a `.env` file in this directory. Set
-`DB_PASSWORD` **and** `SECRET_KEY` there (or export them in your shell) before
-starting the services.
+Docker Compose reads sensitive values from files under the `secrets/`
+directory. Create `secrets/db_password.txt` and `secrets/secret_key.txt`
+containing your database password and Flask secret key before starting the
+services. The files will be mounted into `/run/secrets` automatically.
 
 Alternatively you can launch the app with Gunicorn or uWSGI. This is the
 recommended approach for any production deployment. A sample Gunicorn

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,13 +7,11 @@ services:
       dockerfile: Dockerfile.prod
     environment:
       YOSAI_ENV: production
-      SECRET_KEY: ${SECRET_KEY}
       DB_TYPE: postgresql
       DB_HOST: db
       DB_PORT: 5432
       DB_NAME: yosai_intel
       DB_USER: postgres
-      DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     depends_on:
@@ -30,13 +28,16 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    secrets:
+      - secret_key
+      - db_password
 
   db:
     image: postgres:15
     environment:
       POSTGRES_DB: yosai_intel
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password.txt
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./database_setup.sql:/docker-entrypoint-initdb.d/init.sql
@@ -48,6 +49,8 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
+    secrets:
+      - db_password
 
   redis:
     image: redis:7
@@ -65,3 +68,9 @@ services:
 volumes:
   postgres_data:
   redis_data:
+
+secrets:
+  db_password:
+    file: secrets/db_password.txt
+  secret_key:
+    file: secrets/secret_key.txt

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -32,8 +32,10 @@ to your organization policy.
 ## Docker and Cloud Secret Usage
 
 Secrets can be supplied as Docker secrets when running with Docker
-Compose. Mount files under `/run/secrets` and the application will read
-them via environment variables. For cloud deployments the
+Compose. The production compose file expects `secrets/db_password.txt`
+and `secrets/secret_key.txt` which are mounted under `/run/secrets`. The
+application reads these files and exposes them through environment
+variables. For cloud deployments the
 `SecretManager` supports `env`, `aws`, and `vault` backends. Set the
 `SECRET_BACKEND` variable to select the desired provider.
 

--- a/secrets/db_password.txt
+++ b/secrets/db_password.txt
@@ -1,0 +1,1 @@
+replace-with-db-password

--- a/secrets/secret_key.txt
+++ b/secrets/secret_key.txt
@@ -1,0 +1,1 @@
+replace-with-secret-key


### PR DESCRIPTION
## Summary
- remove env vars from `docker-compose.prod.yml`
- mount secrets for the app and database containers
- document providing Docker secrets
- keep example secret files under `secrets/`

## Testing
- `black . --check` *(fails: would reformat 142 files)*

------
https://chatgpt.com/codex/tasks/task_e_686ae12ab6048320af4bffac90fd2707