### PR TITLE
Implement format detection and export utilities

### DIFF
--- a/file_processing/column_mapper.py
+++ b/file_processing/column_mapper.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+from rapidfuzz import process
+
+from core.callback_controller import CallbackController, CallbackEvent
+
+REQUIRED_COLUMNS = ["person_id", "door_id", "access_result", "timestamp"]
+OPTIONAL_COLUMNS = ["device_name", "location"]
+
+
+def map_columns(
+    df: pd.DataFrame,
+    canonical_names: Dict[str, Iterable[str]],
+    *,
+    fuzzy_threshold: int = 80,
+    controller: Optional[CallbackController] = None,
+) -> pd.DataFrame:
+    """Rename columns in ``df`` using provided mapping rules."""
+    controller = controller or CallbackController()
+    df_out = df.copy()
+    reverse: Dict[str, str] = {}
+    for canon, aliases in canonical_names.items():
+        reverse[canon.lower()] = canon
+        for alias in aliases:
+            reverse[alias.lower()] = canon
+
+    renamed = {}
+    for col in df_out.columns:
+        target = reverse.get(str(col).lower())
+        if target:
+            renamed[col] = target
+    if renamed:
+        df_out = df_out.rename(columns=renamed)
+
+    unmapped = set(df_out.columns) - set(canonical_names)
+    choices = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
+    for col in unmapped:
+        best = process.extractOne(str(col), choices)
+        if best and best[1] >= fuzzy_threshold:
+            df_out = df_out.rename(columns={col: best[0]})
+        else:
+            suggestions = process.extract(str(col), choices, limit=3)
+            controller.fire_event(
+                CallbackEvent.SYSTEM_WARNING,
+                "column_mapper",
+                {
+                    "warning": "MappingWarning",
+                    "column": col,
+                    "suggestions": [s[0] for s in suggestions],
+                },
+            )
+    return df_out
+

--- a/file_processing/data_processor.py
+++ b/file_processing/data_processor.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+from core.callback_controller import CallbackController, CallbackEvent
+from .format_detector import FormatDetector, UnsupportedFormatError
+from .readers import ArchiveReader, CSVReader, ExcelReader, FWFReader, JSONReader
+
+
+class DataProcessor:
+    """Process input files using ``FormatDetector`` and apply transformations."""
+
+    def __init__(self, readers: Optional[list] = None, hint: Optional[Dict] = None) -> None:
+        self.format_detector = FormatDetector(
+            readers or [CSVReader(), JSONReader(), ExcelReader(), FWFReader(), ArchiveReader()]
+        )
+        self.hint = hint or {}
+        self.pipeline_metadata: Dict[str, Dict] = {}
+        self.callback_controller = CallbackController()
+
+    def load_file(self, file_path: str) -> pd.DataFrame:
+        try:
+            df_raw, meta = self.format_detector.detect_and_load(file_path, hint=self.hint)
+            self.pipeline_metadata["last_ingest"] = meta
+            return df_raw
+        except UnsupportedFormatError as exc:
+            self.callback_controller.fire_event(
+                CallbackEvent.SYSTEM_ERROR,
+                file_path,
+                {"error": str(exc)},
+            )
+            raise
+
+    # Placeholder for additional processing steps
+    def process(self, file_path: str) -> pd.DataFrame:
+        return self.load_file(file_path)
+

--- a/file_processing/exporter.py
+++ b/file_processing/exporter.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+from core.callback_controller import CallbackController, CallbackEvent
+from core.unicode_processor import UnicodeProcessor
+from .column_mapper import REQUIRED_COLUMNS
+
+
+class ExportError(Exception):
+    """Raised when export cannot proceed."""
+
+
+def _validate_columns(df: pd.DataFrame) -> None:
+    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ExportError(f"Missing required columns: {missing}")
+
+
+def export_to_csv(df: pd.DataFrame, path: str, meta: Dict) -> None:
+    controller = CallbackController()
+    _validate_columns(df)
+    df_clean = UnicodeProcessor.sanitize_dataframe(df)
+    out_path = Path(path)
+    df_clean.to_csv(out_path, index=False, encoding="utf-8-sig")
+    meta_path = out_path.with_suffix(".meta.json")
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    controller.fire_event(
+        CallbackEvent.FILE_PROCESSING_COMPLETE,
+        str(out_path),
+        {"export": "csv"},
+    )
+
+
+def export_to_json(df: pd.DataFrame, path: str, meta: Dict) -> None:
+    controller = CallbackController()
+    _validate_columns(df)
+    df_clean = UnicodeProcessor.sanitize_dataframe(df)
+    out_path = Path(path)
+    out_path.write_text(df_clean.to_json(orient="records", force_ascii=False), encoding="utf-8")
+    meta_path = out_path.with_suffix(".meta.json")
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    controller.fire_event(
+        CallbackEvent.FILE_PROCESSING_COMPLETE,
+        str(out_path),
+        {"export": "json"},
+    )
+

