### PR TITLE
Fix type hints and imports

### DIFF
--- a/core/service_container.py
+++ b/core/service_container.py
@@ -33,7 +33,7 @@ class ServiceLifetime(Enum):
 class ServiceRegistration:
     service_type: Type
     implementation: Union[Type, Callable]
-    protocol: Optional[Type[Protocol]]
+    protocol: Optional[type]
     lifetime: ServiceLifetime
     factory: Optional[Callable]
     dependencies: List[tuple[str, Type]]
@@ -65,7 +65,7 @@ class ServiceContainer:
         service_key: str,
         instance: Any,
         *,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
     ) -> "ServiceContainer":
         """Compatibility helper mirroring :class:`DIContainer.register`."""
         self._services[service_key] = ServiceRegistration(
@@ -92,7 +92,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         """Register a singleton implementation or instance."""
@@ -104,7 +104,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         return self._register_service(
@@ -115,7 +115,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         return self._register_service(
@@ -127,7 +127,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]],
+        protocol: Optional[type],
         lifetime: ServiceLifetime,
         factory: Optional[Callable],
     ) -> "ServiceContainer":
@@ -191,14 +191,14 @@ class ServiceContainer:
             raise DependencyInjectionError("Unknown service lifetime")
 
     def _get_singleton(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         if key not in self._instances:
             self._instances[key] = self._create_instance(key, reg, proto)
         return self._instances[key]
 
     def _get_scoped(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         scope = self._scoped_instances.setdefault(self._current_scope, {})
         if key not in scope:
@@ -206,7 +206,7 @@ class ServiceContainer:
         return scope[key]
 
     def _create_instance(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         self._resolution_stack.append(key)
         try:

--- a/quick_audit_runner.py
+++ b/quick_audit_runner.py
@@ -40,7 +40,7 @@ def main():
     if args.conflicts_only:
         show_conflicts_only(results)
     elif args.detailed:
-        show_detailed_results(results)
+        show_detailed_results(results, auditor)
     else:
         show_quick_summary(results)
     
@@ -98,7 +98,7 @@ def show_quick_summary(results):
    3. Run detailed audit: python3 quick_audit_runner.py --detailed --save
 """)
 
-def show_detailed_results(results):
+def show_detailed_results(results, auditor: YourSystemCallbackAuditor) -> None:
     """Show detailed results"""
     print(auditor.generate_detailed_report(results))
 

--- a/run_focused_audit.py
+++ b/run_focused_audit.py
@@ -4,8 +4,12 @@ Simple runner for the focused dashboard callback audit
 This avoids the 41k file issue by targeting only your dashboard directories
 """
 
+from tailored_callback_auditor import (
+    YourSystemCallbackAuditor as FocusedDashboardAuditor,
+)
+
+
 if __name__ == "__main__":
-    from focused_dashboard_auditor import FocusedDashboardAuditor
     
     print("🎯 RUNNING FOCUSED DASHBOARD CALLBACK AUDIT")
     print("Targeting: core/, pages/, components/, services/, analytics/, plugins/")

--- a/tailored_callback_auditor.py
+++ b/tailored_callback_auditor.py
@@ -8,7 +8,7 @@ import ast
 import os
 import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Optional
+from typing import Any, Dict, List, Set, Tuple, Optional
 from dataclasses import dataclass
 from collections import defaultdict, Counter
 import json
@@ -83,7 +83,7 @@ class YourSystemCallbackAuditor:
             ]
         }
     
-    def scan_complete_codebase(self) -> Dict[str, any]:
+    def scan_complete_codebase(self) -> Dict[str, Any]:
         """Comprehensive scan of your entire codebase"""
         print("🔍 Starting comprehensive callback pattern audit...")
         
@@ -264,9 +264,10 @@ class YourSystemCallbackAuditor:
     
     def _get_decorator_source(self, decorator: ast.AST, lines: List[str]) -> str:
         """Get source code for decorator"""
-        if hasattr(decorator, 'lineno') and decorator.lineno <= len(lines):
+        lineno = getattr(decorator, 'lineno', None)
+        if lineno is not None and lineno <= len(lines):
             # Try to get the full decorator which might span multiple lines
-            start_line = decorator.lineno - 1
+            start_line = lineno - 1
             end_line = start_line
             
             # Find the full decorator by looking for the opening and closing parentheses
@@ -356,8 +357,8 @@ class YourSystemCallbackAuditor:
     
     def _extract_string_value(self, node: ast.AST) -> Optional[str]:
         """Extract string value from AST node"""
-        if isinstance(node, ast.Constant):
-            return str(node.value)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
         elif isinstance(node, ast.Str):  # Python < 3.8
             return node.s
         return None


### PR DESCRIPTION
## Summary
- fix ServiceContainer annotations
- pass auditor instance to `show_detailed_results`
- clean focused audit runner import and trailing newline
- guard AST `lineno` access and string extraction logic

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python -m mypy --config-file mypy.ini .` *(fails: found 2149 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d2e96ae408320a95b3419f098fc3b