### PR TITLE
Fix DI container import path

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -101,13 +101,10 @@ from flask_caching import Cache
 from components.ui.navbar import create_navbar_layout
 from config.complete_service_registration import register_all_application_services
 from config.config import get_config
-from core.enhanced_container import ServiceContainer
 from core.performance_monitor import DIPerformanceMonitor
 from core.plugins.decorators import safe_callback
+from core.service_container import ServiceContainer
 from core.theme_manager import DEFAULT_THEME, apply_theme_settings
-from .plugins import _initialize_plugins
-from .security import initialize_csrf
-from .health import register_health_endpoints
 from pages import get_page_layout
 from pages.deep_analytics import Callbacks as DeepAnalyticsCallbacks
 from pages.deep_analytics import layout as deep_analytics_layout
@@ -117,6 +114,10 @@ from pages.file_upload import register_callbacks as register_upload_callbacks
 from services import get_analytics_service
 from services.analytics_service import AnalyticsService
 from utils.assets_utils import ensure_icon_cache_headers
+
+from .health import register_health_endpoints
+from .plugins import _initialize_plugins
+from .security import initialize_csrf
 
 # Optional callback system -------------------------------------------------
 try:  # pragma: no cover - graceful import fallback
@@ -855,8 +856,6 @@ def _register_global_callbacks(manager: TrulyUnifiedCallbacksType) -> None:
         # Don't raise in test mode
         if "pytest" not in sys.modules:
             raise
-
-
 
 
 def _setup_layout(app: "Dash") -> None:


### PR DESCRIPTION
## Summary
- use the advanced `ServiceContainer` implementation in `app_factory`

## Testing
- `flake8 core/app_factory/__init__.py`
- `mypy core/app_factory/__init__.py` *(fails: missing dependencies)*
- `pytest -k service_container -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c1d84388320aeb93f269ca8d2bf