### PR TITLE
Add max_display_rows config support

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -114,6 +114,7 @@ class AnalyticsConfig:
     query_timeout_seconds: int = 600
     force_full_dataset_analysis: bool = True
     max_memory_mb: int = 1024
+    max_display_rows: int = 10000
 
 
 
@@ -312,7 +313,10 @@ class ConfigManager(ConfigProviderProtocol):
             analytics_data = yaml_config["analytics"]
             for key, value in analytics_data.items():
                 if hasattr(self.config.analytics, key):
-                    setattr(self.config.analytics, key, value)
+                    if key == "max_display_rows":
+                        setattr(self.config.analytics, key, int(value))
+                    else:
+                        setattr(self.config.analytics, key, value)
 
         if "monitoring" in yaml_config:
             mon_data = yaml_config["monitoring"]

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -21,7 +21,10 @@ from core.unicode_utils import sanitize_for_utf8
 
 
 def _get_max_display_rows() -> int:
-    return get_analytics_config().max_display_rows or 10000
+    try:
+        return get_analytics_config().max_display_rows or dynamic_config.analytics.max_display_rows
+    except Exception:
+        return dynamic_config.analytics.max_display_rows
 from core.unicode_processor import safe_format_number
 from services.analytics_service import MAX_DISPLAY_ROWS
 
@@ -119,7 +122,8 @@ def process_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 def create_file_preview(df: pd.DataFrame, max_rows: int | None = None) -> Dict[str, Any]:
     """Create safe preview data without UI components"""
     try:
-        rows = max_rows or _get_max_display_rows()
+        limit = _get_max_display_rows()
+        rows = min(max_rows if max_rows is not None else limit, limit)
         preview_df = df.head(rows)
 
         # Ensure all data is JSON serializable and Unicode-safe


### PR DESCRIPTION
## Summary
- add `max_display_rows` to `AnalyticsConfig`
- update YAML loading logic to handle `max_display_rows`
- cap row preview count in `create_file_preview`
- allow fallback to dynamic config when secrets missing
- test max_display_rows functionality

## Testing
- `pytest -q tests/test_max_display_rows.py`

------
https://chatgpt.com/codex/tasks/task_e_686b8d0eb19c8320a1c1d7a9475534a2