### PR TITLE
Add PluginPackageBuilder and refactor plugin test

### DIFF
--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -5,30 +5,29 @@ from dash import Dash, html
 from config.config import ConfigManager
 from core.container import Container as DIContainer
 from core.plugins.auto_config import setup_plugins
-from tests.test_auto_configuration import _create_package, _set_env
+from tests.test_auto_configuration import _set_env
+from tests.utils.plugin_package_builder import PluginPackageBuilder
 
 
 def test_plugin_discovery_and_callback_registration(monkeypatch, tmp_path):
     _set_env(monkeypatch)
-    _create_package(tmp_path)
-    sys.path.insert(0, str(tmp_path))
     registry = None
-    try:
-        app = Dash(__name__)
-        app.layout = html.Div()
-        cfg = ConfigManager()
-        cfg.config.plugin_settings["auto_plugin"] = {"enabled": True}
-        registry = setup_plugins(
-            app,
-            container=DIContainer(),
-            config_manager=cfg,
-            package="auto_pkg",
-        )
-        assert "auto_plugin" in registry.plugin_manager.plugins
-        assert "auto_cb" in registry.coordinator.registered_callbacks
-        routes = [r.rule for r in app.server.url_map.iter_rules()]
-        assert "/health/plugins" in routes
-    finally:
-        sys.path.remove(str(tmp_path))
-        if registry:
-            registry.plugin_manager.stop_health_monitor()
+    with PluginPackageBuilder(tmp_path) as builder:
+        try:
+            app = Dash(__name__)
+            app.layout = html.Div()
+            cfg = ConfigManager()
+            cfg.config.plugin_settings[builder.plugin_name] = {"enabled": True}
+            registry = setup_plugins(
+                app,
+                container=DIContainer(),
+                config_manager=cfg,
+                package=builder.package_name,
+            )
+            assert builder.plugin_name in registry.plugin_manager.plugins
+            assert builder.callback_id in registry.coordinator.registered_callbacks
+            routes = [r.rule for r in app.server.url_map.iter_rules()]
+            assert "/health/plugins" in routes
+        finally:
+            if registry:
+                registry.plugin_manager.stop_health_monitor()

--- a/tests/utils/plugin_package_builder.py
+++ b/tests/utils/plugin_package_builder.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+from contextlib import AbstractContextManager
+from pathlib import Path
+import textwrap
+
+
+class PluginPackageBuilder(AbstractContextManager):
+    """Helper to create a temporary plugin package for tests."""
+
+    def __init__(
+        self,
+        base_dir: Path,
+        package_name: str = "auto_pkg",
+        plugin_name: str = "auto_plugin",
+        version: str = "0.1",
+        description: str = "auto plugin",
+        author: str = "tester",
+        callback_id: str = "auto_cb",
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        self._package_name = package_name
+        self._plugin_name = plugin_name
+        self.version = version
+        self.description = description
+        self.author = author
+        self._callback_id = callback_id
+        self._pkg_path = self.base_dir / self._package_name
+
+    # path of the created package
+    @property
+    def package_path(self) -> Path:
+        return self._pkg_path
+
+    @property
+    def package_name(self) -> str:
+        return self._package_name
+
+    @property
+    def plugin_name(self) -> str:
+        return self._plugin_name
+
+    @property
+    def callback_id(self) -> str:
+        return self._callback_id
+
+    def _write_files(self) -> None:
+        self._pkg_path.mkdir()
+        (self._pkg_path / "__init__.py").write_text("")
+        plugin_code = f"""
+from dash import Output, Input
+from services.data_processing.core.protocols import PluginMetadata
+from core.plugins.callback_unifier import CallbackUnifier
+
+class AutoPlugin:
+    metadata = PluginMetadata(
+        name="{self._plugin_name}",
+        version="{self.version}",
+        description="{self.description}",
+        author="{self.author}",
+    )
+
+    def __init__(self):
+        self.callback_registered = False
+
+    def load(self, container, config):
+        container.register("auto_service", "ok")
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        return True
+
+    def stop(self):
+        return True
+
+    def health_check(self):
+        return {{"healthy": True}}
+
+    def register_callbacks(self, manager, container):
+        @CallbackUnifier(manager)(
+            Output("out", "children"),
+            Input("in", "value"),
+            callback_id="{self._callback_id}",
+            component_name="AutoPlugin",
+        )
+        def cb(value):
+            return f"auto:{{value}}"
+
+        self.callback_registered = True
+        return True
+
+def create_plugin():
+    return AutoPlugin()
+"""
+        (self._pkg_path / "plug.py").write_text(textwrap.dedent(plugin_code))
+
+    def __enter__(self) -> "PluginPackageBuilder":
+        self._write_files()
+        sys.path.insert(0, str(self.base_dir))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if str(self.base_dir) in sys.path:
+            sys.path.remove(str(self.base_dir))
+        # do not suppress exceptions
+        return None


### PR DESCRIPTION
## Summary
- create `PluginPackageBuilder` utility for building temporary plugin packages
- use the new builder in the plugin consolidation integration test

## Testing
- `pytest tests/integration/test_plugin_consolidation_integration.py -q` *(fails: ModuleNotFoundError: No module named 'services.analytics_service')*

------
https://chatgpt.com/codex/tasks/task_e_686cc98b4b4c83209c7da939bc33bedc