### PR TITLE
Fix runtime checks on service protocols

### DIFF
--- a/core/protocols.py
+++ b/core/protocols.py
@@ -81,6 +81,7 @@ class AnalyticsServiceProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class FileProcessorProtocol(Protocol):
     """Protocol for file processing operations"""
 
@@ -130,6 +131,7 @@ class ConfigurationProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class SerializationProtocol(Protocol):
     """Protocol for JSON serialization services"""
 
@@ -149,6 +151,7 @@ class SerializationProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class CallbackProtocol(Protocol):
     """Protocol for services that wrap and validate callbacks"""
 
@@ -163,6 +166,7 @@ class CallbackProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class ConfigProviderProtocol(Protocol):
     """Protocol for objects that supply configuration sections."""
 

--- a/services/data_processing/core/protocols.py
+++ b/services/data_processing/core/protocols.py
@@ -19,6 +19,7 @@ from typing import (
 import pandas as pd
 
 
+@runtime_checkable
 class DatabaseProtocol(Protocol):
     """Protocol defining database operations contract"""
 
@@ -38,6 +39,7 @@ class DatabaseProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class AnalyticsServiceProtocol(Protocol):
     """Protocol for analytics service operations"""
 
@@ -57,6 +59,7 @@ class AnalyticsServiceProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class FileProcessorProtocol(Protocol):
     """Protocol for file processing operations"""
 
@@ -76,6 +79,7 @@ class FileProcessorProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class ConfigurationProtocol(Protocol):
     """Protocol for configuration management"""
 
@@ -95,6 +99,7 @@ class ConfigurationProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class SerializationProtocol(Protocol):
     """Protocol for JSON serialization services"""
 
@@ -114,6 +119,7 @@ class SerializationProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class CallbackProtocol(Protocol):
     """Protocol for services that wrap and validate callbacks"""
 
@@ -128,6 +134,7 @@ class CallbackProtocol(Protocol):
         ...
 
 
+@runtime_checkable
 class AnalyticsProtocol(Protocol):
     """Protocol for analytics services"""
 
@@ -239,6 +246,7 @@ class ServicePluginProtocol(PluginProtocol, Protocol):
         ...
 
 
+@runtime_checkable
 class PluginManagerProtocol(Protocol):
     """Protocol for plugin management"""
 


### PR DESCRIPTION
## Summary
- add `@runtime_checkable` decorator to several protocol classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686cfa7be0ac832086e5f92ef95066e3