### PR TITLE
Organize debug helpers into tools package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Additional icons can live in the same directory as long as their paths match the
 Run the debug helper to verify that icon files exist and can be served:
 
 ```bash
-python scripts/debug_navbar_icons.py
+python -m tools.debug assets
 ```
-Pass icon names to check custom files.
+Pass icon names after the command to check custom files.
 
 ## 🚀 Quick Start
 

--- a/debug_callback_registry.py
+++ b/debug_callback_registry.py
@@ -1,41 +1,8 @@
 #!/usr/bin/env python3
-"""Debug callback registration conflicts and validate fixes"""
+"""Backward-compatible wrapper for callback diagnostics."""
 
-from core.app_factory import create_app
-from core.callback_registry import _callback_registry
+from tools.debug.callbacks import debug_callback_conflicts, validate_callback_system
 
-
-def debug_callback_conflicts():
-    app = create_app()
-    print("\ud83d\udd0d Callback Registration Analysis:")
-    print(f"Total registered callbacks: {len(_callback_registry.registered_callbacks)}")
-    for cid, source in _callback_registry.callback_sources.items():
-        print(f"  \u2705 {cid} (from {source})")
-    conflicts = _callback_registry.get_conflicts()
-    if conflicts:
-        print("\u26a0\ufe0f Potential conflicts found")
-    else:
-        print("\u2705 No callback conflicts detected")
-
-
-def validate_assets():
-    from pathlib import Path
-
-    required_icons = [
-        "assets/navbar_icons/analytics.png",
-        "assets/navbar_icons/graphs.png",
-        "assets/navbar_icons/export.png",
-        "assets/navbar_icons/settings.png",
-        "assets/navbar_icons/upload.png",
-    ]
-    missing = [icon for icon in required_icons if not Path(icon).exists()]
-    if missing:
-        print(f"\u274c Missing assets: {missing}")
-        return False
-    print("\u2705 All navbar assets present")
-    return True
-
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual tool
     debug_callback_conflicts()
-    validate_assets()
+    validate_callback_system()

--- a/scripts/debug_navbar_icons.py
+++ b/scripts/debug_navbar_icons.py
@@ -1,66 +1,9 @@
 #!/usr/bin/env python3
-"""Debug helper for navbar icon serving.
+"""Wrapper to run navbar icon diagnostics."""
 
-Run this script to verify icon files exist and Dash can serve them via
-``get_nav_icon``. By default it checks the standard icons defined in the
-README but you can pass custom icon names as arguments.
-"""
-from __future__ import annotations
+from tools.debug.assets import debug_navbar_icons
 
-import argparse
-import os
-from typing import Iterable
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    import sys
 
-from core.app_factory import create_app
-from utils.assets_debug import check_navbar_assets
-from utils.assets_utils import get_nav_icon
-
-DEFAULT_ICONS = [
-    "dashboard",
-    "analytics",
-    "graphs",
-    "upload",
-    "print",
-    "settings",
-    "logout",
-]
-
-
-def debug_navbar_icons(icon_names: Iterable[str] | None = None) -> None:
-    """Print icon existence and test asset URLs."""
-    icons = list(icon_names or DEFAULT_ICONS)
-
-    os.environ.setdefault("YOSAI_ENV", "development")
-    os.environ.setdefault("SECRET_KEY", "debug")
-
-    app = create_app(mode="simple")
-    results = check_navbar_assets(icons, warn=False)
-    client = app.server.test_client()
-
-    for name in icons:
-        exists = results.get(name, False)
-        url = get_nav_icon(app, name)
-        status = None
-        if url:
-            try:
-                res = client.get(url)
-                status = res.status_code
-            except Exception:
-                status = "error"
-        print(f"{name}: file={'yes' if exists else 'no'}, url={url!r}, status={status}")
-
-
-def _main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Debug navbar icons")
-    parser.add_argument(
-        "icons",
-        nargs="*",
-        metavar="ICON",
-        help="Icon names without .png extension",
-    )
-    args = parser.parse_args(argv)
-    debug_navbar_icons(args.icons or None)
-
-
-if __name__ == "__main__":
-    _main()
+    debug_navbar_icons(sys.argv[1:] or None)

