### PR TITLE
Fix unicode processor fallback

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -102,9 +102,9 @@ def get_unicode_processor() -> UnicodeProcessorProtocol:
 
     provider = container.get(UnicodeProcessorProtocol)
     if provider is None:
-        from .unicode_processor import DefaultUnicodeProcessor
+        from .unicode import UnicodeProcessor
 
-        provider = DefaultUnicodeProcessor()
+        provider = UnicodeProcessor()
         container.register(
             "unicode_processor",
             provider,


### PR DESCRIPTION
## Summary
- instantiate UnicodeProcessor in DI container

## Testing
- `pre-commit run --files core/container.py` *(fails: mypy errors in unrelated files)*
- `pytest tests/test_unicode_processor.py -k unicode_processor -q` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686cfbbea9548320a1ad58042898c9a0