### PR TITLE
Remove unused dashboard/graphs icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ yosai_intel_dashboard/
 Store PNG images for the navigation bar in `assets/navbar_icons/`. The
 application expects the following files:
 
-* `dashboard.png`
 * `analytics.png`
-* `graphs.png`
 * `upload.png`
 * `print.png`
 * `settings.png`

--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -122,9 +122,7 @@ def create_navbar_layout() -> Optional[Any]:
         app = dash.get_app()
         check_navbar_assets(
             [
-                "dashboard",
                 "analytics",
-                "graphs",
                 "upload",
                 "print",
                 "settings",


### PR DESCRIPTION
## Summary
- clean up README navbar icon list
- drop dashboard and graphs checks from navbar asset validation

## Testing
- `pytest tests/utils/test_assets_debug.py tests/utils/test_assets_utils.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b27e9d5b88320bae5045deab15b66