### PR TITLE
Refactor UploadDataService access

### DIFF
--- a/services/analytics_processing.py
+++ b/services/analytics_processing.py
@@ -10,6 +10,7 @@ from core.unicode_utils import sanitize_for_utf8
 from services import get_analytics_service
 from services.ai_suggestions import generate_column_suggestions
 from services.upload_data_service import get_uploaded_data
+from services.interfaces import get_upload_data_service
 from utils.preview_utils import serialize_dataframe_preview
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ def process_suggests_analysis(data_source: str) -> Dict[str, Any]:
             filename = None
             if data_source.startswith("upload:"):
                 filename = data_source.replace("upload:", "")
-            uploaded_files = get_uploaded_data()
+            uploaded_files = get_uploaded_data(get_upload_data_service())
             if not uploaded_files:
                 return {"error": "No uploaded files found"}
             if filename is None or filename not in uploaded_files:
@@ -161,7 +162,7 @@ def process_quality_analysis(data_source: str) -> Dict[str, Any]:
             filename = None
             if data_source.startswith("upload:"):
                 filename = data_source.replace("upload:", "")
-            uploaded_files = get_uploaded_data()
+            uploaded_files = get_uploaded_data(get_upload_data_service())
             if not uploaded_files:
                 return {"error": "No uploaded files found"}
             if filename is None or filename not in uploaded_files:
@@ -197,7 +198,7 @@ def create_data_quality_display(data_source: str) -> html.Div | dbc.Card | dbc.A
     try:
         if data_source.startswith("upload:"):
             filename = data_source.replace("upload:", "")
-            uploaded_files = get_uploaded_data()
+            uploaded_files = get_uploaded_data(get_upload_data_service())
             if filename in uploaded_files:
                 df = uploaded_files[filename]
                 total_rows = len(df)
@@ -242,7 +243,7 @@ def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str,
             filename = None
             if data_source.startswith("upload:"):
                 filename = data_source.replace("upload:", "")
-            uploaded_files = get_uploaded_data()
+            uploaded_files = get_uploaded_data(get_upload_data_service())
             if not uploaded_files:
                 return {"error": "No uploaded files found"}
             if filename is None or filename not in uploaded_files:

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -150,8 +150,9 @@ class AnalyticsService(AnalyticsServiceProtocol):
         # FORCE CHECK: If uploaded data exists, use it regardless of source
         try:
             from services.upload_data_service import get_uploaded_data
+            from services.interfaces import get_upload_data_service
 
-            uploaded_data = get_uploaded_data()
+            uploaded_data = get_uploaded_data(get_upload_data_service())
 
             if uploaded_data and source in ["uploaded", "sample"]:
                 logger.info(f"Forcing uploaded data usage (source was: {source})")

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover - optional AI suggestions
         return {}
 from security.unicode_security_handler import UnicodeSecurityHandler
 from utils.preview_utils import serialize_dataframe_preview
+from services.interfaces import get_upload_data_service
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
     try:
         from services.upload_data_service import get_uploaded_data  # lazy import
 
-        uploaded_files = get_uploaded_data()
+        uploaded_files = get_uploaded_data(get_upload_data_service())
         for filename in uploaded_files.keys():
             options.append({"label": f"File: {filename}", "value": f"upload:{filename}"})
     except Exception:
@@ -72,7 +73,7 @@ def get_latest_uploaded_source_value() -> Optional[str]:
     try:
         from services.upload_data_service import get_uploaded_filenames  # lazy import
 
-        filenames = get_uploaded_filenames()
+        filenames = get_uploaded_filenames(get_upload_data_service())
         if filenames:
             return f"upload:{filenames[-1]}"
     except ImportError as exc:  # pragma: no cover - best effort

--- a/services/summary_reporting.py
+++ b/services/summary_reporting.py
@@ -34,8 +34,11 @@ class SummaryReporter:
 
         try:
             from services.upload_data_service import get_uploaded_filenames
+            from services.interfaces import get_upload_data_service
 
