### PR TITLE
Fix missing TYPE_CHECKING import

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -17,6 +17,8 @@ except Exception:  # pragma: no cover - optional Dash dependency
     html = SimpleNamespace()
     no_update = None
 
+from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 


### PR DESCRIPTION
## Summary
- fix imports in `pages/file_upload.py` by adding `TYPE_CHECKING`

## Testing
- `pre-commit run --files pages/file_upload.py` *(fails: Found 532 errors in 93 files)*

------
https://chatgpt.com/codex/tasks/task_e_686bd885506483209d898a1131a2eb87