### PR TITLE
Refactor Unicode utilities

### DIFF
--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -240,7 +240,7 @@ class UnifiedFileValidator:
     def sanitize_filename(self, filename: str) -> str:
         """Validate and sanitize a filename."""
         cleaned = self._sanitize_string(filename)
-        cleaned = UnicodeProcessor.safe_encode(cleaned)
+        cleaned = UnicodeProcessor.safe_encode_text(cleaned)
 
         if os.path.basename(cleaned) != cleaned:
             raise ValidationError("Path separators not allowed in filename")

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from services.configuration_service import ConfigurationServiceProtocol
 from core.performance_file_processor import PerformanceFileProcessor
-from core.unicode import process_large_csv_content, sanitize_data_frame
+from core.unicode import process_large_csv_content, sanitize_dataframe
 from core.unicode_utils import sanitize_for_utf8
 from services.data_processing.core.protocols import FileProcessorProtocol
 from utils.file_validator import safe_decode_with_unicode_handling
@@ -150,7 +150,7 @@ class FileProcessorService(BaseService):
                 )
                 if len(df_alt.columns) > len(df.columns):
                     df = df_alt
-            return sanitize_data_frame(df)
+            return sanitize_dataframe(df)
         except Exception as exc:
             raise ValueError(f"Could not parse CSV file: {exc}")
 
@@ -167,7 +167,7 @@ class FileProcessorService(BaseService):
                 df = pd.DataFrame([data])
             else:
                 raise ValueError("JSON must be an object or array")
-            return sanitize_data_frame(df)
+            return sanitize_dataframe(df)
         except json.JSONDecodeError as exc:
             raise ValueError(f"Invalid JSON format: {exc}")
         except Exception as e:
@@ -178,7 +178,7 @@ class FileProcessorService(BaseService):
         logger.debug("Processing Excel content")
         try:
             df = pd.read_excel(io.BytesIO(content), dtype=str, keep_default_na=False)
-            return sanitize_data_frame(df)
+            return sanitize_dataframe(df)
         except Exception as e:
             raise ValueError(f"Error reading Excel file: {e}")
 

--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -19,7 +19,8 @@ from .core.validator import ClientSideValidator as UploadValidator
 from utils.upload_store import UploadedDataStore as UploadStorage
 from .controllers.upload_controller import UnifiedUploadController as UploadController
 from .utils.file_parser import FileParser
