### PR TITLE
Add troubleshooting doc for Flask CLI error

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ following steps:
    plain HTTP version from loading. Use the browser's development settings to
    clear site data, including service workers and caches, and remove any HSTS
    entries before reloading the page.
+7. If `python app.py` fails with `NameError: name '_env_file_callback' is not defined`,
+   Flask was likely installed incorrectly. Reinstall it to restore the missing
+   function:
+   ```bash
+   pip install --force-reinstall "Flask>=2.2.5"
+   ```
+   See [docs/troubleshooting.md](docs/troubleshooting.md) for details.
 
 ### Production Deployment
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+This guide covers solutions to common issues when setting up or running the dashboard.
+
+## Flask CLI NameError
+
+If running `python app.py` fails with a traceback ending in:
+
+```
+NameError: name '_env_file_callback' is not defined
+```
+
+Flask may have been installed incorrectly or corrupted. Reinstall Flask in your virtual environment:
+
+```bash
+pip install --force-reinstall "Flask>=2.2.5"
+```
+
+This restores the missing function in `flask/cli.py` and allows the dashboard to start normally.


### PR DESCRIPTION
## Summary
- add new `docs/troubleshooting.md` covering a missing `_env_file_callback`
- reference new doc from README troubleshooting section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d129e13748320bb0142d75249278a