--- a/file_processing/format_detector.py
+++ b/file_processing/format_detector.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Optional, Tuple, Dict
+
+import pandas as pd
+
+from core.callback_controller import CallbackController, CallbackEvent
+from core.unicode_processor import UnicodeProcessor
+
+
+class UnsupportedFormatError(Exception):
+    """Raised when no reader can parse a given file."""
+
+
+class FormatDetector:
+    """Try a series of readers to detect and load file formats."""
+
+    def __init__(self, readers: Optional[Iterable] = None) -> None:
+        self.readers: List = list(readers) if readers else []
+        self.callback_controller = CallbackController()
+
+    def detect_and_load(
+        self, file_path: str, hint: Optional[Dict] = None
+    ) -> Tuple[pd.DataFrame, Dict]:
+        """Return ``DataFrame`` and metadata using the first succeeding reader."""
+        hint = hint or {}
+        for reader in self.readers:
+            try:
+                df = reader.read(file_path, hint=hint)
+                df = UnicodeProcessor.sanitize_dataframe(df)
+                meta = {
+                    "source_path": file_path,
+                    "ingest_ts": datetime.utcnow().isoformat(),
+                    "detected_type": reader.format_name,
+                    "original_columns": list(df.columns),
+                    **hint,
+                }
+                return df, meta
+            except reader.CannotParse as exc:
+                self.callback_controller.fire_event(
+                    CallbackEvent.SYSTEM_WARNING,
+                    reader.format_name,
+                    {"warning": str(exc)},
+                )
+                continue
+        raise UnsupportedFormatError(file_path)
+

--- a/file_processing/readers/__init__.py
+++ b/file_processing/readers/__init__.py
@@ -1,0 +1,16 @@
+from .base import BaseReader
+from .csv_reader import CSVReader
+from .json_reader import JSONReader
+from .excel_reader import ExcelReader
+from .fwf_reader import FWFReader
+from .archive_reader import ArchiveReader
+
+__all__ = [
+    "BaseReader",
+    "CSVReader",
+    "JSONReader",
+    "ExcelReader",
+    "FWFReader",
+    "ArchiveReader",
+]
+

--- a/file_processing/readers/archive_reader.py
+++ b/file_processing/readers/archive_reader.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from .base import BaseReader
+from .csv_reader import CSVReader
+from .excel_reader import ExcelReader
+from .fwf_reader import FWFReader
+from .json_reader import JSONReader
+from core.callback_controller import CallbackController, CallbackEvent
+from ..format_detector import FormatDetector
+
+
+class ArchiveReader(BaseReader):
+    """Read archives containing a single supported file."""
+
+    format_name = "archive"
+
+    def __init__(self) -> None:
+        self.callback_controller = CallbackController()
+
+    def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
+        path = Path(file_path)
+        if not path.is_file():
+            raise ArchiveReader.CannotParse("not a file")
+        if path.suffix.lower() not in {'.zip', '.tar', '.gz', '.tgz'}:
+            raise ArchiveReader.CannotParse("extension mismatch")
+        try:
+            if zipfile.is_zipfile(path):
+                with zipfile.ZipFile(path) as zf:
+                    names = [n for n in zf.namelist() if not n.endswith("/")]
+                    if not names:
+                        raise ArchiveReader.CannotParse("empty archive")
+                    with zf.open(names[0]) as fh:
+                        tmp_bytes = fh.read()
+            elif tarfile.is_tarfile(path):
+                with tarfile.open(path) as tf:
+                    members = [m for m in tf.getmembers() if m.isfile()]
+                    if not members:
+                        raise ArchiveReader.CannotParse("empty archive")
+                    fh = tf.extractfile(members[0])
+                    assert fh is not None
+                    tmp_bytes = fh.read()
+            else:
+                raise ArchiveReader.CannotParse("unsupported archive")
+        except Exception as exc:
+            raise ArchiveReader.CannotParse(str(exc)) from exc
+
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_bytes(tmp_bytes)
+        try:
+            detector = FormatDetector([
+                CSVReader(),
+                JSONReader(),
+                ExcelReader(),
+                FWFReader(),
+            ])
+            df, _ = detector.detect_and_load(str(tmp_path), hint=hint)
+        finally:
+            try:
+                tmp_path.unlink()
+            except Exception:
+                pass
+        return df
+

