### PR TITLE
Inject device learning service

### DIFF
--- a/services/upload/core/processor.py
+++ b/services/upload/core/processor.py
@@ -11,8 +11,7 @@ from components.file_preview import create_file_preview_ui
 from services.data_enhancer import get_ai_column_suggestions
 from services.data_processing.async_file_processor import AsyncFileProcessor
 from services.upload.utils.file_parser import create_file_preview
-from services.device_learning_service import get_device_learning_service
-from utils.upload_store import UploadedDataStore
+from services.upload.protocols import DeviceLearningServiceProtocol
 
 from ..async_processor import AsyncUploadProcessor
 from ..protocols import (
@@ -31,10 +30,12 @@ class UploadProcessingService(UploadProcessingServiceProtocol):
     def __init__(
         self,
         store: UploadStorageProtocol,
+        learning_service: DeviceLearningServiceProtocol,
         processor: Optional[FileProcessorProtocol] = None,
         validator: Optional[UploadValidatorProtocol] = None,
     ) -> None:
         self.store = store
+        self.learning_service = learning_service
         self.processor = processor or AsyncFileProcessor()
         self.validator = validator
         self.async_processor = AsyncUploadProcessor()
@@ -80,10 +81,9 @@ class UploadProcessingService(UploadProcessingServiceProtocol):
 
     def auto_apply_learned_mappings(self, df: pd.DataFrame, filename: str) -> bool:
         try:
-            learning_service = get_device_learning_service()
-            learned = learning_service.get_learned_mappings(df, filename)
+            learned = self.learning_service.get_learned_mappings(df, filename)
             if learned:
-                learning_service.apply_learned_mappings_to_global_store(df, filename)
+                self.learning_service.apply_learned_mappings_to_global_store(df, filename)
                 logger.info("🤖 Auto-applied %s learned device mappings", len(learned))
                 return True
             return False
@@ -214,8 +214,7 @@ class UploadProcessingService(UploadProcessingServiceProtocol):
                 current_file_info = file_info_dict[filename]
 
                 try:
-                    learning_service = get_device_learning_service()
-                    user_mappings = learning_service.get_user_device_mappings(filename)
+                    user_mappings = self.learning_service.get_user_device_mappings(filename)
                     if user_mappings:
                         from services.ai_mapping_store import ai_mapping_store
 

--- a/services/upload/protocols.py
+++ b/services/upload/protocols.py
@@ -118,6 +118,41 @@ class UploadStorageProtocol(Protocol):
         """Remove all stored upload data."""
         ...
 
+    # Optional methods used by higher level services
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        """Load a previously saved dataframe."""
+        ...  # pragma: no cover - optional protocol method
+
+    def wait_for_pending_saves(self) -> None:
+        """Wait for any background saves to finish."""
+        ...  # pragma: no cover - optional protocol method
+
+
+class DeviceLearningServiceProtocol(Protocol):
+    """Protocol for persistent device learning services."""
+
+    @abstractmethod
+    def get_learned_mappings(self, df: pd.DataFrame, filename: str) -> Dict[str, Any]:
+        """Return learned device mappings for the given file."""
+        ...
+
+    @abstractmethod
+    def apply_learned_mappings_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
+        """Apply learned mappings to the global AI mapping store."""
+        ...
+
+    @abstractmethod
+    def get_user_device_mappings(self, filename: str) -> Dict[str, Any]:
+        """Load user-confirmed device mappings for a filename."""
+        ...
+
+    @abstractmethod
+    def save_user_device_mappings(
+        self, df: pd.DataFrame, filename: str, user_mappings: Dict[str, Any]
+    ) -> bool:
+        """Persist user-confirmed device mappings."""
+        ...
+
 
 class UploadAnalyticsProtocol(Protocol):
     """Protocol for analyzing uploaded data."""

--- a/services/upload/service_registration.py
+++ b/services/upload/service_registration.py
@@ -21,6 +21,7 @@ from services.upload.core.validator import ClientSideValidator
 from services.upload.controllers.upload_controller import UnifiedUploadController
 from services.data_processing.async_file_processor import AsyncFileProcessor
 from utils.upload_store import UploadedDataStore
+from services.device_learning_service import DeviceLearningService
 
 
 def register_upload_services(container: ServiceContainer) -> None:
@@ -30,6 +31,12 @@ def register_upload_services(container: ServiceContainer) -> None:
         "upload_storage",
         UploadedDataStore,
         protocol=UploadStorageProtocol,
+    )
+
+    container.register_singleton(
+        "device_learning_service",
+        DeviceLearningService,
+        protocol=DeviceLearningServiceProtocol,
     )
 
     container.register_singleton(

--- a/tests/test_device_mapping_save.py
+++ b/tests/test_device_mapping_save.py
@@ -7,6 +7,7 @@ import pandas as pd
 from services.upload import UploadProcessingService
 from upload_core import UploadCore
 from utils.upload_store import UploadedDataStore
+from services.device_learning_service import DeviceLearningService
 
 
 def _encode_df(df: pd.DataFrame) -> str:
@@ -29,8 +30,9 @@ def test_immediate_confirm_after_upload(monkeypatch, tmp_path):
     store = UploadedDataStore(storage_dir=tmp_path)
     monkeypatch.setattr(file_upload, "_uploaded_data_store", store)
 
-    cb = Callbacks()
-    cb.processing = UploadProcessingService(store)
+    learning = DeviceLearningService()
+    processing = UploadProcessingService(store, learning)
+    cb = Callbacks(processing, learning, store)
     ok, msg = cb.validator.validate("data.csv", _encode_df(pd.DataFrame()))
     assert ok, msg
 

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -5,7 +5,8 @@ import pandas as pd
 
 from services.upload import UploadProcessingService
 from upload_core import UploadCore
-from utils.upload_store import uploaded_data_store as _uploaded_data_store
+from utils.upload_store import UploadedDataStore
+from services.device_learning_service import DeviceLearningService
 
 
 def test_multi_part_upload_row_count():
@@ -22,8 +23,10 @@ def test_multi_part_upload_row_count():
     part1 = prefix + b64[:mid]
     part2 = prefix + b64[mid:]
 
-    cb = UploadCore()
-    cb.processing = UploadProcessingService(_uploaded_data_store)
+    store = UploadedDataStore()
+    learning = DeviceLearningService()
+    processing = UploadProcessingService(store, learning)
+    cb = UploadCore(processing, learning, store)
     # ensure validator attribute is initialized
     ok, msg = cb.validator.validate("sample.csv", part1)
     assert ok, msg
@@ -32,5 +35,5 @@ def test_multi_part_upload_row_count():
     )
     info = res[2]
     assert info["sample.csv"]["rows"] == len(df)
