### PR TITLE
Improve service container dependency analysis

### DIFF
--- a/tests/di/test_dependency_discovery.py
+++ b/tests/di/test_dependency_discovery.py
@@ -1,0 +1,41 @@
+import pytest
+
+from core.service_container import ServiceContainer
+
+
+class Foo:
+    pass
+
+
+class Bar:
+    def __init__(self, foo: Foo):
+        self.foo = foo
+
+
+class WithForwardRef:
+    def __init__(self, other: "Bar"):
+        self.other = other
+
+
+class Unresolved:
+    def __init__(self, missing: "MissingType"):
+        self.missing = missing
+
+
+def test_dependencies_resolved_using_type_hints():
+    c = ServiceContainer()
+    c.register_singleton("foo", Foo)
+    c.register_transient("bar", Bar)
+    c.register_transient("fw", WithForwardRef)
+    reg_bar = c._services["bar"]
+    reg_fw = c._services["fw"]
+    assert reg_bar.dependencies == [("foo", Foo)]
+    assert reg_fw.dependencies == [("other", Bar)]
+
+
+def test_unresolved_annotation_keeps_string():
+    c = ServiceContainer()
+    # Should not raise when registering
+    c.register_transient("un", Unresolved)
+    reg = c._services["un"]
+    assert reg.dependencies == [("missing", "MissingType")]


### PR DESCRIPTION
## Summary
- use `typing.get_type_hints` to resolve constructor annotations
- gracefully fall back when annotations can't be resolved
- test dependency discovery with normal, forward and unresolved annotations

## Testing
- `pytest tests/di/test_dependency_discovery.py -q`
- `pytest tests/di/test_service_container.py tests/di/test_dependency_discovery.py -q`
- `pytest -q` *(fails: 148 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d25c6472c83208e1b5b2e69eb21f4