### PR TITLE
Fix page transition delay by removing redundant loading spinner

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -518,13 +518,9 @@ def _create_main_layout() -> html.Div:
                 className="top-panel",
             ),
             # Main content area (dynamically populated)
-            dcc.Loading(
-                id="page-loading",
-                type="circle",
-                children=html.Main(
-                    id="page-content",
-                    className="main-content p-4 transition-fade-move transition-start",
-                ),
+            html.Main(
+                id="page-content",
+                className="main-content p-4 transition-fade-move transition-start",
             ),
             # Global data stores
             dcc.Store(id="global-store", data={}),


### PR DESCRIPTION
## Summary
- simplify main layout to avoid unnecessary dash Loading wrapper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686af7415108832093adc508c11040f7