### PR TITLE
Add test builders for uploads

### DIFF
--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 import importlib.util
 import sys
 from pathlib import Path
@@ -87,8 +89,8 @@ ChunkedUploadManager = chunk_mod.ChunkedUploadManager
 
 def test_resumable_upload_and_error_callback(tmp_path, monkeypatch):
     data_file = tmp_path / "sample.csv"
-    df = pd.DataFrame({"a": range(15)})
-    df.to_csv(data_file, index=False)
+    df = DataFrameBuilder().add_column("a", range(15)).build()
+    UploadFileBuilder().with_dataframe(df).write_csv(data_file)
 
     store = SimpleStore(tmp_path / "store")
     cmgr = ChunkedUploadManager(store, metadata_dir=tmp_path / "meta", initial_chunk_size=5)

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -1,6 +1,6 @@
 import dash
 import dash_bootstrap_components as dbc
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from dash import dcc, html
 
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
@@ -16,8 +16,9 @@ def _create_upload_app():
 
 
 def test_upload_progress_sse(dash_duo, tmp_path):
-    csv = tmp_path / "sample.csv"
-    pd.DataFrame({"a": [1, 2]}).to_csv(csv, index=False)
+    csv = UploadFileBuilder().with_dataframe(
+        DataFrameBuilder().add_column("a", [1, 2]).build()
+    ).write_csv(tmp_path / "sample.csv")
     app = _create_upload_app()
     dash_duo.start_server(app)
     assert not dash_duo.find_elements("#upload-progress-interval")

--- a/tests/test_async_upload_processor.py
+++ b/tests/test_async_upload_processor.py
@@ -1,17 +1,20 @@
 import asyncio
 
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from services.upload.async_processor import AsyncUploadProcessor
 
 
 def test_async_upload_processor_csv_parquet(tmp_path):
-    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    csv_path = tmp_path / "sample.csv"
+    df = (
+        DataFrameBuilder()
+        .add_column("a", [1, 2, 3])
+        .add_column("b", ["x", "y", "z"])
+        .build()
+    )
+    csv_path = UploadFileBuilder().with_dataframe(df).write_csv(tmp_path / "sample.csv")
+    df.to_parquet(tmp_path / "sample.parquet", index=False)
     parquet_path = tmp_path / "sample.parquet"
-
-    df.to_csv(csv_path, index=False)
-    df.to_parquet(parquet_path, index=False)
 
     proc = AsyncUploadProcessor()
 

--- a/tests/test_chunked_upload_manager.py
+++ b/tests/test_chunked_upload_manager.py
@@ -1,13 +1,15 @@
 import pandas as pd
 import pytest
 
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
+
 from services.upload.chunked_upload_manager import ChunkedUploadManager
 from utils.upload_store import UploadedDataStore
 
 
 def _create_csv(path, rows=30):
-    df = pd.DataFrame({"a": range(rows)})
-    df.to_csv(path, index=False)
+    df = DataFrameBuilder().add_column("a", range(rows)).build()
+    UploadFileBuilder().with_dataframe(df).write_csv(path)
     return df
 
 

--- a/tests/test_chunked_upload_manager_async.py
+++ b/tests/test_chunked_upload_manager_async.py
@@ -1,14 +1,17 @@
 import asyncio
 import pandas as pd
+import pandas as pd
 import pytest
+
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from services.upload.chunked_upload_manager_async import ChunkedUploadManager
 from utils.upload_store import UploadedDataStore
 
 
 def _create_csv(path, rows=30):
-    df = pd.DataFrame({"a": range(rows)})
-    df.to_csv(path, index=False)
+    df = DataFrameBuilder().add_column("a", range(rows)).build()
+    UploadFileBuilder().with_dataframe(df).write_csv(path)
     return df
 
 

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -1,7 +1,6 @@
 import asyncio
-import base64
 
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from services.upload import UploadProcessingService
 from upload_core import UploadCore
@@ -9,14 +8,13 @@ from utils.upload_store import uploaded_data_store as _uploaded_data_store
 
 
 def test_multi_part_upload_row_count():
