### PR TITLE
Refactor stubs into fixtures

### DIFF
--- a/tests/components/test_nav_icon.py
+++ b/tests/components/test_nav_icon.py
@@ -1,9 +1,12 @@
+import pytest
 from dash import html
 import sys
 import types
 
 from components.ui.navbar import _nav_icon
 from tests.fake_navbar_factory import FakeNavbarFactory
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 if "core.unicode_processor" not in sys.modules:
     stub = types.ModuleType("core.unicode_processor")

--- a/tests/components/test_ui_callback_helpers.py
+++ b/tests/components/test_ui_callback_helpers.py
@@ -1,5 +1,5 @@
 from unittest import mock
-
+import pytest
 import dash
 
 from components.column_verification import (
@@ -15,6 +15,8 @@ from components.simple_device_mapping import (
 from components.simple_device_mapping import (
     register_callbacks as register_device_callbacks,
 )
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 
 def test_toggle_custom_field():

--- a/tests/components/test_verification_modals.py
+++ b/tests/components/test_verification_modals.py
@@ -1,5 +1,8 @@
+import pytest
 import dash_bootstrap_components as dbc
 from dash import dcc, html
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
 from components.column_verification import create_column_verification_modal
 from components.device_verification import create_device_verification_modal

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 
 from dash import Dash, html
 
@@ -7,6 +8,8 @@ from core.container import Container as DIContainer
 from core.plugins.auto_config import setup_plugins
 from tests.test_auto_configuration import _set_env
 from tests.utils.plugin_package_builder import PluginPackageBuilder
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 
 def test_plugin_discovery_and_callback_registration(monkeypatch, tmp_path):

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -1,3 +1,4 @@
+import pytest
 import dash
 import dash_bootstrap_components as dbc
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
@@ -6,6 +7,8 @@ from dash import dcc, html
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 from pages import file_upload
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
 
 def _create_upload_app():

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 from dash import Dash, Input, Output
 
@@ -10,6 +11,8 @@ from core.plugins.auto_config import setup_plugins
 from core.plugins.callback_unifier import CallbackUnifier
 from core.plugins.decorators import safe_callback
 from services.data_processing.core.protocols import PluginMetadata
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 REQUIRED_VARS = [
     "SECRET_KEY",

--- a/tests/test_callback_helpers.py
+++ b/tests/test_callback_helpers.py
@@ -4,6 +4,8 @@ import dash_bootstrap_components as dbc
 import pytest
 from dash import html
 
+pytestmark = pytest.mark.usefixtures("fake_dbc")
+
 import pages.deep_analytics.callbacks as cb
 
 

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -1,9 +1,12 @@
+import pytest
 import dash
 from dash import Input, Output
 
 from core.callback_registry import CallbackRegistry
 from core.plugins.decorators import unified_callback
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 
 def test_unified_decorator_with_coordinator():

--- a/tests/test_dash_pages.py
+++ b/tests/test_dash_pages.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 
+import pytest
 import dash
 import dash_bootstrap_components as dbc
 import pandas as pd
@@ -13,6 +14,8 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from pages import file_upload
 from pages.deep_analytics import layout as analytics_layout
 from pages.deep_analytics import register_callbacks as register_analytics_callbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
 
 def _create_upload_app():

--- a/tests/test_device_mapping_save.py
+++ b/tests/test_device_mapping_save.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 
+import pytest
 import dash_bootstrap_components as dbc
 import pandas as pd
 
@@ -9,6 +10,8 @@ from upload_core import UploadCore
 from utils.upload_store import UploadedDataStore
 from services.device_learning_service import DeviceLearningService
 from tests.fakes import FakeUploadDataService
+
+pytestmark = pytest.mark.usefixtures("fake_dbc")
 
 
 def _encode_df(df: pd.DataFrame) -> str:

--- a/tests/test_master_callback_system.py
+++ b/tests/test_master_callback_system.py
@@ -1,8 +1,11 @@
+import pytest
 from dash import Dash
 from dash.dependencies import Input, Output
 
 from core.master_callback_system import MasterCallbackSystem
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 
 def test_mcs_is_wrapper():

--- a/tests/test_security_display_fix.py
+++ b/tests/test_security_display_fix.py
@@ -1,6 +1,9 @@
+import pytest
 import dash_bootstrap_components as dbc
 
 from pages.deep_analytics.analysis import create_analysis_results_display
+
+pytestmark = pytest.mark.usefixtures("fake_dbc")
 
 
 def test_security_display_fix():

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -1,8 +1,11 @@
+import pytest
 import dash
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Output, Input
 
 from core.theme_manager import apply_theme_settings, sanitize_theme, DEFAULT_THEME
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
 
 def create_theme_app():

--- a/tests/test_unified_callback_coordinator.py
+++ b/tests/test_unified_callback_coordinator.py
@@ -4,6 +4,8 @@ from dash import Dash, Input, Output
 from core.callback_events import CallbackEvent
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
+pytestmark = pytest.mark.usefixtures("fake_dash")
+
 
 def test_duplicate_callback_registration():
     app = Dash(__name__)

--- a/tests/test_unified_callback_manager.py
+++ b/tests/test_unified_callback_manager.py
@@ -1,7 +1,10 @@
+import pytest
 from dash import Dash
 
 from core import TrulyUnifiedCallbacks
 from core.error_handling import error_handler
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 
 def test_execute_group_with_errors_and_retry():

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -1,4 +1,5 @@
 import enum
+import pytest
 
 from dash import Dash, html
 from flask.json.provider import DefaultJSONProvider
@@ -16,6 +17,8 @@ from config.config import ConfigManager
 from core.container import Container as DIContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.plugins.unified_registry import UnifiedPluginRegistry
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 from services.data_processing.core.protocols import PluginMetadata
 
 

--- a/tests/utils/test_assets_utils.py
+++ b/tests/utils/test_assets_utils.py
@@ -1,7 +1,10 @@
+import pytest
 import dash
 import importlib.util
 from pathlib import Path
 from flask import Flask
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
 
 spec = importlib.util.spec_from_file_location(
     "assets_utils", Path(__file__).resolve().parents[2] / "utils" / "assets_utils.py"


### PR DESCRIPTION
## Summary
- remove global path and module stubs from `conftest`
- provide reusable `fake_dash` and `fake_dbc` fixtures
- mark tests to request these new fixtures

## Testing
- `pytest tests/test_master_callback_system.py::test_mcs_is_wrapper -q` *(fails: numpy.dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_686ce256e9a883208097c1a6a27d5e29