### PR TITLE
Fix aria-label support in drag drop upload area

### DIFF
--- a/components/upload/drag_drop_upload_area.py
+++ b/components/upload/drag_drop_upload_area.py
@@ -2,7 +2,6 @@
 """Accessible drag and drop upload area component."""
 from __future__ import annotations
 
-import dash_bootstrap_components as dbc
 from dash import dcc, html
 
 
@@ -40,12 +39,11 @@ def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
                             id=f"{upload_id}-label",
                             className="mb-1",
                         ),
-                        dbc.Button(
+                        html.Button(
                             "Use Camera",
                             id=camera_id,
-                            color="secondary",
-                            size="sm",
-                            className="mt-2",
+                            className="btn btn-secondary mt-2",
+                            type="button",
                             **{"aria-label": "Use camera to capture"},
                         ),
                     ],


### PR DESCRIPTION
## Summary
- swap `dbc.Button` with `html.Button` in `DragDropUploadArea`
- remove unused import

## Testing
- `pre-commit run --hook-stage manual --files components/upload/drag_drop_upload_area.py` *(fails: mypy errors unrelated to this change)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b1f72b03c8320a54c822fececc9d2