### PR TITLE
Fix type alias import for unified callbacks

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,15 @@
-# Core package
+"""Core package exports and typing utilities."""
+
+from typing import TYPE_CHECKING, Any
+
+from .truly_unified_callbacks import TrulyUnifiedCallbacks
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .truly_unified_callbacks import (
+        TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType,
+    )
+else:  # pragma: no cover - fallback at runtime
+    TrulyUnifiedCallbacksType = Any  # type: ignore[misc]
+
+__all__ = ["TrulyUnifiedCallbacks", "TrulyUnifiedCallbacksType"]
+

--- a/docs/type_import_pattern.md
+++ b/docs/type_import_pattern.md
@@ -1,0 +1,12 @@
+# Importing `TrulyUnifiedCallbacksType`
+
+Use this template when you need the `TrulyUnifiedCallbacksType` for type hints without creating runtime dependencies:
+
+```python
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
+else:  # pragma: no cover - fallback runtime alias
+    TrulyUnifiedCallbacksType = Any
+```

--- a/validate_core_import.py
+++ b/validate_core_import.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Test that core module imports without errors"""
+
+def test_core_import():
+    try:
+        import core
+        print("\N{white heavy check mark} core module imports successfully")
+        return True
+    except NameError as e:
+        print(f"\N{cross mark} NameError: {e}")
+        return False
+    except ImportError as e:
+        print(f"\N{cross mark} ImportError: {e}")
+        return False
+
+if __name__ == "__main__":
+    success = test_core_import()
+    if success:
+        print("\U0001F389 Type import issue resolved!")
+    else:
+        print("\U0001F4A5 Still has import issues")


### PR DESCRIPTION
## Summary
- add export helpers and typing alias in `core/__init__.py`
- document how to import `TrulyUnifiedCallbacksType`
- add a helper script to verify `core` imports cleanly

## Testing
- `python validate_core_import.py`
- `pytest -q` *(fails: 84 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686db263b5208320a412d9b27b279df0