### PR TITLE
Remove importlib container loading from DI integration test

### DIFF
--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,18 +1,4 @@
-import importlib.util
-import sys
-from pathlib import Path
-from types import SimpleNamespace
-
-ROOT = Path(__file__).resolve().parents[2]
-spec = importlib.util.spec_from_file_location("container", ROOT / "core" / "container.py")
-container_module = importlib.util.module_from_spec(spec)
-sys.modules["container"] = container_module
-spec.loader.exec_module(container_module)  # type: ignore
-Container = container_module.Container
-
-sys.path.append(str(ROOT))
-
-sys.modules.setdefault("pandas", SimpleNamespace(DataFrame=object))
+from core.container import Container
 
 from config.config import ConfigManager
 from services.analytics_service import AnalyticsService


### PR DESCRIPTION
## Summary
- clean up DI container integration test
- use standard import for Container
- drop manual pandas stub and sys.path edits

## Testing
- `pytest -q tests/di/test_di_container_integration.py` *(fails: Can't instantiate abstract class AnalyticsService)*

------
https://chatgpt.com/codex/tasks/task_e_686cf2e0da7c83208b13f3616940f68a