### PR TITLE
Add EnhancedConnectionPool and migration manager

### DIFF
--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -342,12 +342,12 @@ class EnhancedPostgreSQLManager(DatabaseManager):
 
     def __init__(self, config: DatabaseConfig, retry_config: RetryConfig | None = None):
         super().__init__(config)
-        from .connection_pool import DatabaseConnectionPool
+        from database.connection_pool import EnhancedConnectionPool
         from .connection_retry import ConnectionRetryManager, RetryConfig
         from .unicode_handler import UnicodeQueryHandler
 
         self.retry_manager = ConnectionRetryManager(retry_config or RetryConfig())
-        self.pool = DatabaseConnectionPool(
+        self.pool = EnhancedConnectionPool(
             self._create_connection,
             self.config.initial_pool_size,
             self.config.max_pool_size,

--- a/database/connection_pool.py
+++ b/database/connection_pool.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+from config.database_exceptions import ConnectionValidationFailed
+from config.database_manager import DatabaseConnection
+
+
+class CircuitBreaker:
+    """Simple circuit breaker implementation."""
+
+    def __init__(self, failure_threshold: int = 5, recovery_timeout: int = 30) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._failures = 0
+        self._opened_at: float | None = None
+        self._lock = threading.Lock()
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failures = 0
+            self._opened_at = None
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._failures += 1
+            if self._failures >= self.failure_threshold:
+                self._opened_at = time.time()
+
+    def allows_request(self) -> bool:
+        with self._lock:
+            if self._opened_at is None:
+                return True
+            if time.time() - self._opened_at >= self.recovery_timeout:
+                self._failures = 0
+                self._opened_at = None
+                return True
+            return False
+
+
+class EnhancedConnectionPool:
+    """Connection pool with circuit breaker and metrics tracking."""
+
+    def __init__(
+        self,
+        factory: Callable[[], DatabaseConnection],
+        initial_size: int,
+        max_size: int,
+        timeout: int,
+        shrink_timeout: int,
+        *,
+        failure_threshold: int = 5,
+        recovery_timeout: int = 30,
+        threshold: float = 0.8,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._factory = factory
+        self._initial_size = initial_size
+        self._max_pool_size = max(max_size, initial_size)
+        self._max_size = initial_size
+        self._timeout = timeout
+        self._shrink_timeout = shrink_timeout
+        self._threshold = threshold
+
+        self._pool: List[Tuple[DatabaseConnection, float]] = []
+        self._active = 0
+        self.circuit_breaker = CircuitBreaker(failure_threshold, recovery_timeout)
+        self.metrics: Dict[str, Any] = {
+            "acquired": 0,
+            "released": 0,
+            "failed": 0,
+            "timeouts": 0,
+            "acquire_times": [],
+        }
+
+        for _ in range(initial_size):
+            conn = self._factory()
+            self._pool.append((conn, time.time()))
+            self._active += 1
+
+    # ------------------------------------------------------------------
+    def _maybe_expand(self) -> None:
+        if self._max_size == 0:
+            return
+        usage = (self._active - len(self._pool)) / self._max_size
+        if usage >= self._threshold and self._max_size < self._max_pool_size:
+            self._max_size = min(self._max_size * 2, self._max_pool_size)
+
+    # ------------------------------------------------------------------
+    def _shrink_idle_connections(self) -> None:
+        now = time.time()
+        new_pool: List[Tuple[DatabaseConnection, float]] = []
+        for conn, ts in self._pool:
+            if now - ts > self._shrink_timeout and self._max_size > self._initial_size:
+                conn.close()
+                self._active -= 1
+                self._max_size -= 1
+            else:
+                new_pool.append((conn, ts))
+        self._pool = new_pool
+
+    # ------------------------------------------------------------------
+    def get_connection(self) -> DatabaseConnection:
+        start = time.time()
+        if not self.circuit_breaker.allows_request():
+            raise ConnectionValidationFailed("circuit open")
+        deadline = start + self._timeout
+        while True:
+            with self._lock:
+                self._shrink_idle_connections()
+                self._maybe_expand()
+
+                if self._pool:
+                    conn, _ = self._pool.pop()
+                    if not conn.health_check():
+                        conn.close()
+                        self._active -= 1
+                        self.metrics["failed"] += 1
+                        self.circuit_breaker.record_failure()
+                        if not self.circuit_breaker.allows_request():
+                            raise ConnectionValidationFailed("circuit open")
+                        continue
+                    self.metrics["acquired"] += 1
+                    self.metrics["acquire_times"].append(time.time() - start)
+                    self.circuit_breaker.record_success()
+                    return conn
+
+                if self._active < self._max_size:
+                    conn = self._factory()
+                    if not conn.health_check():
+                        conn.close()
+                        self.metrics["failed"] += 1
+                        self.circuit_breaker.record_failure()
+                        if not self.circuit_breaker.allows_request():
+                            raise ConnectionValidationFailed("circuit open")
+                        continue
+                    self._active += 1
+                    self.metrics["acquired"] += 1
+                    self.metrics["acquire_times"].append(time.time() - start)
+                    self.circuit_breaker.record_success()
+                    return conn
+
+            if time.time() >= deadline:
+                self.metrics["timeouts"] += 1
+                self.circuit_breaker.record_failure()
+                raise TimeoutError("No available connection in pool")
+            time.sleep(0.05)
+
+    # ------------------------------------------------------------------
+    def release_connection(self, conn: DatabaseConnection) -> None:
+        with self._lock:
+            self._shrink_idle_connections()
+            if not conn.health_check():
+                conn.close()
+                self._active -= 1
+                self.metrics["failed"] += 1
+                self.circuit_breaker.record_failure()
+                return
+
+            if len(self._pool) >= self._max_size:
+                conn.close()
+                self._active -= 1
+            else:
+                self._pool.append((conn, time.time()))
+            self.metrics["released"] += 1
+
+    # ------------------------------------------------------------------
+    def health_check(self) -> bool:
+        with self._lock:
+            temp: List[Tuple[DatabaseConnection, float]] = []
+            healthy = True
+            while self._pool:
+                conn, ts = self._pool.pop()
+                if not conn.health_check():
+                    healthy = False
+                    conn.close()
+                    self._active -= 1
+                    self.metrics["failed"] += 1
+                    if self._max_size > self._initial_size:
+                        self._max_size -= 1
+                else:
+                    temp.append((conn, ts))
+            for item in temp:
+                self.release_connection(item[0])
+            if not healthy:
+                self.circuit_breaker.record_failure()
+            else:
+                self.circuit_breaker.record_success()
+            return healthy
+
+    # ------------------------------------------------------------------
+    def get_metrics(self) -> Dict[str, Any]:
+        data = self.metrics.copy()
+        times = data.pop("acquire_times")
+        data["avg_acquire_time"] = (sum(times) / len(times)) if times else 0.0
+        data["active"] = self._active
+        return data
+
+
+__all__ = ["EnhancedConnectionPool", "CircuitBreaker"]

--- a/database/migrations.py
+++ b/database/migrations.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from alembic import command
+from alembic.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationManager:
+    """Manage Alembic database migrations with simple rollback support."""
+
+    def __init__(self, config_path: str = "alembic.ini") -> None:
+        self.config = Config(config_path)
+        self._history: List[str] = []
+
+    def upgrade(self, revision: str = "head") -> None:
+        command.upgrade(self.config, revision)
+        self._history.append(revision)
+        logger.info("Upgraded to %s", revision)
+
+    def downgrade(self, revision: str) -> None:
+        command.downgrade(self.config, revision)
+        if self._history:
+            self._history.pop()
+        logger.info("Downgraded to %s", revision)
+
+    def rollback(self) -> None:
+        if len(self._history) < 2:
+            prev = "base"
+        else:
+            prev = self._history[-2]
+        command.downgrade(self.config, prev)
+        if self._history:
+            self._history.pop()
+        logger.info("Rolled back to %s", prev)
+
+    def current(self) -> None:
+        command.current(self.config)
+
+
+__all__ = ["MigrationManager"]

--- a/tests/test_enhanced_connection_pool.py
+++ b/tests/test_enhanced_connection_pool.py
@@ -1,0 +1,48 @@
+import pytest
+
+from database.connection_pool import EnhancedConnectionPool, CircuitBreaker
+from config.database_manager import MockConnection
+from config.database_exceptions import ConnectionValidationFailed
+
+
+def factory():
+    return MockConnection()
+
+
+def test_pool_metrics():
+    pool = EnhancedConnectionPool(factory, 1, 2, timeout=1, shrink_timeout=1)
+    conn = pool.get_connection()
+    pool.release_connection(conn)
+    metrics = pool.get_metrics()
+    assert metrics["acquired"] == 1
+    assert metrics["released"] == 1
+    assert metrics["active"] <= 2
+
+
+class BadConn:
+    def health_check(self):
+        return False
+
+    def close(self):
+        pass
+
+
+def bad_factory():
+    return BadConn()
+
+
+def test_circuit_breaker_opens_on_failures():
+    pool = EnhancedConnectionPool(
+        bad_factory,
+        1,
+        1,
+        timeout=0.1,
+        shrink_timeout=0,
+        failure_threshold=2,
+        recovery_timeout=1,
+    )
+    with pytest.raises(ConnectionValidationFailed):
+        pool.get_connection()
+    # second attempt should immediately fail due to open circuit
+    with pytest.raises(ConnectionValidationFailed):
+        pool.get_connection()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,35 @@
+import pytest
+
+from database.migrations import MigrationManager
+
+
+class Dummy:
+    def __init__(self):
+        self.called = []
+
+    def upgrade(self, cfg, rev):
+        self.called.append(("upgrade", rev))
+
+    def downgrade(self, cfg, rev):
+        self.called.append(("downgrade", rev))
+
+    def current(self, cfg):
+        self.called.append(("current", None))
+
+
+@pytest.fixture
+def monkeypatched_commands(monkeypatch):
+    dummy = Dummy()
+    monkeypatch.setattr("alembic.command.upgrade", dummy.upgrade)
+    monkeypatch.setattr("alembic.command.downgrade", dummy.downgrade)
+    monkeypatch.setattr("alembic.command.current", dummy.current)
+    return dummy
+
+
+def test_migration_upgrade_and_rollback(monkeypatched_commands):
+    mgr = MigrationManager("alembic.ini")
+    mgr.upgrade("head")
+    assert ("upgrade", "head") in monkeypatched_commands.called
+    mgr.rollback()
+    # rollback triggers downgrade
+    assert ("downgrade", "base") in monkeypatched_commands.called


### PR DESCRIPTION
## Summary
- provide new `database.connection_pool` with metrics and circuit breaker
- implement Alembic-based `MigrationManager`
- update PostgreSQL manager to use enhanced pool
- add tests for new connection pool and migration manager

## Testing
- `pytest -q tests/test_enhanced_connection_pool.py tests/test_migrations.py`

------
https://chatgpt.com/codex/tasks/task_e_686ae12e01ec832096e9b0250f174963