### PR TITLE
Fix register_handler references

### DIFF
--- a/analytics/controllers/unified_controller.py
+++ b/analytics/controllers/unified_controller.py
@@ -59,14 +59,14 @@ class UnifiedAnalyticsController:
 
             callback = wrapped
 
-        self._manager.register_handler(
+        self._manager.register_callback(
             self._EVENT_MAP[event], callback, priority=priority
         )
 
     def register_security_callbacks(self, callback_dict: Dict[str, callable]):
         """Consolidated callback registration for security analysis"""
         for event_name, callback_func in callback_dict.items():
-            self.register_handler(event_name, callback_func, secure=True)
+            self.register_callback(event_name, callback_func, secure=True)
 
     # ------------------------------------------------------------------
     def handle_unregister(self, event: str, callback: Callable[..., Any]) -> None:

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -524,6 +524,6 @@ def setup_isolated_security_testing(
 
         handler = _handler
         for event in SecurityEvent:
-            controller.register_handler(event, lambda d, e=event: _handler(d, e))
+            controller.register_callback(event, lambda d, e=event: _handler(d, e))
 
     return controller, handler

--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -674,7 +674,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the coordinator."""
 
-    manager.register_handler(
+    manager.register_callback(
         Output({"type": "custom-field", "index": MATCH}, "style"),
         Input({"type": "column-mapping", "index": MATCH}, "value"),
         callback_id="toggle_custom_field",
@@ -682,7 +682,7 @@ def register_callbacks(
     )(toggle_custom_field)
 
     if controller is not None:
-        controller.register_handler(
+        controller.register_callback(
             "on_analysis_error",
             lambda aid, err: logger.error("Column verification error: %s", err),
         )

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -302,7 +302,7 @@ def register_callbacks(
     )(mark_device_as_edited)
 
     if controller is not None:
-        controller.register_handler(
+        controller.register_callback(
             "on_analysis_error",
             lambda aid, err: logger.error("Device verification error: %s", err),
         )

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -565,7 +565,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.register_handler(
+    manager.register_callback(
         Output("simple-device-modal", "children"),
         Input("simple-device-modal", "is_open"),
         prevent_initial_call=True,
@@ -573,7 +573,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(populate_simple_device_modal)
 
-    manager.register_handler(
+    manager.register_callback(
         Output("simple-device-modal", "is_open"),
         [
             Input("open-device-mapping", "n_clicks"),
@@ -586,7 +586,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(toggle_simple_device_modal)
 
-    manager.register_handler(
+    manager.register_callback(
         Output("device-save-status", "children"),
         [
             Input({"type": "device-floor", "index": ALL}, "value"),
@@ -600,7 +600,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(save_user_inputs)
 
-    manager.register_handler(
+    manager.register_callback(
         [
             Output({"type": "device-floor", "index": ALL}, "value"),
             Output({"type": "device-access", "index": ALL}, "value"),
@@ -615,7 +615,7 @@ def register_callbacks(
     )(apply_ai_device_suggestions)
 
     if controller is not None:
-        controller.register_handler(
+        controller.register_callback(
             "on_analysis_error",
             lambda aid, err: logger.error("Device mapping error: %s", err),
         )

--- a/core/callback_controller.py
+++ b/core/callback_controller.py
@@ -228,7 +228,7 @@ def callback_handler(event: CallbackEvent, weak: bool = False):
 
     def decorator(func: CallbackProtocol) -> CallbackProtocol:
         controller = CallbackController()
-        controller.register_handler(event, func, weak)
+        controller.register_callback(event, func, weak)
         return func
 
     return decorator
@@ -248,7 +248,7 @@ class TemporaryCallback:
         self.controller = controller or CallbackController()
 
     def __enter__(self) -> CallbackProtocol:
-        self.controller.register_handler(self.event, self.callback)
+        self.controller.register_callback(self.event, self.callback)
         return self.callback
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/core/master_callback_system.py
+++ b/core/master_callback_system.py
@@ -55,7 +55,7 @@ class MasterCallbackSystem(TrulyUnifiedCallbacks):
 
             func = wrapped
 
-        self.callback_manager.register_handler(event, func, priority=priority)
+        self.callback_manager.register_callback(event, func, priority=priority)
 
     # ------------------------------------------------------------------
     def trigger_event(self, event: CallbackEvent, *args: Any, **kwargs: Any):
@@ -82,7 +82,7 @@ class MasterCallbackSystem(TrulyUnifiedCallbacks):
         **kwargs: Any,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Wrap ``Dash.callback`` and track registrations."""
-        return self.register_handler(
+        return self.register_callback(
 
             outputs,
             inputs,

--- a/core/plugins/callback_unifier.py
+++ b/core/plugins/callback_unifier.py
@@ -26,13 +26,13 @@ class CallbackUnifier:
 
             if hasattr(self._target, "register_callback"):
                 try:
-                    return self._target.register_handler(
+                    return self._target.register_callback(
                         outputs, inputs, states, **kwargs
                     )(wrapped)
                 except TypeError:
                     sig = inspect.signature(self._target.register_callback)
                     filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
-                    return self._target.register_handler(
+                    return self._target.register_callback(
                         outputs, inputs, states, **filtered
                     )(wrapped)
             if hasattr(self._target, "callback"):

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -589,7 +589,7 @@ def register_callbacks(
         return display, options, alert
 
     if controller is not None:
-        controller.register_handler(
+        controller.register_callback(
             "on_analysis_error",
             lambda aid, err: logger.error("Deep analytics error: %s", err),
         )

--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -49,8 +49,8 @@ class ValidationMiddleware:
 
     def register_callbacks(self, manager: CallbackManager) -> None:
         """Register validation hooks with the callback manager."""
-        manager.register_handler(CallbackEvent.BEFORE_REQUEST, self.validate_request)
-        manager.register_handler(CallbackEvent.AFTER_REQUEST, self.sanitize_response)
+        manager.register_callback(CallbackEvent.BEFORE_REQUEST, self.validate_request)
+        manager.register_callback(CallbackEvent.AFTER_REQUEST, self.sanitize_response)
 
     def validate_request(self) -> None:
         # Enforce maximum request body size

--- a/tools/complete_callback_cleanup.py
+++ b/tools/complete_callback_cleanup.py
@@ -80,7 +80,7 @@ def test_unified_callbacks() -> None:
     assert results == [5]
 
     # Dash callbacks
-    @coord.register_handler(
+    @coord.register_callback(
         Output("out", "children"),
         Input("in", "value"),
         callback_id="t",

--- a/upload_callbacks.py
+++ b/upload_callbacks.py
@@ -22,7 +22,7 @@ class UploadCallbackManager:
 
         for defs in [uc.upload_callbacks(), uc.progress_callbacks(), uc.validation_callbacks()]:
             for func, outputs, inputs, states, cid, extra in defs:
-                manager.register_handler(
+                manager.register_callback(
                     outputs,
                     inputs,
                     states,


### PR DESCRIPTION
## Summary
- replace incorrect `register_handler` calls with `register_callback`
- update decorator use in tools

## Testing
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d4281aa0483209c58be52f75f7e8d