### PR TITLE
Add legacy callback migration scripts

### DIFF
--- a/tools/detect_legacy_callbacks.py
+++ b/tools/detect_legacy_callbacks.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Scan code for legacy callback controller usage."""
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+
+class LegacyCallbackDetector:
+    """Detect deprecated callback imports and method calls."""
+
+    IMPORT_RE = re.compile(
+        r"services\.data_processing\.callback_controller|callbacks\.controller"
+    )
+    INSTANTIATE_RE = re.compile(r"\bCallbackController\s*\(")
+    CALL_RE = re.compile(r"\.fire_event\s*\(")
+
+    def __init__(self) -> None:
+        self.imports: Dict[str, List[str]] = {}
+        self.instantiations: Dict[str, List[str]] = {}
+        self.calls: Dict[str, List[str]] = {}
+
+    def scan_file(self, path: Path) -> None:
+        text = path.read_text(errors="ignore")
+        imports = self.IMPORT_RE.findall(text)
+        if imports:
+            self.imports[str(path)] = imports
+        inst = self.INSTANTIATE_RE.findall(text)
+        if inst:
+            self.instantiations[str(path)] = inst
+        calls = self.CALL_RE.findall(text)
+        if calls:
+            self.calls[str(path)] = calls
+
+    def scan(self, root: Path) -> Dict[str, Dict[str, List[str]]]:
+        for py in root.rglob("*.py"):
+            if "tests" in py.parts:
+                continue
+            self.scan_file(py)
+        return {
+            "imports": self.imports,
+            "instantiations": self.instantiations,
+            "calls": self.calls,
+        }

--- a/tools/migrate_callbacks.py
+++ b/tools/migrate_callbacks.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utilities for rewriting legacy callback imports."""
+
+import difflib
+from pathlib import Path
+
+_REPLACEMENTS = {
+    "services.data_processing.callback_controller": "core.truly_unified_callbacks",
+    "callbacks.controller": "core.truly_unified_callbacks",
+}
+
+
+def migrate_file(path: Path, *, backup: bool = False, show_diff: bool = False) -> bool:
+    """Rewrite legacy callback imports in ``path``.
+
+    Returns ``True`` if the file was modified.
+    """
+    text = path.read_text()
+    new_text = text
+    for old, new in _REPLACEMENTS.items():
+        new_text = new_text.replace(old, new)
+
+    if new_text == text:
+        return False
+
+    if backup:
+        backup_path = path.with_suffix(path.suffix + ".bak")
+        backup_path.write_text(text)
+
+    path.write_text(new_text)
+
+    if show_diff:
+        diff = difflib.unified_diff(
+            text.splitlines(True),
+            new_text.splitlines(True),
+            fromfile=str(path),
+            tofile=str(path),
+        )
+        print("".join(diff))
+
+    return True


### PR DESCRIPTION
## Summary
- add LegacyCallbackDetector for scanning old callback imports and calls
- add migrate_file utility for rewriting imports to `core.truly_unified_callbacks`
- ensure complete_callback_cleanup imports new utilities

## Testing
- `black tools/detect_legacy_callbacks.py tools/migrate_callbacks.py tools/complete_callback_cleanup.py`
- `isort tools/detect_legacy_callbacks.py tools/migrate_callbacks.py tools/complete_callback_cleanup.py`
- `flake8 tools/detect_legacy_callbacks.py tools/migrate_callbacks.py tools/complete_callback_cleanup.py`
- `mypy tools/detect_legacy_callbacks.py tools/migrate_callbacks.py tools/complete_callback_cleanup.py` *(failed: Found 590 errors in 97 files)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686cf2d1a02c83208b80599e95076897