--- a/file_processing/readers/base.py
+++ b/file_processing/readers/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import pandas as pd
+
+from core.unicode_processor import UnicodeProcessor
+
+
+class BaseReader:
+    """Base class for file readers."""
+
+    format_name: str = "base"
+
+    class CannotParse(Exception):
+        """Raised when a reader cannot parse a file."""
+
+    def read(self, file_path: str, hint: Optional[Dict] = None) -> pd.DataFrame:
+        raise NotImplementedError
+
+    @staticmethod
+    def _sanitize(df: pd.DataFrame) -> pd.DataFrame:
+        return UnicodeProcessor.sanitize_dataframe(df)
+

--- a/file_processing/readers/csv_reader.py
+++ b/file_processing/readers/csv_reader.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import BaseReader
+from core.callback_controller import CallbackController, CallbackEvent
+
+
+class CSVReader(BaseReader):
+    """Read comma separated value files."""
+
+    format_name = "csv"
+
+    def __init__(self) -> None:
+        self.callback_controller = CallbackController()
+
+    def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
+        hint = hint or {}
+        if not str(file_path).lower().endswith(".csv"):
+            raise CSVReader.CannotParse("extension mismatch")
+        try:
+            df = pd.read_csv(file_path, **hint)
+        except Exception as exc:
+            raise CSVReader.CannotParse(str(exc)) from exc
+
+        control_ratio = self._control_char_ratio(df)
+        if control_ratio > 0.1:
+            self.callback_controller.fire_event(
+                CallbackEvent.SYSTEM_WARNING,
+                file_path,
+                {"warning": "ControlCharWarning", "ratio": control_ratio},
+            )
+
+        return self._sanitize(df)
+
+    @staticmethod
+    def _control_char_ratio(df: pd.DataFrame) -> float:
+        text = "".join(
+            df[col].dropna().astype(str).str.cat(sep="")
+            for col in df.select_dtypes(include="object").columns
+        )
+        if not text:
+            return 0.0
+        ctrl = sum(1 for ch in text if ord(ch) < 32 or ord(ch) == 127)
+        return ctrl / len(text)
+

--- a/file_processing/readers/excel_reader.py
+++ b/file_processing/readers/excel_reader.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import BaseReader
+from core.callback_controller import CallbackController, CallbackEvent
+
+
+class ExcelReader(BaseReader):
+    """Read Excel files (xls/xlsx)."""
+
+    format_name = "excel"
+
+    def __init__(self) -> None:
+        self.callback_controller = CallbackController()
+
+    def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
+        if not str(file_path).lower().endswith(('.xls', '.xlsx')):
+            raise ExcelReader.CannotParse("extension mismatch")
+        try:
+            df = pd.read_excel(file_path, **(hint or {}))
+        except Exception as exc:
+            raise ExcelReader.CannotParse(str(exc)) from exc
+
+        ratio = CSVReader._control_char_ratio(df)
+        if ratio > 0.1:
+            self.callback_controller.fire_event(
+                CallbackEvent.SYSTEM_WARNING,
+                file_path,
+                {"warning": "ControlCharWarning", "ratio": ratio},
+            )
+        return self._sanitize(df)
+
+
+from .csv_reader import CSVReader
+

