### PR TITLE
Fix import error handling for services.upload

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -82,53 +82,23 @@ try:
         get_trigger_id,
         save_ai_training_data,
     )
-except Exception:  # pragma: no cover - optional dependency for tests
-    AISuggestionService = type("AISuggestionService", (), {})
-    ModalService = type("ModalService", (), {})
-
-    class UploadProcessingService:  # type: ignore
-        async_processor = None
-
-        def __init__(self, *_a, **_kw):
-            pass
-
-        async def process_files(self, *_a, **_kw):
-            return ([], [], {}, [], {}, None, None)
-
-    class ChunkedUploadManager:  # type: ignore
-        def start_file(self, *_a, **_kw):
-            pass
-
-        def finish_file(self, *_a, **_kw):
-            pass
-
-        def get_progress(self, *_a, **_kw):
-            return 0
-
-    def get_trigger_id():
-        return "trig"
-
-    def save_ai_training_data(*_a, **_kw):
-        pass
+except ImportError as exc:  # pragma: no cover - optional dependency for tests
+    raise ImportError(
+        "services.upload package is required for file upload functionality"
+    ) from exc
 
 
 try:
     from services.upload.unified_controller import UnifiedUploadController
-except Exception:  # pragma: no cover - optional dependency for tests
-    UnifiedUploadController = None
+except ImportError as exc:  # pragma: no cover - optional dependency for tests
+    raise ImportError("services.upload.unified_controller module is required") from exc
 
 try:
     from services.upload.upload_queue_manager import UploadQueueManager
-except Exception:  # pragma: no cover - optional dependency for tests
-
-    class UploadQueueManager:  # type: ignore
-        files: list[str] = []
-
-        def add_file(self, *_a, **_kw):
-            pass
-
-        def mark_complete(self, *_a, **_kw):
-            pass
+except ImportError as exc:  # pragma: no cover - optional dependency for tests
+    raise ImportError(
+        "services.upload.upload_queue_manager module is required"
+    ) from exc
 
 
 from services.upload.validators import ClientSideValidator
@@ -1049,6 +1019,7 @@ class Callbacks:
                 dismissable=True,
                 duration=8000,
             )
+
 
 def register_upload_callbacks(
     manager: "TrulyUnifiedCallbacks",

--- a/tests/test_file_upload_import_failure.py
+++ b/tests/test_file_upload_import_failure.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_file_upload_requires_services(monkeypatch):
+    monkeypatch.setitem(sys.modules, "services.upload", None)
+    monkeypatch.setitem(sys.modules, "services.upload.unified_controller", None)
+    monkeypatch.setitem(sys.modules, "services.upload.upload_queue_manager", None)
+    sys.modules.pop("pages.file_upload", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("pages.file_upload")


### PR DESCRIPTION
## Summary
- handle missing `services.upload` using `ImportError`
- remove dummy fallbacks and add test for missing dependency

## Testing
- `pytest tests/test_file_upload_import_failure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686bceec339c8320bb01c4fb43542f6d