### PR TITLE
Improve navbar icon caching docs and tests

### DIFF
--- a/tests/utils/test_icon_cache_headers.py
+++ b/tests/utils/test_icon_cache_headers.py
@@ -1,0 +1,28 @@
+import pytest
+from flask import Flask, Response
+
+from utils.assets_utils import ensure_icon_cache_headers
+
+
+def _make_app():
+    flask_app = Flask(__name__)
+
+    class DummyDash:
+        server = flask_app
+
+    return flask_app, DummyDash()
+
+
+def test_icon_cache_headers():
+    flask_app, dummy = _make_app()
+
+    @flask_app.route('/assets/navbar_icons/foo.png')
+    def icon():
+        return Response(b'data', content_type='image/png')
+
+    ensure_icon_cache_headers(dummy)
+
+    client = flask_app.test_client()
+    res = client.get('/assets/navbar_icons/foo.png')
+    assert res.headers.get('Cache-Control') == 'public, max-age=3600'
+    assert 'ETag' in res.headers

--- a/utils/assets_utils.py
+++ b/utils/assets_utils.py
@@ -22,7 +22,32 @@ def get_nav_icon(app, name: str) -> str | None:
 
 
 def ensure_icon_cache_headers(app):
-    """Add cache headers for icon assets to prevent loading issues."""
+    """Add cache headers for icon assets to prevent loading issues.
+
+    This registers an ``after_request`` hook on ``app.server`` that sets
+    ``Cache-Control`` and ``ETag`` headers for responses under
+    ``/assets/navbar_icons``. It helps browsers cache navbar icons instead of
+    reloading them on every page.
+
+    Parameters
+    ----------
+    app : dash.Dash
+        The Dash application whose underlying Flask ``server`` should receive
+        the headers.
+
+    Returns
+    -------
+    dash.Dash
+        The provided ``app`` for convenience so calls can be chained.
+
+    Examples
+    --------
+    >>> from dash import Dash
+    >>> from utils.assets_utils import ensure_icon_cache_headers
+    >>> dash_app = Dash(__name__)
+    >>> ensure_icon_cache_headers(dash_app)
+    >>> # ``dash_app.server`` will now add caching headers for icon responses
+    """
 
     @app.server.after_request
     def add_icon_cache_headers(response):


### PR DESCRIPTION
## Summary
- document ensure_icon_cache_headers usage
- add tests for caching headers

## Testing
- `pytest tests/utils/test_icon_cache_headers.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_686dc87d0f0c8320a369d4b3a5a00fb8