--- a/file_processing/readers/fwf_reader.py
+++ b/file_processing/readers/fwf_reader.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import BaseReader
+from core.callback_controller import CallbackController, CallbackEvent
+
+
+class FWFReader(BaseReader):
+    """Read fixed-width formatted files."""
+
+    format_name = "fwf"
+
+    def __init__(self) -> None:
+        self.callback_controller = CallbackController()
+
+    def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
+        hint = hint or {}
+        if not str(file_path).lower().endswith('.fwf'):
+            raise FWFReader.CannotParse("extension mismatch")
+        try:
+            df = pd.read_fwf(file_path, **hint)
+        except Exception as exc:
+            raise FWFReader.CannotParse(str(exc)) from exc
+
+        ratio = CSVReader._control_char_ratio(df)
+        if ratio > 0.1:
+            self.callback_controller.fire_event(
+                CallbackEvent.SYSTEM_WARNING,
+                file_path,
+                {"warning": "ControlCharWarning", "ratio": ratio},
+            )
+        return self._sanitize(df)
+
+
+from .csv_reader import CSVReader
+

--- a/file_processing/readers/json_reader.py
+++ b/file_processing/readers/json_reader.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import pandas as pd
+
+from .base import BaseReader
+from core.callback_controller import CallbackController, CallbackEvent
+
+
+class JSONReader(BaseReader):
+    """Read JSON or JSON lines files."""
+
+    format_name = "json"
+
+    def __init__(self) -> None:
+        self.callback_controller = CallbackController()
+
+    def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
+        hint = hint or {}
+        if not str(file_path).lower().endswith(".json"):
+            raise JSONReader.CannotParse("extension mismatch")
+        try:
+            with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+            try:
+                data = json.loads(text)
+                df = pd.json_normalize(data)
+            except json.JSONDecodeError:
+                df = pd.read_json(text, lines=True)
+        except Exception as exc:
+            raise JSONReader.CannotParse(str(exc)) from exc
+
+        ratio = CSVReader._control_char_ratio(df)
+        if ratio > 0.1:
+            self.callback_controller.fire_event(
+                CallbackEvent.SYSTEM_WARNING,
+                file_path,
+                {"warning": "ControlCharWarning", "ratio": ratio},
+            )
+        return self._sanitize(df)
+
+
+from .csv_reader import CSVReader
+

--- a/tests/file_processing/test_column_mapper.py
+++ b/tests/file_processing/test_column_mapper.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pathlib import Path
+
+from file_processing.column_mapper import map_columns
+from core.callback_controller import CallbackController, CallbackEvent
+
+
+def test_exact_mapping(tmp_path: Path):
+    df = pd.DataFrame({"person": [1], "door": ["d"]})
+    mapping = {"person_id": ["person"], "door_id": ["door"]}
+    out = map_columns(df, mapping)
+    assert "person_id" in out.columns and "door_id" in out.columns
+
+
+def test_fuzzy_mapping(tmp_path: Path):
+    df = pd.DataFrame({"pers": [1], "dor": ["d"]})
+    mapping = {"person_id": [], "door_id": []}
+    controller = CallbackController()
+    events = []
+
+    def track(ctx):
+        events.append(ctx.data)
+
+    controller.register_callback(CallbackEvent.SYSTEM_WARNING, track)
+    out = map_columns(df, mapping, controller=controller)
+    assert "person_id" in out.columns
+    assert events
+

--- a/tests/file_processing/test_data_processor.py
+++ b/tests/file_processing/test_data_processor.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from pathlib import Path
+
+from file_processing.data_processor import DataProcessor
+
+
+def test_load_file_updates_metadata(tmp_path: Path):
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "f.csv"
+    df.to_csv(path, index=False)
+    processor = DataProcessor()
+    out = processor.load_file(str(path))
+    assert "last_ingest" in processor.pipeline_metadata
+    assert out.equals(df)
+

