### PR TITLE
Introduce fake protocol fixtures for tests

### DIFF
--- a/tests/callbacks/test_file_upload_module_split.py
+++ b/tests/callbacks/test_file_upload_module_split.py
@@ -46,8 +46,6 @@ class _Dyn:
 dyn_mod.dynamic_config = _Dyn()
 sys.modules['config.dynamic_config'] = dyn_mod
 
-sys.modules['services.device_learning_service'] = types.ModuleType('services.device_learning_service')
-sys.modules['services.device_learning_service'].get_device_learning_service = lambda: None
 
 uds_mod = types.ModuleType('utils.upload_store')
 uds_mod.uploaded_data_store = object()
@@ -121,9 +119,6 @@ sys.modules['pages.deep_analytics'] = types.ModuleType('pages.deep_analytics')
 sys.modules['pages.export'] = types.ModuleType('pages.export')
 sys.modules['pages.settings'] = types.ModuleType('pages.settings')
 
-# Finally import the module under test
-file_upload = importlib.import_module('pages.file_upload')
-
-
-def test_module_imports():
+def test_module_imports(fake_device_learning_service):
+    file_upload = importlib.import_module('pages.file_upload')
     assert hasattr(file_upload, 'layout')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,31 @@ sys.path.insert(0, str(stub_dir))
 
 import shutil
 import tempfile
-from typing import Generator
+from typing import Any, Generator
 
 import pandas as pd
 import pytest
+
+try:
+    from services.upload.protocols import UploadStorageProtocol
+except Exception:  # pragma: no cover - optional dep fallback
+    from typing import Protocol
+
+    class UploadStorageProtocol(Protocol):
+        def add_file(self, filename: str, dataframe: pd.DataFrame) -> None: ...
+        def get_all_data(self) -> dict[str, pd.DataFrame]: ...
+        def clear_all(self) -> None: ...
+
+try:
+    from core.protocols import ConfigurationProtocol
+except Exception:  # pragma: no cover - optional dep fallback
+    class ConfigurationProtocol(Protocol):
+        def get_database_config(self) -> dict[str, Any]: ...
+        def get_app_config(self) -> dict[str, Any]: ...
+        def get_security_config(self) -> dict[str, Any]: ...
+        def get_upload_config(self) -> dict[str, Any]: ...
+        def reload_config(self) -> None: ...
+        def validate_config(self) -> dict[str, Any]: ...
 
 from core.container import Container
 
@@ -117,3 +138,121 @@ def mock_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     }
     for key, value in auth_vars.items():
         monkeypatch.setenv(key, value)
