### PR TITLE
Fix type hints for Container placeholder page

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -108,6 +108,7 @@ except Exception:  # pragma: no cover - fallback when unavailable
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     import dash_bootstrap_components as dbc
+    from dash_bootstrap_components import Container as DbcContainer
     from dash import Dash, Input, Output
     from dash import dcc as Dcc
     from dash import html as Html
@@ -673,7 +674,7 @@ def _create_error_page(message: str) -> Any:
     )
 
 
-def _create_placeholder_page(title: str, subtitle: str, message: str) -> dbc.Container:
+def _create_placeholder_page(title: str, subtitle: str, message: str) -> "DbcContainer":
     """Create placeholder page for missing modules"""
     return dbc.Container(
         [


### PR DESCRIPTION
## Summary
- import `Container` from dash_bootstrap_components inside `TYPE_CHECKING`
- update `_create_placeholder_page` return type annotation

## Testing
- `black --check core/app_factory.py`
- `flake8 core/app_factory.py` *(fails: module level import not at top of file and other issues)*
- `mypy core/app_factory.py` *(fails: multiple errors across project)*
- `pytest -q` *(fails: import errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686c74b4b3988320935d7a0b8abbf349