--- a/tests/file_processing/test_exporter.py
+++ b/tests/file_processing/test_exporter.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+import pandas as pd
+from pathlib import Path
+import os
+
+from file_processing.exporter import export_to_csv, export_to_json, ExportError
+
+
+def test_export_csv(tmp_path: Path):
+    df = pd.DataFrame({"person_id": ["u"], "door_id": ["d"], "access_result": ["x"], "timestamp": ["2024"]})
+    path = tmp_path / "out.csv"
+    export_to_csv(df, str(path), {})
+    assert path.exists()
+    meta = path.with_suffix(".meta.json")
+    assert meta.exists()
+    content = path.read_bytes()
+    assert content.startswith(b"\xef\xbb\xbf")
+
+
+def test_export_json(tmp_path: Path):
+    df = pd.DataFrame({"person_id": ["u"], "door_id": ["d"], "access_result": ["x"], "timestamp": ["2024"]})
+    path = tmp_path / "out.json"
+    export_to_json(df, str(path), {"a": 1})
+    assert path.exists() and path.with_suffix(".meta.json").exists()
+    data = json.loads(path.read_text())
+    assert data[0]["person_id"] == "u"
+
+
+def test_export_missing(tmp_path: Path):
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(ExportError):
+        export_to_csv(df, str(tmp_path / "f.csv"), {})
+

--- a/tests/file_processing/test_format_detector.py
+++ b/tests/file_processing/test_format_detector.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from file_processing.format_detector import FormatDetector, UnsupportedFormatError
+from file_processing.readers import (
+    CSVReader,
+    JSONReader,
+    ExcelReader,
+    FWFReader,
+    ArchiveReader,
+)
+
+
+@pytest.fixture()
+def detector():
+    return FormatDetector([CSVReader(), JSONReader(), ExcelReader(), FWFReader(), ArchiveReader()])
+
+
+def test_detect_csv(tmp_path: Path, detector):
+    df = pd.DataFrame({"a": [1, 2]})
+    csv_path = tmp_path / "test.csv"
+    df.to_csv(csv_path, index=False)
+    out, meta = detector.detect_and_load(str(csv_path))
+    assert list(out.columns) == ["a"]
+    assert meta["detected_type"] == "csv"
+
+
+def test_detect_json(tmp_path: Path, detector):
+    df = pd.DataFrame({"b": [1]})
+    json_path = tmp_path / "test.json"
+    df.to_json(json_path, orient="records")
+    out, meta = detector.detect_and_load(str(json_path))
+    assert "b" in out.columns
+    assert meta["detected_type"] == "json"
+
+
+def test_detect_excel(tmp_path: Path, detector):
+    df = pd.DataFrame({"c": [1]})
+    xl_path = tmp_path / "t.xlsx"
+    df.to_excel(xl_path, index=False)
+    out, meta = detector.detect_and_load(str(xl_path))
+    assert "c" in out.columns
+    assert meta["detected_type"] == "excel"
+
+
+def test_unsupported(tmp_path: Path, detector):
+    txt = tmp_path / "t.txt"
+    txt.write_text("hello")
+    with pytest.raises(UnsupportedFormatError):
+        detector.detect_and_load(str(txt))
+

--- a/tests/file_processing/test_readers.py
+++ b/tests/file_processing/test_readers.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from file_processing.readers import CSVReader, JSONReader, ExcelReader
+
+
+@pytest.mark.parametrize("reader,ext,writer", [
+    (CSVReader(), ".csv", lambda df, p: df.to_csv(p, index=False)),
+    (JSONReader(), ".json", lambda df, p: df.to_json(p, orient="records")),
+    (ExcelReader(), ".xlsx", lambda df, p: df.to_excel(p, index=False)),
+])
+def test_reader_success(tmp_path: Path, reader, ext, writer):
+    df = pd.DataFrame({"a": [1, 2]})
+    path = tmp_path / f"t{ext}"
+    writer(df, path)
+    out = reader.read(str(path))
+    assert len(out) == len(df)
+
+
+def test_cannot_parse(tmp_path: Path):
+    path = tmp_path / "bad.csv"
+    path.write_text("")
+    with pytest.raises(CSVReader.CannotParse):
+        CSVReader().read(str(path))
+


### PR DESCRIPTION
## Summary
- add modular file readers and format detector
- implement data processor integration
- provide column mapping with fuzzy fallback
- enable CSV and JSON export with metadata
- include comprehensive unit tests

## Testing
- `pytest tests/file_processing -q`

------
https://chatgpt.com/codex/tasks/task_e_686b44d49600832084a803ec2f99631a