### PR TITLE
Add testing architecture guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,7 @@ bandit -r .
 
 Run `isort .` to automatically sort imports before committing changes.
 
+See [docs/test_architecture.md](docs/test_architecture.md) for details on the
+protocols used in tests and examples of injecting your own test doubles.
+
 Please ensure tests and linters pass before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)
 - [Data Processing](docs/data_processing.md)
+- [Testing Architecture](docs/test_architecture.md)
 
 Core service protocols live in `services/interfaces.py`. Components obtain
 implementations from the `ServiceContainer` when an explicit instance is not
@@ -246,6 +247,8 @@ pip install -r requirements-dev.txt
 ```
 Detailed instructions are provided in
 [docs/test_setup.md](docs/test_setup.md).
+The overall design of our test protocols and injection approach is
+documented in [docs/test_architecture.md](docs/test_architecture.md).
 
 Run the complete test suite:
 ```bash

--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -1,0 +1,42 @@
+# Testing Architecture
+
+This project uses **protocols** and a simple dependency injection container to keep services loosely coupled and easy to test. New service interfaces live in `services/` and are defined using Python `Protocol` classes. Components depend only on these interfaces so tests can supply lightweight replacements.
+
+## Service Protocols
+
+The following protocols describe the core behaviour expected from each service. Implementations are registered with the `ServiceContainer` and can be swapped during tests:
+
+- `UploadValidatorProtocol`
+- `ExportServiceProtocol`
+- `DoorMappingServiceProtocol`
+- `SecurityServiceProtocol`
+- `AuthenticationProtocol`
+
+These interfaces can be found under `services/interfaces.py` and `services/security/protocols.py`.
+
+## Dependency Injection
+
+`ServiceContainer` in `core.service_container` manages service lifetimes and resolves dependencies based on the protocols. Services register themselves as singletons or transients. Test suites create a fresh container and register stubs or mocks as needed:
+
+```python
+from core.service_container import ServiceContainer
+from services.interfaces import UploadValidatorProtocol
+
+class DummyValidator(UploadValidatorProtocol):
+    def validate(self, filename: str, content: str) -> tuple[bool, str]:
+        return True, ""
+
+    def to_json(self) -> str:
+        return "{}"
+
+container = ServiceContainer()
+container.register_singleton("upload_validator", DummyValidator)
+```
+
+Tests then retrieve `upload_validator` from the container and pass it to the component under test.
+
+## Sample Test Doubles
+
+Several tests provide custom stubs that implement these protocols. They avoid heavy dependencies like Dash or database connections. See `tests/test_service_integration.py` and `tests/test_protocol_compliance.py` for examples of simple stubs providing the minimum required behaviour.
+
+Use this approach to isolate units under test and speed up execution.


### PR DESCRIPTION
## Summary
- document dependency injection approach
- reference guide in README and CONTRIBUTING

## Testing
- `pre-commit run --files README.md docs/test_architecture.md CONTRIBUTING.md`
- `pytest tests/test_service_integration.py::TestServiceIntegration::test_analytics_uses_database_protocol -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_686cc9ddd38c8320a3081d1def867b87