### PR TITLE
Remove Flask stubs from column standardizer test

### DIFF
--- a/tests/test_column_standardizer.py
+++ b/tests/test_column_standardizer.py
@@ -1,14 +1,6 @@
 import pandas as pd
-import sys
-import types
 
-import tests.stubs.flask as flask_stub
-
-flask_stub.request = types.SimpleNamespace(path="/")
-flask_stub.url_for = lambda *a, **k: "/"
-sys.modules["flask"] = flask_stub
-
-from utils.ai_column_mapper import standardize_column_names
+from utils.mapping_helpers import standardize_column_names
 
 
 def test_standardize_mixed_language_columns():


### PR DESCRIPTION
## Summary
- simplify `tests/test_column_standardizer.py`
- drop the Flask stub

## Testing
- `pytest -q tests/test_column_standardizer.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cfefd520483209c1df503d44bb043