### PR TITLE
Add callback migration best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ The running application exposes Swagger-based API docs at `http://<host>:<port>/
 - Callback design: [docs/callback_architecture.md](docs/callback_architecture.md)
 - State stores: [docs/state_management.md](docs/state_management.md)
 - Ops reference: [docs/operations_guide.md](docs/operations_guide.md)
+- Callback migration: [docs/migration_callback_system.md](docs/migration_callback_system.md)
 
 Update the spec by running `python tools/generate_openapi.py` which writes `docs/openapi.json` for the UI.
 ## Usage Examples

--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -33,3 +33,18 @@ python tools/complete_callback_cleanup.py
 The script scans for deprecated imports, rewrites them to use
 `TrulyUnifiedCallbacks`, validates that `services/data_processing/callback_controller.py`
 is absent and performs a simple runtime check of the new system.
+
+## Best Practices for Migration
+
+- **Always specify `callback_id` and `component_name`** when calling
+  `TrulyUnifiedCallbacks.register_callback`. Unique identifiers allow the
+  framework to detect duplicate output registrations and group callbacks by
+  namespace.
+- **Check for conflicts** using `callbacks.get_callback_conflicts()` before
+  deploying. The registry prevents accidental duplicates but reviewing the
+  report helps catch logical errors in complex pages.
+- **Enable Unicode safety** with `unicode_safe=True` or by using
+  `UnicodeAwareTrulyUnifiedCallbacks`. Surrogate pairs and non‑printable
+  characters are sanitized automatically to avoid UTF‑8 errors.
+- **Remove legacy imports** after migration and verify that tests pass. The
+  `tools/complete_callback_cleanup.py` helper can assist with large refactors.


### PR DESCRIPTION
## Summary
- document migration best practices for the TrulyUnifiedCallbacks system
- reference the new migration guide in the main README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d070e81e4832089bc7c2c45beae4a