### PR TITLE
Fix ServiceContainer import

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -102,7 +102,7 @@ from components.ui.navbar import create_navbar_layout
 from config.complete_service_registration import register_all_application_services
 from config.config import get_config
 from core.container import Container as DIContainer
-from core.enhanced_container import ServiceContainer
+from core.service_container import ServiceContainer
 from core.performance_monitor import DIPerformanceMonitor
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.secrets_manager import validate_secrets

--- a/core/protocols.py
+++ b/core/protocols.py
@@ -423,7 +423,7 @@ class UnicodeProcessorProtocol(Protocol):
         ...
 
 
-from .enhanced_container import ServiceContainer
+from .service_container import ServiceContainer
 
 
 def _get_container(

--- a/services/interfaces.py
+++ b/services/interfaces.py
@@ -90,7 +90,7 @@ class UploadDataServiceProtocol(Protocol):
 # Use the same ServiceContainer implementation as ``core.app_factory``
 # to avoid type mismatches when helpers are accessed through the
 # application-wide dependency injection container.
-from core.enhanced_container import ServiceContainer
+from core.service_container import ServiceContainer
 
 
 def _get_container(

--- a/services/upload/protocols.py
+++ b/services/upload/protocols.py
@@ -244,7 +244,7 @@ class UploadQueueManagerProtocol(Protocol):
     ) -> List[Tuple[str, Any]]: ...
 
 
-from core.enhanced_container import ServiceContainer
+from core.service_container import ServiceContainer
 
 
 def _get_container(

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -7,7 +7,7 @@ from services.interfaces import (
     UploadDataServiceProtocol,
     get_upload_data_service,
 )
-from core.enhanced_container import ServiceContainer
+from core.service_container import ServiceContainer
 from utils.upload_store import uploaded_data_store, UploadedDataStore
 
 


### PR DESCRIPTION
## Summary
- use the advanced ServiceContainer implementation

## Testing
- `pip install pandas`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flasgger')*

------
https://chatgpt.com/codex/tasks/task_e_686d1f3dfc548320ab1230e140262bd5