### PR TITLE
Document python package requirements

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -11,7 +11,8 @@ python -m venv venv
 source venv/bin/activate
 ```
 
-Install the application and development requirements:
+Install the application and development requirements **before** running any
+tests:
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
@@ -19,6 +20,38 @@ pip install -r requirements-dev.txt
 Alternatively you can run `./scripts/setup.sh` to install both files at once.
 `requirements-dev.txt` includes additional packages such as **PyYAML** that are
 required by the tests but not needed in production.
+
+### Required Python Packages
+
+`requirements.txt` lists all core dependencies. The most important packages are:
+
+- `Flask` and extensions (`Flask-Babel`, `Flask-Login`, `Flask-WTF`,
+  `Flask-Compress`, `Flask-Talisman`, `Flask-Caching`)
+- `dash`, `dash-bootstrap-components`, `dash-extensions`, `dash-leaflet`
+- `plotly`
+- `pandas`, `numpy`
+- `authlib`, `python-jose`
+- `cssutils`
+- `scipy`, `scikit-learn`, `joblib`
+- `psutil`
+- `psycopg2-binary`
+- `requests`
+- `sqlparse`, `bleach`
+- `PyYAML`
+- `flasgger`
+- `python-dotenv`
+- `pytest`
+- `pyarrow`, `polars`
+- `gunicorn`
+- `chardet`
+- `pyopenssl`
+- `SQLAlchemy`
+
+Some pages rely on optional packages. For example, the upload and analytics
+pages require **pandas** to manipulate CSV files. The monitoring endpoint uses
+**psutil** for CPU and memory metrics, while the file processing utilities
+depend on **chardet** to detect text encoding. Ensure these packages remain
+installed if you intend to use those features.
 
 Install the Node dependencies used for building CSS and running accessibility
 checks:


### PR DESCRIPTION
## Summary
- list all required Python packages in `docs/test_setup.md`
- instruct installing requirement files before tests
- mention optional dependencies for certain pages

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -k 'nothing'` *(fails: ImportError: cannot import name 'AnalyticsService')*

------
https://chatgpt.com/codex/tasks/task_e_686b4d4d6e6483208f864808427f325a