### PR TITLE
Add testing architecture docs and marks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,12 @@ bandit -r .
 Run `isort .` to automatically sort imports before committing changes.
 
 Please ensure tests and linters pass before opening a pull request.
+
+## Test Guidelines
+
+* **Unit tests** should rely on protocol-based fakes for all dependencies. This
+  keeps them fast and ensures the test only depends on behaviour defined in a
+  `Protocol`.
+* **Integration and E2E tests** may use real services such as the database or a
+  running web server. Mark these tests with `@pytest.mark.integration` so they
+  can be selected with `-m integration` or skipped when running only unit tests.

--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -1,0 +1,15 @@
+# Testing Architecture
+
+This project organizes tests into three layers to balance feedback speed with confidence.
+
+## Unit Tests
+
+Unit tests exercise individual functions or classes in isolation. External dependencies are replaced with **protocol-based fakes** to keep the tests fast and focused. A fake implements a minimal `Protocol` matching just the behaviour the unit under test relies on. No real network or disk access should occur in unit tests.
+
+## Integration Tests
+
+Integration tests verify that multiple components work together correctly. They use real implementations for most dependencies and may touch the filesystem, spawn background processes or run a web server. Integration tests are marked with `@pytest.mark.integration` so they can be included or excluded via pytest's `-m` flag.
+
+## End‑to‑End (E2E) Tests
+
+E2E tests drive the application through its user interface—typically with a headless browser via `dash_duo`. They provide the highest level of confidence but are slower to run. These tests also carry the `integration` mark and usually live alongside other integration tests.

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -1,6 +1,9 @@
 import sys
 
+import pytest
 from dash import Dash, html
+
+pytestmark = pytest.mark.integration
 
 from config.config import ConfigManager
 from core.container import Container as DIContainer

--- a/tests/integration/test_unicode_handling_integration.py
+++ b/tests/integration/test_unicode_handling_integration.py
@@ -1,7 +1,10 @@
 import pandas as pd
+import pytest
 
 import core.unicode as handler
 from core.unicode import UnicodeProcessor, sanitize_dataframe
+
+pytestmark = pytest.mark.integration
 
 
 def test_unicode_handler_centralization():
@@ -17,8 +20,8 @@ def test_unicode_handler_centralization():
     assert cleaned_df.iloc[0, 0] == "x"
 
     from security.unicode_security_handler import UnicodeSecurityHandler
+
     assert UnicodeSecurityHandler.sanitize_unicode_input(text) == cleaned
     sec_df = UnicodeSecurityHandler.sanitize_dataframe(df)
     assert list(sec_df.columns) == ["c"]
     assert sec_df.iloc[0, 0] == "x"
-

--- a/tests/integration/test_unicode_upload_endpoint.py
+++ b/tests/integration/test_unicode_upload_endpoint.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
-from security.unicode_security_handler import UnicodeSecurityHandler
 from core.unicode_processor import safe_unicode_encode
+from security.unicode_security_handler import UnicodeSecurityHandler
+
+pytestmark = pytest.mark.integration
 
 
 class SimpleStore:

--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -1,28 +1,37 @@
 import asyncio
+import importlib.util
+import sys
 from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 import pytest
-import importlib.util
-import sys
-from pathlib import Path
+
+pytestmark = pytest.mark.integration
 
 ROOT = Path(__file__).resolve().parents[2]
 
 # provide minimal stubs for config dependencies
 import types
+
 conn_mod = types.ModuleType("config.connection_retry")
+
+
 class RetryConfig:
     def __init__(self, max_attempts=3, base_delay=0.2, jitter=False):
         self.max_attempts = max_attempts
         self.base_delay = base_delay
         self.jitter = jitter
+
+
 class ConnectionRetryManager:
     def __init__(self, cfg=None):
         self.cfg = cfg or RetryConfig()
+
     def run_with_retry(self, func):
         return func()
+
+
 conn_mod.RetryConfig = RetryConfig
 conn_mod.ConnectionRetryManager = ConnectionRetryManager
 sys.modules["config.connection_retry"] = conn_mod
