### PR TITLE
Fix build job dependencies and lint import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           set -xe
           pytest --maxfail=1 --disable-warnings -q --cov=.
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: htmlcov/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,23 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: pip install -r requirements.txt
+        env:
+          PIP_CACHE_DIR: ~/.cache/pip
+        run: |
+          set -xe
+          pip install -r requirements.txt -r requirements-dev.txt
       - name: Black
-        run: black --check . --line-length 88
+        run: |
+          set -xe
+          black --check . --line-length 88 --verbose
       - name: Flake8
-        run: flake8 . --max-line-length 88
+        run: |
+          set -xe
+          flake8 . --max-line-length 88 -v
       - name: PyTest
-        run: pytest --maxfail=1 --disable-warnings -q --cov=.
+        run: |
+          set -xe
+          pytest --maxfail=1 --disable-warnings -q --cov=.
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:

--- a/core/plugins/config/__init__.py
+++ b/core/plugins/config/__init__.py
@@ -1,21 +1,15 @@
 """Minimal plugin config compatibility"""
 
 # Re-export from unified configuration for compatibility
-try:
-    from config.database_manager import DatabaseManager
-    from config.unified_config import (
-        UnifiedConfig,
-        get_config,
-    )
-
-
 from config.config import ConfigManager, get_config
 from config.database_manager import DatabaseManager
+
 
 def get_service_locator() -> ConfigManager:
     """Return configuration object for plugins"""
 
     return get_config()
+
 
 __all__ = [
     "ConfigManager",


### PR DESCRIPTION
## Summary
- install dev dependencies for CI so lint/test tools are present
- add verbose logging to workflow
- remove stray try block and unused import in core/plugins/config

## Testing
- `flake8 core/plugins/config/__init__.py --max-line-length 88`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b68a1e5b48320a03b25605f0d99e9