### PR TITLE
Clarify security testing helper

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -46,8 +46,15 @@ __all__ = [
 
 
 def setup_isolated_security_testing() -> None:
-    """Prepare the analytics.security_patterns module for isolated security tests."""
-    # TODO: implement test setup logic
-    return None
+    """Prepare the :mod:`analytics.security_patterns` package for isolated tests.
+
+    The concrete logic has not been implemented yet. Calling this helper makes
+    it explicit that test specific setup is unavailable and raises a
+    :class:`NotImplementedError`.
+    """
+
+    raise NotImplementedError(
+        "setup_isolated_security_testing has not been implemented yet"
+    )
 
 __all__.append("setup_isolated_security_testing")

--- a/docs/model_cards.md
+++ b/docs/model_cards.md
@@ -42,6 +42,10 @@ DataFrame with access logs containing timestamps, user IDs, door IDs and results
 ### Limitations
 Requires all mandatory columns to be present. Baseline thresholds may need tuning for different deployments.
 
+For unit tests you can reset the callback manager using
+`analytics.security_patterns.setup_isolated_security_testing()`. The helper
+currently raises a `NotImplementedError` until the final setup logic is added.
+
 ## User Behavior Analyzer
 
 ### Purpose

--- a/tests/callbacks/test_security_callback_controller.py
+++ b/tests/callbacks/test_security_callback_controller.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from analytics.security_patterns import (
     SecurityEvent,
@@ -80,3 +81,9 @@ def test_analyzer_triggers_callbacks():
     events = [e[0] for e in controller.history]
     assert SecurityEvent.THREAT_DETECTED in events
     assert SecurityEvent.ANALYSIS_COMPLETE in events
+
+
+def test_setup_isolated_security_testing_not_implemented():
+    """Ensure the setup helper clearly indicates unfinished logic."""
+    with pytest.raises(NotImplementedError):
+        setup_isolated_security_testing()


### PR DESCRIPTION
## Summary
- raise NotImplementedError in `setup_isolated_security_testing`
- document usage of the helper
- test that the function raises the error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and many other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d25c988c48320aeaa11773f1da7ce