### PR TITLE
Fix Pylance issues in app initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,10 +223,9 @@ def main():
         load_dotenv()
 
         # Set Unicode handling early
-        import sys
         if hasattr(sys.stdout, 'reconfigure'):
-            sys.stdout.reconfigure(encoding='utf-8', errors='replace')
-            sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+            sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
 
         from config.dev_mode import setup_dev_mode
         setup_dev_mode()
@@ -259,8 +258,9 @@ def main():
             validator = SecretsValidator(secrets_manager)
 
             if app_config.environment == 'production':
+                secret_key: str = secrets_manager.get('SECRET_KEY', 'dev-key') or 'dev-key'
                 result = validator.validate_secret(
-                    secrets_manager.get('SECRET_KEY', 'dev-key'),
+                    secret_key,
                     environment='production'
                 )
                 if result.get('errors'):


### PR DESCRIPTION
## Summary
- avoid redefining `sys` inside `main`
- ignore `reconfigure` typing errors
- guarantee `validate_secret` receives a string

## Testing
- `isort --check .` *(fails: imports unsorted)*
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy --strict app.py` *(fails: many errors)*
- `pytest` *(fails: missing dependencies)*
- `bandit -r .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d45546bbc8320802dee572f8cec1f