### PR TITLE
Add object_count to core.unicode

### DIFF
--- a/core/unicode/__init__.py
+++ b/core/unicode/__init__.py
@@ -1,11 +1,23 @@
 from ..unicode_processor import *
 from ..unicode_processor import safe_decode_bytes, safe_encode_text
 from ..unicode_decode import safe_unicode_decode
+from typing import Any, Dict, Iterable
 from .processor import (
     UnicodeSecurityProcessor,
     UnicodeSQLProcessor,
     UnicodeTextProcessor,
 )
+
+
+def object_count(items: Iterable[Any]) -> int:
+    """Return the number of unique strings appearing more than once."""
+
+    counts: Dict[str, int] = {}
+    for item in items:
+        if isinstance(item, str):
+            counts[item] = counts.get(item, 0) + 1
+
+    return sum(1 for v in counts.values() if v > 1)
 
 __all__ = [
     "UnicodeProcessor",
@@ -24,6 +36,7 @@ __all__ = [
     "contains_surrogates",
     "process_large_csv_content",
     "safe_format_number",
+    "object_count",
     "UnicodeTextProcessor",
     "UnicodeSQLProcessor",
     "UnicodeSecurityProcessor",

--- a/core/unicode/processor.py
+++ b/core/unicode/processor.py
@@ -15,7 +15,11 @@ _SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
 
 
 class UnicodeTextProcessor:
-    """Clean and normalize arbitrary text."""
+    """Clean and normalize arbitrary text.
+
+    Additional utilities like :func:`core.unicode.object_count` help analyze
+    collections of strings.
+    """
 
     @staticmethod
     def clean_text(text: Any) -> str:

--- a/tests/test_unicode_text_processor.py
+++ b/tests/test_unicode_text_processor.py
@@ -1,0 +1,17 @@
+import pytest
+
+from core.unicode import object_count
+
+
+def test_object_count_basic():
+    items = ["a", "b", "b", "c", "c", "c"]
+    assert object_count(items) == 2
+
+
+def test_object_count_ignores_non_strings():
+    items = ["x", 1, "x", 2, 3, "y"]
+    assert object_count(items) == 1
+
+
+def test_object_count_no_duplicates():
+    assert object_count(["a", "b", "c"]) == 0


### PR DESCRIPTION
## Summary
- add `object_count` helper in `core.unicode`
- reference `object_count` in `UnicodeTextProcessor` docs
- test counting duplicates in `tests/test_unicode_text_processor.py`

## Testing
- `pytest tests/test_unicode_text_processor.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'config.database_manager')*
- `mypy --strict .` *(fails: Found 2359 errors)*
- `flake8` *(fails: command not found)*
- `black --check .` *(fails: 177 files would be reformatted)*
- `isort --check .` *(fails: Imports are incorrectly sorted and/or formatted)*

------
https://chatgpt.com/codex/tasks/task_e_686c90c2cd008320899987798eec06b3