### PR TITLE
Implement persistent upload store

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,11 @@ Uploaded files are now **lazy loaded**. Only the `file_info.json` metadata is
 read at startup; Parquet files are opened on demand when analytics or previews
 require them. This keeps startup fast even with many large uploads.
 
+Uploaded data is persisted inside `temp/uploaded_data`. Each successful
+upload creates a `<name>.parquet` file along with metadata in
+`file_info.json`. The analytics page lists these entries in the **Data Source**
+dropdown so you can revisit earlier uploads without re-uploading them.
+
 **Important:** keep the `temp/uploaded_data` directory intact until device
 mappings have been saved, otherwise the mapping step will fail.
 

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -41,13 +41,12 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
     """Return dropdown options for available data sources."""
     options: List[Dict[str, str]] = []
     try:
-        from pages.file_upload import get_uploaded_data  # lazy import
+        from services.upload_data_service import get_uploaded_data  # lazy import
 
         uploaded_files = get_uploaded_data()
-        if uploaded_files:
-            for filename in uploaded_files.keys():
-                options.append({"label": f"File: {filename}", "value": f"upload:{filename}"})
-    except ImportError:
+        for filename in uploaded_files.keys():
+            options.append({"label": f"File: {filename}", "value": f"upload:{filename}"})
+    except Exception:
         pass
     try:
         service = get_analytics_service_safe()
@@ -71,7 +70,7 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
 def get_latest_uploaded_source_value() -> Optional[str]:
     """Return the dropdown value for the most recently uploaded file."""
     try:
-        from pages.file_upload import get_uploaded_filenames  # lazy import
+        from services.upload_data_service import get_uploaded_filenames  # lazy import
 
         filenames = get_uploaded_filenames()
         if filenames:


### PR DESCRIPTION
## Summary
- document persistent upload storage
- list uploaded files in analytics engine using service-level helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.database_manager')*

------
https://chatgpt.com/codex/tasks/task_e_686bb100dd6c832095f574893c6fa511