### PR TITLE
Fix missing import in asset utilities

### DIFF
--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -14,8 +14,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
-from core.unicode import safe_unicode_encode
-
+from core.unicode import safe_encode_text
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure navbar asset checks import the correct function

## Testing
- `black utils/assets_debug.py --check`
- `isort utils/assets_debug.py --check`
- `pytest -q tests/utils/test_assets_debug.py::test_check_navbar_assets_warn -q` *(fails: Missing required test dependencies: yaml, psutil)*

------
https://chatgpt.com/codex/tasks/task_e_686dd1fbedac8320bdaca24529119997