### PR TITLE
Fix core container test import

### DIFF
--- a/tests/di/test_container_core.py
+++ b/tests/di/test_container_core.py
@@ -1,15 +1,6 @@
-import importlib.util
-import sys
-from pathlib import Path
-from types import ModuleType
 from unittest.mock import Mock
 
-ROOT = Path(__file__).resolve().parents[2]
-spec = importlib.util.spec_from_file_location("container", ROOT / "core" / "container.py")
-module = importlib.util.module_from_spec(spec)
-sys.modules["container"] = module
-spec.loader.exec_module(module)  # type: ignore
-Container = module.Container
+from core.container import Container
 
 
 def test_container_initialization():


### PR DESCRIPTION
## Summary
- remove dynamic import logic from `test_container_core`
- import `Container` straight from `core.container`

## Testing
- `pytest -q tests/di/test_container_core.py`

------
https://chatgpt.com/codex/tasks/task_e_686ced0891f48320bf5c1473c64f6752