### PR TITLE
Add safety check before clientside callback

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -573,6 +573,8 @@ def register_navbar_callbacks(
         def update_theme_store(value: Optional[str]):
             return sanitize_theme(value)
 
+        if manager.app is None:
+            return
         manager.app.clientside_callback(
             "function(data){if(window.setAppTheme&&data){window.setAppTheme(data);} return '';}",
             Output("theme-dummy-output", "children"),


### PR DESCRIPTION
## Summary
- ensure manager.app exists before registering clientside callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686cf7ec9b5c8320b3e34203d8a0e324