### PR TITLE
Update protocol type hints

### DIFF
--- a/core/service_container.py
+++ b/core/service_container.py
@@ -11,7 +11,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Protocol,
     Type,
     TypeVar,
     Union,
@@ -33,7 +32,7 @@ class ServiceLifetime(Enum):
 class ServiceRegistration:
     service_type: Type
     implementation: Union[Type, Callable]
-    protocol: Optional[Type[Protocol]]
+    protocol: Optional[type]
     lifetime: ServiceLifetime
     factory: Optional[Callable]
     dependencies: List[tuple[str, Type]]
@@ -65,7 +64,7 @@ class ServiceContainer:
         service_key: str,
         instance: Any,
         *,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
     ) -> "ServiceContainer":
         """Compatibility helper mirroring :class:`DIContainer.register`."""
         self._services[service_key] = ServiceRegistration(
@@ -92,7 +91,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         """Register a singleton implementation or instance."""
@@ -104,7 +103,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         return self._register_service(
@@ -115,7 +114,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]] = None,
+        protocol: Optional[type] = None,
         factory: Optional[Callable] = None,
     ) -> "ServiceContainer":
         return self._register_service(
@@ -127,7 +126,7 @@ class ServiceContainer:
         self,
         service_key: str,
         implementation: Any,
-        protocol: Optional[Type[Protocol]],
+        protocol: Optional[type],
         lifetime: ServiceLifetime,
         factory: Optional[Callable],
     ) -> "ServiceContainer":
@@ -191,14 +190,14 @@ class ServiceContainer:
             raise DependencyInjectionError("Unknown service lifetime")
 
     def _get_singleton(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         if key not in self._instances:
             self._instances[key] = self._create_instance(key, reg, proto)
         return self._instances[key]
 
     def _get_scoped(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         scope = self._scoped_instances.setdefault(self._current_scope, {})
         if key not in scope:
@@ -206,7 +205,7 @@ class ServiceContainer:
         return scope[key]
 
     def _create_instance(
-        self, key: str, reg: ServiceRegistration, proto: Optional[Type]
+        self, key: str, reg: ServiceRegistration, proto: Optional[type]
     ) -> Any:
         self._resolution_stack.append(key)
         try:


### PR DESCRIPTION
## Summary
- drop `Protocol` from DI container type hints
- use plain `type` for protocol parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d3413a13083208326b9cfc272a549