### PR TITLE
Restore register_navbar_callbacks stub

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -107,3 +107,8 @@ def create_navbar_layout(theme: str = "light"):
         color="light",
         className="shadow-sm",
     )
+
+
+def register_navbar_callbacks(manager, service=None):
+    """Compatibility stub - no callbacks currently needed."""
+    manager.navbar_registered = True


### PR DESCRIPTION
## Summary
- add a no-op `register_navbar_callbacks` to match existing imports

## Testing
- `black components/ui/navbar.py --check`
- `flake8 components/ui/navbar.py` *(fails: command not found)*
- `mypy components/ui/navbar.py` *(fails: found 453 errors in unrelated files)*
- `pytest -k navbar -q` *(fails: missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ddb55a720832095ac6d9e39186452