### PR TITLE
Fix MAX_DISPLAY_ROWS imports

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -23,7 +23,13 @@ try:
     from config.dynamic_config import dynamic_config
 except Exception:  # pragma: no cover - optional config
     dynamic_config = None
-from services.analytics_service import MAX_DISPLAY_ROWS
+
+from config.constants import MAX_DISPLAY_ROWS as DEFAULT_MAX_DISPLAY_ROWS
+
+if dynamic_config is not None:
+    MAX_DISPLAY_ROWS = dynamic_config.analytics.max_display_rows
+else:  # pragma: no cover - fallback for optional config
+    MAX_DISPLAY_ROWS = DEFAULT_MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 

--- a/config/constants.py
+++ b/config/constants.py
@@ -140,6 +140,10 @@ class CacheConstants:
     purge_count: int = 50
 
 
+# Convenience constant for data previews
+MAX_DISPLAY_ROWS: int = AnalyticsConstants.max_display_rows
+
+
 # Network defaults
 DEFAULT_APP_HOST: str = "127.0.0.1"
 DEFAULT_APP_PORT: int = 8050

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -61,8 +61,6 @@ logger = logging.getLogger(__name__)
 
 from config.dynamic_config import dynamic_config
 
-MAX_DISPLAY_ROWS = dynamic_config.analytics.max_display_rows
-
 # Thresholds used for row count sanity checks
 ROW_LIMIT_WARNING = 150
 """Warning threshold when exactly 150 rows are returned."""

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -27,7 +27,6 @@ def _get_max_display_rows() -> int:
     except Exception:
         return dynamic_config.analytics.max_display_rows
 from core.unicode_processor import safe_format_number
-from services.analytics_service import MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -5,12 +5,18 @@ from typing import Any
 import pandas as pd
 
 from config.config import get_analytics_config
-from services.analytics_service import MAX_DISPLAY_ROWS
+from config.dynamic_config import dynamic_config
 from services.upload.utils.file_parser import UnicodeFileProcessor
 
 
 def _get_max_display_rows() -> int:
-    return get_analytics_config().max_display_rows or 10000
+    try:
+        return (
+            get_analytics_config().max_display_rows
+            or dynamic_config.analytics.max_display_rows
+        )
+    except Exception:
+        return dynamic_config.analytics.max_display_rows
 
 
 class AsyncUploadProcessor:

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -27,7 +27,6 @@ def _get_max_display_rows() -> int:
     except Exception:
         return dynamic_config.analytics.max_display_rows
 from core.unicode_processor import safe_format_number
-from services.analytics_service import MAX_DISPLAY_ROWS
 
 logger = logging.getLogger(__name__)
 

--- a/tests/callbacks/test_file_upload_module_split.py
+++ b/tests/callbacks/test_file_upload_module_split.py
@@ -65,7 +65,6 @@ col_mod.save_verified_mappings = lambda *a, **k: None
 sys.modules['components.column_verification'] = col_mod
 
 svc_analytics_service = types.ModuleType('services.analytics_service')
-svc_analytics_service.MAX_DISPLAY_ROWS = 100
 sys.modules['services.analytics_service'] = svc_analytics_service
 
 core_unicode = types.ModuleType('core.unicode')

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -76,7 +76,6 @@ for attr in [
     setattr(dbc_mod, attr, lambda *a, **k: None)
 sys.modules["dash_bootstrap_components"] = dbc_mod
 svc_analytics_service = types.ModuleType("services.analytics_service")
-svc_analytics_service.MAX_DISPLAY_ROWS = 100
 sys.modules["services.analytics_service"] = svc_analytics_service
 core_unicode = types.ModuleType("core.unicode")
 core_unicode.safe_unicode_decode = lambda x, **_: x

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from config.config import ConfigManager
 from config.dynamic_config import dynamic_config
-from services.analytics_service import MAX_DISPLAY_ROWS
+from config.constants import MAX_DISPLAY_ROWS
 from services.data_processing.file_processor import create_file_preview
 
 

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -22,9 +22,6 @@ from core.protocols import AnalyticsServiceProtocol
 # Provide lightweight stubs for heavy service modules
 analytics_service_stub = types.ModuleType("services.analytics_service")
 
-MAX_DISPLAY_ROWS = 100
-analytics_service_stub.MAX_DISPLAY_ROWS = MAX_DISPLAY_ROWS
-
 class StubAnalyticsService(AnalyticsServiceProtocol):
     def get_dashboard_summary(self):
         return {}

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -20,7 +20,6 @@ sys.modules.setdefault("services", services_pkg)
 from core.protocols import AnalyticsServiceProtocol
 
 analytics_stub = types.ModuleType("services.analytics_service")
-analytics_stub.MAX_DISPLAY_ROWS = 100
 
 class StubAnalyticsService(AnalyticsServiceProtocol):
     def get_dashboard_summary(self):

--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -5,12 +5,18 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from config.config import get_analytics_config
+from config.dynamic_config import dynamic_config
 from core.unicode_utils import sanitize_for_utf8
-from services.analytics_service import MAX_DISPLAY_ROWS
 
 
 def _get_max_display_rows() -> int:
-    return get_analytics_config().max_display_rows or 10000
+    try:
+        return (
+            get_analytics_config().max_display_rows
+            or dynamic_config.analytics.max_display_rows
+        )
+    except Exception:  # pragma: no cover - fallback path
+        return dynamic_config.analytics.max_display_rows
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- define `MAX_DISPLAY_ROWS` in `config.constants`
- reference `dynamic_config.analytics.max_display_rows` inside components
- drop constant from `analytics_service`
- clean up unused imports in services
- adjust tests to stop expecting `MAX_DISPLAY_ROWS` in `analytics_service`

## Testing
- `python scripts/validate_consolidation.py` *(fails: No such file or directory)*
- `pytest tests/test_max_display_rows.py -q` *(fails: ModuleNotFoundError: psutil)*

------
https://chatgpt.com/codex/tasks/task_e_686cc30ea5948320ad63c9657805ce72