### PR TITLE
Update legacy unicode audit module path

### DIFF
--- a/tools/legacy_unicode_audit.py
+++ b/tools/legacy_unicode_audit.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Set
 
 
-LEGACY_MODULE = "utils.unicode_utils"
+LEGACY_MODULE = "core.unicode_utils"
 LEGACY_FUNCS: Set[str] = {
     "clean_unicode_text",
     "safe_decode_bytes",


### PR DESCRIPTION
## Summary
- track unicode helpers under new `core.unicode_utils` path

## Testing
- `pytest tests/test_unicode_utils.py::test_normalize_unicode_safely_nfkc -q`
- `pytest tests/test_unicode_utils.py -q` *(fails: sanitize_for_utf8 normalization)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0d92f1483209bcd88672e7bcd63