### PR TITLE
Fix navbar icon classes

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -93,10 +93,13 @@ def _nav_icon(app: Any, name: str, alt: str) -> Any:
     """Return ``Img`` tag or Font-Awesome fallback for the given icon name."""
     url = get_nav_icon(app, name)
     if url:
-        return html.Img(src=url, className="nav-icon", alt=alt)
+        return html.Img(src=url, className="nav-icon nav-icon--image", alt=alt)
 
     glyph = fallback_icons.get(name, "fas fa-circle")
-    return html.I(className=f"{glyph} nav-icon", **{"aria-hidden": "true"})
+    return html.I(
+        className=f"{glyph} nav-icon nav-icon--fallback",
+        **{"aria-hidden": "true"},
+    )
 
 
 def nav_icon(name: str, alt: str) -> Any:
@@ -108,7 +111,10 @@ def nav_icon(name: str, alt: str) -> Any:
         return _nav_icon(app, name, alt)
     except Exception:  # pragma: no cover - graceful fallback
         glyph = fallback_icons.get(name, "fas fa-circle")
-        return html.I(className=f"{glyph} nav-icon", **{"aria-hidden": "true"})
+        return html.I(
+            className=f"{glyph} nav-icon nav-icon--fallback",
+            **{"aria-hidden": "true"},
+        )
 
 
 def create_navbar_layout() -> Optional[Any]:

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -68,12 +68,12 @@ def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = Tru
     if path.is_file():
         return html.Img(
             src=f"/assets/navbar_icons/{filename}",
-            className="nav-icon",
+            className="nav-icon nav-icon--image",
             alt=alt,
         )
     if warn:
         logger.warning("Missing navbar icon: %s", safe_unicode_encode(filename))
-    return html.Span(fallback_text, className="nav-icon")
+    return html.Span(fallback_text, className="nav-icon nav-icon--fallback")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- tweak navbar icon HTML classes for images vs fallbacks
- update assets debugging helpers accordingly

## Testing
- `pytest tests/utils/test_assets_debug.py tests/utils/test_assets_utils.py -q` *(fails: ModuleNotFoundError: No module named 'flask_compress')*

------
https://chatgpt.com/codex/tasks/task_e_686b27db74448320b0c500125ac5beb4