-            health["uploaded_files"] = len(get_uploaded_filenames())
+            health["uploaded_files"] = len(
+                get_uploaded_filenames(get_upload_data_service())
+            )
         except ImportError:
             health["uploaded_files"] = "not_available"
         return health
@@ -45,8 +48,9 @@ class SummaryReporter:
         options = [{"label": "Sample Data", "value": "sample"}]
         try:
             from services.upload_data_service import get_uploaded_filenames
+            from services.interfaces import get_upload_data_service
 
-            uploaded_files = get_uploaded_filenames()
+            uploaded_files = get_uploaded_filenames(get_upload_data_service())
             if uploaded_files:
                 options.append(
                     {
@@ -80,8 +84,11 @@ class SummaryReporter:
         }
         try:
             from services.upload_data_service import get_uploaded_filenames
+            from services.interfaces import get_upload_data_service
 
-            status["uploaded_files"] = len(get_uploaded_filenames())
+            status["uploaded_files"] = len(
+                get_uploaded_filenames(get_upload_data_service())
+            )
         except ImportError:
             status["uploaded_files"] = 0
         return status

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -3,7 +3,11 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from services.interfaces import UploadDataServiceProtocol
+from services.interfaces import (
+    UploadDataServiceProtocol,
+    get_upload_data_service,
+)
+from core.enhanced_container import ServiceContainer
 from utils.upload_store import uploaded_data_store, UploadedDataStore
 
 
@@ -32,29 +36,54 @@ class UploadDataService(UploadDataServiceProtocol):
     def load_dataframe(self, filename: str) -> pd.DataFrame:
         return self.store.load_dataframe(filename)
 
-
-# Default service used by module-level helper functions
-_default_service = UploadDataService()
-
-
-def get_uploaded_data() -> Dict[str, pd.DataFrame]:
-    return _default_service.get_uploaded_data()
-
-
-def get_uploaded_filenames() -> List[str]:
-    return _default_service.get_uploaded_filenames()
+def _resolve_service(
+    service: UploadDataServiceProtocol | None,
+    container: ServiceContainer | None,
+) -> UploadDataServiceProtocol:
+    if service is not None:
+        return service
+    return get_upload_data_service(container)
 
 
-def clear_uploaded_data() -> None:
-    _default_service.clear_uploaded_data()
+def get_uploaded_data(
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> Dict[str, pd.DataFrame]:
+    svc = _resolve_service(service, container)
+    return svc.get_uploaded_data()
 
 
-def get_file_info() -> Dict[str, Dict[str, Any]]:
-    return _default_service.get_file_info()
+def get_uploaded_filenames(
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> List[str]:
+    svc = _resolve_service(service, container)
+    return svc.get_uploaded_filenames()
 
 
-def load_dataframe(filename: str) -> pd.DataFrame:
-    return _default_service.load_dataframe(filename)
+def clear_uploaded_data(
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> None:
+    svc = _resolve_service(service, container)
+    svc.clear_uploaded_data()
+
+
+def get_file_info(
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> Dict[str, Dict[str, Any]]:
+    svc = _resolve_service(service, container)
+    return svc.get_file_info()
+
+
+def load_dataframe(
+    filename: str,
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> pd.DataFrame:
+    svc = _resolve_service(service, container)
+    return svc.load_dataframe(filename)
 
 
 __all__ = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,18 @@ def di_container() -> Container:
 
 
 @pytest.fixture
+def upload_data_service(tmp_path: Path):
+    """Provide a fresh ``UploadDataService`` backed by a temp store."""
+
+    from utils.upload_store import UploadedDataStore
+    from services.upload_data_service import UploadDataService
+
+    store = UploadedDataStore(storage_dir=tmp_path)
+    service = UploadDataService(store)
+    yield service
+
+
+@pytest.fixture
 def sample_access_data() -> pd.DataFrame:
     """Sample access data for testing"""
 


### PR DESCRIPTION
## Summary
- remove `_default_service` global and refactor helper functions to resolve services through `ServiceContainer`
- update callers to request a service explicitly
- add fixture `upload_data_service` for tests

## Testing
- `pytest -q` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ce24f3248832080482ae10a568ff5