### PR TITLE
Fix safe_unicode_decode import

### DIFF
--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -15,6 +15,7 @@ import pandas as pd
 from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
+from core.unicode_decode import safe_unicode_decode
 
 # Core processing imports only - NO UI COMPONENTS
 from core.unicode_utils import sanitize_for_utf8
@@ -38,8 +39,6 @@ class UnicodeFileProcessor:
             # Detect encoding
             detected = chardet.detect(content)
             encoding = detected.get('encoding') or 'utf-8'
-
-            from core.unicode_decode import safe_unicode_decode
 
             return safe_unicode_decode(content, encoding)
         except Exception as e:


### PR DESCRIPTION
## Summary
- import safe_unicode_decode at the module level
- rely on the module import inside `safe_decode_content`

## Testing
- `flake8 services/data_processing/file_processor.py`
- `pytest tests/test_file_processor.py -k unicode_processor_isolation -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686b8d101b788320aaab0b50e0798b47