### PR TITLE
Fix navbar icons list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,17 @@ yosai_intel_dashboard/
 ### Navbar Icons
 
 Store PNG images for the navigation bar in `assets/navbar_icons/`. The
-application expects the files `dashboard.png`, `analytics.png`, `graphs.png`,
-`upload.png`, `print.png`, `settings.png` and `logout.png`. Additional icons can live in the same
-directory as long as their paths match the references in
+application expects the following files:
+
+* `dashboard.png`
+* `analytics.png`
+* `graphs.png`
+* `upload.png`
+* `print.png`
+* `settings.png`
+* `logout.png`
+
+Additional icons can live in the same directory as long as their paths match the references in
 `components/ui/navbar.py`.
 
 ## 🚀 Quick Start


### PR DESCRIPTION
## Summary
- clarify list of expected navbar icon files

## Testing
- `pre-commit run --files README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b0053cd308320ba035b9b00a538ab