### PR TITLE
Fix type checks for dynamic app attributes

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import sys
 
 import logging
 import os
+from typing import Any, cast
 
 from flask import request
 
@@ -183,7 +184,7 @@ def main():
                 manager.trigger(CallbackEvent.AFTER_REQUEST, current)
                 return current
 
-            app._callback_manager = manager  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+            cast(Any, app)._callback_manager = manager
             # Validate that Dash can serve static assets after request hooks
             # have been registered. This avoids triggering a request before the
             # hooks are in place, which previously caused Flask to raise a

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -212,11 +212,11 @@ def _create_full_app() -> dash.Dash:
         ensure_icon_cache_headers(app)
 
         # Expose the service container on the app instance
-        app._service_container = service_container
+        cast(Any, app)._service_container = service_container
 
         # Initialize caching once per app instance
         cache = Cache(app.server, config={"CACHE_TYPE": "simple"})
-        app.cache = cache
+        cast(Any, app).cache = cache
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -293,7 +293,7 @@ def _create_full_app() -> dash.Dash:
             and config_manager.get_app_config().environment == "production"
         ):
             try:
-                app._csrf_plugin = setup_enhanced_csrf_protection(
+                cast(Any, app)._csrf_plugin = setup_enhanced_csrf_protection(
                     app, CSRFMode.PRODUCTION
                 )
             except Exception as e:  # pragma: no cover - best effort
@@ -396,7 +396,7 @@ def _create_simple_app() -> dash.Dash:
         ensure_icon_cache_headers(app)
 
         cache = Cache(app.server, config={"CACHE_TYPE": "simple"})
-        app.cache = cache
+        cast(Any, app).cache = cache
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -515,7 +515,7 @@ def _create_json_safe_app() -> dash.Dash:
         ensure_icon_cache_headers(app)
 
         cache = Cache(app.server, config={"CACHE_TYPE": "simple"})
-        app.cache = cache
+        cast(Any, app).cache = cache
 
         app.index_string = f"""
 <!DOCTYPE html>
@@ -905,7 +905,7 @@ def _initialize_plugins(app: dash.Dash, config_manager: Any) -> None:
     plugin_auto.scan_and_configure("plugins")
     plugin_auto.generate_health_endpoints()
     registry = plugin_auto.registry
-    app._yosai_plugin_manager = registry.plugin_manager
+    cast(Any, app)._yosai_plugin_manager = registry.plugin_manager
 
     @app.server.teardown_appcontext  # type: ignore[attr-defined]
     def _shutdown_plugin_manager(exc=None):
@@ -967,8 +967,8 @@ def _register_callbacks(app: dash.Dash, config_manager: Any) -> None:
             from services.interfaces import get_export_service
             register_navbar_callbacks(coordinator, get_export_service())
 
-            app._upload_callbacks = UploadCallbacks()
-            app._deep_analytics_callbacks = DeepAnalyticsCallbacks()
+            cast(Any, app)._upload_callbacks = UploadCallbacks()
+            cast(Any, app)._deep_analytics_callbacks = DeepAnalyticsCallbacks()
 
             if config_manager.get_app_config().environment == "development" and hasattr(
                 coordinator, "print_callback_summary"

--- a/core/json_serialization_plugin.py
+++ b/core/json_serialization_plugin.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 import pandas as pd
 
@@ -383,7 +383,7 @@ class JsonSerializationPlugin:
                     # This is a Dash app
                     app.server.json_provider_class = self._yosai_json_provider_class
                     app.server.json = self._yosai_json_provider_class(app.server)
-                    app._yosai_json_plugin = self
+                    cast(Any, app)._yosai_json_plugin = self
                     self.logger.info("Applied JSON serialization to Dash app")
                 elif hasattr(app, "json_provider_class") and hasattr(
                     self, "_yosai_json_provider_class"

--- a/core/plugins/auto_config.py
+++ b/core/plugins/auto_config.py
@@ -1,7 +1,7 @@
 """Utility helpers for automatic plugin setup."""
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 
 from dash import Dash
 
@@ -25,7 +25,7 @@ class PluginAutoConfiguration:
         self.app = app
         self.container = container or DIContainer()
         # Expose container on the app for decorators like ``safe_callback``
-        self.app._yosai_container = self.container
+        cast(Any, self.app)._yosai_container = self.container
         self.config_manager = config_manager or ConfigManager()
         self.package = package
         self.registry = UnifiedPluginRegistry(

--- a/dash_csrf_plugin/plugin.py
+++ b/dash_csrf_plugin/plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 
 import dash
 
@@ -48,8 +48,8 @@ class DashCSRFPlugin:
         self._initialized = True
 
         if not hasattr(app, "_plugins"):
-            app._plugins = {}
-        app._plugins["csrf"] = self
+            cast(Any, app)._plugins = {}
+        cast(Any, app)._plugins["csrf"] = self
 
         self._run_hooks("after_init")
         logger.info("Dash CSRF Plugin initialized")


### PR DESCRIPTION
## Summary
- ensure service container and cache assignments are type safe
- cast dynamic plugin attributes on the Dash app
- expose container safely in PluginAutoConfiguration
- apply casts in CSRF and JSON plugins
- cast callback manager in `app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_686c446941d48320a5b21bcc210fbbbd