### PR TITLE
Fix dash stub for callback tests

### DIFF
--- a/callback_tests/conftest.py
+++ b/callback_tests/conftest.py
@@ -1,5 +1,20 @@
 import pytest
-import dash
+from pathlib import Path
+import sys, types
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import dash
+except ModuleNotFoundError:
+    dash = types.SimpleNamespace(no_update=None)
+    sys.modules['dash'] = dash
+
+# Provide dash.exceptions.PreventUpdate when dash isn't installed
+if 'dash.exceptions' not in sys.modules:
+    sys.modules['dash.exceptions'] = types.SimpleNamespace(PreventUpdate=Exception)
 
 # Ensure dash.no_update is defined for tests
 if not hasattr(dash, "no_update"):


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in callback tests
- fallback to a dummy dash module if Dash isn't installed
- ensure `dash.exceptions.PreventUpdate` is stubbed for tests

## Testing
- `pytest callback_tests/test_file_upload_module_split.py::test_module_imports -q`
- `pytest callback_tests/test_upload_callbacks_split.py::test_schedule_upload_task_none -q`


------
https://chatgpt.com/codex/tasks/task_e_686b8d9c67988320b1f67db07a7efff5