+
+
+class _FakeUploadStorage(UploadStorageProtocol):
+    """In-memory implementation of :class:`UploadStorageProtocol`."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, pd.DataFrame] = {}
+
+    def add_file(self, filename: str, dataframe: pd.DataFrame) -> None:
+        self._data[filename] = dataframe
+
+    def get_all_data(self) -> dict[str, pd.DataFrame]:
+        return {name: df.copy() for name, df in self._data.items()}
+
+    def clear_all(self) -> None:
+        self._data.clear()
+
+    # Additional helpers used by tests
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        return self._data[filename].copy()
+
+    def wait_for_pending_saves(self) -> None:  # pragma: no cover - no async work
+        return None
+
+
+@pytest.fixture
+def fake_upload_storage(monkeypatch: pytest.MonkeyPatch) -> Generator[_FakeUploadStorage, None, None]:
+    """Provide an in-memory upload storage fake."""
+
+    store = _FakeUploadStorage()
+    import utils.upload_store as upload_store_module
+
+    monkeypatch.setattr(upload_store_module, "UploadedDataStore", lambda *a, **k: store)
+    monkeypatch.setattr(upload_store_module, "uploaded_data_store", store)
+
+    yield store
+
+    store.clear_all()
+
+
+class _FakeConfig(ConfigurationProtocol):
+    """Simple fake implementing :class:`ConfigurationProtocol`."""
+
+    def __init__(self) -> None:
+        self.database: dict[str, Any] = {}
+        self.app: dict[str, Any] = {}
+        self.security: dict[str, Any] = {}
+        self.upload: dict[str, Any] = {}
+
+    def get_database_config(self) -> dict[str, Any]:
+        return self.database
+
+    def get_app_config(self) -> dict[str, Any]:
+        return self.app
+
+    def get_security_config(self) -> dict[str, Any]:
+        return self.security
+
+    def get_upload_config(self) -> dict[str, Any]:
+        return self.upload
+
+    def reload_config(self) -> None:
+        return None
+
+    def validate_config(self) -> dict[str, Any]:
+        return {}
+
+
+@pytest.fixture
+def fake_config_provider() -> Generator[_FakeConfig, None, None]:
+    """Yield a fresh fake configuration provider for each test."""
+
+    cfg = _FakeConfig()
+    yield cfg
+    cfg.database.clear()
+    cfg.app.clear()
+    cfg.security.clear()
+    cfg.upload.clear()
+
+
+class _FakeLearningService:
+    """Lightweight fake for device learning service."""
+
+    def __init__(self) -> None:
+        self.mappings: dict[str, dict[str, Any]] = {}
+
+    def save_device_mappings(self, df: pd.DataFrame, filename: str, device_mappings: dict[str, Any]) -> str:
+        self.mappings[filename] = device_mappings
+        return "test_fp"
+
+    def get_learned_mappings(self, df: pd.DataFrame, filename: str) -> dict[str, Any]:
+        return self.mappings.get(filename, {})
+
+    def apply_learned_mappings_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
+        return bool(self.mappings.get(filename))
+
+    def save_user_device_mappings(self, df: pd.DataFrame, filename: str, mappings: dict[str, Any]) -> bool:
+        self.mappings[filename] = mappings
+        return True
+
+    def get_user_device_mappings(self, filename: str) -> dict[str, Any]:
+        return self.mappings.get(filename, {})
+
+
+@pytest.fixture
+def fake_device_learning_service(monkeypatch: pytest.MonkeyPatch) -> Generator[_FakeLearningService, None, None]:
+    """Provide a fake device learning service accessible via the usual import path."""
+
+    service = _FakeLearningService()
+    import types, sys
+
+    module = types.ModuleType("services.device_learning_service")
+    module.get_device_learning_service = lambda: service
+    monkeypatch.setitem(sys.modules, "services.device_learning_service", module)
+
+    yield service
+
+    service.mappings.clear()

--- a/tests/integration/test_unicode_upload_endpoint.py
+++ b/tests/integration/test_unicode_upload_endpoint.py
@@ -1,25 +1,9 @@
-from pathlib import Path
-
 import pandas as pd
 
 from security.unicode_security_handler import UnicodeSecurityHandler
 from core.unicode_processor import safe_unicode_encode
 
 
-class SimpleStore:
-    def __init__(self, path):
-        self.data = {}
-        self.path = Path(path)
-        self.path.mkdir(parents=True, exist_ok=True)
-
-    def add_file(self, name: str, df: pd.DataFrame) -> None:
-        self.data[name] = df
-
-    def load_dataframe(self, name: str) -> pd.DataFrame:
-        return self.data[name]
-
-    def wait_for_pending_saves(self) -> None:  # compatibility
-        pass
 
 
 def test_upload_dataframe_sanitization():
@@ -29,12 +13,12 @@ def test_upload_dataframe_sanitization():
     assert cleaned.iloc[0, 0] == "v"
 
 
-def test_non_ascii_filename_persistence(tmp_path):
+def test_non_ascii_filename_persistence(fake_upload_storage):
     df = pd.DataFrame({"a": [1]})
     filename = "данные\ud83d.csv"
     safe_name = safe_unicode_encode(filename)
 
-    store = SimpleStore(tmp_path)
+    store = fake_upload_storage
     store.add_file(safe_name, df)
 
     assert safe_name.endswith("данные.csv")

--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -31,25 +31,6 @@ spec_queue = importlib.util.spec_from_file_location(
 )
 queue_mod = importlib.util.module_from_spec(spec_queue)
 
-class SimpleStore:
-    def __init__(self, path: Path):
-        self.path = Path(path)
-        self.data: dict[str, pd.DataFrame] = {}
-        self.path.mkdir(parents=True, exist_ok=True)
-
-    def add_file(self, name: str, df: pd.DataFrame) -> None:
-        self.data[name] = df
-
-    def load_dataframe(self, name: str) -> pd.DataFrame:
-        return self.data[name]
-
-    def wait_for_pending_saves(self) -> None:
-        pass
-
-upload_store_mod = types.ModuleType("utils.upload_store")
-upload_store_mod.UploadedDataStore = SimpleStore
-sys.modules["utils.upload_store"] = upload_store_mod
-
 class CallbackEvent:
     ANALYSIS_ERROR = "ANALYSIS_ERROR"
 
@@ -85,12 +66,12 @@ ChunkedUploadManager = chunk_mod.ChunkedUploadManager
 
 
 
-def test_resumable_upload_and_error_callback(tmp_path, monkeypatch):
+def test_resumable_upload_and_error_callback(tmp_path, monkeypatch, fake_upload_storage):
     data_file = tmp_path / "sample.csv"
     df = pd.DataFrame({"a": range(15)})
     df.to_csv(data_file, index=False)
 
-    store = SimpleStore(tmp_path / "store")
+    store = fake_upload_storage
     cmgr = ChunkedUploadManager(store, metadata_dir=tmp_path / "meta", initial_chunk_size=5)
     queue = UploadQueueManager(max_concurrent=1)
     queue.add_files([data_file])


### PR DESCRIPTION
## Summary
- add fakes for `UploadStorageProtocol`, `ConfigurationProtocol` and `DeviceLearningServiceProtocol`
- use these fixtures in callback and integration tests
- remove ad-hoc stubs in affected tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686cc9dac4c08320b93bde40596e2486