### PR TITLE
Remove unused FakeUploadDataService implementation

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -83,27 +83,6 @@ class FakeDeviceLearningService(DeviceLearningServiceProtocol):
         self.saved[filename] = user_mappings
         return True
 
-
-class FakeUploadDataService(UploadDataServiceProtocol):
-    def __init__(self) -> None:
-        self.store: Dict[str, pd.DataFrame] = {}
-
-    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
-        return self.store.copy()
-
-    def get_uploaded_filenames(self) -> List[str]:
-        return list(self.store.keys())
-
-    def clear_uploaded_data(self) -> None:
-        self.store.clear()
-
-    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
-        return {name: {"rows": len(df)} for name, df in self.store.items()}
-
-    def load_dataframe(self, filename: str) -> pd.DataFrame:
-        return self.store.get(filename, pd.DataFrame())
-
-
 class FakeColumnVerifier(ColumnVerifierProtocol):
     def create_column_verification_modal(self, file_info: Dict[str, Any]) -> Any:
         return {"modal": file_info}


### PR DESCRIPTION
## Summary
- keep the version of `FakeUploadDataService` that uses an injected store
- remove the duplicate implementation that created its own internal store

## Testing
- `pytest -q tests/test_process_uploaded_files.py::test_multi_part_upload_row_count -vv` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cfeff8cec83208806e60fb9adc015