### PR TITLE
Fix navbar callbacks and add unicode safe decorator

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -5,7 +5,7 @@ Resolves flash/disappear issues on upload file link clicks.
 """
 
 import dash_bootstrap_components as dbc
-from dash import html, dcc, Input, Output, State, no_update
+from dash import html, Input, Output, State
 from typing import Optional, Any
 import logging
 
@@ -105,14 +105,21 @@ def create_navbar_layout() -> dbc.Navbar:
     except Exception as e:
         logger.error(f"Navbar creation failed: {e}")
         # Return minimal fallback navbar
-        return dbc.Navbar([
-            dbc.Container([
-                dbc.NavbarBrand("Dashboard", href="/"),
-                dbc.Nav([
-                    dbc.NavItem(dbc.NavLink("Upload", href="/file-upload")),
-                ], navbar=True)
-            ])
-        ])
+        return dbc.Navbar(
+            [
+                dbc.Container(
+                    [
+                        dbc.NavbarBrand("Dashboard", href="/"),
+                        dbc.Nav(
+                            [
+                                dbc.NavItem(dbc.NavLink("Upload", href="/file-upload")),
+                            ],
+                            navbar=True,
+                        ),
+                    ]
+                )
+            ]
+        )
 
 
 def register_navbar_callbacks(manager, service: Optional[Any] = None) -> None:
@@ -125,7 +132,7 @@ def register_navbar_callbacks(manager, service: Optional[Any] = None) -> None:
             State("navbar-collapse", "is_open"),
             callback_id="navbar_toggle",
             component_name="navbar",
-            prevent_initial_call=True
+            prevent_initial_call=True,
         )
         def toggle_navbar_collapse(n_clicks, is_open):
             """Toggle navbar collapse state."""
@@ -133,57 +140,18 @@ def register_navbar_callbacks(manager, service: Optional[Any] = None) -> None:
                 return not is_open
             return is_open
 
-        # Register navigation click handlers using existing system  
-        @manager.unified_callback(
-            Output("nav-upload-link", "style"),
-            Input("nav-upload-link", "n_clicks"),
-            callback_id="navbar_upload_click",
-            component_name="navbar",
-            prevent_initial_call=True
-        )
-        def handle_upload_click(n_clicks):
-            """Handle upload link clicks - prevent flash by returning stable style."""
-            if n_clicks:
-                # Return stable style to prevent flash
-                return {"pointer-events": "auto", "opacity": "1"}
-            return no_update
-
-        @manager.unified_callback(
-            Output("nav-analytics-link", "style"),
-            Input("nav-analytics-link", "n_clicks"),
-            callback_id="navbar_analytics_click", 
-            component_name="navbar",
-            prevent_initial_call=True
-        )
-        def handle_analytics_click(n_clicks):
-            """Handle analytics link clicks."""
-            if n_clicks:
-                return {"pointer-events": "auto", "opacity": "1"}
-            return no_update
-
-        @manager.unified_callback(
-            Output("nav-settings-link", "style"),
-            Input("nav-settings-link", "n_clicks"),
-            callback_id="navbar_settings_click",
-            component_name="navbar", 
-            prevent_initial_call=True
-        )
-        def handle_settings_click(n_clicks):
-            """Handle settings link clicks."""
-            if n_clicks:
-                return {"pointer-events": "auto", "opacity": "1"}
-            return no_update
-
         # Mark as registered
-        if hasattr(manager, 'navbar_registered'):
+        if hasattr(manager, "navbar_registered"):
             manager.navbar_registered = True
 
-        logger.info("Navbar callbacks registered successfully with TrulyUnifiedCallbacks")
+        logger.info(
+            "Navbar callbacks registered successfully with TrulyUnifiedCallbacks"
+        )
 
     except Exception as e:
         logger.error(f"Navbar callback registration failed: {e}")
         # Fallback: just mark as registered
-        if hasattr(manager, 'navbar_registered'):
+        if hasattr(manager, "navbar_registered"):
             manager.navbar_registered = True
 
 

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -1,4 +1,3 @@
-from core.plugins.decorators import unicode_safe_callback
 """Dash callback handlers for the deep analytics page."""
 
 from typing import TYPE_CHECKING, Any
@@ -550,7 +549,6 @@ def register_callbacks(
             raise ValueError(f"Unsupported callback manager: {type(manager)}")
 
         callback_manager.register_operation(
-
             "analysis_buttons",
             lambda s, t, b, a, sug, q, u, ds: cb.handle_analysis_buttons(
                 s, t, b, a, sug, q, u, ds
@@ -623,7 +621,6 @@ def register_callbacks(
     _callback_registry.register_deduplicated(
         ["deep_analytics_operations"], _do_registration, source_module="deep_analytics"
     )
-
 
 
 __all__ = ["Callbacks", "register_callbacks"]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from dash import html
 
-from core.callback_registry import (
-    _callback_registry,
-    handle_register_with_deduplication,
-)
-from core.plugins.decorators import unicode_safe_callback
+from core.callback_registry import _callback_registry
 from core.unicode import safe_encode_text
+
+try:
+    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+except Exception:  # pragma: no cover - fallback when unavailable
+    TrulyUnifiedCallbacks = None  # type: ignore
 
 try:  # Lazy import for optional heavy dependencies
     from components.upload import UnifiedUploadComponent
@@ -186,4 +187,5 @@ __all__ = [
     "register_upload_callbacks",
     "register_callbacks",
     "check_upload_system_health",
-    "load_page",]
+    "load_page",
+]


### PR DESCRIPTION
## Summary
- implement `unicode_safe_callback` in `core.unicode`
- simplify navbar callback registration and remove style mutation
- update imports in deep analytics and file upload pages
- ensure fallback when TrulyUnifiedCallbacks is missing

## Testing
- `flake8 core/unicode.py components/ui/navbar.py pages/file_upload.py --max-line-length 120`
- `mypy core/unicode.py components/ui/navbar.py pages/file_upload.py pages/deep_analytics/callbacks.py --ignore-missing-imports --config-file /dev/null` *(fails: No [mypy] section in config file)*
- `pytest tests/test_basic_navbar.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e1d7078b08320af354fe355612a22