### PR TITLE
Add requirements-test.txt for test deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Install dependencies before running the tests:
 # Option 1: use the helper script
 ./scripts/setup.sh
 # Option 2: install packages manually
-pip install -r requirements.txt -r requirements-dev.txt
+pip install -r requirements.txt -r requirements-test.txt
 ```
 For minimal CI environments you can run `./scripts/install_test_deps.sh` which
 only installs the Python dependencies required for the tests.
@@ -715,6 +715,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines. In short:
    ```bash
    pip install -r requirements.txt
    pip install -r requirements-dev.txt
+   pip install -r requirements-test.txt
    ```
 2. Ensure all tests pass: `pytest`
 3. Format code with `black` and run `flake8`

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -11,15 +11,14 @@ python -m venv venv
 source venv/bin/activate
 ```
 
-Install the application and development requirements **before** running any
-tests:
+Install the application and test requirements **before** running any tests:
 ```bash
 pip install -r requirements.txt
-pip install -r requirements-dev.txt
+pip install -r requirements-test.txt
 ```
-Alternatively you can run `./scripts/setup.sh` to install both files at once.
-`requirements-dev.txt` includes additional packages such as **PyYAML** that are
-required by the tests but not needed in production.
+Alternatively you can run `./scripts/setup.sh` to install the standard
+dependencies. `requirements-test.txt` includes additional packages such as
+**PyYAML** that are required by the tests but not needed in production.
 
 ### Required Python Packages
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# Packages required exclusively for running the tests
+pytest==7.4.0
+pytest-cov>=2.12.0
+PyYAML>=6.0
+psutil>=5.9.0

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -4,4 +4,4 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
 
-pip install -r "$ROOT_DIR/requirements.txt" -r "$ROOT_DIR/requirements-dev.txt"
+pip install -r "$ROOT_DIR/requirements.txt" -r "$ROOT_DIR/requirements-test.txt"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,16 @@
 import sys
 import types
 from pathlib import Path
+import importlib.util
+
+
+_missing_packages = [pkg for pkg in ("yaml", "psutil") if importlib.util.find_spec(pkg) is None]
+if _missing_packages:
+    missing = ", ".join(_missing_packages)
+    raise RuntimeError(
+        f"Missing required test dependencies: {missing}. "
+        "Install them with `pip install -r requirements-test.txt`."
+    )
 
 try:  # use real package if available
     import dash_bootstrap_components  # noqa: F401


### PR DESCRIPTION
## Summary
- add `requirements-test.txt`
- document using it in `docs/test_setup.md`
- mention the file in README testing and contribution sections
- update `scripts/install_test_deps.sh` to install it
- warn in `tests/conftest.py` when test packages are missing

## Testing
- `pip install -r requirements-test.txt`
- `pip install -r requirements.txt` *(fails: building wheel for scikit-learn cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686d25d2776483208ed8f8cf47c044e8