### PR TITLE
Improve navbar asset setup and tests

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -110,7 +110,13 @@ from pages.file_upload import layout as upload_layout
 from pages.file_upload import register_callbacks as register_upload_callbacks
 from services import get_analytics_service
 from services.analytics_service import AnalyticsService
-from utils.assets_utils import ensure_icon_cache_headers, ensure_navbar_assets
+from utils.assets_utils import (
+    ensure_icon_cache_headers,
+    ensure_navbar_assets,
+    ensure_all_navbar_assets,
+    NAVBAR_ICON_NAMES,
+)
+from utils.assets_debug import check_navbar_assets
 from core.callback_registry import GlobalCallbackRegistry, _callback_registry
 
 from .health import register_health_endpoints
@@ -163,6 +169,16 @@ def create_app(mode: Optional[str] = None) -> "Dash":
         config_manager = DummyConfigManager()  # Initialize config manager
 
         logger.info("🏗️ Creating Dash application...")
+
+        # Ensure navbar icons are available before constructing the Dash app
+        try:
+            ensure_all_navbar_assets()
+            summary = check_navbar_assets(NAVBAR_ICON_NAMES, warn=False)
+            missing = [n for n, ok in summary.items() if not ok]
+            if missing:
+                logger.warning("Missing navbar icons: %s", ", ".join(missing))
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.debug("ensure_all_navbar_assets failed: %s", exc)
 
         # Determine app mode
         mode = mode or os.environ.get("YOSAI_APP_MODE", "full")

--- a/tests/utils/test_assets_utils.py
+++ b/tests/utils/test_assets_utils.py
@@ -18,7 +18,7 @@ get_nav_icon = assets_utils.get_nav_icon
 def _make_app(monkeypatch):
     # Create a minimal Dash app for testing
     monkeypatch.setenv("YOSAI_ENV", "development")
-    return dash.Dash(__name__, assets_folder="assets")
+    return dash.Dash()
 
 
 def test_get_nav_icon_existing(monkeypatch):
@@ -53,3 +53,53 @@ def test_get_nav_icon_flask_app(monkeypatch):
         get_nav_icon(flask_app, "analytics")
         == "/assets/navbar_icons/analytics.png"
     )
+
+
+def test_ensure_all_navbar_assets_without_pillow(tmp_path, monkeypatch):
+    monkeypatch.setattr(assets_utils, "ASSET_ICON_DIR", tmp_path)
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("PIL"):
+            raise ImportError("no pillow")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assets_utils.ensure_all_navbar_assets()
+
+    for icon in [
+        "analytics.png",
+        "graphs.png",
+        "export.png",
+        "settings.png",
+        "upload.png",
+    ]:
+        assert (tmp_path / icon).exists()
+
+    assert (tmp_path / "analytics.svg").is_file()
+
+
+def test_ensure_navbar_assets_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(assets_utils, "ASSET_ICON_DIR", tmp_path)
+
+    def dummy_check(names, warn=True):
+        return {name: (tmp_path / f"{name}.png").is_file() for name in names}
+
+    monkeypatch.setattr(assets_utils, "check_navbar_assets", dummy_check)
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("PIL"):
+            raise ImportError("no pillow")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    summary = assets_utils.ensure_navbar_assets()
+    assert all(summary.values())
+    assert (tmp_path / "analytics.svg").is_file()

--- a/utils/assets_utils.py
+++ b/utils/assets_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import logging
 from flask import request, url_for
+from utils.assets_debug import check_navbar_assets
 
 ASSET_ICON_DIR = Path(__file__).resolve().parent.parent / "assets" / "navbar_icons"
 
@@ -36,9 +37,32 @@ def ensure_icon_cache_headers(app):
     return app
 
 
-def ensure_navbar_assets(app=None) -> None:
-    """Ensure navbar icons exist or create simple placeholders."""
+def ensure_navbar_assets(app=None) -> dict[str, bool]:
+    """Ensure navbar icons exist or create simple placeholders.
+
+    Returns a mapping of icon names to their existence state after the
+    creation attempt.
+    """
+    missing_before = [
+        name
+        for name in NAVBAR_ICON_NAMES
+        if not (ASSET_ICON_DIR / f"{name}.png").exists()
+    ]
+    if missing_before:
+        logging.getLogger(__name__).info(
+            "Attempting to create missing navbar icons: %s",
+            ", ".join(missing_before),
+        )
+
     ensure_all_navbar_assets(app)
+
+    summary = check_navbar_assets(NAVBAR_ICON_NAMES, warn=False)
+    missing_after = [n for n, ok in summary.items() if not ok]
+    if missing_after:
+        logging.getLogger(__name__).warning(
+            "Navbar icons still missing: %s", ", ".join(missing_after)
+        )
+    return summary
 
 
 def create_analytics_icon(path: Path) -> None:
@@ -119,20 +143,25 @@ def create_upload_icon(path: Path) -> None:
         path.touch()
 
 
+# Mapping of required navbar icon filenames to their creator functions
+NAVBAR_ICONS = {
+    "analytics.png": create_analytics_icon,
+    "graphs.png": create_graphs_icon,
+    "export.png": create_export_icon,
+    "settings.png": create_settings_icon,
+    "upload.png": create_upload_icon,
+}
+
+# List of icon base names without the extension for convenience
+NAVBAR_ICON_NAMES = [Path(name).stem for name in NAVBAR_ICONS]
+
+
 def ensure_all_navbar_assets(app=None) -> None:
     """Ensure all required navbar icons exist with basic creation."""
 
-    navbar_icons = {
-        "analytics.png": create_analytics_icon,
-        "graphs.png": create_graphs_icon,
-        "export.png": create_export_icon,
-        "settings.png": create_settings_icon,
-        "upload.png": create_upload_icon,
-    }
-
     ASSET_ICON_DIR.mkdir(parents=True, exist_ok=True)
 
-    for icon_name, creator in navbar_icons.items():
+    for icon_name, creator in NAVBAR_ICONS.items():
         path = ASSET_ICON_DIR / icon_name
         if path.exists():
             continue
@@ -151,4 +180,5 @@ __all__ = [
     "ensure_icon_cache_headers",
     "ensure_navbar_assets",
     "ensure_all_navbar_assets",
+    "NAVBAR_ICON_NAMES",
 ]


### PR DESCRIPTION
## Summary
- report missing navbar icons in `ensure_navbar_assets`
- create mapping for navbar icon creators
- call `ensure_all_navbar_assets` before app construction and log any missing files
- test fallback icon creation when Pillow is unavailable

## Testing
- `pytest tests/utils/test_assets_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc86241f48320b298c94aca24be03