### PR TITLE
Add Bandit and Safety checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
           set -xe
           flake8 . --max-line-length 88 -v
 
+      - name: Bandit
+        run: |
+          set -xe
+          bandit -r . --severity-level high
+
+      - name: Safety
+        run: |
+          set -xe
+          safety check -r requirements.txt -r requirements-dev.txt --full-report
+
       - name: PyTest
         run: |
           set -xe


### PR DESCRIPTION
## Summary
- run bandit and safety after flake8 in CI

## Testing
- `flake8 . --max-line-length 88 -v` *(fails: command not found)*
- `pip install -r requirements.txt -r requirements-dev.txt -q` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_686d25d11a6c8320982ac2efd8f3b9c4