### PR TITLE
Fix debug asset serving path

### DIFF
--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -48,7 +48,11 @@ def check_navbar_assets(
 
 def debug_dash_asset_serving(app: Any, icon: str = "analytics.png") -> bool:
     """Check if Dash server can serve an icon from the assets directory."""
-    path = f"/assets/navbar_icons/{icon}"
+
+    if hasattr(app, "get_asset_url"):
+        path = app.get_asset_url(f"navbar_icons/{icon}")
+    else:
+        path = f"/assets/navbar_icons/{icon}"
 
     # Skip probe when the icon file is missing.  This avoids unnecessary
     # network requests during startup when optional icons have been removed.


### PR DESCRIPTION
## Summary
- ensure `debug_dash_asset_serving` uses the Dash app's asset URL when available

## Testing
- `pytest -q tests/utils/test_asset_serving.py::test_debug_dash_asset_serving` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686dd44fc2bc832082ade7d681f02ff3