### PR TITLE
Refactor app factory DI helpers

### DIFF
--- a/tests/di/test_app_factory_helpers.py
+++ b/tests/di/test_app_factory_helpers.py
@@ -1,73 +1,48 @@
-import importlib.util
-import sys
-from types import ModuleType, SimpleNamespace
-from pathlib import Path
+import importlib
+from types import SimpleNamespace
 
-# Ensure stub modules are importable before loading the factory
-ROOT = Path(__file__).resolve().parents[2]
-STUB_DIR = ROOT / "tests" / "stubs"
-sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(STUB_DIR))
+from core.service_container import ServiceContainer
+from core.protocols import UnicodeProcessorProtocol
+from core.app_factory import (
+    _initialize_plugins,
+    _setup_layout,
+    _register_callbacks,
+    _configure_swagger,
+)
+from tests.fake_unicode_processor import FakeUnicodeProcessor
+from tests.fake_configuration import FakeConfiguration
 
-
-spec = importlib.util.spec_from_file_location("core.app_factory", ROOT / "core" / "app_factory.py")
-app_factory = importlib.util.module_from_spec(spec)
-sys.modules["core.app_factory"] = app_factory
-comp_pkg = ModuleType("components")
-comp_pkg.__path__ = []
-sys.modules.setdefault("components", comp_pkg)
-ui_pkg = ModuleType("components.ui")
-ui_pkg.__path__ = []
-sys.modules.setdefault("components.ui", ui_pkg)
-sys.modules.setdefault("components.ui.navbar", ModuleType("components.ui.navbar"))
-sys.modules["components.ui.navbar"].create_navbar_layout = lambda: "navbar"
-sys.modules.setdefault("core.unicode_processor", ModuleType("core.unicode_processor"))
-sys.modules["core.unicode_processor"].safe_format_number = lambda *a, **k: ""
-sys.modules.setdefault("core.unicode", ModuleType("core.unicode"))
-config_pkg = ModuleType("config")
-config_pkg.__path__ = []
-sys.modules.setdefault("config", config_pkg)
-sys.modules.setdefault("config.config", ModuleType("config.config"))
-sys.modules["config.config"].get_config = lambda: SimpleNamespace(get_app_config=lambda: SimpleNamespace(environment="development"), get_analytics_config=lambda: SimpleNamespace(title="title"))
-core_pkg = ModuleType("core")
-core_pkg.__path__ = []
-sys.modules.setdefault("core", core_pkg)
-sys.modules.setdefault("core.container", ModuleType("core.container"))
-sys.modules["core.container"].Container = object
-sys.modules.setdefault("core.enhanced_container", ModuleType("core.enhanced_container"))
-sys.modules["core.enhanced_container"].ServiceContainer = object
-sys.modules.setdefault("core.plugins.auto_config", ModuleType("core.plugins.auto_config"))
-sys.modules["core.plugins.auto_config"].PluginAutoConfiguration = lambda *a, **k: None
-sys.modules.setdefault("core.secrets_manager", ModuleType("core.secrets_manager"))
-sys.modules["core.secrets_manager"].validate_secrets = lambda: {}
-sys.modules.setdefault("core.theme_manager", ModuleType("core.theme_manager"))
-sys.modules["core.theme_manager"].DEFAULT_THEME = "light"
-sys.modules["core.theme_manager"].apply_theme_settings = lambda app: None
-sys.modules["core.theme_manager"].sanitize_theme = lambda x: x
-sys.modules.setdefault("dash_csrf_plugin", ModuleType("dash_csrf_plugin"))
-sys.modules["dash_csrf_plugin"].CSRFMode = SimpleNamespace(PRODUCTION="prod")
-sys.modules["dash_csrf_plugin"].setup_enhanced_csrf_protection = lambda *a, **k: None
-sys.modules.setdefault("services", ModuleType("services"))
-sys.modules["services"].get_analytics_service = lambda: SimpleNamespace(health_check=lambda: "ok")
-sys.modules.setdefault("core.cache", ModuleType("core.cache"))
-sys.modules["core.cache"].cache = SimpleNamespace(init_app=lambda x: None)
-spec.loader.exec_module(app_factory)  # type: ignore
 
 class DummyServer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.teardown_funcs = []
         self.config = {}
