### PR TITLE
Fix cleanup script imports

### DIFF
--- a/tools/complete_callback_cleanup.py
+++ b/tools/complete_callback_cleanup.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List
+import sys
 
-from .detect_legacy_callbacks import LegacyCallbackDetector
-from .migrate_callbacks import migrate_file
+# Ensure project root is on sys.path when run as a script
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.detect_legacy_callbacks import LegacyCallbackDetector
+from tools.migrate_callbacks import migrate_file
 
 
 def scan_for_legacy_refs(path: Path) -> Dict[str, List[str]]:


### PR DESCRIPTION
## Summary
- use absolute imports in `complete_callback_cleanup.py`
- ensure it can still be executed directly by adjusting `sys.path`

## Testing
- `python tools/complete_callback_cleanup.py` *(fails: Legacy imports remain)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686cefd7ed408320aac1382f91d938a8