### PR TITLE
Fix future import order and add validation script

### DIFF
--- a/import_sorting_template.py
+++ b/import_sorting_template.py
@@ -1,0 +1,18 @@
+"""Module docstring."""
+
+# __future__ imports - ALWAYS FIRST
+from __future__ import annotations
+
+# Standard library imports
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Third-party imports
+import dash
+import pandas as pd
+
+# Local application imports
+from core import something
+from services import something_else

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""File upload page wiring the reusable upload component."""
 from __future__ import annotations
+"""File upload page wiring the reusable upload component."""
 
 import logging
 import types

--- a/validate_future_imports.py
+++ b/validate_future_imports.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate that __future__ imports are correctly positioned in all Python files."""
+
+import ast
+import os
+from pathlib import Path
+
+
+def check_future_imports(file_path: Path):
+    """Check if __future__ imports are properly positioned."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        tree = ast.parse(content)
+
+        future_imports = []
+        other_imports = []
+
+        for i, node in enumerate(tree.body):
+            if isinstance(node, ast.ImportFrom) and node.module == '__future__':
+                future_imports.append(i)
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                other_imports.append(i)
+
+        if future_imports and other_imports:
+            first_future = min(future_imports)
+            first_other = min(other_imports)
+            if first_other < first_future:
+                return False, (
+                    f"Regular import at position {first_other} before __future__ import at {first_future}"
+                )
+        return True, "OK"
+    except Exception as exc:  # pragma: no cover - simple diagnostics
+        return False, f"Error parsing file: {exc}"
+
+
+def scan_project(base: Path | str = Path('.')):
+    """Scan all Python files in project for __future__ import issues."""
+    base_path = Path(base)
+    python_files = [p for p in base_path.rglob('*.py') if not p.name.startswith('.')]
+    issues = []
+
+    for file_path in python_files:
+        is_valid, message = check_future_imports(file_path)
+        if not is_valid:
+            issues.append(f"{file_path}: {message}")
+
+    return issues
+
+
+if __name__ == "__main__":
+    print("🔍 Scanning for __future__ import issues...")
+    problems = scan_project()
+    if problems:
+        print("❌ Found issues:")
+        for issue in problems:
+            print(f"  {issue}")
+    else:
+        print("✅ All __future__ imports properly positioned!")


### PR DESCRIPTION
## Summary
- fix `file_upload` module's `__future__` import order
- add a validation script for `__future__` imports
- provide an import sorting template

## Testing
- `python -m py_compile pages/file_upload.py`
- `python app.py` *(fails: No module named 'flask')*
- `python -c "import pages.file_upload; print('✅ Import successful')"` *(fails: No module named 'dash')*
- `python validate_future_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_686db85450b08320ac2437711500343e