### PR TITLE
Update testing instructions and add helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ compression is automatically handled at runtime by `flask-compress`.
 
 Install dependencies before running the tests:
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-# or simply run ./scripts/setup.sh
+# Option 1: use the helper script
+./scripts/setup.sh
+# Option 2: install packages manually
+pip install -r requirements.txt -r requirements-dev.txt
 ```
+For minimal CI environments you can run `./scripts/install_test_deps.sh` which
+only installs the Python dependencies required for the tests.
 Detailed instructions are provided in
 [docs/test_setup.md](docs/test_setup.md).
 The overall design of our test protocols and injection approach is

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Install only the Python dependencies required for running the tests.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+
+pip install -r "$ROOT_DIR/requirements.txt" -r "$ROOT_DIR/requirements-dev.txt"


### PR DESCRIPTION
## Summary
- clarify test dependency install commands in README
- add `scripts/install_test_deps.sh` helper for CI environments

## Testing
- `pytest -k test_ai_column_mapper_adapter.py -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686ce26a97f48320a868a5ec723c731e