### PR TITLE
Fix callback wrapper and asset handling

### DIFF
--- a/scripts/validate_callback_system.py
+++ b/scripts/validate_callback_system.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate that callback system and assets are available."""
+
+from pathlib import Path
+
+
+def validate_callback_system() -> bool:
+    try:
+        from core.app_factory import create_app
+
+        app = create_app(mode="simple")
+        required = ["callback", "unified_callback", "register_callback"]
+        missing = [m for m in required if not hasattr(app, m)]
+        if missing:
+            print(f"\u274c Missing methods: {missing}")
+            return False
+        print("\u2705 All callback methods available")
+
+        @app.unified_callback(
+            outputs="test-output.children",
+            inputs="test-input.value",
+        )
+        def test_cb(value):
+            return f"Test: {value}"
+
+        print("\u2705 Callback registration successful")
+        return True
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"\u274c Callback system validation failed: {e}")
+        return False
+
+
+def validate_assets() -> bool:
+    required = [
+        "assets/navbar_icons/analytics.png",
+        "assets/navbar_icons/graphs.png",
+        "assets/navbar_icons/export.png",
+    ]
+    missing = [path for path in required if not Path(path).exists()]
+    if missing:
+        print(f"\u26a0\ufe0f  Missing assets: {missing}")
+        return False
+    print("\u2705 All required assets present")
+    return True
+
+
+if __name__ == "__main__":
+    print("\U0001f50d Validating callback system and dependencies...")
+    ok_callbacks = validate_callback_system()
+    ok_assets = validate_assets()
+    if ok_callbacks and ok_assets:
+        print("\U0001f389 All systems validated successfully!")
+    else:
+        print("\U0001f4a5 Validation issues found - check logs above")

--- a/tools/debug_dash_object.py
+++ b/tools/debug_dash_object.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Utility to inspect available methods on a Dash app object."""
+from typing import Any
+
+
+def debug_dash_object(app: Any) -> None:
+    print(f"App type: {type(app)}")
+    print(f"App class: {app.__class__}")
+
+    callback_methods = [attr for attr in dir(app) if "callback" in attr.lower()]
+    print(f"Available callback methods: {callback_methods}")
+
+    wrapper_attrs = []
+    for attr in ["_unified_wrapper", "_callback_registry", "_yosai_container"]:
+        if hasattr(app, attr):
+            wrapper_attrs.append(attr)
+    print(f"Wrapper attributes: {wrapper_attrs}")
+
+
+if __name__ == "__main__":
+    from core.app_factory import create_app
+
+    app = create_app(mode="simple")
+    debug_dash_object(app)

--- a/utils/assets_utils.py
+++ b/utils/assets_utils.py
@@ -36,4 +36,35 @@ def ensure_icon_cache_headers(app):
     return app
 
 
-__all__ = ["get_nav_icon", "ensure_icon_cache_headers"]
+def ensure_navbar_assets(app=None) -> None:
+    """Ensure navbar icons exist or create simple placeholders."""
+    required_icons = [
+        "analytics.png",
+        "graphs.png",
+        "export.png",
+        "settings.png",
+        "upload.png",
+    ]
+    ASSET_ICON_DIR.mkdir(parents=True, exist_ok=True)
+
+    for icon in required_icons:
+        path = ASSET_ICON_DIR / icon
+        if path.exists():
+            continue
+        try:
+            from PIL import Image, ImageDraw  # type: ignore
+
+            img = Image.new("RGBA", (24, 24), (100, 100, 100, 255))
+            draw = ImageDraw.Draw(img)
+            draw.rectangle([4, 4, 20, 20], fill=(255, 255, 255, 255))
+            img.save(path)
+            logging.getLogger(__name__).info("Created placeholder icon %s", path)
+        except Exception:  # pragma: no cover - best effort fallback
+            path.touch()
+            logging.getLogger(__name__).warning(
+                "Created empty placeholder for %s - install Pillow for better icons",
+                path,
+            )
+
+
+__all__ = ["get_nav_icon", "ensure_icon_cache_headers", "ensure_navbar_assets"]


### PR DESCRIPTION
## Summary
- wrap Dash app with `TrulyUnifiedCallbacks` when available
- provide fallbacks when the callback wrapper is missing
- allow page modules to accept either a wrapped app or plain Dash app
- add utility for ensuring navbar icons and create placeholders when missing
- add scripts for debugging the Dash object and validating callback methods

## Testing
- `black utils/assets_utils.py core/app_factory/__init__.py pages/deep_analytics/callbacks.py pages/file_upload.py tools/debug_dash_object.py scripts/validate_callback_system.py`
- `pytest -q` *(fails: ModuleNotFoundError: dash)*

------
https://chatgpt.com/codex/tasks/task_e_686dbab3381483209ce40290ee202399