### PR TITLE
Expose safe_callback alias

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from .decorators import safe_callback
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -28,4 +30,5 @@ __all__ = [
     "PluginAutoConfiguration",
     "EnhancedThreadSafePluginManager",
     "PLUGINS_AVAILABLE",
+    "safe_callback",
 ]

--- a/core/plugins/decorators.py
+++ b/core/plugins/decorators.py
@@ -42,8 +42,13 @@ def handle_safe(app_or_container: Any = None) -> Callable:
         return decorator
 
 
+safe_callback = handle_safe
+
+
 def handle_unified(target: Any, *cb_args: Any, **cb_kwargs: Any) -> Callable:
     """Return decorator registering callbacks on any supported target."""
     from .callback_unifier import CallbackUnifier
 
     return CallbackUnifier(target, safe_callback(target))(*cb_args, **cb_kwargs)
+__all__ = ["handle_safe", "handle_unified", "safe_callback"]
+


### PR DESCRIPTION
## Summary
- add `safe_callback` alias in decorators
- export `safe_callback` from `core.plugins`

## Testing
- `python - <<'PY'
from core.plugins.decorators import safe_callback
print('import alias works', callable(safe_callback))
from core.plugins import safe_callback as sc
print('package alias works', sc is safe_callback)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686d1c4b4adc8320aef1df876c446318