### PR TITLE
refactor unicode test setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,49 +3,6 @@
 import sys
 from pathlib import Path
 import types
-if "core.unicode_processor" not in sys.modules:
-    _m = types.ModuleType("core.unicode_processor")
-
-    class Dummy:
-        pass
-
-    _m.DefaultUnicodeProcessor = Dummy
-    _m.safe_decode_bytes = lambda *a, **k: ""
-    _m.safe_encode_text = lambda *a, **k: ""
-    _m.safe_decode = lambda *a, **k: ""
-    _m.safe_encode = lambda *a, **k: ""
-    _m.sanitize_dataframe = lambda df, **k: df
-    _m.sanitize_data_frame = lambda df, **k: df
-    _m.handle_surrogate_characters = lambda t: t
-    _m.clean_unicode_surrogates = lambda t: t
-    _m.sanitize_unicode_input = lambda t: t
-    _m.contains_surrogates = lambda t: False
-    _m.process_large_csv_content = lambda *a, **k: ""
-    _m.safe_format_number = lambda v: str(v)
-    _m.UnicodeProcessor = Dummy
-    _m.ChunkedUnicodeProcessor = Dummy
-    _m.safe_unicode_encode = lambda t: t
-    _m.sanitize_unicode_input = lambda t: t
-    sys.modules["core.unicode_processor"] = _m
-
-if "core.unicode" not in sys.modules:
-    u = types.ModuleType("core.unicode")
-    u.UnicodeProcessor = Dummy
-    u.ChunkedUnicodeProcessor = Dummy
-    u.UnicodeTextProcessor = Dummy
-    u.UnicodeSQLProcessor = Dummy
-    u.UnicodeSecurityProcessor = Dummy
-    u.clean_unicode_text = lambda t: t
-    u.safe_decode_bytes = lambda *a, **k: ""
-    u.safe_encode_text = lambda *a, **k: ""
-    u.sanitize_dataframe = lambda df, **k: df
-    u.contains_surrogates = lambda t: False
-    u.process_large_csv_content = lambda *a, **k: ""
-    u.safe_format_number = lambda v: str(v)
-    u.object_count = lambda items: 0
-    u.safe_unicode_encode = lambda t: t
-    u.sanitize_unicode_input = lambda t: t
-    sys.modules["core.unicode"] = u
 
 if "dash_bootstrap_components" not in sys.modules:
     dbc_stub = types.ModuleType("dash_bootstrap_components")
@@ -70,6 +27,7 @@ from typing import Any, Generator
 import pandas as pd
 import pytest
 import asyncio
+from tests.fake_unicode_processor import FakeUnicodeProcessor
 
 try:
     from services.upload.protocols import UploadStorageProtocol
@@ -116,6 +74,13 @@ def di_container() -> Container:
     """Create DI container for tests"""
 
     return Container()
+
+
+@pytest.fixture
+def fake_unicode_processor() -> FakeUnicodeProcessor:
+    """Provide a minimal UnicodeProcessor for DI usage."""
+
+    return FakeUnicodeProcessor()
 
 
 @pytest.fixture

--- a/tests/di/test_app_factory_helpers.py
+++ b/tests/di/test_app_factory_helpers.py
@@ -9,7 +9,6 @@ from core.app_factory import (
     _register_callbacks,
     _configure_swagger,
 )
-from tests.fake_unicode_processor import FakeUnicodeProcessor
 from tests.fake_configuration import FakeConfiguration
 
 
@@ -28,20 +27,18 @@ class DummyApp:
         self.server = DummyServer()
 
 
-def _make_container() -> ServiceContainer:
+def _make_container(proc: UnicodeProcessorProtocol) -> ServiceContainer:
     container = ServiceContainer()
     container.register_singleton("config_manager", FakeConfiguration)
     container.register_singleton(
-        "unicode_processor",
-        lambda: FakeUnicodeProcessor(),
-        protocol=UnicodeProcessorProtocol,
+        "unicode_processor", lambda: proc, protocol=UnicodeProcessorProtocol
     )
     return container
 
 
-def test_initialize_plugins():
+def test_initialize_plugins(fake_unicode_processor):
     app = DummyApp()
-    container = _make_container()
+    container = _make_container(fake_unicode_processor)
     cfg = container.get("config_manager")
 
     auto_instances = []
@@ -98,9 +95,9 @@ def test_setup_layout(monkeypatch):
     assert app.layout() == "layout1"
 
 
-def test_register_callbacks(monkeypatch):
+def test_register_callbacks(monkeypatch, fake_unicode_processor):
     app = DummyApp()
-    container = _make_container()
+    container = _make_container(fake_unicode_processor)
     cfg = container.get("config_manager")
 
     calls = {}


### PR DESCRIPTION
## Summary
- remove module shims from `conftest`
- provide `fake_unicode_processor` fixture
- use fixture in DI helper tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ced0d2260832086fea229b43cb9cf