### PR TITLE
Update tests for unified callbacks

### DIFF
--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -3,13 +3,13 @@ import dash_bootstrap_components as dbc
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from dash import dcc, html
 
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core import TrulyUnifiedCallbacks
 from pages import file_upload
 
 
 def _create_upload_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
     file_upload.register_upload_callbacks(coord)
     app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
     return app

--- a/tests/test_dash_pages.py
+++ b/tests/test_dash_pages.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from dash import dcc, html
 
-from core.unified_callback_coordinator import UnifiedCallbackCoordinator
+from core import TrulyUnifiedCallbacks
 from pages import file_upload
 from pages.deep_analytics import layout as analytics_layout
 from pages.deep_analytics import register_callbacks as register_analytics_callbacks
@@ -16,7 +16,7 @@ from pages.deep_analytics import register_callbacks as register_analytics_callba
 
 def _create_upload_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
     file_upload.register_upload_callbacks(coord)
     app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
     return app
@@ -24,7 +24,7 @@ def _create_upload_app():
 
 def _create_analytics_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
     register_analytics_callbacks(coord)
     app.layout = html.Div([dcc.Location(id="url"), analytics_layout()])
     return app

--- a/tests/test_unified_callback_coordinator.py
+++ b/tests/test_unified_callback_coordinator.py
@@ -4,14 +4,12 @@ from dash import Dash, Input, Output
 from core.callback_events import CallbackEvent
 from core.callback_manager import CallbackManager
 from core.callback_migration import UnifiedCallbackCoordinatorWrapper
-from core.unified_callback_coordinator import (
-    UnifiedCallbackCoordinator,
-)
+from core import TrulyUnifiedCallbacks
 
 
 def test_duplicate_callback_registration():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),
@@ -36,7 +34,7 @@ def test_duplicate_callback_registration():
 
 def test_output_conflict_detection():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),
@@ -61,7 +59,7 @@ def test_output_conflict_detection():
 
 def test_allow_duplicate_output():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),
@@ -86,7 +84,7 @@ def test_allow_duplicate_output():
 
 def test_allow_duplicate_on_output_obj():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),
@@ -109,7 +107,7 @@ def test_allow_duplicate_on_output_obj():
 
 def test_callback_registration_to_app():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),
@@ -126,7 +124,7 @@ def test_callback_registration_to_app():
 
 def test_get_callback_conflicts():
     app = Dash(__name__)
-    coord = UnifiedCallbackCoordinator(app)
+    coord = TrulyUnifiedCallbacks(app)
 
     @coord.register_callback(
         Output("out", "children"),

--- a/tests/test_unified_callback_manager.py
+++ b/tests/test_unified_callback_manager.py
@@ -1,9 +1,11 @@
-from core.callbacks import UnifiedCallbackManager
+from dash import Dash
+
+from core import TrulyUnifiedCallbacks
 from core.error_handling import error_handler
 
 
 def test_execute_group_with_errors_and_retry():
-    manager = UnifiedCallbackManager()
+    manager = TrulyUnifiedCallbacks(Dash(__name__))
 
     calls = {"fail": 0}
 
@@ -24,7 +26,7 @@ def test_execute_group_with_errors_and_retry():
 
 
 def test_timeout_records_error():
-    manager = UnifiedCallbackManager()
+    manager = TrulyUnifiedCallbacks(Dash(__name__))
 
     def slow():
         import time


### PR DESCRIPTION
## Summary
- use `TrulyUnifiedCallbacks` in tests instead of legacy coordinator/manager
- update helper app factories in integration tests

## Testing
- `pytest tests/test_unified_callback_coordinator.py tests/test_unified_callback_manager.py -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686cd929c36c8320aea35a82e9a7e3c9