@@ -30,6 +39,7 @@ spec_queue = importlib.util.spec_from_file_location(
     "upload_queue_manager", ROOT / "services" / "upload" / "upload_queue_manager.py"
 )
 queue_mod = importlib.util.module_from_spec(spec_queue)
+
 
 class SimpleStore:
     def __init__(self, path: Path):
@@ -46,12 +56,15 @@ class SimpleStore:
     def wait_for_pending_saves(self) -> None:
         pass
 
+
 upload_store_mod = types.ModuleType("utils.upload_store")
 upload_store_mod.UploadedDataStore = SimpleStore
 sys.modules["utils.upload_store"] = upload_store_mod
 
+
 class CallbackEvent:
     ANALYSIS_ERROR = "ANALYSIS_ERROR"
+
 
 class CallbackContext:
     def __init__(self, event_type, source_id, timestamp, data=None):
@@ -59,6 +72,7 @@ class CallbackContext:
         self.source_id = source_id
         self.timestamp = timestamp
         self.data = data or {}
+
 
 class CallbackManager:
     def __init__(self):
@@ -70,6 +84,7 @@ class CallbackManager:
     def trigger(self, event, ctx):
         for cb in list(self.callbacks):
             cb(ctx)
+
 
 sys.modules["upload_queue_manager"] = queue_mod
 spec_queue.loader.exec_module(queue_mod)  # type: ignore
@@ -84,14 +99,15 @@ spec_chunk.loader.exec_module(chunk_mod)  # type: ignore
 ChunkedUploadManager = chunk_mod.ChunkedUploadManager
 
 
-
 def test_resumable_upload_and_error_callback(tmp_path, monkeypatch):
     data_file = tmp_path / "sample.csv"
     df = pd.DataFrame({"a": range(15)})
     df.to_csv(data_file, index=False)
 
     store = SimpleStore(tmp_path / "store")
-    cmgr = ChunkedUploadManager(store, metadata_dir=tmp_path / "meta", initial_chunk_size=5)
+    cmgr = ChunkedUploadManager(
+        store, metadata_dir=tmp_path / "meta", initial_chunk_size=5
+    )
     queue = UploadQueueManager(max_concurrent=1)
     queue.add_files([data_file])
 

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -1,10 +1,13 @@
 import dash
 import dash_bootstrap_components as dbc
 import pandas as pd
+import pytest
 from dash import dcc, html
 
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
 from pages import file_upload
+
+pytestmark = pytest.mark.integration
 
 
 def _create_upload_app():

--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -6,6 +6,8 @@ import pandas as pd
 import pytest
 
 from models import ModelFactory
+
+pytestmark = pytest.mark.integration
 from services import create_analytics_service, get_analytics_service
 
 

--- a/tests/test_callback_helpers.py
+++ b/tests/test_callback_helpers.py
@@ -1,4 +1,5 @@
 import types
+from typing import Protocol
 
 import dash_bootstrap_components as dbc
 import pytest
@@ -34,7 +35,10 @@ def test_run_service_analysis_error(monkeypatch):
 
 
 def test_run_unique_patterns_analysis(monkeypatch):
