### PR TITLE
Add protocol interfaces and fakes

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -5,7 +5,7 @@ Allows manual verification of AI-suggested column mappings
 Feeds back to AI training data
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, Any, Dict
 
 import pandas as pd
 from dash import ALL, MATCH, Input, Output, State, callback, dcc, html
@@ -16,6 +16,18 @@ if TYPE_CHECKING:
 import logging
 
 from analytics.controllers import UnifiedAnalyticsController
+
+
+class ColumnVerifierProtocol(Protocol):
+    """Protocol for column verification helpers."""
+
+    def create_column_verification_modal(self, file_info: Dict[str, Any]) -> Any:
+        ...
+
+    def register_callbacks(
+        self, manager: "TrulyUnifiedCallbacks", controller: UnifiedAnalyticsController | None = None
+    ) -> None:
+        ...
 
 logger = logging.getLogger(__name__)
 import json

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Protocol
 
 from .constants import (
     AnalyticsConstants,
@@ -10,6 +10,16 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
+
+
+class ConfigurationServiceProtocol(Protocol):
+    """Minimal configuration service interface."""
+
+    def get_max_upload_size_mb(self) -> int:
+        ...
+
+    def get_max_upload_size_bytes(self) -> int:
+        ...
 
 
 class DynamicConfigManager:

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -8,6 +8,25 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from services.upload.protocols import DeviceLearningServiceProtocol
+from typing import Protocol
+
+
+class DeviceServiceProtocol(Protocol):
+    """Lightweight interface for device learning services."""
+
+    def get_learned_mappings(self, df: pd.DataFrame, filename: str) -> Dict[str, Dict]:
+        ...
+
+    def apply_learned_mappings_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
+        ...
+
+    def get_user_device_mappings(self, filename: str) -> Dict[str, Any]:
+        ...
+
+    def save_user_device_mappings(
+        self, df: pd.DataFrame, filename: str, user_mappings: Dict[str, Any]
+    ) -> bool:
+        ...
 
 import pandas as pd
 from dash import html

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -4,6 +4,26 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from utils.upload_store import uploaded_data_store
+from typing import Protocol
+
+
+class UploadDataServiceProtocol(Protocol):
+    """Abstraction for accessing uploaded data."""
+
+    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        ...
+
+    def get_uploaded_filenames(self) -> List[str]:
+        ...
+
+    def clear_uploaded_data(self) -> None:
+        ...
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
+        ...
+
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        ...
 
 logger = logging.getLogger(__name__)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -6,6 +6,11 @@ import pandas as pd
 
 from services.upload.protocols import UploadStorageProtocol
 from services.interfaces import DeviceLearningServiceProtocol
+from services.upload_data_service import UploadDataServiceProtocol
+from utils.upload_store import UploadStoreProtocol
+from components.column_verification import ColumnVerifierProtocol
+from config.dynamic_config import ConfigurationServiceProtocol
+from core.unicode_processor import UnicodeProcessorProtocol
 
 class FakeUploadStore(UploadStorageProtocol):
     def __init__(self) -> None:
@@ -55,3 +60,56 @@ class FakeDeviceLearningService(DeviceLearningServiceProtocol):
     def save_user_device_mappings(self, df: pd.DataFrame, filename: str, user_mappings: Dict[str, Any]) -> bool:
         self.saved[filename] = user_mappings
         return True
+
+
+class FakeUploadDataService(UploadDataServiceProtocol):
+    def __init__(self) -> None:
+        self.store: Dict[str, pd.DataFrame] = {}
+
+    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        return self.store.copy()
+
+    def get_uploaded_filenames(self) -> List[str]:
+        return list(self.store.keys())
+
+    def clear_uploaded_data(self) -> None:
+        self.store.clear()
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
+        return {name: {"rows": len(df)} for name, df in self.store.items()}
+
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        return self.store.get(filename, pd.DataFrame())
+
+
+class FakeColumnVerifier(ColumnVerifierProtocol):
+    def create_column_verification_modal(self, file_info: Dict[str, Any]) -> Any:
+        return {"modal": file_info}
+
+    def register_callbacks(self, manager: Any, controller: Any | None = None) -> None:
+        pass
+
+
+class FakeConfigurationService(ConfigurationServiceProtocol):
+    def __init__(self, max_mb: int = 50) -> None:
+        self.max_mb = max_mb
+
+    def get_max_upload_size_mb(self) -> int:
+        return self.max_mb
+
+    def get_max_upload_size_bytes(self) -> int:
+        return self.max_mb * 1024 * 1024
+
+
+class FakeUnicodeProcessor(UnicodeProcessorProtocol):
+    def clean_text(self, text: str, replacement: str = "") -> str:
+        return text.replace("\ud800", replacement).replace("\udfff", replacement)
+
+    def safe_encode_text(self, value: Any) -> str:
+        return str(value) if value is not None else ""
+
+    def safe_decode_text(self, data: bytes, encoding: str = "utf-8") -> str:
+        try:
+            return data.decode(encoding, errors="ignore")
+        except Exception:
+            return ""

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -12,6 +12,32 @@ import pandas as pd
 
 from file_conversion.file_converter import FileConverter
 from services.upload.protocols import UploadStorageProtocol
+from typing import Protocol
+
+
+class UploadStoreProtocol(Protocol):
+    """Interface for uploaded data storage backends."""
+
+    def add_file(self, filename: str, dataframe: pd.DataFrame) -> None:
+        ...
+
+    def get_all_data(self) -> Dict[str, pd.DataFrame]:
+        ...
+
+    def clear_all(self) -> None:
+        ...
+
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        ...
+
+    def get_filenames(self) -> List[str]:
+        ...
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
+        ...
+
+    def wait_for_pending_saves(self) -> None:
+        ...
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add `DeviceServiceProtocol`, `UploadStoreProtocol`, `ColumnVerifierProtocol`, `UploadDataServiceProtocol`, and `ConfigurationServiceProtocol`
- provide lightweight fakes for new protocols

## Testing
- `pytest -k fake_unicode_processor -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686cdafccc408320a3aeb120444dea95