### PR TITLE
Fix unicode callback import

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from core.exceptions import ConfigurationError
 from utils import debug_dash_asset_serving
+from core.unicode import unicode_safe_callback
 
 import traceback
 from pathlib import Path


### PR DESCRIPTION
## Summary
- import `unicode_safe_callback` in app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686e2333119883209a271b8bd0ed9738