### PR TITLE
Refactor device mapping test

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -135,3 +135,10 @@ class FakeUnicodeProcessor(UnicodeProcessorProtocol):
             return data.decode(encoding, errors="ignore")
         except Exception:
             return ""
+
+
+class FakeGraphs:
+    """Minimal graphs substitute used in tests."""
+
+    GRAPH_FIGURES: dict[str, Any] = {}
+

--- a/tests/test_device_mapping_save.py
+++ b/tests/test_device_mapping_save.py
@@ -22,11 +22,13 @@ def _encode_df(df: pd.DataFrame) -> str:
 
 def test_immediate_confirm_after_upload(monkeypatch, tmp_path, async_runner):
     import importlib
-    import sys
-    import types
+    import pages
+    from tests.fakes import FakeGraphs
 
-    sys.modules["pages.graphs"] = types.ModuleType("pages.graphs")
-    sys.modules["pages.graphs"].GRAPH_FIGURES = {}
+    fake_graphs = FakeGraphs()
+    monkeypatch.setattr(pages, "graphs", fake_graphs, raising=False)
+    if hasattr(pages, "_pages"):
+        monkeypatch.setitem(pages._pages, "graphs", fake_graphs)
 
     file_upload = importlib.import_module("pages.file_upload")
     Callbacks = UploadCore


### PR DESCRIPTION
## Summary
- stop manipulating `sys.modules` in device mapping test
- add `FakeGraphs` test helper

## Testing
- `pytest -q tests/test_device_mapping_save.py::test_immediate_confirm_after_upload -vv` *(fails: DataProcessorProtocol is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686ced09ed5c83208c9cf371de6fdce0