### PR TITLE
Refactor session timeout tests

### DIFF
--- a/tests/session_tests/test_session_lifetime.py
+++ b/tests/session_tests/test_session_lifetime.py
@@ -1,43 +1,65 @@
 import sys
 from pathlib import Path
-import types
 from dataclasses import dataclass, field
 from typing import Dict
 from flask import Flask, session
+
+from core.protocols import ConfigurationProtocol
 
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 @dataclass
-class SecurityConfig:
+class FakeSecurityConfig:
     session_timeout: int = 3600
     session_timeout_by_role: Dict[str, int] = field(default_factory=dict)
 
-def _setup_fake_config(cfg):
-    pkg = types.ModuleType("config")
-    sub = types.ModuleType("config.config")
-    sub.get_security_config = lambda: cfg
-    pkg.config = sub
-    sys.modules["config"] = pkg
-    sys.modules["config.config"] = sub
 
-_setup_fake_config(SecurityConfig())
+class FakeConfiguration(ConfigurationProtocol):
+    """Minimal configuration stub for session tests."""
+
+    def __init__(self, security: FakeSecurityConfig | None = None) -> None:
+        self.security = security or FakeSecurityConfig()
+
+    def get_database_config(self) -> dict:
+        return {}
+
+    def get_app_config(self) -> dict:
+        return {}
+
+    def get_security_config(self) -> FakeSecurityConfig:
+        return self.security
+
+    def get_upload_config(self) -> dict:
+        return {}
+
+    def reload_config(self) -> None:
+        pass
+
+    def validate_config(self) -> dict:
+        return {"valid": True}
+
 from core.auth import User, _determine_session_timeout, _apply_session_timeout
 
 
 def test_determine_session_timeout(monkeypatch):
-    cfg = SecurityConfig(session_timeout=3600,
-                         session_timeout_by_role={"admin": 7200, "basic": 1800})
-    monkeypatch.setattr("core.auth.get_security_config", lambda: cfg)
+    cfg = FakeConfiguration(
+        FakeSecurityConfig(
+            session_timeout=3600,
+            session_timeout_by_role={"admin": 7200, "basic": 1800},
+        )
+    )
+    monkeypatch.setattr("core.auth.get_security_config", cfg.get_security_config)
     assert _determine_session_timeout(["basic"]) == 1800
     assert _determine_session_timeout(["unknown"]) == 3600
     assert _determine_session_timeout(["admin", "basic"]) == 7200
 
 
 def test_apply_session_timeout_sets_flask_values(monkeypatch):
-    cfg = SecurityConfig(session_timeout=3600,
-                         session_timeout_by_role={"admin": 7200})
-    monkeypatch.setattr("core.auth.get_security_config", lambda: cfg)
+    cfg = FakeConfiguration(
+        FakeSecurityConfig(session_timeout=3600, session_timeout_by_role={"admin": 7200})
+    )
+    monkeypatch.setattr("core.auth.get_security_config", cfg.get_security_config)
     app = Flask(__name__)
     app.secret_key = "x"
     user = User("1", "Admin", "a@b.com", ["admin"])


### PR DESCRIPTION
## Summary
- remove custom module injection in `test_session_lifetime`
- add `FakeConfiguration` adhering to `ConfigurationProtocol`
- patch `get_security_config` during tests

## Testing
- `pytest tests/session_tests/test_session_lifetime.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ced0982848320a0cdf314506388d6