-    class FakeService:
+    class AnalyticsProtocol(Protocol):
+        def get_unique_patterns_analysis(self, data_source): ...
+
+    class FakeService(AnalyticsProtocol):
         def get_unique_patterns_analysis(self, data_source):
             return {
                 "status": "success",
@@ -89,7 +93,7 @@ def test_run_unique_patterns_analysis(monkeypatch):
 
 
 def test_run_unique_patterns_analysis_no_data(monkeypatch):
-    class FakeService:
+    class FakeService(AnalyticsProtocol):
         def get_unique_patterns_analysis(self, data_source):
             return {"status": "no_data"}
 

--- a/tests/test_dash_pages.py
+++ b/tests/test_dash_pages.py
@@ -9,6 +9,8 @@ import pytest
 from dash import dcc, html
 
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+
+pytestmark = pytest.mark.integration
 from pages import file_upload
 from pages.deep_analytics import layout as analytics_layout
 from pages.deep_analytics import register_callbacks as register_analytics_callbacks

--- a/tests/test_database_analytics_service.py
+++ b/tests/test_database_analytics_service.py
@@ -1,7 +1,13 @@
+from typing import Protocol
+
 from services.database_analytics_service import DatabaseAnalyticsService
 
 
-class FakeConnection:
+class ConnectionProtocol(Protocol):
+    def execute_query(self, query, params=None): ...
+
+
+class FakeConnection(ConnectionProtocol):
     def execute_query(self, query, params=None):
         if "GROUP BY event_type, status" in query:
             return [
@@ -21,7 +27,11 @@ class FakeConnection:
         return []
 
 
-class FakeDBManager:
+class DBManagerProtocol(Protocol):
+    def get_connection(self) -> ConnectionProtocol: ...
+
+
+class FakeDBManager(DBManagerProtocol):
     def get_connection(self):
         return FakeConnection()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,11 @@
 """Integration tests for modular AI components."""
 
 import pandas as pd
+import pytest
 
 from services.ai_device_generator import AIDeviceGenerator
+
+pytestmark = pytest.mark.integration
 from services.consolidated_learning_service import get_learning_service
 
 

--- a/tests/test_jwks_cache.py
+++ b/tests/test_jwks_cache.py
@@ -5,6 +5,7 @@ import logging
 import socket
 import sys
 import types
+from typing import Protocol
 
 import pytest
 
@@ -24,7 +25,13 @@ def setup_auth(monkeypatch):
     return module
 
 
-class FakeResp(io.BytesIO):
+class ResponseProtocol(Protocol):
+    def __enter__(self): ...
+
+    def __exit__(self, exc_type, exc, tb): ...
+
+
+class FakeResp(io.BytesIO, ResponseProtocol):
     def __enter__(self):
         return self
 

--- a/tests/test_memory_abort.py
+++ b/tests/test_memory_abort.py
@@ -1,10 +1,16 @@
+from typing import Protocol
+
 import pandas as pd
 import pytest
 
 from core.performance_file_processor import PerformanceFileProcessor
 
 
-class FakeProcess:
+class ProcessProtocol(Protocol):
+    def memory_info(self): ...
+
+
+class FakeProcess(ProcessProtocol):
     def __init__(self, rss_values):
         self._rss = rss_values
         self.calls = 0
@@ -13,17 +19,21 @@ class FakeProcess:
         class Mem:
             def __init__(self, rss):
                 self.rss = rss
+
         rss = self._rss[min(self.calls, len(self._rss) - 1)]
         self.calls += 1
         return Mem(rss)
 
+
 def test_abort_on_memory_limit(monkeypatch, tmp_path):
-    df = pd.DataFrame({'a': range(10)})
-    path = tmp_path / 'data.csv'
+    df = pd.DataFrame({"a": range(10)})
+    path = tmp_path / "data.csv"
     df.to_csv(path, index=False)
 
     fake_proc = FakeProcess([10 * 1024 * 1024, 200 * 1024 * 1024])
-    monkeypatch.setattr('core.performance_file_processor.psutil.Process', lambda: fake_proc)
+    monkeypatch.setattr(
+        "core.performance_file_processor.psutil.Process", lambda: fake_proc
+    )
 
     processor = PerformanceFileProcessor(chunk_size=5, max_memory_mb=50)
     with pytest.raises(MemoryError):

--- a/tests/test_secrets_integration.py
+++ b/tests/test_secrets_integration.py
@@ -1,4 +1,8 @@
+import pytest
+
 from core.secrets_manager import SecretsManager
+
+pytestmark = pytest.mark.integration
 
 
 def test_env_overrides_docker(tmp_path, monkeypatch):

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -1,7 +1,10 @@
-import pytest
+import pathlib
 import sys
 import types
-import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.integration
 
 dash_mod = types.ModuleType("dash")
 dash_dash_mod = types.ModuleType("dash.dash")
@@ -21,6 +24,7 @@ from core.protocols import AnalyticsServiceProtocol
 
 analytics_stub = types.ModuleType("services.analytics_service")
 
+
 class StubAnalyticsService(AnalyticsServiceProtocol):
     def get_dashboard_summary(self):
         return {}
@@ -34,17 +38,22 @@ class StubAnalyticsService(AnalyticsServiceProtocol):
     def generate_report(self, report_type: str, params: dict):
         return {}
 
+
 analytics_stub.AnalyticsService = StubAnalyticsService
 sys.modules.setdefault("services.analytics_service", analytics_stub)
 
 upload_reg_stub = types.ModuleType("services.upload.service_registration")
+
+
 def _register_upload_services(container):
     container.register_singleton("upload_processor", object)
+
+
 upload_reg_stub.register_upload_services = _register_upload_services
 sys.modules.setdefault("services.upload.service_registration", upload_reg_stub)
 
-from core.service_container import ServiceContainer
 from config.complete_service_registration import register_all_services
+from core.service_container import ServiceContainer
 
 
 class TestServiceIntegration:

--- a/tests/test_summary_reporting_module.py
+++ b/tests/test_summary_reporting_module.py
@@ -1,7 +1,13 @@
+from typing import Protocol
+
 from services.summary_reporting import SummaryReporter
 
 
-class FakeDB:
+class DBProtocol(Protocol):
+    def health_check(self) -> bool: ...
+
+
+class FakeDB(DBProtocol):
     def __init__(self, healthy=True):
         self.healthy = healthy
 

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -1,8 +1,11 @@
 import dash
 import dash_bootstrap_components as dbc
-from dash import html, dcc, Output, Input
+import pytest
+from dash import Input, Output, dcc, html
 
-from core.theme_manager import apply_theme_settings, sanitize_theme, DEFAULT_THEME
+from core.theme_manager import DEFAULT_THEME, apply_theme_settings, sanitize_theme
+
+pytestmark = pytest.mark.integration
 
 
 def create_theme_app():
@@ -47,9 +50,13 @@ def test_theme_persistence_on_reload(dash_duo):
     assert dropdown.get_attribute("value") == DEFAULT_THEME
 
     dash_duo.select_dcc_dropdown("#theme-dropdown", "light")
-    dash_duo.wait_for(lambda: "light-mode" in dash_duo.find_element("html").get_attribute("class"))
+    dash_duo.wait_for(
+        lambda: "light-mode" in dash_duo.find_element("html").get_attribute("class")
+    )
 
     dash_duo.driver.refresh()
-    dash_duo.wait_for(lambda: "light-mode" in dash_duo.find_element("html").get_attribute("class"))
+    dash_duo.wait_for(
+        lambda: "light-mode" in dash_duo.find_element("html").get_attribute("class")
+    )
     dropdown = dash_duo.find_element("#theme-dropdown")
     assert dropdown.get_attribute("value") == "light"

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -3,6 +3,9 @@ import tempfile
 from pathlib import Path
 
 import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.integration
 
 from core.callback_events import CallbackEvent
 from core.callback_manager import CallbackManager
@@ -18,7 +21,9 @@ from core.unicode_processor import (
 
 class CallbackController(CallbackManager):
     def fire_event(self, event: CallbackEvent, source_id: str, data=None):
-        ctx = type("Ctx", (), {"event_type": event, "source_id": source_id, "data": data or {}})
+        ctx = type(
+            "Ctx", (), {"event_type": event, "source_id": source_id, "data": data or {}}
+        )
         self.trigger(event, ctx)
 
     def register_error_handler(self, handler):
@@ -38,6 +43,7 @@ def callback_handler(event: CallbackEvent):
     def decorator(func):
         _GLOBAL.register_callback(event, func)
         return func
+
     return decorator
 
 
@@ -51,31 +57,34 @@ from services.data_processing.file_processor import (
 
 class TestUnicodeProcessor:
     def test_clean_surrogate_chars_basic(self):
-        text = "Hello\uD83D\uDE00World"
-        assert UnicodeProcessor.clean_surrogate_chars(text) == "Hello\U0001F600World"
+        text = "Hello\ud83d\ude00World"
+        assert UnicodeProcessor.clean_surrogate_chars(text) == "Hello\U0001f600World"
 
     def test_clean_surrogate_chars_isolated_surrogates(self):
-        text = "Test\uD83DText"
+        text = "Test\ud83dText"
         assert UnicodeProcessor.clean_surrogate_chars(text) == "TestText"
-        text = "Test\uDE00Text"
+        text = "Test\ude00Text"
         assert UnicodeProcessor.clean_surrogate_chars(text) == "TestText"
 
     def test_clean_surrogate_chars_with_replacement(self):
-        text = "Hello\uD83DWorld"
-        assert UnicodeProcessor.clean_surrogate_chars(text, replacement="X") == "HelloXWorld"
+        text = "Hello\ud83dWorld"
+        assert (
+            UnicodeProcessor.clean_surrogate_chars(text, replacement="X")
+            == "HelloXWorld"
+        )
 
     def test_safe_decode_bytes_utf8_with_surrogates(self):
-        text = "Test\uD83D\uDE00Text"
+        text = "Test\ud83d\ude00Text"
         data = text.encode("utf-8", "surrogatepass")
         result = UnicodeProcessor.safe_decode_bytes(data)
-        assert result == "Test\U0001F600Text"
+        assert result == "Test\U0001f600Text"
 
     def test_safe_decode_bytes_fallback_encoding(self):
         text = "Caf\xe9".encode("latin-1")
         assert UnicodeProcessor.safe_decode_bytes(text, "latin-1") == "Café"
 
     def test_safe_encode_text_various_types(self):
-        assert UnicodeProcessor.safe_encode_text("Test\uD83D") == "Test"
+        assert UnicodeProcessor.safe_encode_text("Test\ud83d") == "Test"
         assert UnicodeProcessor.safe_encode_text(None) == ""
         assert UnicodeProcessor.safe_encode_text(pd.NA) == ""
         assert UnicodeProcessor.safe_encode_text(123) == "123"
@@ -84,15 +93,19 @@ class TestUnicodeProcessor:
         assert UnicodeProcessor.safe_encode_text(bytes_val) == "hello"
 
     def test_sanitize_dataframe_columns_and_data(self):
-        df = pd.DataFrame({"col\uD83D": ["value1\uDE00", "value2"], "normal": ["n1", "n2\uD83D"]})
+        df = pd.DataFrame(
+            {"col\ud83d": ["value1\ude00", "value2"], "normal": ["n1", "n2\ud83d"]}
+        )
         out = UnicodeProcessor.sanitize_dataframe(df)
         assert "col" in out.columns
-        assert "\uD83D" not in str(out.columns)
+        assert "\ud83d" not in str(out.columns)
         assert out.iloc[0, 0] == "value1"
         assert out.iloc[1, 1] == "n2"
 
     def test_sanitize_dataframe_dangerous_prefixes(self):
-        df = pd.DataFrame({"=danger": ["=formula", "+cmd", "-opt", "@imp"], "n": ["a", "b", "c", "d"]})
+        df = pd.DataFrame(
+            {"=danger": ["=formula", "+cmd", "-opt", "@imp"], "n": ["a", "b", "c", "d"]}
+        )
         out = UnicodeProcessor.sanitize_dataframe(df)
         assert "danger" in out.columns
         assert out.iloc[0, 0] == "formula"
@@ -111,13 +124,13 @@ class TestUnicodeProcessor:
         assert list(out.columns) == ["col_0", "col_1"]
 
     def test_sanitize_dataframe_string_dtype(self):
-        df = pd.DataFrame({"a": pd.Series(["x\uD800", "y"], dtype="string")})
+        df = pd.DataFrame({"a": pd.Series(["x\ud800", "y"], dtype="string")})
         out = UnicodeProcessor.sanitize_dataframe(df)
         assert out.loc[0, "a"] == "x"
         assert out["a"].dtype == "string"
 
     def test_sanitize_dataframe_nested_structures(self):
-        df = pd.DataFrame({"col": [["a\uD83D", {"k\uD83D": "v\uDE00"}]]})
+        df = pd.DataFrame({"col": [["a\ud83d", {"k\ud83d": "v\ude00"}]]})
         out = UnicodeProcessor.sanitize_dataframe(df)
         cell = out.iloc[0, 0]
         assert cell[0] == "a"
@@ -141,9 +154,9 @@ class TestChunkedUnicodeProcessor:
         assert result == "Hello World! " * 1000
 
     def test_process_large_content_with_surrogates(self):
-        content = ("Test\uD83D\uDE00Content" * 500).encode("utf-8", "surrogatepass")
+        content = ("Test\ud83d\ude00Content" * 500).encode("utf-8", "surrogatepass")
         result = ChunkedUnicodeProcessor.process_large_content(content, chunk_size=50)
-        assert result == "Test\U0001F600Content" * 500
+        assert result == "Test\U0001f600Content" * 500
 
 
 class TestCallbackController:
@@ -155,6 +168,7 @@ class TestCallbackController:
         def cb(ctx):
             called["e"] = ctx.event_type
             called["s"] = ctx.source_id
+
         controller.register_callback(CallbackEvent.FILE_UPLOAD_START, cb)
         controller.fire_event(CallbackEvent.FILE_UPLOAD_START, "src", {"f": 1})
         assert called["e"] == CallbackEvent.FILE_UPLOAD_START
@@ -167,6 +181,7 @@ class TestCallbackController:
 
         def cb(ctx):
             hits.append(ctx.event_type)
+
         controller.register_callback(CallbackEvent.ANALYSIS_START, cb)
         controller.fire_event(CallbackEvent.ANALYSIS_START, "t", {})
         assert controller.unregister_callback(CallbackEvent.ANALYSIS_START, cb)
@@ -232,12 +247,12 @@ class TestRobustFileProcessor:
         assert list(df.columns) == ["name", "age", "city"]
 
     def test_process_csv_with_unicode_surrogates(self):
-        csv = "name\uD83D,value\ntest\uDE00,123".encode("utf-8", "surrogatepass")
+        csv = "name\ud83d,value\ntest\ude00,123".encode("utf-8", "surrogatepass")
         proc = RobustFileProcessor()
         df, err = proc.process_file(csv, "u.csv")
         assert err is None
-        assert "\uD83D" not in str(df.columns)
-        assert "\uDE00" not in str(df.values)
+        assert "\ud83d" not in str(df.columns)
+        assert "\ude00" not in str(df.values)
 
     def test_process_csv_different_delimiters(self):
         csv = "name;age;city\nJohn;30;NYC".encode("utf-8")
@@ -247,18 +262,20 @@ class TestRobustFileProcessor:
         assert df.iloc[0]["name"] == "John"
 
     def test_process_json_basic(self):
-        data = json.dumps([{"name": "John", "age": 30}, {"name": "Jane", "age": 25}]).encode("utf-8")
+        data = json.dumps(
+            [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}]
+        ).encode("utf-8")
         proc = RobustFileProcessor()
         df, err = proc.process_file(data, "test.json")
         assert err is None and len(df) == 2
 
     def test_process_json_with_surrogates(self):
-        text = json.dumps({"name\uD83D": "val\uDE00"})
+        text = json.dumps({"name\ud83d": "val\ude00"})
         proc = RobustFileProcessor()
         df, err = proc.process_file(text.encode("utf-8", "surrogatepass"), "u.json")
         assert err is None
-        assert "\uD83D" not in str(df.columns)
-        assert "\uDE00" not in str(df.values)
+        assert "\ud83d" not in str(df.columns)
+        assert "\ude00" not in str(df.values)
 
     def test_process_excel_basic(self):
         df_original = pd.DataFrame({"name": ["John", "Jane"], "age": [30, 25]})
@@ -306,16 +323,16 @@ class TestRobustFileProcessor:
 
 class TestPublicAPI:
     def test_clean_unicode_text_function(self):
-        assert clean_unicode_text("Hello\uD83DWorld") == "HelloWorld"
+        assert clean_unicode_text("Hello\ud83dWorld") == "HelloWorld"
 
     def test_safe_decode_function(self):
         assert safe_decode(b"Hello") == "Hello"
 
     def test_safe_encode_function(self):
-        assert safe_encode("Hello\uD83D") == "Hello"
+        assert safe_encode("Hello\ud83d") == "Hello"
 
     def test_sanitize_dataframe_function(self):
-        df = pd.DataFrame({"col\uD83D": ["val\uDE00"]})
+        df = pd.DataFrame({"col\ud83d": ["val\ude00"]})
         out = sanitize_dataframe(df)
         assert "col" in out.columns and out.iloc[0, 0] == "val"
 
@@ -328,9 +345,9 @@ class TestPublicAPI:
 class TestIntegration:
     def test_end_to_end_unicode_file_processing(self):
         content = (
-            "name\uD83D,age,city\uDE00\n"
-            "John\uD83D\uDE00,30,NYC\n"
-            "=Jane\uDFFF,25,LA\uD800"
+            "name\ud83d,age,city\ude00\n"
+            "John\ud83d\ude00,30,NYC\n"
+            "=Jane\udfff,25,LA\ud800"
         ).encode("utf-8", "surrogatepass")
         events = []
 
@@ -344,7 +361,7 @@ class TestIntegration:
         proc = RobustFileProcessor(controller)
         df, err = proc.process_file(content, "complex.csv")
         assert err is None and len(df) == 2
-        assert all("\uD83D" not in c and "\uDE00" not in c for c in df.columns)
+        assert all("\ud83d" not in c and "\ude00" not in c for c in df.columns)
         jane_row = df[df.iloc[:, 0].str.contains("Jane", na=False)]
         assert len(jane_row) == 1 and not jane_row.iloc[0, 0].startswith("=")
         assert CallbackEvent.FILE_PROCESSING_START in events

--- a/tests/test_unified_file_system_integration.py
+++ b/tests/test_unified_file_system_integration.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 
 from core.callback_events import CallbackEvent
+
+pytestmark = pytest.mark.integration
 from core.callback_manager import CallbackManager
 
 

--- a/tests/test_upload_fix.py
+++ b/tests/test_upload_fix.py
@@ -1,8 +1,9 @@
-from pathlib import Path
-import sys
 import shutil
+import sys
+from pathlib import Path
 
 import pandas as pd
+import pytest
 
 # Ensure the real Dash package is used even if test stubs are on sys.path
 stub_dir = Path(__file__).resolve().parent / "stubs"
@@ -10,17 +11,19 @@ if str(stub_dir) in sys.path:
     sys.path.remove(str(stub_dir))
 
 import dash
-from dash import dcc, html
 import dash_bootstrap_components as dbc
 import pytest
+from dash import dcc, html
 
 if str(stub_dir) not in sys.path:
     sys.path.insert(0, str(stub_dir))
 
 from core.unified_callback_coordinator import UnifiedCallbackCoordinator
-from pages import file_upload
+
+pytestmark = pytest.mark.integration
 from components.upload import UnifiedUploadComponent
 from core.unicode import safe_unicode_encode
+from pages import file_upload
 
 
 @pytest.fixture
@@ -48,7 +51,9 @@ def _create_app() -> dash.Dash:
     return app
 
 
-def test_file_upload_component_integration(_skip_if_no_chromedriver, dash_duo, tmp_path):
+def test_file_upload_component_integration(
+    _skip_if_no_chromedriver, dash_duo, tmp_path
+):
 
     files = create_sample_files(tmp_path)
     app = _create_app()
@@ -58,7 +63,9 @@ def test_file_upload_component_integration(_skip_if_no_chromedriver, dash_duo, t
     to_send = "\n".join(str(p) for p in files.values())
     file_input.send_keys(to_send)
 
-    dash_duo.wait_for_text_to_contain("#upload-results", "Successfully uploaded", timeout=10)
+    dash_duo.wait_for_text_to_contain(
+        "#upload-results", "Successfully uploaded", timeout=10
+    )
     dash_duo.wait_for_text_to_equal("#upload-progress", "100%", timeout=10)
 
     uploaded = file_upload.get_uploaded_filenames()


### PR DESCRIPTION
## Summary
- document testing layers and when to use fakes
- explain protocol-based fakes in CONTRIBUTING
- mark integration tests with `@pytest.mark.integration`
- use local Protocols for fakes in unit tests

## Testing
- `flake8 tests/... CONTRIBUTING.md`
- `black tests/... --check`
- `isort tests/... CONTRIBUTING.md --check`
- `pytest tests/test_summary_reporting_module.py tests/test_callback_helpers.py -q` *(fails: ModuleNotFoundError: No module named 'chardet')*


------
https://chatgpt.com/codex/tasks/task_e_686cc9d5382c83208872d42b3e58697c