### PR TITLE
Refactor TestContainerBuilder stubs

### DIFF
--- a/tests/builders.py
+++ b/tests/builders.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import os
-import pathlib
-import sys
-import types
 from typing import Any, Dict
 
 import pandas as pd
@@ -16,32 +13,21 @@ from core.service_container import ServiceContainer
 class TestContainerBuilder:
     """Helper for constructing ServiceContainer instances for tests."""
 
+
     def __init__(self) -> None:
         self._container = ServiceContainer()
-        self._stub_modules()
 
     # ------------------------------------------------------------------
-    def _stub_modules(self) -> None:
-        """Insert minimal stubs for heavy optional dependencies."""
-        dash_mod = types.ModuleType("dash")
-        dash_dash_mod = types.ModuleType("dash.dash")
-        dash_dash_mod.no_update = object()
-        sys.modules.setdefault("dash", dash_mod)
-        sys.modules.setdefault("dash.dash", dash_dash_mod)
-        sys.modules.setdefault("bleach", types.ModuleType("bleach"))
-        sqlparse_mod = types.ModuleType("sqlparse")
-        sqlparse_mod.tokens = object()
-        sys.modules.setdefault("sqlparse", sqlparse_mod)
+    def with_dash_stubs(self) -> "TestContainerBuilder":
+        class _Dash:
+            no_update = object()
 
-        services_pkg = types.ModuleType("services")
-        services_pkg.__path__ = [
-            str(pathlib.Path(__file__).resolve().parents[1] / "services")
-        ]
-        sys.modules.setdefault("services", services_pkg)
+        self._container.register_singleton("dash", _Dash)
+        return self
 
-        analytics_stub = types.ModuleType("services.analytics_service")
-
-        class StubAnalyticsService(AnalyticsServiceProtocol):
+    # ------------------------------------------------------------------
+    def with_fake_analytics_service(self) -> "TestContainerBuilder":
+        class FakeAnalyticsService(AnalyticsServiceProtocol):
             def get_dashboard_summary(self) -> Dict[str, Any]:
                 return {}
 
@@ -56,16 +42,17 @@ class TestContainerBuilder:
             ) -> Dict[str, Any]:
                 return {}
 
-        analytics_stub.AnalyticsService = StubAnalyticsService
-        sys.modules.setdefault("services.analytics_service", analytics_stub)
+        self._container.register_singleton(
+            "analytics_service",
+            FakeAnalyticsService,
+            protocol=AnalyticsServiceProtocol,
+        )
+        return self
 
-        upload_reg_stub = types.ModuleType("services.upload.service_registration")
-
-        def _register_upload_services(container: ServiceContainer) -> None:
-            container.register_singleton("upload_processor", object)
-
-        upload_reg_stub.register_upload_services = _register_upload_services
-        sys.modules.setdefault("services.upload.service_registration", upload_reg_stub)
+    # ------------------------------------------------------------------
+    def with_upload_services(self) -> "TestContainerBuilder":
+        self._container.register_singleton("upload_processor", object)
+        return self
 
     # ------------------------------------------------------------------
     def with_env_defaults(self) -> "TestContainerBuilder":

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -37,7 +37,13 @@ class TestProtocolCompliance:
 
     def test_all_registered_services_implement_protocols(self):
         container = (
-            TestContainerBuilder().with_env_defaults().with_all_services().build()
+            TestContainerBuilder()
+            .with_env_defaults()
+            .with_all_services()
+            .with_fake_analytics_service()
+            .with_upload_services()
+            .with_dash_stubs()
+            .build()
         )
         results = container.validate_registrations()
         assert len(results["protocol_violations"]) == 0

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -6,7 +6,15 @@ from tests.builders import TestContainerBuilder
 class TestServiceIntegration:
     @pytest.fixture
     def configured_container(self):
-        return TestContainerBuilder().with_env_defaults().with_all_services().build()
+        return (
+            TestContainerBuilder()
+            .with_env_defaults()
+            .with_all_services()
+            .with_fake_analytics_service()
+            .with_upload_services()
+            .with_dash_stubs()
+            .build()
+        )
 
     def test_analytics_uses_database_protocol(self, configured_container):
         analytics = configured_container.get("analytics_service")


### PR DESCRIPTION
## Summary
- remove module stubbing from TestContainerBuilder
- add builder helpers to register test doubles
- update tests to use new helpers

## Testing
- `pytest -q` *(fails: 111 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ce254c9608320a4cd54e3e0ab6d43