### PR TITLE
Replace jose stub module with monkeypatch.setattr

### DIFF
--- a/tests/test_jwks_cache.py
+++ b/tests/test_jwks_cache.py
@@ -3,7 +3,6 @@ import io
 import json
 import logging
 import socket
-import sys
 import types
 
 import pytest
@@ -11,13 +10,15 @@ import pytest
 
 def setup_auth(monkeypatch):
     # stub jose.jwt before importing core.auth
+    import jose.jwt as orig_jwt
+
     jwt_stub = types.SimpleNamespace(
         decode=lambda *a, **kw: {"decoded": True},
         get_unverified_header=lambda token: {"kid": "testkey"},
     )
-    jose_stub = types.SimpleNamespace(jwt=jwt_stub)
-    monkeypatch.setitem(sys.modules, "jose", jose_stub)
-    monkeypatch.setitem(sys.modules, "jose.jwt", jwt_stub)
+
+    monkeypatch.setattr(orig_jwt, "decode", jwt_stub.decode)
+    monkeypatch.setattr(orig_jwt, "get_unverified_header", jwt_stub.get_unverified_header)
 
     module = importlib.import_module("core.auth")
     importlib.reload(module)


### PR DESCRIPTION
## Summary
- patch jwks tests to stub jose methods using monkeypatch.setattr

## Testing
- `PYTHONPATH=tests/stubs pytest tests/test_jwks_cache.py::test_jwks_cached -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_686cfefef5548320b0e3e6a7cc9a32b2