### PR TITLE
Integrate AI column mapper into file processor

### DIFF
--- a/column_mapper.py
+++ b/column_mapper.py
@@ -1,0 +1,3 @@
+from utils.ai_column_mapper import AIColumnMapperAdapter
+
+__all__ = ["AIColumnMapperAdapter"]

--- a/example_ai_adapter.py
+++ b/example_ai_adapter.py
@@ -1,0 +1,3 @@
+from components.plugin_adapter import ComponentPluginAdapter
+
+__all__ = ["ComponentPluginAdapter"]

--- a/file_processor.py
+++ b/file_processor.py
@@ -1,0 +1,37 @@
+from typing import Optional, Dict, List
+import pandas as pd
+
+from column_mapper import AIColumnMapperAdapter
+from example_ai_adapter import ComponentPluginAdapter
+
+
+def load_raw_file(path: str) -> pd.DataFrame:
+    """Load raw file as DataFrame supporting CSV, JSON and Excel."""
+    lower = path.lower()
+    if lower.endswith('.csv'):
+        return pd.read_csv(path)
+    if lower.endswith('.json'):
+        return pd.read_json(path)
+    if lower.endswith(('.xlsx', '.xls')):
+        return pd.read_excel(path)
+    raise ValueError(f"Unsupported file type: {path}")
+
+
+def process_file(
+    path: str,
+    custom_mappings: Optional[Dict[str, List[str]]] = None,
+    use_japanese: bool = False
+) -> pd.DataFrame:
+    """Load and process a file applying AI-assisted column mapping."""
+    df_raw = load_raw_file(path)
+
+    ai_adapter = ComponentPluginAdapter()
+    mapper = AIColumnMapperAdapter(
+        ai_adapter,
+        custom_mappings=custom_mappings,
+        use_japanese=use_japanese
+    )
+    df_raw = mapper.map_and_standardize(df_raw)
+
+    # Further validation, enrichment, anomaly detection would continue here.
+    return df_raw


### PR DESCRIPTION
## Summary
- provide new simple `file_processor` module with AI column mapping
- export a simplified column mapper wrapper and example adapter

## Testing
- `PYTHONPATH=. pytest tests/test_ai_column_mapper_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7ac01d4c8320aafd8de530f50154