### PR TITLE
Fix callback naming in data processing docs

### DIFF
--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -28,7 +28,7 @@ classDiagram
     UnifiedFileValidator <|-- Processor
     DataEnhancer <|-- Processor
     Processor --> AnalyticsEngine
-    AnalyticsEngine --> CallbackController
+    AnalyticsEngine --> CallbackManager
 ```
 
 This separation makes the pipeline extensible and easier to test as new data sources are added.


### PR DESCRIPTION
## Summary
- update diagram in `data_processing.md` to use `CallbackManager`

## Testing
- `isort . --check --diff`
- `black --check .`
- `flake8 .`
- `mypy --strict .`
- `bandit -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf2d533c48320ba0a4cbf27b60398