### PR TITLE
Clean up legacy callback coordinator names

### DIFF
--- a/core/callbacks/__init__.py
+++ b/core/callbacks/__init__.py
@@ -1,4 +1,8 @@
-"""Unified callback utilities"""
+"""Unified callback utilities.
+
+``UnifiedCallbackManager`` is provided purely for backwards compatibility and
+is simply an alias of :class:`TrulyUnifiedCallbacks`.
+"""
 
 from ..truly_unified_callbacks import Operation, TrulyUnifiedCallbacks as UnifiedCallbackManager
 

--- a/core/master_callback_system.py
+++ b/core/master_callback_system.py
@@ -12,7 +12,6 @@ from .callback_events import CallbackEvent
 from .callback_manager import CallbackManager
 from .security_validator import SecurityValidator
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
-from .unified_callback_coordinator import UnifiedCallbackCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +26,6 @@ class MasterCallbackSystem(TrulyUnifiedCallbacks):
         security_validator: Optional[SecurityValidator] = None,
     ) -> None:
         super().__init__(app)
-        self.coordinator = UnifiedCallbackCoordinator(app)
         self.callback_manager = CallbackManager()
         self.security = security_validator or SecurityValidator()
 
@@ -83,7 +81,7 @@ class MasterCallbackSystem(TrulyUnifiedCallbacks):
         **kwargs: Any,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Wrap ``Dash.callback`` and track registrations."""
-        return self.coordinator.register_callback(
+        return self.register_callback(
             outputs,
             inputs,
             states,
@@ -96,11 +94,11 @@ class MasterCallbackSystem(TrulyUnifiedCallbacks):
     # ------------------------------------------------------------------
     def get_callback_conflicts(self):
         """Return mapping of output identifiers to conflicting callback IDs."""
-        return self.coordinator.get_callback_conflicts()
+        return super().get_callback_conflicts()
 
     # ------------------------------------------------------------------
     def print_callback_summary(self) -> None:  # pragma: no cover - passthrough
-        self.coordinator.print_callback_summary()
+        super().print_callback_summary()
 
     # ------------------------------------------------------------------
     def get_metrics(self, event: CallbackEvent):

--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -57,8 +57,9 @@ events.register_callback(CallbackEvent.ANALYSIS_COMPLETE, on_complete)
 
 ## Grouped Operations
 
-`UnifiedCallbackManager` can execute a series of operations sequentially. This
-is useful when a Dash callback needs to orchestrate multiple steps.
+`UnifiedCallbackManager` (an alias of `TrulyUnifiedCallbacks` exposed from
+`core.callbacks`) can execute a series of operations sequentially. This is
+useful when a Dash callback needs to orchestrate multiple steps.
 
 ```python
 from core.callbacks import UnifiedCallbackManager

--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -1,20 +1,19 @@
 # Callback System Migration
 
 This release finalizes the move to the unified callback framework. The
-`UnifiedCallbackCoordinator` and its `UnifiedCallbackCoordinatorWrapper` helper
-have been removed. Modules should now rely solely on `TrulyUnifiedCallbacks`,
+The legacy coordinator classes have been removed. Modules should now rely solely
+on `TrulyUnifiedCallbacks`,
 `CallbackManager` for event hooks and, when multiple steps need to be executed,
-`UnifiedCallbackManager`.
+`UnifiedCallbackManager` (an alias of `TrulyUnifiedCallbacks`).
 
 ## Migrating
 
-1. Replace any imports of `UnifiedCallbackCoordinator` or the wrapper with
-   `TrulyUnifiedCallbacks`.
+1. Import `TrulyUnifiedCallbacks` for registering Dash callbacks.
 2. Import `CallbackManager` and `CallbackEvent` from `core` and register event
    hooks using `CallbackManager.register_callback`.
 3. Trigger events via `CallbackManager.trigger` or `trigger_async`.
-4. Organize multi-step operations using `UnifiedCallbackManager` and call
-   `execute_group` within Dash callbacks.
+4. Organize multi-step operations using `UnifiedCallbackManager` (alias of
+   `TrulyUnifiedCallbacks`) and call `execute_group` within Dash callbacks.
 
 All modules must migrate to this API before upgrading. The legacy wrappers are
 no longer shipped with the project.

--- a/scripts/migrate_plugin_system.py
+++ b/scripts/migrate_plugin_system.py
@@ -55,14 +55,14 @@ def generate_unified_config(imports: Dict[str, Set[str]], output: Path) -> None:
 
 
 def convert_callbacks(root: Path, dry_run: bool = False) -> None:
-    """Replace ``UnifiedCallbackCoordinator`` with ``CallbackUnifier``."""
+    """Replace references to the old coordinator with ``TrulyUnifiedCallbacks``."""
     for py in root.rglob("*.py"):
         if "tests" in py.parts or "plugins" in py.parts:
             continue
         text = py.read_text()
         if "UnifiedCallbackCoordinator" in text:
             new_text = text.replace(
-                "UnifiedCallbackCoordinator", "CallbackUnifier"
+                "UnifiedCallbackCoordinator", "TrulyUnifiedCallbacks"
             )
             if not dry_run:
                 py.write_text(new_text)

--- a/tools/detect_legacy_callbacks.py
+++ b/tools/detect_legacy_callbacks.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Set
 LEGACY_MODULES = {
     "security_callback_controller",
     "services.data_processing.callback_controller",
-    "core.unified_callback_coordinator",
+    "core.truly_unified_callbacks",
 }
 
 LEGACY_NAMES = {
@@ -14,7 +14,7 @@ LEGACY_NAMES = {
     "SecurityCallbackController": "CallbackController",
     "security_callback_controller": "callback_controller",
     "emit_security_event": "fire_event",
-    "UnifiedCallbackCoordinator": "CallbackUnifier",
+    "UnifiedCallbackCoordinator": "TrulyUnifiedCallbacks",
 }
 
 

--- a/tools/migrate_callbacks.py
+++ b/tools/migrate_callbacks.py
@@ -14,7 +14,7 @@ NAME_MAP = {
     "SecurityCallbackController": "CallbackController",
     "security_callback_controller": "callback_controller",
     "emit_security_event": "fire_event",
-    "UnifiedCallbackCoordinator": "CallbackUnifier",
+    "UnifiedCallbackCoordinator": "TrulyUnifiedCallbacks",
 }
 
 


### PR DESCRIPTION
## Summary
- remove `UnifiedCallbackCoordinator` import from `MasterCallbackSystem`
- document that `UnifiedCallbackManager` aliases `TrulyUnifiedCallbacks`
- update migration and architecture docs
- tweak migration scripts to replace the old coordinator with `TrulyUnifiedCallbacks`

## Testing
- `pytest tests/test_master_callback_system.py::test_basic_dash_registration -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686cde5518b88320803b03b09ddac669