### PR TITLE
Remove camera capture feature

### DIFF
--- a/assets/js/upload-handlers.js
+++ b/assets/js/upload-handlers.js
@@ -87,7 +87,6 @@
     if(!upload){ return; }
     const area = byId(`${UPLOAD_ID}-area`);
     const previewList = byId(`${UPLOAD_ID}-previews`);
-    const cameraBtn = byId(`${UPLOAD_ID}-camera`);
     const input = upload.querySelector('input[type="file"]');
     if(!input){ return; }
     const config = getConfig(upload);
@@ -107,24 +106,6 @@
       });
     }
 
-    if(cameraBtn){
-      cameraBtn.addEventListener('click', ()=>{
-        const camInput = document.createElement('input');
-        camInput.type = 'file';
-        camInput.accept = 'image/*';
-        camInput.capture = 'environment';
-        camInput.addEventListener('change', ()=>{
-          if(camInput.files.length){
-            const dt = new DataTransfer();
-            Array.from(input.files).forEach(f=>dt.items.add(f));
-            Array.from(camInput.files).forEach(f=>dt.items.add(f));
-            input.files = dt.files;
-            input.dispatchEvent(new Event('change', {bubbles:true}));
-          }
-        });
-        camInput.click();
-      });
-    }
 
     input.addEventListener('change', async function(e){
       e.stopImmediatePropagation();

--- a/components/upload/drag_drop_upload_area.py
+++ b/components/upload/drag_drop_upload_area.py
@@ -14,7 +14,6 @@ def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
     """
 
     status_id = f"{upload_id}-status"
-    camera_id = f"{upload_id}-camera"
     preview_id = f"{upload_id}-previews"
 
     return html.Div(
@@ -38,13 +37,6 @@ def DragDropUploadArea(upload_id: str = "drag-drop-upload") -> html.Div:
                             "Drag and drop files or press Enter to select",
                             id=f"{upload_id}-label",
                             className="mb-1",
-                        ),
-                        html.Button(
-                            "Use Camera",
-                            id=camera_id,
-                            className="btn btn-secondary mt-2",
-                            type="button",
-                            **{"aria-label": "Use camera to capture"},
                         ),
                     ],
                     className="drag-drop-upload__inner",

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -13,15 +13,13 @@ The component toggles state classes so you can style hover, dragging and uploadi
 
 File previews are rendered as thumbnails for images or with a generic file icon for other types.
 
-On mobile devices a **Use Camera** button activates the device camera and inserts the captured photo into the file list.
-
 Behind the scenes the upload is handled by a background worker. A task ID is
 returned immediately and progress events are streamed over Server‑Sent Events at
 `/upload/progress/<task_id>`. When processing completes the UI refreshes the
 `file-info-store` so analytics pages can use the new data without reloading the
 entire app.
 
-Supported file types are CSV and JSON. Large files are streamed to avoid exhausting browser memory. You may upload multiple files at once; they will be processed sequentially.
+Supported file types include CSV, JSON, and Excel (`.xls`/`.xlsx`). Large files are streamed to avoid exhausting browser memory. You may upload multiple files at once; they will be processed sequentially.
 
 ## Configuration Options
 
@@ -46,7 +44,6 @@ and is also sent to any connected monitoring systems.
 - Ensure contrast ratios meet WCAG AA guidelines and that keyboard focus is visible.
 - The area exposes `role="button"` and supports keyboard activation via the Enter key.
 - Touch targets, including the Upload button and remove icons, should be at least 44&times;44&nbsp;px.
-- The **Use Camera** button invokes the mobile camera when available.
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary
- update docs about file types and remove camera instructions
- drop camera button from drag-drop upload
- clean JS to stop searching for the camera button

## Testing
- `black components/upload/drag_drop_upload_area.py`
- `isort components/upload/drag_drop_upload_area.py`
- `flake8 components/upload/drag_drop_upload_area.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.data_processing')*

------
https://chatgpt.com/codex/tasks/task_e_686b280b76548320bd0323dc7d51a572