### PR TITLE
Add column standardizer and AI mapping tests

### DIFF
--- a/ai_column_mapper_adapter.py
+++ b/ai_column_mapper_adapter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from column_standardizer import standardize_column_names
+
+
+class AIColumnMapperAdapter:
+    """Adapter that maps columns using AI suggestions then standardizes names."""
+
+    def __init__(self, adapter: object | None = None) -> None:
+        if adapter is None:
+            from components.plugin_adapter import ComponentPluginAdapter
+            adapter = ComponentPluginAdapter()
+        self.adapter = adapter
+
+    def map_and_standardize(self, df: pd.DataFrame) -> pd.DataFrame:
+        try:
+            suggestions: Dict[str, str] = self.adapter.suggest_columns(df.columns.tolist())
+        except Exception:
+            suggestions = {}
+        mapping = {src: dest for src, dest in suggestions.items() if dest}
+        mapped = df.rename(columns=mapping)
+        return standardize_column_names(mapped)
+
+
+__all__ = ["AIColumnMapperAdapter"]

--- a/column_standardizer.py
+++ b/column_standardizer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+# Mapping of known column headers in various languages to standard field names
+COLUMN_NAME_MAP: Dict[str, str] = {
+    "Timestamp": "timestamp",
+    "Person ID": "person_id",
+    "Token ID": "token_id",
+    "Device name": "door_id",
+    "Access result": "access_result",
+    "タイムスタンプ": "timestamp",
+    "ユーザーID": "person_id",
+    "トークンID": "token_id",
+    "ドア名": "door_id",
+    "結果": "access_result",
+}
+
+
+def standardize_column_names(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename known column headers to canonical snake_case names."""
+    mapping = {col: COLUMN_NAME_MAP[col] for col in df.columns if col in COLUMN_NAME_MAP}
+    return df.rename(columns=mapping)
+
+
+__all__ = ["standardize_column_names", "COLUMN_NAME_MAP"]

--- a/tests/test_ai_column_mapper_adapter.py
+++ b/tests/test_ai_column_mapper_adapter.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from ai_column_mapper_adapter import AIColumnMapperAdapter
+
+
+class DummyAdapter:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def suggest_columns(self, columns):
+        return {c: self._mapping.get(c, "") for c in columns}
+
+
+def test_map_and_standardize(monkeypatch):
+    df = pd.DataFrame({"RawA": [1], "RawB": [2]})
+
+    dummy = DummyAdapter({"RawA": "Person ID", "RawB": "ドア名"})
+    adapter = AIColumnMapperAdapter(dummy)
+
+    out = adapter.map_and_standardize(df)
+    assert list(out.columns) == ["person_id", "door_id"]

--- a/tests/test_column_standardizer.py
+++ b/tests/test_column_standardizer.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from column_standardizer import standardize_column_names
+
+
+def test_standardize_mixed_language_columns():
+    df = pd.DataFrame(columns=["Timestamp", "ユーザーID", "Token ID", "ドア名", "結果"])
+    out = standardize_column_names(df)
+    assert list(out.columns) == [
+        "timestamp",
+        "person_id",
+        "token_id",
+        "door_id",
+        "access_result",
+    ]


### PR DESCRIPTION
## Summary
- add `column_standardizer` utility with japanese/english mappings
- add `AIColumnMapperAdapter` that uses plugin suggestions and standardizes columns
- create tests for standardizing columns and the adapter logic

## Testing
- `pytest -q tests/test_column_standardizer.py tests/test_ai_column_mapper_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_686b7588a38c8320906f3bfd7e37ed2d