### PR TITLE
Fix safe imports for Dash utilities

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -28,11 +28,24 @@ try:  # pragma: no cover - graceful import fallback
     unicode_safe_encode = safe_encode
     unicode_sanitize_df = sanitize_dataframe
 
-    from .assets_debug import (
-        check_navbar_assets,
-        debug_dash_asset_serving,
-        navbar_icon,
-    )
+    # Safe imports with fallbacks
+    try:
+        from .assets_debug import (
+            check_navbar_assets,
+            debug_dash_asset_serving,
+            log_asset_info,
+        )
+    except ImportError:
+        # Provide fallbacks when dash imports fail
+        def check_navbar_assets(*args, **kwargs):
+            return True
+
+        def debug_dash_asset_serving(*args, **kwargs):
+            return True
+
+        def log_asset_info(*args, **kwargs):
+            return None
+
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
     from .mapping_helpers import standardize_column_names, AIColumnMapperAdapter
@@ -53,11 +66,24 @@ except Exception:  # pragma: no cover - fallback when core.unicode unavailable
     unicode_safe_encode = UnicodeSecurityProcessor.sanitize_unicode_input
     unicode_sanitize_df = sanitize_data_frame
 
-    from .assets_debug import (
-        check_navbar_assets,
-        debug_dash_asset_serving,
-        navbar_icon,
-    )
+    # Safe imports with fallbacks
+    try:
+        from .assets_debug import (
+            check_navbar_assets,
+            debug_dash_asset_serving,
+            log_asset_info,
+        )
+    except ImportError:
+        # Provide fallbacks when dash imports fail
+        def check_navbar_assets(*args, **kwargs):
+            return True
+
+        def debug_dash_asset_serving(*args, **kwargs):
+            return True
+
+        def log_asset_info(*args, **kwargs):
+            return None
+
     from .assets_utils import get_nav_icon
     from .preview_utils import serialize_dataframe_preview
     from .mapping_helpers import standardize_column_names, AIColumnMapperAdapter
@@ -88,6 +114,7 @@ __all__: list[str] = [
     # Existing utilities
     "check_navbar_assets",
     "debug_dash_asset_serving",
+    "log_asset_info",
     "navbar_icon",
     "get_nav_icon",
     "serialize_dataframe_preview",

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -1,8 +1,17 @@
+#!/usr/bin/env python3
+"""Debug utilities for Dash asset serving with safe imports."""
+
+try:
+    from dash import html  # type: ignore
+    DASH_AVAILABLE = True
+except ImportError:
+    # Provide fallback for when dash is not available
+    DASH_AVAILABLE = False
+    html = None
+
 import logging
 from pathlib import Path
-from typing import Any, Dict, Iterable
-
-from dash import html  # type: ignore
+from typing import Any, Optional, Dict, Iterable
 
 from core.unicode import safe_unicode_encode
 
@@ -59,6 +68,12 @@ def debug_dash_asset_serving(app: Any, icon: str = "analytics.png") -> bool:
         return False
 
 
+def log_asset_info(icon: str) -> None:
+    """Log whether a navbar icon file exists."""
+    path = NAVBAR_ICON_DIR / icon
+    logger.info("Icon path %s exists=%s", path, path.is_file())
+
+
 def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = True):
     """Return an ``Img`` component or fallback text for missing icons.
 
@@ -79,5 +94,6 @@ def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = Tru
 __all__ = [
     "check_navbar_assets",
     "debug_dash_asset_serving",
+    "log_asset_info",
     "navbar_icon",
 ]


### PR DESCRIPTION
## Summary
- safeguard dash imports in `utils/assets_debug.py`
- add simple `log_asset_info` helper
- expose new helper via `utils/__init__` with fallbacks

## Testing
- `pytest -k assets_debug -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686b9cda6a748320ace9197ba4167fdf