### PR TITLE
Add configuration service protocol and inject into services

### DIFF
--- a/config/complete_service_registration.py
+++ b/config/complete_service_registration.py
@@ -44,11 +44,20 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
     ConfigManager = _config.ConfigManager
     from core.logging_config import LoggingService
     from core.database import DatabaseManager
+    from services.configuration_service import (
+        ConfigurationServiceProtocol,
+        DynamicConfigurationService,
+    )
 
     container.register_singleton(
         "config_manager",
         ConfigManager,
         protocol=ConfigurationProtocol,
+    )
+    container.register_singleton(
+        "configuration_service",
+        DynamicConfigurationService,
+        protocol=ConfigurationServiceProtocol,
     )
     container.register_singleton(
         "logging_service",

--- a/services/configuration_service.py
+++ b/services/configuration_service.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+from config.dynamic_config import DynamicConfigManager, dynamic_config
+
+
+class ConfigurationServiceProtocol(Protocol):
+    """Interface for accessing runtime configuration values."""
+
+    def get_max_upload_size_mb(self) -> int:
+        ...
+
+    def get_max_upload_size_bytes(self) -> int:
+        ...
+
+    def validate_large_file_support(self) -> bool:
+        ...
+
+    def get_upload_chunk_size(self) -> int:
+        ...
+
+    def get_max_parallel_uploads(self) -> int:
+        ...
+
+    def get_validator_rules(self) -> Dict[str, Any]:
+        ...
+
+    def get_ai_confidence_threshold(self) -> int:
+        ...
+
+    def get_db_pool_size(self) -> int:
+        ...
+
+
+class DynamicConfigurationService(ConfigurationServiceProtocol):
+    """Adapter exposing ``DynamicConfigManager`` via ``ConfigurationServiceProtocol``."""
+
+    def __init__(self, manager: DynamicConfigManager = dynamic_config) -> None:
+        self._cfg = manager
+
+    # Simple pass-through wrappers
+    def get_max_upload_size_mb(self) -> int:
+        return self._cfg.get_max_upload_size_mb()
+
+    def get_max_upload_size_bytes(self) -> int:
+        return self._cfg.get_max_upload_size_bytes()
+
+    def validate_large_file_support(self) -> bool:
+        return self._cfg.validate_large_file_support()
+
+    def get_upload_chunk_size(self) -> int:
+        return self._cfg.get_upload_chunk_size()
+
+    def get_max_parallel_uploads(self) -> int:
+        return self._cfg.get_max_parallel_uploads()
+
+    def get_validator_rules(self) -> Dict[str, Any]:
+        return self._cfg.get_validator_rules()
+
+    def get_ai_confidence_threshold(self) -> int:
+        return self._cfg.get_ai_confidence_threshold()
+
+    def get_db_pool_size(self) -> int:
+        return self._cfg.get_db_pool_size()
+
+
+__all__ = [
+    "ConfigurationServiceProtocol",
+    "DynamicConfigurationService",
+]

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
+from services.configuration_service import ConfigurationServiceProtocol
 
 # ADD after existing imports
 from services.ai_device_generator import AIDeviceGenerator
@@ -43,9 +43,10 @@ class DeviceAttributeData:
 class DoorMappingService:
     """Service for handling door mapping and device attribute assignment"""
 
-    def __init__(self):
+    def __init__(self, config: ConfigurationServiceProtocol) -> None:
         self.ai_model_version = "v2.3"
-        self.confidence_threshold = dynamic_config.get_ai_confidence_threshold()
+        self.config = config
+        self.confidence_threshold = config.get_ai_confidence_threshold()
 
     def process_uploaded_data(
         self, df: pd.DataFrame, client_profile: str = "auto"

--- a/services/input_validator.py
+++ b/services/input_validator.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-from config.dynamic_config import dynamic_config
+from services.configuration_service import (
+    ConfigurationServiceProtocol,
+    DynamicConfigurationService,
+)
 
 
 @dataclass
@@ -29,8 +32,13 @@ class ValidationResult:
 class InputValidator:
     """Validate basic properties of uploaded files."""
 
-    def __init__(self, max_size_mb: Optional[int] = None) -> None:
-        self.max_size_mb = max_size_mb or dynamic_config.security.max_upload_mb
+    def __init__(
+        self,
+        max_size_mb: Optional[int] = None,
+        config: ConfigurationServiceProtocol | None = None,
+    ) -> None:
+        self.config = config or DynamicConfigurationService()
+        self.max_size_mb = max_size_mb or self.config.get_max_upload_size_mb()
 
     _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
 

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
 from core.protocols import ConfigurationProtocol
+from services.configuration_service import ConfigurationServiceProtocol
 
-class FakeConfiguration(ConfigurationProtocol):
+class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):
     """Simple config for unit tests."""
 
     def __init__(self) -> None:
@@ -50,3 +51,28 @@ class FakeConfiguration(ConfigurationProtocol):
 
     def validate_config(self) -> dict:
         return {"valid": True}
+
+    # -- ConfigurationServiceProtocol methods ---------------------------------
+    def get_max_upload_size_mb(self) -> int:
+        return self.security.max_upload_mb
+
+    def get_max_upload_size_bytes(self) -> int:
+        return self.get_max_upload_size_mb() * 1024 * 1024
+
+    def validate_large_file_support(self) -> bool:
+        return self.get_max_upload_size_mb() >= 50
+
+    def get_upload_chunk_size(self) -> int:
+        return self.uploads.DEFAULT_CHUNK_SIZE
+
+    def get_max_parallel_uploads(self) -> int:
+        return self.uploads.MAX_PARALLEL_UPLOADS
+
+    def get_validator_rules(self) -> dict:
+        return self.uploads.VALIDATOR_RULES
+
+    def get_ai_confidence_threshold(self) -> int:
+        return getattr(self.performance, "ai_confidence_threshold", 75)
+
+    def get_db_pool_size(self) -> int:
+        return getattr(self.performance, "db_pool_size", 10)

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,6 +1,7 @@
 import pytest
 
-from config.config import DatabaseConfig, dynamic_config
+from config.config import DatabaseConfig
+from tests.fake_configuration import FakeConfiguration
 from config.connection_pool import DatabaseConnectionPool
 from config.database_manager import MockConnection
 
@@ -11,7 +12,8 @@ def factory():
 
 def test_database_config_default_pool_sizes():
     cfg = DatabaseConfig()
-    assert cfg.initial_pool_size == dynamic_config.get_db_pool_size()
+    fake_cfg = FakeConfiguration()
+    assert cfg.initial_pool_size == fake_cfg.get_db_pool_size()
     assert cfg.max_pool_size == cfg.initial_pool_size * 2
 
     pool = DatabaseConnectionPool(

--- a/tests/test_file_processor_service_surrogates.py
+++ b/tests/test_file_processor_service_surrogates.py
@@ -4,6 +4,8 @@ import types
 import os
 from pathlib import Path
 
+from tests.fake_configuration import FakeConfiguration
+
 from core.unicode import sanitize_unicode_input
 
 
@@ -71,7 +73,7 @@ def load_service():
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module.FileProcessorService()
+    return module.FileProcessorService(FakeConfiguration())
 
 
 def test_decode_with_surrogate_pairs():

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -1,13 +1,15 @@
 import pandas as pd
 
 from config.config import ConfigManager
-from config.dynamic_config import dynamic_config
+from tests.fake_configuration import FakeConfiguration
+
+fake_cfg = FakeConfiguration()
 from config.constants import MAX_DISPLAY_ROWS
 from services.data_processing.file_processor import create_file_preview
 
 
 def test_dynamic_config_default_display_rows():
-    assert dynamic_config.analytics.max_display_rows == 10000
+    assert fake_cfg.analytics.max_display_rows == 10000
 
 
 def test_config_manager_loads_max_display_rows(tmp_path, monkeypatch):

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -1,14 +1,16 @@
 import pandas as pd
 import pytest
 
-from config.dynamic_config import dynamic_config
+from tests.fake_configuration import FakeConfiguration
+
+fake_cfg = FakeConfiguration()
 from core.performance import get_performance_monitor
 from services.data_processing.file_handler import process_file_simple
 from services.data_processing.unified_file_validator import process_dataframe
 
 
 def test_memory_limit_abort_csv(monkeypatch, tmp_path):
-    monkeypatch.setattr(dynamic_config.performance, "memory_usage_threshold_mb", 1)
+    monkeypatch.setattr(fake_cfg.performance, "memory_usage_threshold_mb", 1)
     monitor = get_performance_monitor()
     monitor.memory_threshold_mb = 1
     df = pd.DataFrame({"a": range(10)})
@@ -20,7 +22,7 @@ def test_memory_limit_abort_csv(monkeypatch, tmp_path):
 
 
 def test_memory_limit_abort_json(monkeypatch):
-    monkeypatch.setattr(dynamic_config.performance, "memory_usage_threshold_mb", 1)
+    monkeypatch.setattr(fake_cfg.performance, "memory_usage_threshold_mb", 1)
     monitor = get_performance_monitor()
     monitor.memory_threshold_mb = 1
     data = b"[{\"a\":1},{\"a\":2}]"

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -1,6 +1,8 @@
 import pytest
 
-from config.dynamic_config import dynamic_config
+from tests.fake_configuration import FakeConfiguration
+
+fake_cfg = FakeConfiguration()
 from services.data_processing.unified_file_validator import UnifiedFileValidator
 
 
@@ -13,7 +15,7 @@ def test_malicious_filename_is_invalid():
 
 def test_oversized_upload_is_invalid():
     validator = UnifiedFileValidator()
-    too_big = dynamic_config.security.max_upload_mb * 1024 * 1024 + 1
+    too_big = fake_cfg.security.max_upload_mb * 1024 * 1024 + 1
     result = validator.validate_file_meta("big.csv", too_big)
     assert result["valid"] is False
     assert any("File too large" in issue for issue in result["issues"])

--- a/tests/test_upload_service_env.py
+++ b/tests/test_upload_service_env.py
@@ -1,21 +1,16 @@
 import base64
 import importlib
 
-from config import dynamic_config as dyn_module
+from tests.fake_configuration import FakeConfiguration
 from services.data_processing import file_processor as upload_module
 
 
 def test_env_max_upload_limit(monkeypatch):
-    monkeypatch.setenv("MAX_UPLOAD_MB", "1")
-    importlib.reload(dyn_module)
-    importlib.reload(upload_module)
+    cfg = FakeConfiguration()
+    monkeypatch.setattr(cfg.security, "max_upload_mb", 1)
 
-    max_bytes = dyn_module.dynamic_config.security.max_upload_mb * 1024 * 1024
+    max_bytes = cfg.security.max_upload_mb * 1024 * 1024
     data = base64.b64encode(b"A" * (max_bytes + 1)).decode()
     contents = f"data:text/csv;base64,{data}"
-    result = upload_module.process_uploaded_file(contents, "big.csv")
+    result = upload_module.process_uploaded_file(contents, "big.csv", config=cfg)
     assert result["success"] is False
-
-    monkeypatch.delenv("MAX_UPLOAD_MB", raising=False)
-    importlib.reload(dyn_module)
-    importlib.reload(upload_module)


### PR DESCRIPTION
## Summary
- define `ConfigurationServiceProtocol` and implement `DynamicConfigurationService`
- register the service in `ServiceContainer`
- inject configuration into `FileProcessorService`, `DoorMappingService`, and `InputValidator`
- use the configuration fake in tests

## Testing
- `pytest -q` *(fails: ImportError in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_686cdb0448e48320a673f428d28271f0