### PR TITLE
Add network default constants

### DIFF
--- a/config/cache_manager.py
+++ b/config/cache_manager.py
@@ -5,14 +5,16 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from .constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
+
 
 @dataclass
 class CacheConfig:
     """Cache configuration"""
 
     type: str = "memory"
-    host: str = "localhost"
-    port: int = 6379
+    host: str = DEFAULT_CACHE_HOST
+    port: int = DEFAULT_CACHE_PORT
 
 
 logger = logging.getLogger(__name__)
@@ -72,8 +74,8 @@ def from_environment() -> CacheConfig:
     """Create ``CacheConfig`` from environment variables."""
     return CacheConfig(
         type=os.getenv("CACHE_TYPE", "memory"),
-        host=os.getenv("CACHE_HOST", "localhost"),
-        port=int(os.getenv("CACHE_PORT", 6379)),
+        host=os.getenv("CACHE_HOST", DEFAULT_CACHE_HOST),
+        port=int(os.getenv("CACHE_PORT", DEFAULT_CACHE_PORT)),
     )
 
 

--- a/config/config.py
+++ b/config/config.py
@@ -18,6 +18,14 @@ from core.secret_manager import SecretManager
 from .config_validator import ConfigValidator
 from .dynamic_config import dynamic_config
 from .environment import get_environment, select_config_file
+from .constants import (
+    DEFAULT_APP_HOST,
+    DEFAULT_APP_PORT,
+    DEFAULT_DB_HOST,
+    DEFAULT_DB_PORT,
+    DEFAULT_CACHE_HOST,
+    DEFAULT_CACHE_PORT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +44,8 @@ class AppConfig:
 
     title: str = "Yōsai Intel Dashboard"
     debug: bool = True
-    host: str = "127.0.0.1"
-    port: int = 8050
+    host: str = DEFAULT_APP_HOST
+    port: int = DEFAULT_APP_PORT
     secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
     environment: str = "development"
 
@@ -47,8 +55,8 @@ class DatabaseConfig:
     """Database configuration"""
 
     type: str = "sqlite"
-    host: str = "localhost"
-    port: int = 5432
+    host: str = DEFAULT_DB_HOST
+    port: int = DEFAULT_DB_PORT
     name: str = "yosai.db"
     user: str = "user"
     password: str = ""
@@ -127,8 +135,8 @@ class CacheConfig:
     """Cache backend settings"""
 
     type: str = "memory"
-    host: str = "localhost"
-    port: int = 6379
+    host: str = DEFAULT_CACHE_HOST
+    port: int = DEFAULT_CACHE_PORT
     database: int = 0
     timeout_seconds: int = 300
     key_prefix: str = "yosai:"
@@ -495,7 +503,7 @@ class ConfigManager(ConfigProviderProtocol):
             ):
                 warnings.append("Production database requires password")
 
-            if self.config.app.host == "127.0.0.1":
+            if self.config.app.host == DEFAULT_APP_HOST:
                 warnings.append("Production should not run on localhost")
 
         if self.config.app.debug and self.config.app.host == "0.0.0.0":

--- a/config/constants.py
+++ b/config/constants.py
@@ -138,3 +138,14 @@ class CacheConstants:
 
     max_items: int = 100
     purge_count: int = 50
+
+
+# Network defaults
+DEFAULT_APP_HOST: str = "127.0.0.1"
+DEFAULT_APP_PORT: int = 8050
+
+DEFAULT_DB_HOST: str = "localhost"
+DEFAULT_DB_PORT: int = 5432
+
+DEFAULT_CACHE_HOST: str = "localhost"
+DEFAULT_CACHE_PORT: int = 6379

--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Protocol
 
 from .database_exceptions import ConnectionValidationFailed, DatabaseError
+from .constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,8 @@ class DatabaseConfig:
     """Database configuration dataclass"""
 
     type: str = "sqlite"
-    host: str = "localhost"
-    port: int = 5432
+    host: str = DEFAULT_DB_HOST
+    port: int = DEFAULT_DB_PORT
     name: str = "yosai.db"
     user: str = "user"
     password: str = ""

--- a/core/plugins/config/cache_manager.py
+++ b/core/plugins/config/cache_manager.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 import redis
 
 from .interfaces import ICacheManager
+from config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +91,8 @@ class RedisCacheManager(ICacheManager):
     def _client(self) -> redis.Redis:
         if self.redis_client is None:
             self.redis_client = redis.Redis(
-                host=getattr(self.config, "host", "localhost"),
-                port=getattr(self.config, "port", 6379),
+                host=getattr(self.config, "host", DEFAULT_CACHE_HOST),
+                port=getattr(self.config, "port", DEFAULT_CACHE_PORT),
                 db=getattr(self.config, "db", 0),
             )
         return self.redis_client

--- a/core/plugins/config/database_manager.py
+++ b/core/plugins/config/database_manager.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 import psycopg2
 from psycopg2.extras import RealDictCursor
+from config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
 
 from .interfaces import ConnectionResult, IDatabaseManager
 
@@ -59,8 +60,8 @@ class PostgreSQLDatabaseManager(IDatabaseManager):
         try:
             logger.info("Creating PostgreSQL connection")
             self.connection = psycopg2.connect(
-                host=getattr(self.config, "host", "localhost"),
-                port=getattr(self.config, "port", 5432),
+                host=getattr(self.config, "host", DEFAULT_DB_HOST),
+                port=getattr(self.config, "port", DEFAULT_DB_PORT),
                 dbname=getattr(
                     self.config, "name", getattr(self.config, "database", "postgres")
                 ),

--- a/dash_csrf_plugin/cli.py
+++ b/dash_csrf_plugin/cli.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any, Dict
 
 import click
+from config.constants import DEFAULT_APP_PORT
 
 from .config import CSRFConfig, CSRFMode
 from .plugin import DashCSRFPlugin
@@ -106,7 +107,7 @@ def generate_key(length):
 @cli.command()
 @click.argument("app_module")
 @click.option("--host", "-h", default="127.0.0.1", help="Host to bind to")
-@click.option("--port", "-p", default=8050, help="Port to bind to")
+@click.option("--port", "-p", default=DEFAULT_APP_PORT, help="Port to bind to")
 @click.option("--debug", is_flag=True, help="Enable debug mode")
 def run(app_module, host, port, debug):
     """Run a Dash app with CSRF protection"""

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,4 +1,6 @@
-bind = "0.0.0.0:8050"
+from config.constants import DEFAULT_APP_PORT
+
+bind = f"0.0.0.0:{DEFAULT_APP_PORT}"
 workers = 4
 threads = 2
 loglevel = "info"

--- a/tests/test_default_constants.py
+++ b/tests/test_default_constants.py
@@ -1,0 +1,7 @@
+import config.constants as constants
+
+
+def test_default_ports():
+    assert constants.DEFAULT_APP_PORT == 8050
+    assert constants.DEFAULT_DB_PORT == 5432
+    assert constants.DEFAULT_CACHE_PORT == 6379


### PR DESCRIPTION
## Summary
- centralize network defaults in `config/constants.py`
- refactor configuration and cache/database managers to use these constants
- propagate defaults to CLI and Gunicorn settings
- add tests for new constants

## Testing
- `pytest tests/test_default_constants.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ae12c937483208be5704f5805aa82