### PR TITLE
Improve navbar icon utility

### DIFF
--- a/tests/utils/test_assets_utils.py
+++ b/tests/utils/test_assets_utils.py
@@ -1,16 +1,29 @@
-from core.app_factory import create_app
-from utils.assets_utils import get_nav_icon
+import dash
+import importlib.util
+from pathlib import Path
+from flask import Flask
+
+spec = importlib.util.spec_from_file_location(
+    "assets_utils", Path(__file__).resolve().parents[2] / "utils" / "assets_utils.py"
+)
+assets_utils = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(assets_utils)
+get_nav_icon = assets_utils.get_nav_icon
 
 
 def _make_app(monkeypatch):
+    # Create a minimal Dash app for testing
     monkeypatch.setenv("YOSAI_ENV", "development")
-    monkeypatch.setenv("SECRET_KEY", "test")
-    return create_app(mode="simple")
+    return dash.Dash(__name__, assets_folder="assets")
 
 
 def test_get_nav_icon_existing(monkeypatch):
     app = _make_app(monkeypatch)
-    assert get_nav_icon(app, "analytics") is not None
+    assert (
+        get_nav_icon(app, "analytics")
+        == "/assets/navbar_icons/analytics.png"
+    )
 
 
 def test_get_nav_icon_missing(monkeypatch):
@@ -21,11 +34,19 @@ def test_get_nav_icon_missing(monkeypatch):
 def test_get_nav_icon_fallback(monkeypatch):
     app = _make_app(monkeypatch)
 
-    def fake_get_asset_url(path):
-        return None
+    def raise_error(*args, **kwargs):
+        raise RuntimeError("boom")
 
-    app.get_asset_url = fake_get_asset_url
+    monkeypatch.setattr(assets_utils, "url_for", raise_error)
     assert (
         get_nav_icon(app, "analytics")
+        == "/assets/navbar_icons/analytics.png"
+    )
+
+
+def test_get_nav_icon_flask_app(monkeypatch):
+    flask_app = Flask(__name__)
+    assert (
+        get_nav_icon(flask_app, "analytics")
         == "/assets/navbar_icons/analytics.png"
     )


### PR DESCRIPTION
## Summary
- update `get_nav_icon` to work with Dash or Flask apps
- use `url_for('assets', ...)` first, fall back to absolute path
- adjust tests for new helper

## Testing
- `pytest -q tests/utils/test_assets_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686b377f3d188320ae29860e048a0955