--- a/scripts/validate_callback_system.py
+++ b/scripts/validate_callback_system.py
@@ -1,54 +1,13 @@
 #!/usr/bin/env python3
-"""Validate that callback system and assets are available."""
+"""Wrapper to run callback diagnostics."""
 
-from pathlib import Path
+from tools.debug.callbacks import debug_callback_conflicts, validate_callback_system
 
-
-def validate_callback_system() -> bool:
-    try:
-        from core.app_factory import create_app
-
-        app = create_app(mode="simple")
-        required = ["callback", "unified_callback", "register_callback"]
-        missing = [m for m in required if not hasattr(app, m)]
-        if missing:
-            print(f"\u274c Missing methods: {missing}")
-            return False
-        print("\u2705 All callback methods available")
-
-        @app.unified_callback(
-            outputs="test-output.children",
-            inputs="test-input.value",
-        )
-        def test_cb(value):
-            return f"Test: {value}"
-
-        print("\u2705 Callback registration successful")
-        return True
-    except Exception as e:  # pragma: no cover - best effort
-        print(f"\u274c Callback system validation failed: {e}")
-        return False
-
-
-def validate_assets() -> bool:
-    required = [
-        "assets/navbar_icons/analytics.png",
-        "assets/navbar_icons/graphs.png",
-        "assets/navbar_icons/export.png",
-    ]
-    missing = [path for path in required if not Path(path).exists()]
-    if missing:
-        print(f"\u26a0\ufe0f  Missing assets: {missing}")
-        return False
-    print("\u2705 All required assets present")
-    return True
-
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual tool
     print("\U0001f50d Validating callback system and dependencies...")
     ok_callbacks = validate_callback_system()
-    ok_assets = validate_assets()
-    if ok_callbacks and ok_assets:
-        print("\U0001f389 All systems validated successfully!")
+    debug_callback_conflicts()
+    if ok_callbacks:
+        print("\U0001f389 Diagnostics completed successfully!")
     else:
-        print("\U0001f4a5 Validation issues found - check logs above")
+        print("\U0001f4a5 Issues found - check logs above")

--- a/tools/debug/__init__.py
+++ b/tools/debug/__init__.py
@@ -1,0 +1,12 @@
+"""Debug helper package."""
+
+from .assets import check_navbar_assets, debug_dash_asset_serving, debug_navbar_icons
+from .callbacks import debug_callback_conflicts, validate_callback_system
+
+__all__ = [
+    "debug_navbar_icons",
+    "check_navbar_assets",
+    "debug_dash_asset_serving",
+    "debug_callback_conflicts",
+    "validate_callback_system",
+]

--- a/tools/debug/__main__.py
+++ b/tools/debug/__main__.py
@@ -1,0 +1,40 @@
+"""Unified CLI for debug helpers."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable
+
+from .assets import debug_navbar_icons
+from .callbacks import debug_callback_conflicts, validate_callback_system
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run debug diagnostics")
+    sub = parser.add_subparsers(dest="command")
+
+    assets_p = sub.add_parser("assets", help="Check navbar assets")
+    assets_p.add_argument(
+        "icons", nargs="*", metavar="ICON", help="Icon names without .png"
+    )
+
+    sub.add_parser("callbacks", help="Run callback diagnostics")
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "assets":
+        debug_navbar_icons(args.icons or None)
+        return
+    if args.command == "callbacks":
+        debug_callback_conflicts()
+        validate_callback_system()
+        return
+
+    # default: run all
+    debug_navbar_icons(None)
+    debug_callback_conflicts()
+    validate_callback_system()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    main()

--- a/tools/debug/assets.py
+++ b/tools/debug/assets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Asset debugging helpers."""
+
+import os
+from typing import Iterable
+
+from core.app_factory import create_app
+from utils.assets_debug import check_navbar_assets, debug_dash_asset_serving
+from utils.assets_utils import get_nav_icon
+
+DEFAULT_ICONS = [
+    "dashboard",
+    "analytics",
+    "graphs",
+    "upload",
+    "print",
+    "settings",
+    "logout",
+]
+
+
+def debug_navbar_icons(icon_names: Iterable[str] | None = None) -> None:
+    """Print icon existence and test asset URLs."""
+    icons = list(icon_names or DEFAULT_ICONS)
+
+    os.environ.setdefault("YOSAI_ENV", "development")
+    os.environ.setdefault("SECRET_KEY", "debug")
+
+    app = create_app(mode="simple")
+    results = check_navbar_assets(icons, warn=False)
+    client = app.server.test_client()
+
+    for name in icons:
+        exists = results.get(name, False)
+        url = get_nav_icon(app, name)
+        status = None
+        if url:
+            try:
+                res = client.get(url)
+                status = res.status_code
+            except Exception:
+                status = "error"
+        print(f"{name}: file={'yes' if exists else 'no'}, url={url!r}, status={status}")
+
+
+__all__ = ["debug_navbar_icons", "check_navbar_assets", "debug_dash_asset_serving"]