-from .utils.unicode_handler import safe_unicode_encode, decode_upload_content
+from .utils.unicode_handler import decode_upload_content
+from core.unicode_processor import safe_encode_text
 
 __all__ = [
     "UploadProcessingServiceProtocol",
@@ -34,7 +35,7 @@ __all__ = [
     "UploadStorage",
     "UploadController",
     "FileParser",
-    "safe_unicode_encode",
+    "safe_encode_text",
     "decode_upload_content",
 ]
 

--- a/services/upload/utils/unicode_handler.py
+++ b/services/upload/utils/unicode_handler.py
@@ -5,29 +5,15 @@ import base64
 import logging
 from typing import Union, Tuple
 
+from core.unicode_processor import safe_encode_text
+
 logger = logging.getLogger(__name__)
 
 
 def safe_unicode_encode(text: Union[str, bytes, None]) -> str:
-    """Safely encode text to UTF-8, replacing problematic characters."""
-    if text is None:
-        return ""
-    if isinstance(text, bytes):
-        for encoding in ["utf-8", "latin-1", "cp1252"]:
-            try:
-                text = text.decode(encoding)
-                break
-            except UnicodeDecodeError:
-                continue
-        else:
-            text = text.decode("utf-8", errors="replace")
-    if isinstance(text, str):
-        try:
-            text.encode("utf-8")
-            return text
-        except UnicodeEncodeError:
-            return text.encode("utf-8", errors="replace").decode("utf-8")
-    return str(text)
+    """Deprecated alias for :func:`safe_encode_text`."""
+
+    return safe_encode_text(text)
 
 
 def decode_upload_content(content: str, filename: str) -> Tuple[bytes, str]:
@@ -41,7 +27,7 @@ def decode_upload_content(content: str, filename: str) -> Tuple[bytes, str]:
     except Exception as exc:
         logger.error("Failed to decode upload content: %s", exc)
         raise ValueError(f"Invalid file content: {exc}")
-    return decoded, safe_unicode_encode(filename)
+    return decoded, safe_encode_text(filename)
 
 
 __all__ = ["safe_unicode_encode", "decode_upload_content"]

--- a/tests/integration/test_unicode_upload_endpoint.py
+++ b/tests/integration/test_unicode_upload_endpoint.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from security.unicode_security_handler import UnicodeSecurityHandler
-from core.unicode_processor import safe_unicode_encode
+from core.unicode_processor import safe_encode_text
 
 
 
@@ -16,7 +16,7 @@ def test_upload_dataframe_sanitization():
 def test_non_ascii_filename_persistence(fake_upload_storage):
     df = pd.DataFrame({"a": [1]})
     filename = "данные\ud83d.csv"
-    safe_name = safe_unicode_encode(filename)
+    safe_name = safe_encode_text(filename)
 
     store = fake_upload_storage
     store.add_file(safe_name, df)

--- a/tests/test_unicode_cleaner.py
+++ b/tests/test_unicode_cleaner.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from core.unicode_processor import (
     UnicodeProcessor,
-    safe_unicode_encode,
+    safe_encode_text,
     sanitize_dataframe,
 )
 
@@ -21,7 +21,7 @@ def test_safe_unicode_encode_returns_utf8_without_surrogates():
     bytes_value = text.encode("utf-8", "surrogatepass")
 
     for value in (text, bytes_value):
-        result = safe_unicode_encode(value)
+        result = safe_encode_text(value)
         assert isinstance(result, str)
         assert result == "XY"
         assert not any(0xD800 <= ord(ch) <= 0xDFFF for ch in result)

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -10,8 +10,8 @@ from core.unicode_processor import (
     ChunkedUnicodeProcessor,
     UnicodeProcessor,
     clean_unicode_text,
-    safe_decode,
-    safe_encode,
+    safe_decode_bytes,
+    safe_encode_text,
     sanitize_dataframe,
 )
 
@@ -309,10 +309,10 @@ class TestPublicAPI:
         assert clean_unicode_text("Hello\uD83DWorld") == "HelloWorld"
 
     def test_safe_decode_function(self):
-        assert safe_decode(b"Hello") == "Hello"
+        assert safe_decode_bytes(b"Hello") == "Hello"
 
     def test_safe_encode_function(self):
-        assert safe_encode("Hello\uD83D") == "Hello"
+        assert safe_encode_text("Hello\uD83D") == "Hello"
 
     def test_sanitize_dataframe_function(self):
         df = pd.DataFrame({"col\uD83D": ["val\uDE00"]})

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -6,11 +6,10 @@ import pytest
 
 from core.unicode_processor import (
     contains_surrogates,
-    safe_decode,
-    safe_encode,
+    safe_decode_bytes,
+    safe_encode_text,
     safe_format_number,
-    safe_unicode_encode,
-    sanitize_data_frame,
+    sanitize_dataframe,
 )
 from security.unicode_security_validator import UnicodeSecurityValidator
 from security.validation_exceptions import ValidationError
@@ -18,15 +17,15 @@ from security.validation_exceptions import ValidationError
 
 def test_safe_unicode_encode_surrogates():
     text = "A" + chr(0xD800) + "B"
-    assert safe_unicode_encode(text) == "AB"
+    assert safe_encode_text(text) == "AB"
 
     encoded = ("X" + chr(0xDC00) + "Y").encode("utf-8", "surrogatepass")
-    assert safe_unicode_encode(encoded) == "XY"
+    assert safe_encode_text(encoded) == "XY"
 
 
 def test_sanitize_data_frame():
     df = pd.DataFrame({"=bad" + chr(0xDC00): ["=cmd()", "ok" + chr(0xD800)]})
-    cleaned = sanitize_data_frame(df)
+    cleaned = sanitize_dataframe(df)
     assert list(cleaned.columns) == ["bad"]
     assert cleaned.iloc[0, 0] == "cmd()"
     assert cleaned.iloc[1, 0] == "ok"
@@ -35,10 +34,10 @@ def test_sanitize_data_frame():
 def test_unicode_processor_thread_safety():
     df = pd.DataFrame({"=bad": ["=cmd()" + chr(0xD800), "ok"]})
 
-    expected = sanitize_data_frame(df)
+    expected = sanitize_dataframe(df)
 
     def worker(_: int) -> pd.DataFrame:
-        return sanitize_data_frame(df)
+        return sanitize_dataframe(df)
 
     with ThreadPoolExecutor(max_workers=5) as exc:
         results = list(exc.map(worker, range(10)))
@@ -50,14 +49,14 @@ def test_unicode_processor_thread_safety():
 
 def test_clean_surrogate_control_nfkc():
     text = "Ａ" + "😀" + "\x00" + chr(0xD800) + "B" + "\u212B"
-    result = safe_unicode_encode(text)
+    result = safe_encode_text(text)
     # emoji should survive, others cleaned
     assert result == "A😀BÅ"
 
 
 def test_dataframe_sanitization_edge_cases():
     df = pd.DataFrame({"=bad\x00": ["=cmd" + chr(0xD800), "\x07\u212B"]})
-    cleaned = sanitize_data_frame(df)
+    cleaned = sanitize_dataframe(df)
     assert list(cleaned.columns) == ["bad"]
     assert cleaned.iloc[0, 0] == "cmd"
     assert cleaned.iloc[1, 0] == "Å"
@@ -65,8 +64,8 @@ def test_dataframe_sanitization_edge_cases():
 
 def test_safe_decode_encode_no_errors():
     data = ("X" + chr(0xD800) + "Y").encode("utf-8", "surrogatepass")
-    decoded = safe_decode(data)
-    encoded = safe_encode(decoded + chr(0xDFFF))
+    decoded = safe_decode_bytes(data)
+    encoded = safe_encode_text(decoded + chr(0xDFFF))
     assert isinstance(decoded, str) and isinstance(encoded, str)
     assert "\ud800" not in decoded and "\udfff" not in encoded
 
@@ -90,7 +89,7 @@ def test_unicode_security_validator():
 
 def test_dataframe_nested_values_cleaned():
     df = pd.DataFrame({"col": [{"a": "ok" + chr(0xD800)}]})
-    cleaned = sanitize_data_frame(df)
+    cleaned = sanitize_dataframe(df)
     assert cleaned.iloc[0, 0]["a"] == "ok"
 
 
@@ -100,6 +99,6 @@ def test_sanitize_dataframe_benchmark():
     df = pd.DataFrame({"=col": ["=1"] * 100})
     start = time.time()
     for _ in range(100):
-        sanitize_data_frame(df)
+        sanitize_dataframe(df)
     assert time.time() - start < 5
 

--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -11,11 +11,7 @@ from core.unicode import (
     clean_unicode_surrogates,
     clean_unicode_text,
     contains_surrogates,
-    handle_surrogate_characters,
-    safe_decode,
-    safe_encode,
     safe_encode_text,
-    sanitize_data_frame,
     sanitize_dataframe,
     sanitize_unicode_input,
 )

--- a/tests/test_upload_fix.py
+++ b/tests/test_upload_fix.py
@@ -20,7 +20,7 @@ if str(stub_dir) not in sys.path:
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from pages import file_upload
 from components.upload import UnifiedUploadComponent
-from core.unicode import safe_unicode_encode
+from core.unicode import safe_encode_text
 
 
 @pytest.fixture
@@ -67,6 +67,6 @@ def test_file_upload_component_integration(_skip_if_no_chromedriver, dash_duo, t
 
 def test_safe_unicode_encode_edge_cases():
     bytes_val = "X".encode("utf-8") + "\ud83d".encode("utf-8", "surrogatepass")
-    assert safe_unicode_encode(bytes_val) == "X"
-    assert safe_unicode_encode("A" + chr(0xD800) + "B") == "AB"
-    assert safe_unicode_encode(None) == ""
+    assert safe_encode_text(bytes_val) == "X"
+    assert safe_encode_text("A" + chr(0xD800) + "B") == "AB"
+    assert safe_encode_text(None) == ""

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional, Dict, Iterable
 
-from core.unicode_processor import safe_unicode_encode
+from core.unicode_processor import safe_encode_text
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +36,11 @@ def check_navbar_assets(
         filename = f"{name}.png"
         path = NAVBAR_ICON_DIR / filename
         exists = path.is_file()
-        results[safe_unicode_encode(name)] = exists
+        results[safe_encode_text(name)] = exists
         if warn and not exists:
             logger.warning(
                 "Navbar icon missing: %s",
-                safe_unicode_encode(str(path)),
+                safe_encode_text(str(path)),
             )
     return results
 
@@ -87,7 +87,7 @@ def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = Tru
             alt=alt,
         )
     if warn:
-        logger.warning("Missing navbar icon: %s", safe_unicode_encode(filename))
+        logger.warning("Missing navbar icon: %s", safe_encode_text(filename))
     return html.Span(fallback_text, className="nav-icon nav-icon--fallback")
 
 


### PR DESCRIPTION
## Summary
- switch services and tests to `safe_encode_text`, `safe_decode_bytes`, and `sanitize_dataframe`
- route legacy upload helper to new helper
- update asset debug utilities

## Testing
- `pytest -q` *(fails: 112 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0d725088320a7a745551ed0c7df