### PR TITLE
Add register_callback alias

### DIFF
--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -157,7 +157,7 @@ class TrulyUnifiedCallbacks:
         return decorator
 
     # ------------------------------------------------------------------
-    def handle_register(
+    def register_callback(
         self,
         outputs: Any,
         inputs: Iterable[Input] | Input | None = None,
@@ -168,7 +168,7 @@ class TrulyUnifiedCallbacks:
         allow_duplicate: bool = False,
         **kwargs: Any,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """Alias for handle_register method - register a Dash callback and track conflicts."""
+        """Alias for handle_register - register a Dash callback and track conflicts."""
         return self.handle_register(
             outputs=outputs,
             inputs=inputs,
@@ -176,7 +176,7 @@ class TrulyUnifiedCallbacks:
             callback_id=callback_id,
             component_name=component_name,
             allow_duplicate=allow_duplicate,
-            **kwargs
+            **kwargs,
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add missing `register_callback` alias for `handle_register`

## Testing
- `pip install dash==2.15.0 dash-bootstrap-components==1.6.0`
- `pytest tests/test_unified_callback_coordinator.py::test_duplicate_callback_registration -q` *(fails: Dash() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686e002fa7fc8320a217c33db2144d6a