--- a/tools/debug/callbacks.py
+++ b/tools/debug/callbacks.py
@@ -1,0 +1,43 @@
+"""Callback debugging helpers."""
+
+from core.app_factory import create_app
+from core.callback_registry import _callback_registry
+
+
+def debug_callback_conflicts() -> None:
+    """Print callback registration info and detect conflicts."""
+    create_app()
+    print("\U0001f50d Callback Registration Analysis:")
+    print(f"Total registered callbacks: {len(_callback_registry.registered_callbacks)}")
+    for cid, source in _callback_registry.callback_sources.items():
+        print(f"  \u2705 {cid} (from {source})")
+    conflicts = _callback_registry.get_conflicts()
+    if conflicts:
+        print("\u26a0\ufe0f Potential conflicts found")
+    else:
+        print("\u2705 No callback conflicts detected")
+
+
+def validate_callback_system() -> bool:
+    """Verify callback methods are available and registration works."""
+    try:
+        app = create_app(mode="simple")
+        required = ["callback", "unified_callback", "register_callback"]
+        missing = [m for m in required if not hasattr(app, m)]
+        if missing:
+            print(f"\u274c Missing methods: {missing}")
+            return False
+        print("\u2705 All callback methods available")
+
+        @app.unified_callback(outputs="test-output.children", inputs="test-input.value")
+        def test_cb(value):
+            return f"Test: {value}"  # pragma: no cover - sanity example
+
+        print("\u2705 Callback registration successful")
+        return True
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"\u274c Callback system validation failed: {e}")
+        return False
+
+
+__all__ = ["debug_callback_conflicts", "validate_callback_system"]


### PR DESCRIPTION
## Summary
- move navbar and callback debug helpers into `tools/debug` package
- add CLI `python -m tools.debug` to run asset and callback checks
- keep wrapper scripts for backwards compatibility
- update README documentation for new command

## Testing
- `black tools/debug/__init__.py tools/debug/assets.py tools/debug/callbacks.py tools/debug/__main__.py debug_callback_registry.py scripts/debug_navbar_icons.py scripts/validate_callback_system.py`
- `isort tools/debug/__init__.py tools/debug/assets.py tools/debug/callbacks.py tools/debug/__main__.py debug_callback_registry.py scripts/debug_navbar_icons.py scripts/validate_callback_system.py`
- `flake8 tools/debug/__init__.py tools/debug/assets.py tools/debug/callbacks.py tools/debug/__main__.py debug_callback_registry.py scripts/debug_navbar_icons.py scripts/validate_callback_system.py`
- `mypy tools/debug/__init__.py tools/debug/assets.py tools/debug/callbacks.py tools/debug/__main__.py debug_callback_registry.py scripts/debug_navbar_icons.py scripts/validate_callback_system.py` *(failed: Missing dependencies)*
- `pytest -q` *(failed: many missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686dc87943e88320bdc86c90dcc2aa07