### PR TITLE
Add run_tests_and_smoke.sh utility

### DIFF
--- a/scripts/run_tests_and_smoke.sh
+++ b/scripts/run_tests_and_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running unit tests..."
+if ! pytest --maxfail=1 --disable-warnings -q --cov=./; then
+    echo "❌ Unit tests failed"
+    exit 1
+fi
+
+echo "✅ Unit tests passed"
+
+echo "Running smoke test..."
+python -m file_processing.orchestrator \
+  --file_path examples/sample_access_events.csv \
+  --output_base tests/output/smoke_test \
+  --hint '{}' \
+  --config config/config.yaml \
+  --device_registry config/device_registry.json \
+  --callback_controller settings/callback_config.yaml
+
+if [ ! -s tests/output/smoke_test.csv ] || [ ! -s tests/output/smoke_test.json ]; then
+    echo "❌ Smoke test failed: missing or empty outputs"
+    exit 1
+fi
+
+echo "✅ Smoke test passed"
+exit 0


### PR DESCRIPTION
## Summary
- add `scripts/run_tests_and_smoke.sh` for quick unit test and smoke test workflow

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=./` *(fails: ModuleNotFoundError: pandas)*
- `scripts/run_tests_and_smoke.sh` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686b7ccc0be8832093fa6010b43754eb