-    df = pd.DataFrame(
-        {
-            "A": [1, 2, 3, 4],
-            "B": ["a", "b", "c", "d"],
-        }
+    df = (
+        DataFrameBuilder()
+        .add_column("A", [1, 2, 3, 4])
+        .add_column("B", ["a", "b", "c", "d"])
+        .build()
     )
-    csv = df.to_csv(index=False)
-    b64 = base64.b64encode(csv.encode()).decode()
+    b64 = UploadFileBuilder().with_dataframe(df).as_base64().split(",", 1)[1]
     prefix = "data:text/csv;base64,"
     mid = len(b64) // 2
     part1 = prefix + b64[:mid]

--- a/tests/test_process_uploaded_files_split.py
+++ b/tests/test_process_uploaded_files_split.py
@@ -1,7 +1,6 @@
 import asyncio
-import base64
 
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from pages import file_upload
 from services.upload import UploadProcessingService
@@ -10,14 +9,17 @@ from utils.upload_store import UploadedDataStore
 
 
 def _encode_df(df: pd.DataFrame) -> str:
-    data = df.to_csv(index=False).encode()
-    b64 = base64.b64encode(data).decode()
-    return f"data:text/csv;base64,{b64}"
+    return UploadFileBuilder().with_dataframe(df).as_base64()
 
 
 def test_process_uploaded_files_split(monkeypatch, tmp_path):
     # create a dataframe large enough to split
-    df = pd.DataFrame({"a": range(10), "b": range(10)})
+    df = (
+        DataFrameBuilder()
+        .add_column("a", range(10))
+        .add_column("b", range(10))
+        .build()
+    )
     df1 = df.iloc[:5]
     df2 = df.iloc[5:]
 

--- a/tests/test_read_uploaded_file.py
+++ b/tests/test_read_uploaded_file.py
@@ -1,14 +1,16 @@
-import base64
-
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from services.data_processing.file_processor import FileProcessor
 
 
 def test_read_uploaded_file_basic():
-    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    encoded = base64.b64encode(df.to_csv(index=False).encode()).decode()
-    contents = f"data:text/csv;base64,{encoded}"
+    df = (
+        DataFrameBuilder()
+        .add_column("a", [1, 2])
+        .add_column("b", [3, 4])
+        .build()
+    )
+    contents = UploadFileBuilder().with_dataframe(df).as_base64()
     processor = FileProcessor()
     loaded, size = processor.read_uploaded_file(contents, "sample.csv")
     assert len(loaded) == len(df)

--- a/tests/test_upload_fix.py
+++ b/tests/test_upload_fix.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 import shutil
 
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 # Ensure the real Dash package is used even if test stubs are on sys.path
 stub_dir = Path(__file__).resolve().parent / "stubs"
@@ -30,13 +30,12 @@ def _skip_if_no_chromedriver() -> None:
 
 
 def create_sample_files(tmp_path: Path) -> dict[str, Path]:
-    df = pd.DataFrame({"col": ["hello", "😀"]})
-    csv = tmp_path / "sample.csv"
+    df = DataFrameBuilder().add_column("col", ["hello", "😀"]).build()
+    csv = UploadFileBuilder().with_dataframe(df).write_csv(tmp_path / "sample.csv")
+    df.to_excel(tmp_path / "sample.xlsx", index=False)
+    df.to_json(tmp_path / "sample.json", force_ascii=False, orient="records")
     excel = tmp_path / "sample.xlsx"
     jsonf = tmp_path / "sample.json"
-    df.to_csv(csv, index=False)
-    df.to_excel(excel, index=False)
-    df.to_json(jsonf, force_ascii=False, orient="records")
     return {"csv": csv, "excel": excel, "json": jsonf}
 
 

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -1,4 +1,4 @@
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder
 
 from services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.data_processing.processor import Processor
@@ -18,14 +18,14 @@ def _make_processor():
     return UploadAnalyticsProcessor(vs, processor)
 
 def test_direct_processing_helper(tmp_path):
-    df1 = pd.DataFrame(
-        {
-            "Timestamp": ["2024-01-01 10:00:00"],
-            "Person ID": ["u1"],
-            "Token ID": ["t1"],
-            "Device name": ["d1"],
-            "Access result": ["Granted"],
-        }
+    df1 = (
+        DataFrameBuilder()
+        .add_column("Timestamp", ["2024-01-01 10:00:00"])
+        .add_column("Person ID", ["u1"])
+        .add_column("Token ID", ["t1"])
+        .add_column("Device name", ["d1"])
+        .add_column("Access result", ["Granted"])
+        .build()
     )
     proc = _make_processor()
     result = proc._process_uploaded_data_directly({"f1.csv": df1})

--- a/tests/test_upload_store_filename_validation.py
+++ b/tests/test_upload_store_filename_validation.py
@@ -1,4 +1,4 @@
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder
 import pytest
 
 from utils.upload_store import UploadedDataStore
@@ -6,7 +6,7 @@ from utils.upload_store import UploadedDataStore
 
 def test_unsafe_filenames_rejected(tmp_path):
     store = UploadedDataStore(storage_dir=tmp_path)
-    df = pd.DataFrame({"a": [1]})
+    df = DataFrameBuilder().add_column("a", [1]).build()
 
     with pytest.raises(ValueError):
         store.add_file("../bad.csv", df)

--- a/tests/test_upload_store_migration.py
+++ b/tests/test_upload_store_migration.py
@@ -1,10 +1,15 @@
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder
 
 from utils.upload_store import UploadedDataStore
 
 
 def test_pkl_migration(tmp_path):
-    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df = (
+        DataFrameBuilder()
+        .add_column("a", [1, 2])
+        .add_column("b", [3, 4])
+        .build()
+    )
     pkl_path = tmp_path / "legacy.csv.pkl"
     df.to_pickle(pkl_path)
 

--- a/tests/test_upload_store_threading.py
+++ b/tests/test_upload_store_threading.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
+from tests.utils.builders import DataFrameBuilder
 
 from utils.upload_store import UploadedDataStore
 
@@ -9,7 +10,7 @@ def test_concurrent_add_file(tmp_path):
     store = UploadedDataStore(storage_dir=tmp_path)
 
     def worker(i: int) -> None:
-        df = pd.DataFrame({"val": [i]})
+        df = DataFrameBuilder().add_column("val", [i]).build()
         store.add_file(f"file_{i}.csv", df)
 
     with ThreadPoolExecutor(max_workers=5) as exc:
@@ -20,7 +21,9 @@ def test_concurrent_add_file(tmp_path):
     assert set(store.get_filenames()) == {f"file_{i}.csv" for i in range(10)}
     data = store.get_all_data()
     for i in range(10):
-        pd.testing.assert_frame_equal(data[f"file_{i}.csv"], pd.DataFrame({"val": [i]}))
+        pd.testing.assert_frame_equal(
+            data[f"file_{i}.csv"], DataFrameBuilder().add_column("val", [i]).build()
+        )
 
     # verify files persisted to disk and can be reloaded
     parquet_files = list(tmp_path.glob("*.parquet"))
@@ -29,5 +32,5 @@ def test_concurrent_add_file(tmp_path):
     assert set(reloaded.get_filenames()) == {f"file_{i}.csv" for i in range(10)}
     for i in range(10):
         pd.testing.assert_frame_equal(
-            reloaded.get_all_data()[f"file_{i}.csv"], pd.DataFrame({"val": [i]})
+            reloaded.get_all_data()[f"file_{i}.csv"], DataFrameBuilder().add_column("val", [i]).build()
         )

--- a/tests/test_upload_validator.py
+++ b/tests/test_upload_validator.py
@@ -1,30 +1,28 @@
-import base64
 from pathlib import Path
 
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from upload_validator import UploadValidator
 
 
 def test_validate_file_upload_dataframe():
-    df = pd.DataFrame({"a": [1]})
+    df = DataFrameBuilder().add_column("a", [1]).build()
     v = UploadValidator(max_size_mb=1)
     res = v.validate_file_upload(df)
     assert res.valid
 
 
 def test_validate_file_upload_base64(tmp_path):
-    data = b"a,b\n1,2\n"
-    b64 = base64.b64encode(data).decode()
-    uri = "data:text/csv;base64," + b64
+    df = DataFrameBuilder().add_column("a", [1]).add_column("b", [2]).build()
+    uri = UploadFileBuilder().with_dataframe(df).as_base64()
     v = UploadValidator(max_size_mb=1)
     res = v.validate_file_upload(uri)
     assert res.valid
 
 
 def test_validate_file_upload_path(tmp_path):
-    path = tmp_path / "file.csv"
-    path.write_text("a,b\n1,2\n")
+    df = DataFrameBuilder().add_column("a", [1]).add_column("b", [2]).build()
+    path = UploadFileBuilder().with_dataframe(df).write_csv(tmp_path / "file.csv")
     v = UploadValidator(max_size_mb=1)
     res = v.validate_file_upload(path)
     assert res.valid

--- a/tests/test_uploaded_chunk_processing.py
+++ b/tests/test_uploaded_chunk_processing.py
@@ -1,31 +1,29 @@
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from services import AnalyticsService
 
 
 def test_process_uploaded_data_directly_chunked(tmp_path):
-    df1 = pd.DataFrame(
-        {
-            "Timestamp": ["2024-01-01 10:00:00", "2024-01-01 11:00:00"],
-            "Person ID": ["u1", "u2"],
-            "Token ID": ["t1", "t2"],
-            "Device name": ["d1", "d1"],
-            "Access result": ["Granted", "Denied"],
-        }
+    df1 = (
+        DataFrameBuilder()
+        .add_column("Timestamp", ["2024-01-01 10:00:00", "2024-01-01 11:00:00"])
+        .add_column("Person ID", ["u1", "u2"])
+        .add_column("Token ID", ["t1", "t2"])
+        .add_column("Device name", ["d1", "d1"])
+        .add_column("Access result", ["Granted", "Denied"])
+        .build()
     )
-    df2 = pd.DataFrame(
-        {
-            "Timestamp": ["2024-01-02 09:00:00"],
-            "Person ID": ["u1"],
-            "Token ID": ["t1"],
-            "Device name": ["d2"],
-            "Access result": ["Granted"],
-        }
+    df2 = (
+        DataFrameBuilder()
+        .add_column("Timestamp", ["2024-01-02 09:00:00"])
+        .add_column("Person ID", ["u1"])
+        .add_column("Token ID", ["t1"])
+        .add_column("Device name", ["d2"])
+        .add_column("Access result", ["Granted"])
+        .build()
     )
-    path1 = tmp_path / "f1.csv"
-    path2 = tmp_path / "f2.csv"
-    df1.to_csv(path1, index=False)
-    df2.to_csv(path2, index=False)
+    path1 = UploadFileBuilder().with_dataframe(df1).write_csv(tmp_path / "f1.csv")
+    path2 = UploadFileBuilder().with_dataframe(df2).write_csv(tmp_path / "f2.csv")
 
     service = AnalyticsService()
     result = service._process_uploaded_data_directly({"f1.csv": path1, "f2.csv": path2})

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -1,4 +1,4 @@
-import pandas as pd
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 from analytics.file_processing_utils import (
     aggregate_counts,
@@ -11,7 +11,7 @@ from services import AnalyticsService
 
 
 def test_load_uploaded_data(monkeypatch):
-    sample = {"file.csv": pd.DataFrame({"A": [1]})}
+    sample = {"file.csv": DataFrameBuilder().add_column("A", [1]).build()}
     monkeypatch.setattr(
         "pages.file_upload.get_uploaded_data", lambda: sample, raising=False
     )
@@ -20,14 +20,14 @@ def test_load_uploaded_data(monkeypatch):
 
 
 def test_clean_uploaded_dataframe():
-    df = pd.DataFrame(
-        {
-            "Timestamp": ["2024-01-01 00:00:00"],
-            "Person ID": ["u1"],
-            "Token ID": ["t1"],
-            "Device name": ["d1"],
-            "Access result": ["Granted"],
-        }
+    df = (
+        DataFrameBuilder()
+        .add_column("Timestamp", ["2024-01-01 00:00:00"])
+        .add_column("Person ID", ["u1"])
+        .add_column("Token ID", ["t1"])
+        .add_column("Device name", ["d1"])
+        .add_column("Access result", ["Granted"])
+        .build()
     )
     service = AnalyticsService()
     cleaned = service.clean_uploaded_dataframe(df)
@@ -42,13 +42,13 @@ def test_clean_uploaded_dataframe():
 
 
 def test_summarize_dataframe():
-    df = pd.DataFrame(
-        {
-            "person_id": ["u1", "u2"],
-            "door_id": ["d1", "d2"],
-            "timestamp": pd.to_datetime(["2024-01-01", "2024-01-02"]),
-            "access_result": ["Granted", "Denied"],
-        }
+    df = (
+        DataFrameBuilder()
+        .add_column("person_id", ["u1", "u2"])
+        .add_column("door_id", ["d1", "d2"])
+        .add_column("timestamp", pd.to_datetime(["2024-01-01", "2024-01-02"]))
+        .add_column("access_result", ["Granted", "Denied"])
+        .build()
     )
     service = AnalyticsService()
     summary = service.summarize_dataframe(df)
@@ -62,12 +62,12 @@ def test_summarize_dataframe():
 def test_count_and_date_helpers():
     from collections import Counter
 
-    df = pd.DataFrame(
-        {
-            "person_id": ["u1", "u2", "u1"],
-            "door_id": ["d1", "d1", "d2"],
-            "timestamp": ["2024-01-01", "2024-01-03", "2024-01-02"],
-        }
+    df = (
+        DataFrameBuilder()
+        .add_column("person_id", ["u1", "u2", "u1"])
+        .add_column("door_id", ["d1", "d1", "d2"])
+        .add_column("timestamp", ["2024-01-01", "2024-01-03", "2024-01-02"])
+        .build()
     )
     service = AnalyticsService()
     u_counts, d_counts = Counter(), Counter()
@@ -82,15 +82,14 @@ def test_count_and_date_helpers():
 
 
 def test_stream_uploaded_file(tmp_path):
-    df = pd.DataFrame(
-        {
-            "Timestamp": ["2024-01-01 10:00:00"],
-            "Person ID": ["u1"],
-            "Device name": ["d1"],
-        }
+    df = (
+        DataFrameBuilder()
+        .add_column("Timestamp", ["2024-01-01 10:00:00"])
+        .add_column("Person ID", ["u1"])
+        .add_column("Device name", ["d1"])
+        .build()
     )
-    path = tmp_path / "x.csv"
-    df.to_csv(path, index=False)
+    path = UploadFileBuilder().with_dataframe(df).write_csv(tmp_path / "x.csv")
     service = AnalyticsService()
     chunks = list(stream_uploaded_file(service.data_loading_service, path, chunksize=1))
     assert len(chunks) == 1
@@ -100,19 +99,19 @@ def test_stream_uploaded_file(tmp_path):
 def test_aggregate_counts():
     from collections import Counter
 
-    df1 = pd.DataFrame(
-        {
-            "person_id": ["u1", "u2"],
-            "door_id": ["d1", "d2"],
-            "timestamp": ["2024-01-01", "2024-01-02"],
-        }
+    df1 = (
+        DataFrameBuilder()
+        .add_column("person_id", ["u1", "u2"])
+        .add_column("door_id", ["d1", "d2"])
+        .add_column("timestamp", ["2024-01-01", "2024-01-02"])
+        .build()
     )
-    df2 = pd.DataFrame(
-        {
-            "person_id": ["u1"],
-            "door_id": ["d1"],
-            "timestamp": ["2024-01-03"],
-        }
+    df2 = (
+        DataFrameBuilder()
+        .add_column("person_id", ["u1"])
+        .add_column("door_id", ["d1"])
+        .add_column("timestamp", ["2024-01-03"])
+        .build()
     )
 
     service = AnalyticsService()

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for test data generation."""

--- a/tests/utils/builders.py
+++ b/tests/utils/builders.py
@@ -1,0 +1,46 @@
+import base64
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import pandas as pd
+
+
+class DataFrameBuilder:
+    """Fluent helper for constructing ``pandas`` DataFrames in tests."""
+
+    def __init__(self, data: Dict[str, Iterable[Any]] | None = None) -> None:
+        self._data: Dict[str, list[Any]] = {
+            k: list(v) for k, v in (data or {}).items()
+        }
+
+    def add_column(self, name: str, values: Iterable[Any]) -> "DataFrameBuilder":
+        self._data[name] = list(values)
+        return self
+
+    def build(self) -> pd.DataFrame:
+        return pd.DataFrame(self._data)
+
+
+class UploadFileBuilder:
+    """Utility for creating upload-like file content."""
+
+    def __init__(self, filename: str = "sample.csv") -> None:
+        self.filename = filename
+        self._df = pd.DataFrame()
+
+    def with_filename(self, name: str) -> "UploadFileBuilder":
+        self.filename = name
+        return self
+
+    def with_dataframe(self, df: pd.DataFrame) -> "UploadFileBuilder":
+        self._df = df
+        return self
+
+    def as_base64(self) -> str:
+        csv_bytes = self._df.to_csv(index=False).encode()
+        encoded = base64.b64encode(csv_bytes).decode()
+        return f"data:text/csv;base64,{encoded}"
+
+    def write_csv(self, path: Path) -> Path:
+        self._df.to_csv(path, index=False)
+        return path


### PR DESCRIPTION
## Summary
- create `DataFrameBuilder` and `UploadFileBuilder` under `tests/utils`
- refactor upload-related tests to use these new helpers

## Testing
- `pytest tests/test_upload_validator.py::test_validate_file_upload_dataframe -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686cc983d0908320ab567eb368f62c7c