### PR TITLE
Add navbar icon tests

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -93,10 +93,13 @@ def _nav_icon(app: Any, name: str, alt: str) -> Any:
     """Return ``Img`` tag or Font-Awesome fallback for the given icon name."""
     url = get_nav_icon(app, name)
     if url:
-        return html.Img(src=url, className="nav-icon", alt=alt)
+        return html.Img(src=url, className="nav-icon nav-icon--image", alt=alt)
 
     glyph = fallback_icons.get(name, "fas fa-circle")
-    return html.I(className=f"{glyph} nav-icon", **{"aria-hidden": "true"})
+    return html.I(
+        className=f"{glyph} nav-icon nav-icon--fallback",
+        **{"aria-hidden": "true"},
+    )
 
 
 def nav_icon(name: str, alt: str) -> Any:
@@ -214,24 +217,32 @@ def create_navbar_layout() -> Optional[Any]:
                                                                 _nav_icon(
                                                                     app,
                                                                     "dashboard",
-                                                                    str(_l("Dashboard")),
+                                                                    str(
+                                                                        _l("Dashboard")
+                                                                    ),
                                                                 ),
                                                                 href="/dashboard",
                                                                 className="navbar-nav-link",
-                                                                title=str(_l("Dashboard")),
+                                                                title=str(
+                                                                    _l("Dashboard")
+                                                                ),
                                                             ),
                                                             html.A(
                                                                 _nav_icon(
                                                                     app,
                                                                     "analytics",
                                                                     str(
-                                                                        _l("Deep Analytics Page")
+                                                                        _l(
+                                                                            "Deep Analytics Page"
+                                                                        )
                                                                     ),
                                                                 ),
                                                                 href="/analytics",
                                                                 className="navbar-nav-link",
                                                                 title=str(
-                                                                    _l("Deep Analytics Page")
+                                                                    _l(
+                                                                        "Deep Analytics Page"
+                                                                    )
                                                                 ),
                                                             ),
                                                             html.A(
@@ -257,11 +268,19 @@ def create_navbar_layout() -> Optional[Any]:
                                                             dbc.DropdownMenu(
                                                                 [
                                                                     dbc.DropdownMenuItem(
-                                                                        str(_l("Export CSV")),
+                                                                        str(
+                                                                            _l(
+                                                                                "Export CSV"
+                                                                            )
+                                                                        ),
                                                                         id="nav-export-csv",
                                                                     ),
                                                                     dbc.DropdownMenuItem(
-                                                                        str(_l("Export JSON")),
+                                                                        str(
+                                                                            _l(
+                                                                                "Export JSON"
+                                                                            )
+                                                                        ),
                                                                         id="nav-export-json",
                                                                     ),
                                                                 ],
@@ -279,7 +298,11 @@ def create_navbar_layout() -> Optional[Any]:
                                                                 [
                                                                     dbc.DropdownMenuItem(
                                                                         dcc.Link(
-                                                                            str(_l("Settings")),
+                                                                            str(
+                                                                                _l(
+                                                                                    "Settings"
+                                                                                )
+                                                                            ),
                                                                             href="/settings",
                                                                             className="dropdown-item",
                                                                         )
@@ -289,22 +312,36 @@ def create_navbar_layout() -> Optional[Any]:
                                                                             id="theme-dropdown",
                                                                             options=[
                                                                                 {
-                                                                                    "label": str(_l("Dark")),
+                                                                                    "label": str(
+                                                                                        _l(
+                                                                                            "Dark"
+                                                                                        )
+                                                                                    ),
                                                                                     "value": "dark",
                                                                                 },
                                                                                 {
-                                                                                    "label": str(_l("Light")),
+                                                                                    "label": str(
+                                                                                        _l(
+                                                                                            "Light"
+                                                                                        )
+                                                                                    ),
                                                                                     "value": "light",
                                                                                 },
                                                                                 {
-                                                                                    "label": str(_l("High Contrast")),
+                                                                                    "label": str(
+                                                                                        _l(
+                                                                                            "High Contrast"
+                                                                                        )
+                                                                                    ),
                                                                                     "value": "high-contrast",
                                                                                 },
                                                                             ],
                                                                             value=DEFAULT_THEME,
                                                                             clearable=False,
                                                                             className="theme-dropdown",
-                                                                            style={"width": "120px"},
+                                                                            style={
+                                                                                "width": "120px"
+                                                                            },
                                                                         ),
                                                                         className="px-2",
                                                                         toggle=False,
@@ -336,7 +373,9 @@ def create_navbar_layout() -> Optional[Any]:
                                                                     "aria-pressed": "true",
                                                                 },
                                                             ),
-                                                            html.Span("|", className="mx-1"),
+                                                            html.Span(
+                                                                "|", className="mx-1"
+                                                            ),
                                                             html.Button(
                                                                 "JP",
                                                                 className="language-btn",
@@ -350,7 +389,11 @@ def create_navbar_layout() -> Optional[Any]:
                                                         id="language-toggle",
                                                     ),
                                                     html.A(
-                                                        _nav_icon(app, "logout", str(_l("Logout"))),
+                                                        _nav_icon(
+                                                            app,
+                                                            "logout",
+                                                            str(_l("Logout")),
+                                                        ),
                                                         href="/login",  # Changed from /logout to /login
                                                         className="navbar-nav-link",
                                                         title=str(_l("Logout")),

--- a/tests/components/test_nav_icon.py
+++ b/tests/components/test_nav_icon.py
@@ -1,0 +1,80 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from dash import html
+
+
+def _load_navbar_module():
+    """Import navbar module with minimal utils stubs to avoid heavy deps."""
+    if "test_navbar_module" in sys.modules:
+        return sys.modules["test_navbar_module"]
+
+    # Load real utils submodules without executing utils/__init__
+    for name in ["assets_utils", "assets_debug"]:
+        full_name = f"utils.{name}"
+        if full_name not in sys.modules:
+            spec = importlib.util.spec_from_file_location(
+                full_name, Path("utils") / f"{name}.py"
+            )
+            mod = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            spec.loader.exec_module(mod)
+            sys.modules[full_name] = mod
+
+    spec = importlib.util.spec_from_file_location(
+        "components.ui.navbar", Path("components/ui/navbar.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    components_pkg = types.ModuleType("components")
+    ui_pkg = types.ModuleType("components.ui")
+    components_pkg.ui = ui_pkg
+    ui_pkg.navbar = module
+    sys.modules.setdefault("components", components_pkg)
+    sys.modules.setdefault("components.ui", ui_pkg)
+    sys.modules["components.ui.navbar"] = module
+    return module
+
+
+navbar = _load_navbar_module()
+_nav_icon = navbar._nav_icon
+
+# Provide minimal stub for core.app_factory.create_app to avoid heavy deps
+core_app_factory = types.ModuleType("core.app_factory")
+
+
+def _stub_create_app(mode: str | None = None):
+    from dash import Dash
+
+    app = Dash(__name__)
+    app.get_asset_url = lambda path: f"/assets/{path}"
+    return app
+
+
+core_app_factory.create_app = _stub_create_app
+sys.modules.setdefault("core.app_factory", core_app_factory)
+from core.app_factory import create_app
+
+
+def _make_app(monkeypatch):
+    monkeypatch.setenv("YOSAI_ENV", "development")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    return create_app(mode="simple")
+
+
+def test_nav_icon_image(monkeypatch):
+    app = _make_app(monkeypatch)
+    comp = _nav_icon(app, "analytics", "Analytics")
+    assert isinstance(comp, html.Img)
+    assert "nav-icon--image" in comp.className
+
+
+def test_nav_icon_fallback(monkeypatch):
+    app = _make_app(monkeypatch)
+    comp = _nav_icon(app, "missing", "Missing")
+    assert isinstance(comp, html.I)
+    assert "nav-icon--fallback" in comp.className


### PR DESCRIPTION
## Summary
- add `_nav_icon` tests using stubbed dependencies
- update navbar icon classes

## Testing
- `pytest tests/components/test_nav_icon.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.data_processing')*

------
https://chatgpt.com/codex/tasks/task_e_686b27dd57f88320baaadca531b9cf6a