### PR TITLE
Fix file_upload page header

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -1,8 +1,11 @@
-#!/usr/bin/env python3#!/usr/bin/env python3
+#!/usr/bin/env python3
 """File upload page wiring the reusable upload component."""
 from __future__ import annotations
 
-from core.plugins.decorators import unicode_safe_callbackimport logging
+import logging
+from typing import Any, Optional
+
+from core.plugins.decorators import unicode_safe_callback
 import types
 from typing import TYPE_CHECKING, Any
 


### PR DESCRIPTION
## Summary
- clean up pages/file_upload.py header

## Testing
- `pytest -k file_upload -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e078337188320943a8e9bc1b5530f