### PR TITLE
Add builder helpers for protocol fakes

### DIFF
--- a/docs/testing_with_protocols.md
+++ b/docs/testing_with_protocols.md
@@ -28,6 +28,19 @@ container = (
 The resulting container behaves like the real application container but avoids
 loading optional dependencies.
 
+`TestContainerBuilder` also exposes helpers for registering fake services. These
+return the builder instance so calls can be chained fluently:
+
+```python
+container = (
+    TestContainerBuilder()
+    .with_configuration()
+    .with_unicode_processor()
+    .with_file_processor()
+    .build()
+)
+```
+
 ## Available Test Doubles
 
 Several fake implementations reside in `tests/fakes.py`:

--- a/tests/builders.py
+++ b/tests/builders.py
@@ -8,9 +8,20 @@ import pandas as pd
 
 from config.complete_service_registration import register_all_services
 from core.service_container import ServiceContainer
-from core.protocols import UnicodeProcessorProtocol
-from services.upload.protocols import UploadStorageProtocol
-from tests.test_doubles import InMemoryUploadStore, SimpleUnicodeProcessor
+from core.protocols import (
+    UnicodeProcessorProtocol,
+    ConfigurationProtocol,
+)
+from services.upload.protocols import (
+    UploadStorageProtocol,
+    FileProcessorProtocol,
+)
+from tests.test_doubles import InMemoryUploadStore
+from tests.fakes import (
+    FakeConfigurationService,
+    FakeFileProcessor,
+    FakeUnicodeProcessor,
+)
 
 
 class TestContainerBuilder:
@@ -34,8 +45,26 @@ class TestContainerBuilder:
     def with_unicode_processor(self) -> "TestContainerBuilder":
         self._container.register_singleton(
             "unicode_processor",
-            SimpleUnicodeProcessor,
+            FakeUnicodeProcessor,
             protocol=UnicodeProcessorProtocol,
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    def with_configuration(self, max_mb: int = 50) -> "TestContainerBuilder":
+        self._container.register_singleton(
+            "config_manager",
+            lambda: FakeConfigurationService(max_mb=max_mb),
+            protocol=ConfigurationProtocol,
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    def with_file_processor(self) -> "TestContainerBuilder":
+        self._container.register_singleton(
+            "file_processor",
+            FakeFileProcessor,
+            protocol=FileProcessorProtocol,
         )
         return self
 


### PR DESCRIPTION
## Summary
- provide fake `FileProcessorProtocol`, `ConfigurationProtocol`, and `UnicodeProcessorProtocol` support in `TestContainerBuilder`
- implement `FakeFileProcessor`
- document new helpers in testing guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686cf2e627a88320b8fce2afd631595f