+
     def teardown_appcontext(self, func):
         self.teardown_funcs.append(func)
         return func
 
+
 class DummyApp:
-    def __init__(self):
+    def __init__(self) -> None:
         self.server = DummyServer()
 
 
-def test_initialize_plugins(monkeypatch):
+def _make_container() -> ServiceContainer:
+    container = ServiceContainer()
+    container.register_singleton("config_manager", FakeConfiguration)
+    container.register_singleton(
+        "unicode_processor",
+        lambda: FakeUnicodeProcessor(),
+        protocol=UnicodeProcessorProtocol,
+    )
+    return container
+
+
+def test_initialize_plugins():
     app = DummyApp()
+    container = _make_container()
+    cfg = container.get("config_manager")
 
     auto_instances = []
 
@@ -91,8 +66,12 @@ def test_initialize_plugins(monkeypatch):
         def generate_health_endpoints(self):
             self.generated = True
 
-    monkeypatch.setattr(app_factory, "PluginAutoConfiguration", DummyAuto)
-    app_factory._initialize_plugins(app, object())
+    _initialize_plugins(
+        app,
+        cfg,
+        container=container,
+        plugin_auto_cls=DummyAuto,
+    )
 
     auto = auto_instances[0]
     assert auto.scanned == "plugins"
@@ -104,53 +83,70 @@ def test_initialize_plugins(monkeypatch):
 
 def test_setup_layout(monkeypatch):
     app = DummyApp()
-    monkeypatch.setattr(app_factory, "_create_main_layout", lambda: "layout1")
-    app_factory._setup_layout(app)
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"),
+        "_create_main_layout",
+        lambda: "layout1",
+    )
+    _setup_layout(app)
     assert app.layout() == "layout1"
-    monkeypatch.setattr(app_factory, "_create_main_layout", lambda: "layout2")
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"),
+        "_create_main_layout",
+        lambda: "layout2",
+    )
     assert app.layout() == "layout1"
 
 
 def test_register_callbacks(monkeypatch):
     app = DummyApp()
-    cfg = SimpleNamespace(get_app_config=lambda: SimpleNamespace(environment="development"))
+    container = _make_container()
+    cfg = container.get("config_manager")
 
     calls = {}
-    def fake_router(mgr):
-        calls["router"] = True
+
+    def fake_router(mgr, proc=None):
+        calls["router"] = proc
+
     def fake_global(mgr):
         calls["global"] = True
-    monkeypatch.setattr(app_factory, "_register_router_callbacks", fake_router)
-    monkeypatch.setattr(app_factory, "_register_global_callbacks", fake_global)
+
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"),
+        "_register_router_callbacks",
+        fake_router,
+    )
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"),
+        "_register_global_callbacks",
+        fake_global,
+    )
+
+    instance = None
 
     class DummyCoord:
         def __init__(self, app):
+            nonlocal instance
+            instance = self
             self.app = app
             self.summary = False
+
         def print_callback_summary(self):
             self.summary = True
-    monkeypatch.setattr(app_factory, "TrulyUnifiedCallbacks", DummyCoord)
 
-    # stub modules for component registrations
-    sys.modules["components.device_verification"] = SimpleNamespace(register_callbacks=lambda m: calls.setdefault("device", True))
-    sys.modules["components.simple_device_mapping"] = SimpleNamespace(register_callbacks=lambda m: calls.setdefault("simple", True))
-    sys.modules["components.ui.navbar"] = SimpleNamespace(
-        register_navbar_callbacks=lambda m, svc=None: calls.setdefault("nav", True)
-    )
-    sys.modules["pages.deep_analytics.callbacks"] = SimpleNamespace(
-        Callbacks=type("CB1", (), {}),
-        register_callbacks=lambda m: calls.setdefault("deep", True),
-    )
-    sys.modules["pages.file_upload"] = SimpleNamespace(
-        Callbacks=type("CB2", (), {}),
-        register_callbacks=lambda m: calls.setdefault("upload", True),
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"), "TrulyUnifiedCallbacks", DummyCoord
     )
 
