### PR TITLE
Fix callback profiling decorator

### DIFF
--- a/core/dash_profile.py
+++ b/core/dash_profile.py
@@ -4,7 +4,7 @@ import time
 from functools import wraps
 
 
-def handle_profile(callback_id: str):
+def profile_callback(callback_id: str):
     """Measure runtime of Dash callback functions."""
 
     def decorator(func):


### PR DESCRIPTION
## Summary
- rename `handle_profile` decorator to `profile_callback`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flasgger')*

------
https://chatgpt.com/codex/tasks/task_e_686d1e23e3448320bc207030dfc89155