### PR TITLE
Add environment defaults fixture for tests

### DIFF
--- a/tests/builders.py
+++ b/tests/builders.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
 import types
@@ -69,15 +68,7 @@ class TestContainerBuilder:
 
     # ------------------------------------------------------------------
     def with_env_defaults(self) -> "TestContainerBuilder":
-        for var in [
-            "SECRET_KEY",
-            "DB_PASSWORD",
-            "AUTH0_CLIENT_ID",
-            "AUTH0_CLIENT_SECRET",
-            "AUTH0_DOMAIN",
-            "AUTH0_AUDIENCE",
-        ]:
-            os.environ.setdefault(var, "test")
+        """Retained for backward compatibility (no-op)."""
         return self
 
     # ------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,21 @@ def sample_doors() -> list[Door]:
     ]
 
 
+@pytest.fixture(autouse=True)
+def env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide default environment variables for tests."""
+    required = {
+        "SECRET_KEY": "test",
+        "DB_PASSWORD": "pwd",
+        "AUTH0_CLIENT_ID": "cid",
+        "AUTH0_CLIENT_SECRET": "secret",
+        "AUTH0_DOMAIN": "domain",
+        "AUTH0_AUDIENCE": "aud",
+    }
+    for key, value in required.items():
+        monkeypatch.setenv(key, value)
+
+
 @pytest.fixture
 def mock_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setup required authentication environment variables"""

--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,5 +1,4 @@
 import importlib.util
-import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,15 +19,6 @@ from services.analytics_service import AnalyticsService
 
 
 def test_container_initializes_without_circular_dependencies():
-    for var in [
-        "SECRET_KEY",
-        "DB_PASSWORD",
-        "AUTH0_CLIENT_ID",
-        "AUTH0_CLIENT_SECRET",
-        "AUTH0_DOMAIN",
-        "AUTH0_AUDIENCE",
-    ]:
-        os.environ.setdefault(var, "test")
     container = Container()
     cfg = ConfigManager()
     analytics = AnalyticsService()

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -36,9 +36,7 @@ class TestProtocolCompliance:
             assert hasattr(SecurityValidator, method)
 
     def test_all_registered_services_implement_protocols(self):
-        container = (
-            TestContainerBuilder().with_env_defaults().with_all_services().build()
-        )
+        container = TestContainerBuilder().with_all_services().build()
         results = container.validate_registrations()
         assert len(results["protocol_violations"]) == 0
         assert len(results["missing_dependencies"]) == 0

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -6,7 +6,7 @@ from tests.builders import TestContainerBuilder
 class TestServiceIntegration:
     @pytest.fixture
     def configured_container(self):
-        return TestContainerBuilder().with_env_defaults().with_all_services().build()
+        return TestContainerBuilder().with_all_services().build()
 
     def test_analytics_uses_database_protocol(self, configured_container):
         analytics = configured_container.get("analytics_service")

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -1,4 +1,3 @@
-import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -6,16 +5,6 @@ from config.config import ConfigManager
 from core.container import Container as DIContainer
 from core.plugins.manager import ThreadSafePluginManager
 from services.data_processing.core.protocols import PluginMetadata
-
-for var in [
-    "SECRET_KEY",
-    "DB_PASSWORD",
-    "AUTH0_CLIENT_ID",
-    "AUTH0_CLIENT_SECRET",
-    "AUTH0_DOMAIN",
-    "AUTH0_AUDIENCE",
-]:
-    os.environ.setdefault(var, "test")
 
 
 class ConcurrencyPlugin:

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -9,7 +9,6 @@ class EnumJSONProvider(DefaultJSONProvider):
         if isinstance(o, enum.Enum):
             return o.name
         return super().default(o)
-import os
 import sys
 
 from config.config import ConfigManager
@@ -52,12 +51,6 @@ class DummyPlugin:
 
 
 def test_registry_registration_and_service():
-    os.environ.setdefault("SECRET_KEY", "test")
-    os.environ.setdefault("DB_PASSWORD", "pwd")
-    os.environ.setdefault("AUTH0_CLIENT_ID", "cid")
-    os.environ.setdefault("AUTH0_CLIENT_SECRET", "csecret")
-    os.environ.setdefault("AUTH0_DOMAIN", "domain")
-    os.environ.setdefault("AUTH0_AUDIENCE", "aud")
     app = Dash(__name__)
     container = DIContainer()
     cfg = ConfigManager()
@@ -71,12 +64,6 @@ def test_registry_registration_and_service():
 
 
 def test_auto_discovery_and_health_endpoint(tmp_path):
-    os.environ.setdefault("SECRET_KEY", "test")
-    os.environ.setdefault("DB_PASSWORD", "pwd")
-    os.environ.setdefault("AUTH0_CLIENT_ID", "cid")
-    os.environ.setdefault("AUTH0_CLIENT_SECRET", "csecret")
-    os.environ.setdefault("AUTH0_DOMAIN", "domain")
-    os.environ.setdefault("AUTH0_AUDIENCE", "aud")
     pkg = tmp_path / "auto_pkg"
     pkg.mkdir()
     (pkg / "__init__.py").write_text("")
@@ -115,12 +102,6 @@ def create_plugin():
 
 def test_validate_plugin_dependencies():
     """Ensure dependency validation reports missing dependencies."""
-    os.environ.setdefault("SECRET_KEY", "test")
-    os.environ.setdefault("DB_PASSWORD", "pwd")
-    os.environ.setdefault("AUTH0_CLIENT_ID", "cid")
-    os.environ.setdefault("AUTH0_CLIENT_SECRET", "csecret")
-    os.environ.setdefault("AUTH0_DOMAIN", "domain")
-    os.environ.setdefault("AUTH0_AUDIENCE", "aud")
     app = Dash(__name__)
     auto = PluginAutoConfiguration(app)
 


### PR DESCRIPTION
## Summary
- add an autoused `env_defaults` fixture so every test has required environment variables
- clean up builder utility and tests to stop setting environment variables directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686ce25e46e483209fac393ec6b0ea25