-    app_factory._register_callbacks(app, cfg)
+    _register_callbacks(app, cfg, container=container)
 
-    assert calls["router"] and calls["global"]
-    assert calls["device"] and calls["simple"] and calls["nav"]
-    assert calls["deep"] and calls["upload"]
+    assert calls["router"] is container.get("unicode_processor")
+    assert calls["global"]
+    assert getattr(instance, "simple_registered", False)
+    assert getattr(instance, "device_registered", False)
+    assert getattr(instance, "deep_registered", False)
+    assert getattr(instance, "upload_registered", False)
+    assert getattr(instance, "navbar_registered", False)
     assert hasattr(app, "_upload_callbacks")
     assert hasattr(app, "_deep_analytics_callbacks")
 
@@ -158,12 +154,16 @@ def test_register_callbacks(monkeypatch):
 def test_configure_swagger(monkeypatch):
     server = DummyServer()
     captured = {}
+
     class DummySwagger:
         def __init__(self, srv, template=None):
             captured["template"] = template
             srv.swagger = True
-    monkeypatch.setattr(app_factory, "Swagger", DummySwagger)
-    app_factory._configure_swagger(server)
+
+    monkeypatch.setattr(
+        importlib.import_module("core.app_factory"), "Swagger", DummySwagger
+    )
+    _configure_swagger(server)
     assert server.config["SWAGGER"]["uiversion"] == 3
     assert captured["template"]["info"]["title"] == "Yōsai Intel Dashboard API"
     assert hasattr(server, "swagger")

--- a/tests/stubs/components/__init__.py
+++ b/tests/stubs/components/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/tests/stubs/components/device_verification.py
+++ b/tests/stubs/components/device_verification.py
@@ -1,0 +1,2 @@
+def register_callbacks(manager):
+    manager.device_registered = True

--- a/tests/stubs/components/simple_device_mapping.py
+++ b/tests/stubs/components/simple_device_mapping.py
@@ -1,0 +1,2 @@
+def register_callbacks(manager):
+    manager.simple_registered = True

--- a/tests/stubs/components/ui/__init__.py
+++ b/tests/stubs/components/ui/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/tests/stubs/components/ui/navbar.py
+++ b/tests/stubs/components/ui/navbar.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def create_navbar_layout():
+    return "navbar"
+
+
+def register_navbar_callbacks(manager, service=None):
+    manager.navbar_registered = True

--- a/tests/stubs/config/complete_service_registration.py
+++ b/tests/stubs/config/complete_service_registration.py
@@ -1,0 +1,5 @@
+from core.service_container import ServiceContainer
+
+
+def register_all_application_services(container: ServiceContainer) -> None:
+    pass

--- a/tests/stubs/config/config.py
+++ b/tests/stubs/config/config.py
@@ -1,5 +1,19 @@
+from types import SimpleNamespace
+
+
 class Dummy:
     max_display_rows = 100
 
+
 def get_analytics_config():
     return Dummy()
+
+
+def get_config():
+    return SimpleNamespace(
+        get_app_config=lambda: SimpleNamespace(
+            environment="development", title="title"
+        ),
+        get_security_config=lambda: SimpleNamespace(csrf_enabled=False),
+        get_analytics_config=get_analytics_config,
+    )

--- a/tests/stubs/core/__init__.py
+++ b/tests/stubs/core/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/tests/stubs/core/plugins/__init__.py
+++ b/tests/stubs/core/plugins/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/tests/stubs/core/plugins/auto_config.py
+++ b/tests/stubs/core/plugins/auto_config.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+
+class PluginAutoConfiguration:
+    def __init__(self, app, *, container=None, config_manager=None, package="plugins"):
+        self.app = app
+        self.container = container
+        self.config_manager = config_manager
+        self.package = package
+
+        class PM:
+            def stop_all_plugins(self):
+                self.stopped = True
+
+            def stop_health_monitor(self):
+                self.monitor_stopped = True
+
+        self.registry = SimpleNamespace(plugin_manager=PM())
+        self.scanned = None
+        self.generated = False
+
+    def scan_and_configure(self, pkg):
+        self.scanned = pkg
+
+    def generate_health_endpoints(self):
+        self.generated = True

