### PR TITLE
Remove redundant safe_unicode_encode in upload page

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -145,17 +145,6 @@ from utils.upload_store import uploaded_data_store as _uploaded_data_store
 logger = logging.getLogger(__name__)
 
 
-def safe_unicode_encode(value: Any) -> str:
-    """Safely encode potentially problematic text to UTF-8."""
-
-    try:
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", "surrogatepass")
-        return str(value).encode("utf-8", "surrogatepass").decode("utf-8", "ignore")
-    except Exception:
-        return str(value)
-
-
 def handle_enhanced_upload(contents: str | None, filename: str | None) -> Any:
     """Basic enhanced upload handler."""
 


### PR DESCRIPTION
## Summary
- use core.unicode.safe_unicode_encode everywhere
- delete local safe_unicode_encode helper

## Testing
- `pytest tests/test_unicode_processor.py tests/test_unicode_cleaner.py tests/test_unicode_migration.py -q` *(fails: ModuleNotFoundError or assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b4d4a5f2c8320826bdd22157ea795