### PR TITLE
Fix analytics service factory cast

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -185,9 +185,12 @@ def _create_full_app() -> "Dash":
     try:
         service_container = ServiceContainer()
         service_container.register_factory("config", get_config)
+        analytics_service_func = cast(
+            Callable[[], AnalyticsService], get_analytics_service
+        )
         service_container.register_factory(
             "analytics_service",
-            lambda: cast(AnalyticsService, get_analytics_service()),
+            analytics_service_func,
         )
         config_manager = service_container.get("config")
         analytics_service = service_container.get("analytics_service")


### PR DESCRIPTION
## Summary
- avoid None call when registering analytics service

## Testing
- `black core/app_factory.py --check`
- `mypy core/app_factory.py` *(fails: returning many errors)*
- `pytest tests/test_analytics_service_threadsafe.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c74b2366c832099998e08681667bc