### PR TITLE
Add print_callback_summary proxy method

### DIFF
--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -33,3 +33,12 @@ class TrulyUnifiedCallbacks:
         if states is None:
             states = []
         return self.app.callback(outputs, inputs, states, **kwargs)
+
+    # ------------------------------------------------------------------
+    def print_callback_summary(self) -> None:
+        """Proxy summary request to the underlying coordinator."""
+        if self.coordinator is not None:
+            self.coordinator.print_callback_summary()
+
+
+__all__ = ["TrulyUnifiedCallbacks"]


### PR DESCRIPTION
## Summary
- allow `TrulyUnifiedCallbacks` to relay callback summary printing

## Testing
- `pytest -k "print_callback_summary" -q` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_686c446de46083208d1664889c153fa8