### PR TITLE
Update SciPy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ numpy>=1.24.0
 authlib==1.2.1
 python-jose==3.3.0
 cssutils==2.8.0
-scipy>=1.13.0
+scipy>=1.12.0
 scikit-learn==1.3.0
 joblib==1.3.2
 psutil>=5.9.0


### PR DESCRIPTION
## Summary
- lower SciPy requirement from 1.13.0 to 1.12.0

## Testing
- `pytest -k "" tests/test_ai_column_mapper_adapter.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686b8a3e925c8320ad1c991e14ba7480