### PR TITLE
Fix callback decorator and unify router

### DIFF
--- a/core/plugins/decorators.py
+++ b/core/plugins/decorators.py
@@ -1,56 +1,131 @@
+from __future__ import annotations
+
 import functools
+import logging
 from typing import Any, Callable, Optional
 
+logger = logging.getLogger(__name__)
 
-def handle_safe(app_or_container: Any = None) -> Callable:
-    """Plugin-aware decorator that uses the JSON serialization plugin"""
+
+def handle_unicode_surrogates(text: str, processor: Optional[Any] = None) -> str:
+    """Handle Unicode surrogate characters safely."""
+    if not isinstance(text, str):
+        return text
+    try:
+        if processor and hasattr(processor, "safe_encode_text"):
+            return processor.safe_encode_text(text)
+        return text.encode("utf-8", errors="ignore").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return text.encode("ascii", errors="ignore").decode("ascii")
+
+
+
+def handle_safe(*args: Any, **kwargs: Any) -> Callable[[Callable], Callable]:
+    """Unified safe callback decorator supporting multiple patterns."""
+
+    # ------------------------------------------------------------------
+    def _plugin_decorator(app_or_container: Any | None, up: Optional[Any] = None) -> Callable[[Callable], Callable]:
+        """Return decorator for plugin style usage."""
+
+        def decorator(func: Callable) -> Callable:
+            @functools.wraps(func)
+            def wrapper(*f_args: Any, **f_kwargs: Any):
+                callback_service = None
+                unicode_proc = up
+                container = None
+                if hasattr(app_or_container, "_yosai_container"):
+                    container = app_or_container._yosai_container
+                elif app_or_container and hasattr(app_or_container, "get"):
+                    container = app_or_container
+                if container:
+                    try:
+                        callback_service = container.get("json_callback_service")
+                    except Exception:
+                        try:
+                            callback_service = container.get("callback_service")
+                        except Exception:
+                            callback_service = None
+                    if unicode_proc is None:
+                        try:
+                            unicode_proc = container.get("unicode_processor")
+                        except Exception:
+                            unicode_proc = None
+                safe_func = callback_service.wrap_callback(func) if callback_service else func
+                safe_args = [
+                    handle_unicode_surrogates(a, unicode_proc) if isinstance(a, str) else a
+                    for a in f_args
+                ]
+                safe_kwargs = {
+                    k: handle_unicode_surrogates(v, unicode_proc) if isinstance(v, str) else v
+                    for k, v in f_kwargs.items()
+                }
+                result = safe_func(*safe_args, **safe_kwargs)
+                if isinstance(result, str):
+                    result = handle_unicode_surrogates(result, unicode_proc)
+                elif isinstance(result, (list, tuple)):
+                    result = [
+                        handle_unicode_surrogates(r, unicode_proc) if isinstance(r, str) else r
+                        for r in result
+                    ]
+                return result
+
+            return wrapper
+
+        return decorator
+
+    # Detect legacy plugin usage pattern
+    if len(args) <= 1 and "callback_id" not in kwargs and "outputs" not in kwargs:
+        app_or_container = args[0] if args else None
+        if callable(app_or_container) and not hasattr(app_or_container, "callback_map"):
+            func = app_or_container
+            return _plugin_decorator(None)(func)
+        return _plugin_decorator(app_or_container, kwargs.get("unicode_processor"))
+
+    # ------------------------------------------------------------------
+    # Legacy registration style: handle_safe(outputs, inputs, callback_id=..., manager=...)
+    outputs = args[0] if args else kwargs.pop("outputs")
+    inputs = args[1] if len(args) > 1 else kwargs.pop("inputs", None)
+    manager = kwargs.pop("manager", None)
+    callback_id = kwargs.pop("callback_id", "unknown")
+    component_name = kwargs.pop("component_name", "app_factory")
+    unicode_proc = kwargs.pop("unicode_processor", None)
+
+    if manager is None:
+        raise TypeError("manager required for registration style usage")
+
+    plugin_deco = _plugin_decorator(getattr(manager, "app", None), unicode_proc)
 
     def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            # Get callback service from container (via plugin)
-            callback_service = None
+        wrapped = plugin_deco(func)
 
-            if hasattr(app_or_container, "_yosai_container"):
-                container = app_or_container._yosai_container
-                try:
-                    callback_service = container.get("json_callback_service")
-                except Exception:
-                    # Fallback to generic callback service
-                    try:
-                        callback_service = container.get("callback_service")
-                    except Exception:
-                        pass
+        def error_wrapper(*f_args: Any, **f_kwargs: Any):
+            try:
+                return wrapped(*f_args, **f_kwargs)
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.error(f"Callback {callback_id} failed: {exc}")
+                if isinstance(outputs, (list, tuple)):
+                    return ["Error"] * len(outputs)
+                return "Error"
 
-            if callback_service:
-                # Use the plugin's callback service to wrap the callback
-                safe_func = callback_service.wrap_callback(func)
-                return safe_func(*args, **kwargs)
+        return manager.unified_callback(
+            outputs,
+            inputs,
+            callback_id=callback_id,
+            component_name=component_name,
+            **kwargs,
+        )(error_wrapper)
 
-            # Fallback - execute without service wrapper
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    # Handle both @safe_callback and @safe_callback(app) usage
-    if callable(app_or_container) and not hasattr(app_or_container, "callback_map"):
-        # Direct usage: @safe_callback when a plain function is passed
-        func = app_or_container
-        return decorator(func)
-    else:
-        # Parameterized usage: @safe_callback(app)
-        return decorator
+    return decorator
 
 
 safe_callback = handle_safe
 
 
-def handle_unified(target: Any, *cb_args: Any, **cb_kwargs: Any) -> Callable:
+def handle_unified(target: Any, *cb_args: Any, **cb_kwargs: Any) -> Callable[[Callable], Callable]:
     """Return decorator registering callbacks on any supported target."""
     from .callback_unifier import CallbackUnifier
 
     return CallbackUnifier(target, safe_callback(target))(*cb_args, **cb_kwargs)
 
+
 __all__ = ["handle_safe", "handle_unified", "safe_callback"]
-
-

--- a/tests/test_callback_fix.py
+++ b/tests/test_callback_fix.py
@@ -1,0 +1,40 @@
+import pytest
+from dash import Dash, Input, Output
+
+from core.plugins.decorators import handle_safe, safe_callback
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+
+
+def test_imports():
+    assert handle_safe is safe_callback
+
+
+def test_plugin_style():
+    @handle_safe()
+    def cb():
+        return "works"
+
+    assert cb() == "works"
+
+
+def test_factory_style_registration():
+    app = Dash(__name__)
+    manager = TrulyUnifiedCallbacks(app)
+
+    @handle_safe(
+        Output("o", "children"),
+        Input("i", "value"),
+        callback_id="test_cb",
+        manager=manager,
+        component_name="test",
+    )
+    def cb2(value=None):
+        return value
+
+    assert "test_cb" in manager.registered_callbacks
+
+
+def test_manager_usage():
+    app = Dash(__name__)
+    manager = TrulyUnifiedCallbacks(app)
+    assert manager.app is app


### PR DESCRIPTION
## Summary
- provide unified `handle_safe` decorator for plugins and callback registration
- revise unicode handling in `handle_unicode_surrogates`
- register router callbacks using `manager.unified_callback`
- add regression tests for decorator behaviour

## Testing
- `pytest tests/test_callback_fix.py -q`
- `pytest -q` *(fails: 85 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686daca21f488320b2dcffa48ec36cf1