### PR TITLE
Fix ServiceContainer import in app_factory

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -101,7 +101,7 @@ from flask_caching import Cache
 from components.ui.navbar import create_navbar_layout
 from config.config import get_config
 from core.container import Container as DIContainer
-from core.enhanced_container import ServiceContainer
+from core.service_container import ServiceContainer
 from core.performance_monitor import DIPerformanceMonitor
 from config.complete_service_registration import register_all_application_services
 from core.plugins.auto_config import PluginAutoConfiguration


### PR DESCRIPTION
## Summary
- use ServiceContainer from `core.service_container`
- run minimal tests

## Testing
- `python3 - <<'EOF'
import os
os.environ.update({'SECRET_KEY':'test','DB_PASSWORD':'dummy','AUTH0_CLIENT_ID':'dummy','AUTH0_CLIENT_SECRET':'dummy','AUTH0_DOMAIN':'dummy','AUTH0_AUDIENCE':'dummy'})
from core.app_factory import create_app
app = create_app(mode="simple")
print("created", app is not None)
EOF`
- `pytest tests/di/test_service_container.py::test_singleton_and_transient -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfd226e308320b384ddd711231d5d