### PR TITLE
Fix redundant ServiceContainer import

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -105,7 +105,6 @@ from config.config import get_config
 from core.service_container import ServiceContainer
 from core.performance_monitor import DIPerformanceMonitor
 from core.plugins.decorators import safe_callback
-from core.service_container import ServiceContainer
 from core.theme_manager import DEFAULT_THEME, apply_theme_settings
 from pages import get_page_layout
 from pages.deep_analytics import Callbacks as DeepAnalyticsCallbacks


### PR DESCRIPTION
## Summary
- remove duplicate `ServiceContainer` import in the app factory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686d3417d1088320acf6dea325a24563