### PR TITLE
Fix Pylance type hint errors

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -114,7 +114,11 @@ if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from dash import dcc as Dcc
     from dash import html as Html
 
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from core.truly_unified_callbacks import (
+        TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType,
+    )
+else:  # pragma: no cover - fallback type alias
+    TrulyUnifiedCallbacksType = Any
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 BUNDLE = "/assets/dist/main.min.css"
@@ -697,7 +701,7 @@ def _create_placeholder_page(title: str, subtitle: str, message: str) -> "DbcCon
     )
 
 
-def _register_router_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
+def _register_router_callbacks(manager: TrulyUnifiedCallbacksType) -> None:
     """Register page routing callbacks."""
 
     def safe_callback(outputs, inputs, callback_id="unknown"):
@@ -882,7 +886,7 @@ def _get_upload_page() -> Any:
     )
 
 
-def _register_global_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
+def _register_global_callbacks(manager: TrulyUnifiedCallbacksType) -> None:
     """Register global application callbacks with consolidated management and Unicode safety"""
 
     if not DASH_AVAILABLE:

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -2,7 +2,7 @@
 """File upload page wiring the reusable upload component."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import logging
 from dash import html
@@ -16,7 +16,11 @@ else:
     _import_error = None
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from dash import html as Html
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
+else:  # pragma: no cover - fallback type alias
+    Html = html  # type: ignore[assignment]
+    TrulyUnifiedCallbacksType = Any
 
 
 logger = logging.getLogger(__name__)
@@ -25,7 +29,7 @@ logger = logging.getLogger(__name__)
 _upload_component = FileUploadComponent() if FileUploadComponent else None
 
 
-def layout() -> html.Div:
+def layout() -> Html.Div:
     """Return the upload page layout wrapped in a container."""
     if _upload_component:
         return html.Div(
@@ -35,7 +39,7 @@ def layout() -> html.Div:
     return html.Div("Upload component unavailable")
 
 
-def register_callbacks(manager: "TrulyUnifiedCallbacks", controller=None) -> None:
+def register_callbacks(manager: TrulyUnifiedCallbacksType, controller=None) -> None:
     """Register upload callbacks using the underlying component."""
     if _upload_component:
         _upload_component.register_callbacks(manager, controller)


### PR DESCRIPTION
## Summary
- ensure TrulyUnifiedCallbacks type hinting works with optional import
- use Html.Div alias for return type in file upload page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.database_manager')*

------
https://chatgpt.com/codex/tasks/task_e_686c877f211c832096c922baf11b086f