--- a/tests/stubs/core/secrets_manager.py
+++ b/tests/stubs/core/secrets_manager.py
@@ -1,0 +1,2 @@
+def validate_secrets():
+    return {}

--- a/tests/stubs/core/theme_manager.py
+++ b/tests/stubs/core/theme_manager.py
@@ -1,0 +1,5 @@
+DEFAULT_THEME = "light"
+
+
+def apply_theme_settings(app):
+    pass

--- a/tests/stubs/core/unicode.py
+++ b/tests/stubs/core/unicode.py
@@ -1,0 +1,1 @@
+from .unicode_processor import *

--- a/tests/stubs/core/unicode_processor.py
+++ b/tests/stubs/core/unicode_processor.py
@@ -1,0 +1,55 @@
+class UnicodeProcessor:
+    def safe_encode_text(self, value):
+        return str(value)
+
+
+class ChunkedUnicodeProcessor:
+    pass
+
+
+class UnicodeTextProcessor:
+    pass
+
+
+class UnicodeSQLProcessor:
+    pass
+
+
+class UnicodeSecurityProcessor:
+    pass
+
+
+def clean_unicode_text(text: str) -> str:
+    return text
+
+
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    return data.decode(encoding, errors="ignore")
+
+
+def safe_encode_text(value):
+    return str(value)
+
+
+def sanitize_dataframe(df):
+    return df
+
+
+def contains_surrogates(text: str) -> bool:
+    return False
+
+
+def process_large_csv_content(content):
+    return content
+
+
+def safe_format_number(value):
+    return str(value)
+
+
+def object_count(obj):
+    return 0
+
+
+def safe_unicode_encode(value):
+    return str(value)

--- a/tests/stubs/dash_csrf_plugin.py
+++ b/tests/stubs/dash_csrf_plugin.py
@@ -1,0 +1,6 @@
+class CSRFMode:
+    PRODUCTION = "prod"
+
+
+def setup_enhanced_csrf_protection(app, mode):
+    return None

--- a/tests/stubs/pages/__init__.py
+++ b/tests/stubs/pages/__init__.py
@@ -1,0 +1,7 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+
+def get_page_layout(name: str):
+    return None

--- a/tests/stubs/pages/deep_analytics/__init__.py
+++ b/tests/stubs/pages/deep_analytics/__init__.py
@@ -1,0 +1,9 @@
+layout = lambda: "deep-layout"
+
+
+class Callbacks:
+    pass
+
+
+def register_callbacks(manager):
+    manager.deep_registered = True

--- a/tests/stubs/pages/file_upload.py
+++ b/tests/stubs/pages/file_upload.py
@@ -1,0 +1,9 @@
+layout = lambda: "upload-layout"
+
+
+class Callbacks:
+    pass
+
+
+def register_callbacks(manager):
+    manager.upload_registered = True

--- a/tests/stubs/services/__init__.py
+++ b/tests/stubs/services/__init__.py
@@ -1,2 +1,11 @@
 from pkgutil import extend_path
+
 __path__ = extend_path(__path__, __name__)
+
+
+def get_analytics_service():
+    class Svc:
+        def health_check(self):
+            return "ok"
+
+    return Svc()

--- a/tests/stubs/services/analytics_service.py
+++ b/tests/stubs/services/analytics_service.py
@@ -1,1 +1,3 @@
-# minimal stub
+class AnalyticsService:
+    def health_check(self):
+        return "ok"

--- a/tests/stubs/services/interfaces.py
+++ b/tests/stubs/services/interfaces.py
@@ -1,0 +1,3 @@
+
+def get_export_service(container=None):
+    return object()


### PR DESCRIPTION
## Summary
- refactor helper functions in `core/app_factory.py` to inject dependencies
- add stub modules for plugin auto config, unicode processor and more
- simplify tests to use a ServiceContainer instead of monkeypatching modules

## Testing
- `pytest tests/di/test_app_factory_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686cdafefae48320ac2c6d0ebf1dfb3f