-    stored = _uploaded_data_store.get_all_data()["sample.csv"]
+    stored = store.get_all_data()["sample.csv"]
     assert len(stored) == len(df)

--- a/tests/test_process_uploaded_files_split.py
+++ b/tests/test_process_uploaded_files_split.py
@@ -7,6 +7,7 @@ from pages import file_upload
 from services.upload import UploadProcessingService
 from upload_core import UploadCore
 from utils.upload_store import UploadedDataStore
+from services.device_learning_service import DeviceLearningService
 
 
 def _encode_df(df: pd.DataFrame) -> str:
@@ -27,8 +28,9 @@ def test_process_uploaded_files_split(monkeypatch, tmp_path):
     store = UploadedDataStore(storage_dir=tmp_path)
     monkeypatch.setattr(file_upload, "_uploaded_data_store", store)
 
-    cb = UploadCore()
-    cb.processing = UploadProcessingService(store)
+    learning = DeviceLearningService()
+    processing = UploadProcessingService(store, learning)
+    cb = UploadCore(processing, learning, store)
     ok, msg = cb.validator.validate("big.csv", contents_list[0])
     assert ok, msg
     result = asyncio.run(cb.process_uploaded_files(contents_list, filenames_list))


### PR DESCRIPTION
## Summary
- define `DeviceLearningServiceProtocol` and expand `UploadStorageProtocol`
- inject the learning service into `UploadProcessingService`
- require explicit dependencies in `UploadCore`
- register `DeviceLearningService` in the DI container
- update tests for new constructor signatures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686cc9d0f5788320a2e2f9007587f7ee