### PR TITLE
Add robust text reader for tools

### DIFF
--- a/tools/legacy_unicode_audit.py
+++ b/tools/legacy_unicode_audit.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 from typing import Dict, List, Set
 
+from tools.robust_file_reader import safe_read_text
+
 
 LEGACY_MODULE = "core.unicode_utils"
 LEGACY_FUNCS: Set[str] = {
@@ -36,7 +38,7 @@ class LegacyUnicodeAudit:
 
     def scan_path(self, path: Path) -> None:
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(safe_read_text(path))
         except Exception:
             return
         for node in ast.walk(tree):

--- a/tools/protocol_extractor.py
+++ b/tools/protocol_extractor.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from tools.robust_file_reader import safe_read_text
+
 
 class StubModuleVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
@@ -170,7 +172,7 @@ def scan_tests(root: Path) -> Dict[str, Dict[str, Dict[str, object]]]:
     visitor = StubModuleVisitor()
     for path in root.rglob("*.py"):
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(safe_read_text(path))
         except Exception:
             continue
         visitor.visit(tree)

--- a/tools/robust_file_reader.py
+++ b/tools/robust_file_reader.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Utility helpers for reading text files with encoding detection."""
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+try:
+    import chardet
+except Exception:  # pragma: no cover - optional dependency
+    chardet = None  # type: ignore
+
+from core.unicode_decode import safe_unicode_decode
+
+
+def _detect_encoding(data: bytes) -> Optional[str]:
+    """Return best-guess encoding for ``data`` using ``chardet`` if available."""
+    if chardet is None:
+        return None
+    try:
+        result = chardet.detect(data)
+        return result.get("encoding")
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def safe_read_text(path: Path, *, fallback_encodings: Optional[Iterable[str]] = None) -> str:
+    """Return text from ``path`` using encoding detection and fallbacks."""
+    data = path.read_bytes()
+    encodings = []
+
+    detected = _detect_encoding(data)
+    if detected:
+        encodings.append(detected)
+
+    if fallback_encodings:
+        encodings.extend(fallback_encodings)
+
+    if "utf-8" not in encodings:
+        encodings.append("utf-8")
+
+    for encoding in encodings:
+        try:
+            return safe_unicode_decode(data, encoding)
+        except Exception:
+            continue
+
+    return safe_unicode_decode(data, "utf-8")
+
+
+__all__ = ["safe_read_text"]

--- a/tools/unicode_cleanup.py
+++ b/tools/unicode_cleanup.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+from tools.robust_file_reader import safe_read_text
 from typing import Dict, List, Tuple
 
 
@@ -24,10 +26,7 @@ def scan_legacy_references(base_dir: str = ".") -> Dict[str, List[Tuple[str, int
 
     found: Dict[str, List[Tuple[str, int]]] = {}
     for path in Path(base_dir).rglob("*.py"):
-        try:
-            text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            text = path.read_text(encoding="utf-8", errors="replace")
+        text = safe_read_text(path)
         matches: List[Tuple[str, int]] = []
         for key, pattern in patterns.items():
             for m in pattern.finditer(text):
@@ -55,7 +54,7 @@ def update_imports(base_dir: str = ".") -> Dict[str, int]:
 
     modified: Dict[str, int] = {}
     for path in Path(base_dir).rglob("*.py"):
-        text = path.read_text(encoding="utf-8")
+        text = safe_read_text(path)
         original = text
         count = 0
         for pattern, repl in replacements.items():


### PR DESCRIPTION
## Summary
- add `safe_read_text` helper to detect encoding using chardet
- switch several maintenance scripts to use the new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686cfbc00d188320bac3aca505bccad0