### PR TITLE
Refactor analytics module imports

### DIFF
--- a/services/analytics/upload_analytics.py
+++ b/services/analytics/upload_analytics.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-import json
-import logging
-import os
-from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pandas as pd
 
-from services.analytics import (
-    analyze_with_chunking,
-    generate_basic_analytics,
-    map_and_clean,
-    summarize_dataframe,
-)
+from services.analytics_summary import summarize_dataframe
+from services.chunked_analysis import analyze_with_chunking
 from services.data_validation import DataValidationService
 
 from ..upload_processing import UploadAnalyticsProcessor as _UploadAnalyticsProcessor

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -55,6 +55,13 @@ class UnicodeFileProcessor:
             )
         return df
 
+    def read_uploaded_file(
+        self, contents: str, filename: str
+    ) -> Tuple[pd.DataFrame, str | None]:
+        """Process ``contents`` and return the DataFrame and error string."""
+        result = process_uploaded_file(contents, filename)
+        return result["data"], result["error"]
+
 def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
     """
     Process uploaded file content safely

--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -12,7 +12,10 @@ class UploadAnalyticsProcessor:
         }
 
     def analyze_uploaded_data(self):
-        return {"status": "success"}
+        data = self.load_uploaded_data()
+        metrics = self._process_uploaded_data_directly(data)
+        metrics["status"] = "success"
+        return metrics
 
     def load_uploaded_data(self):  # pragma: no cover - simple stub
         return {}


### PR DESCRIPTION
## Summary
- decouple `upload_analytics` from `services.analytics` to avoid circular imports
- implement `read_uploaded_file` helper on `UnicodeFileProcessor`
- enhance `analyze_uploaded_data` stub to return calculated metrics

## Testing
- `pytest tests/test_upload_processing_module.py tests/test_process_and_analyze.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4d5f98e883208ae36a732f2d9534