### PR TITLE
Add legacy callback migration utilities

### DIFF
--- a/tools/detect_legacy_callbacks.py
+++ b/tools/detect_legacy_callbacks.py
@@ -1,0 +1,92 @@
+import ast
+import json
+from pathlib import Path
+from typing import Dict, List, Set
+
+LEGACY_MODULES = {
+    "security_callback_controller",
+    "services.data_processing.callback_controller",
+    "core.unified_callback_coordinator",
+}
+
+LEGACY_NAMES = {
+    "SecurityEvent": "CallbackEvent",
+    "SecurityCallbackController": "CallbackController",
+    "security_callback_controller": "callback_controller",
+    "emit_security_event": "fire_event",
+    "UnifiedCallbackCoordinator": "CallbackUnifier",
+}
+
+
+def _full_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_full_name(node.value)}.{node.attr}"
+    return ""
+
+
+class LegacyCallbackDetector:
+    """Scan code for legacy callback API usage."""
+
+    def __init__(self) -> None:
+        self.imports: Dict[str, Set[str]] = {}
+        self.instantiations: Dict[str, Set[str]] = {}
+        self.calls: Dict[str, Set[str]] = {}
+
+    # ------------------------------------------------------------------
+    def scan_file(self, path: Path) -> None:
+        try:
+            tree = ast.parse(path.read_text())
+        except Exception:
+            return
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in LEGACY_MODULES:
+                self.imports.setdefault(str(path), set()).add(node.module)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in LEGACY_MODULES:
+                        self.imports.setdefault(str(path), set()).add(alias.name)
+            elif isinstance(node, ast.Call):
+                name = _full_name(node.func)
+                for legacy in LEGACY_NAMES:
+                    if legacy in name:
+                        self.instantiations.setdefault(str(path), set()).add(name)
+
+            elif isinstance(node, ast.Attribute):
+                if node.attr in {"register_callback", "fire_event"}:
+                    base = _full_name(node.value)
+                    if base in LEGACY_NAMES:
+                        self.calls.setdefault(str(path), set()).add(f"{base}.{node.attr}")
+
+    # ------------------------------------------------------------------
+    def scan(self, root: Path) -> Dict[str, Dict[str, List[str]]]:
+        for py in root.rglob("*.py"):
+            if "tests" in py.parts:
+                continue
+            self.scan_file(py)
+        return {
+            "imports": {k: sorted(v) for k, v in self.imports.items()},
+            "instantiations": {k: sorted(v) for k, v in self.instantiations.items()},
+            "calls": {k: sorted(v) for k, v in self.calls.items()},
+        }
+
+
+# ----------------------------------------------------------------------
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Detect legacy callback APIs")
+    parser.add_argument("path", nargs="?", default=".", help="project path")
+    args = parser.parse_args()
+
+    detector = LegacyCallbackDetector()
+    report = detector.scan(Path(args.path))
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    main()
+

--- a/tools/migrate_callbacks.py
+++ b/tools/migrate_callbacks.py
@@ -1,0 +1,108 @@
+import ast
+import difflib
+import shutil
+from pathlib import Path
+from typing import Dict
+
+MAPPING_MODULES = {
+    "security_callback_controller": "core.callback_controller",
+    "services.data_processing.callback_controller": "core.callback_controller",
+}
+
+NAME_MAP = {
+    "SecurityEvent": "CallbackEvent",
+    "SecurityCallbackController": "CallbackController",
+    "security_callback_controller": "callback_controller",
+    "emit_security_event": "fire_event",
+    "UnifiedCallbackCoordinator": "CallbackUnifier",
+}
+
+
+def migrate_source(source: str) -> str:
+    tree = ast.parse(source)
+    changed = False
+
+    class Transformer(ast.NodeTransformer):
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.AST:
+            nonlocal changed
+            if node.module in MAPPING_MODULES:
+                node.module = MAPPING_MODULES[node.module]
+                for alias in node.names:
+                    if alias.name in NAME_MAP:
+                        alias.name = NAME_MAP[alias.name]
+                changed = True
+            return node
+
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            nonlocal changed
+            if node.id in NAME_MAP:
+                node.id = NAME_MAP[node.id]
+                changed = True
+            return node
+
+        def visit_Attribute(self, node: ast.Attribute) -> ast.AST:
+            nonlocal changed
+            self.generic_visit(node)
+            if node.attr in NAME_MAP:
+                node.attr = NAME_MAP[node.attr]
+                changed = True
+            return node
+
+    Transformer().visit(tree)
+    if not changed:
+        return source
+    return ast.unparse(tree)
+
+
+def migrate_file(path: Path, backup: bool, show_diff: bool) -> bool:
+    original = path.read_text()
+    new_source = migrate_source(original)
+    if new_source == original:
+        return False
+    if backup:
+        shutil.copy2(path, path.with_suffix(path.suffix + ".bak"))
+    if show_diff:
+        for line in difflib.unified_diff(
+            original.splitlines(), new_source.splitlines(), fromfile=str(path), tofile=str(path)
+        ):
+            print(line)
+    path.write_text(new_source)
+    return True
+
+
+def validate(root: Path) -> Dict[str, list]:
+    from detect_legacy_callbacks import LegacyCallbackDetector
+
+    detector = LegacyCallbackDetector()
+    return detector.scan(root)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Migrate legacy callback API usage")
+    parser.add_argument("path", nargs="?", default=".", help="project path")
+    parser.add_argument("--backup", action="store_true", help="Keep .bak files")
+    parser.add_argument("--diff", action="store_true", help="Show unified diff")
+    args = parser.parse_args()
+
+    root = Path(args.path)
+    migrated = 0
+    for py in root.rglob("*.py"):
+        if "tests" in py.parts:
+            continue
+        if migrate_file(py, args.backup, args.diff):
+            migrated += 1
+    print(f"Migrated {migrated} files")
+
+    report = validate(root)
+    if any(report.values()):
+        print("Legacy callback usages remain:")
+        print(report)
+    else:
+        print("Migration complete - no legacy callbacks detected")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    main()
+


### PR DESCRIPTION
## Summary
- add `tools/detect_legacy_callbacks.py` to locate deprecated callback APIs
- add `tools/migrate_callbacks.py` to update imports and names in-place

## Testing
- `pytest -q` *(fails: DefaultUnicodeProcessor missing)*

------
https://chatgpt.com/codex/tasks/task_e_686cd926e3b8832089a2ed7076e77650