### PR TITLE
Fix DI container type mismatch and missing decorator import

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -102,9 +102,11 @@ from components.ui.navbar import create_navbar_layout
 from config.complete_service_registration import register_all_application_services
 from config.config import get_config
 from core.container import Container as DIContainer
-from core.enhanced_container import ServiceContainer
+# Use the protocol-aware service container for application services
+from core.service_container import ServiceContainer
 from core.performance_monitor import DIPerformanceMonitor
 from core.plugins.auto_config import PluginAutoConfiguration
+from core.plugins.decorators import safe_callback
 from core.secrets_manager import validate_secrets
 from core.theme_manager import DEFAULT_THEME, apply_theme_settings
 from dash_csrf_plugin import CSRFMode, setup_enhanced_csrf_protection


### PR DESCRIPTION
## Summary
- use ServiceContainer from `core.service_container` in app factory
- add missing import for `safe_callback` decorator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d1f5787e883209bf4f3a25a5f9ddd