### PR TITLE
Refactor protocol compliance tests

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -19,7 +19,14 @@ from services.data_processing.processor import Processor
 from core.security_validator import SecurityValidator
 from services.db_analytics_helper import DatabaseAnalyticsHelper
 from services.summary_reporting import SummaryReporter
-from core.protocols import AnalyticsServiceProtocol, DatabaseProtocol, StorageProtocol
+from services.analytics.protocols import DataProcessorProtocol
+from core.protocols import (
+    AnalyticsServiceProtocol,
+    ConfigurationProtocol,
+    DatabaseProtocol,
+    EventBusProtocol,
+    StorageProtocol,
+)
 
 
 class ConfigProviderProtocol(Protocol):

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from services.upload.protocols import DeviceLearningServiceProtocol
 from typing import Protocol
+import pandas as pd
 
 
 class DeviceServiceProtocol(Protocol):

--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -18,7 +18,6 @@ from .core.processor import UploadProcessingService
 from .core.validator import ClientSideValidator as UploadValidator
 from utils.upload_store import UploadedDataStore as UploadStorage
 from .controllers.upload_controller import UnifiedUploadController as UploadController
-from .utils.file_parser import FileParser
 from .utils.unicode_handler import decode_upload_content
 from core.unicode_processor import safe_encode_text
 
@@ -34,7 +33,6 @@ __all__ = [
     "UploadValidator",
     "UploadStorage",
     "UploadController",
-    "FileParser",
     "safe_encode_text",
     "decode_upload_content",
 ]

--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -11,7 +11,7 @@ import pandas as pd
 import dash_bootstrap_components as dbc
 from dash import dash_table, dcc, html, no_update
 
-from .protocols import UploadControllerProtocol
+from ..protocols import UploadControllerProtocol
 from dash.dependencies import Input, Output
 
 logger = logging.getLogger(__name__)

--- a/services/upload/core/processor.py
+++ b/services/upload/core/processor.py
@@ -25,6 +25,7 @@ from ..protocols import (
     UploadProcessingServiceProtocol,
     UploadStorageProtocol,
     UploadValidatorProtocol,
+    DeviceLearningServiceProtocol,
 )
 
 logger = logging.getLogger(__name__)

--- a/services/upload/service_registration.py
+++ b/services/upload/service_registration.py
@@ -14,6 +14,8 @@ from services.upload.protocols import (
     FileProcessorProtocol,
     UploadControllerProtocol,
     UploadStorageProtocol,
+)
+from services.interfaces import (
     DeviceLearningServiceProtocol,
     UploadDataServiceProtocol,
 )
@@ -40,7 +42,6 @@ def register_upload_services(container: ServiceContainer) -> None:
         "upload_data_service",
         UploadDataService,
         protocol=UploadDataServiceProtocol,
-        lifetime=ServiceLifetime.SINGLETON,
     )
 
     container.register_singleton(


### PR DESCRIPTION
## Summary
- simplify service registration imports
- patch faulty service imports and configs
- rework protocol compliance tests to use DI container
- use lightweight dummies for heavy services

## Testing
- `pytest tests/test_protocol_compliance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ced0c6cdc8320a7b787d5e1ff4fee