### PR TITLE
Implement advanced ConfigValidator methods

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -12,20 +12,22 @@ import yaml
 
 from core.exceptions import ConfigurationError
 from core.protocols import ConfigurationProtocol
-from core.secrets_validator import SecretsValidator
 from core.secrets_manager import SecretsManager
+from core.secrets_validator import SecretsValidator
 
 from .config_validator import ConfigValidator
-from .dynamic_config import dynamic_config
-from .environment import get_environment, select_config_file
+
+ValidationResult = ConfigValidator.ValidationResult
 from .constants import (
     DEFAULT_APP_HOST,
     DEFAULT_APP_PORT,
-    DEFAULT_DB_HOST,
-    DEFAULT_DB_PORT,
     DEFAULT_CACHE_HOST,
     DEFAULT_CACHE_PORT,
+    DEFAULT_DB_HOST,
+    DEFAULT_DB_PORT,
 )
+from .dynamic_config import dynamic_config
+from .environment import get_environment, select_config_file
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +119,6 @@ class AnalyticsConfig:
     max_display_rows: int = 10000
 
 
-
 @dataclass
 class MonitoringConfig:
     """Runtime monitoring options"""
@@ -163,7 +164,9 @@ class Config:
     analytics: AnalyticsConfig = field(default_factory=AnalyticsConfig)
     monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
     cache: CacheConfig = field(default_factory=CacheConfig)
-    secret_validation: SecretValidationConfig = field(default_factory=SecretValidationConfig)
+    secret_validation: SecretValidationConfig = field(
+        default_factory=SecretValidationConfig
+    )
     environment: str = "development"
     plugin_settings: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
@@ -531,6 +534,14 @@ class ConfigManager(ConfigurationProtocol):
             error_msg = "; ".join(errors)
             logger.error(error_msg)
             raise ConfigurationError(error_msg)
+
+    def validate_current_config(self) -> List[ValidationResult]:
+        """Run validation rules and return results."""
+        results: List[ValidationResult] = []
+        results.extend(ConfigValidator.validate_structure(self.config))
+        results.extend(ConfigValidator.validate_values(self.config))
+        results.extend(ConfigValidator.validate_environment_specific(self.config))
+        return results
 
     def get_app_config(self) -> AppConfig:
         """Get app configuration"""

--- a/config/config_validator.py
+++ b/config/config_validator.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from core.exceptions import ConfigurationError
 
@@ -13,6 +14,29 @@ class ConfigValidator:
     """Validate configuration dictionaries."""
 
     REQUIRED_SECTIONS = {"app", "database", "security"}
+    DEFAULT_RULES: Dict[str, Dict[str, Any]] = {}
+
+    @dataclass
+    class ValidationResult:
+        """Container for a single validation message."""
+
+        message: str
+        severity: str = "info"
+
+    @classmethod
+    def _setup_default_rules(cls) -> None:
+        """Initialize built in validation rules."""
+        if cls.DEFAULT_RULES:
+            return
+
+        cls.DEFAULT_RULES = {
+            "database.type": {
+                "allowed": ["sqlite", "postgresql", "mock"],
+                "severity": "error",
+            },
+            "app.secret_key": {"required": True, "severity": "warning"},
+            "security.secret_key": {"required": True, "severity": "warning"},
+        }
 
     @classmethod
     def validate(cls, data: Dict[str, Any]) -> "Config":
@@ -50,3 +74,107 @@ class ConfigValidator:
         if "environment" in data:
             config.environment = str(data["environment"])
         return config
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def validate_structure(
+        cls, config: "Config"
+    ) -> List["ConfigValidator.ValidationResult"]:
+        """Check that required sections exist."""
+        results: List[ConfigValidator.ValidationResult] = []
+        for section in cls.REQUIRED_SECTIONS:
+            if not hasattr(config, section):
+                results.append(
+                    cls.ValidationResult(
+                        f"Missing configuration section: {section}", "error"
+                    )
+                )
+        return results
+
+    @classmethod
+    def validate_values(
+        cls, config: "Config"
+    ) -> List["ConfigValidator.ValidationResult"]:
+        """Validate configuration option values."""
+        cls._setup_default_rules()
+        results: List[ConfigValidator.ValidationResult] = []
+
+        rules = cls.DEFAULT_RULES
+
+        # database.type allowed values
+        rule = rules.get("database.type")
+        if rule and config.database.type not in rule.get("allowed", []):
+            results.append(
+                cls.ValidationResult(
+                    f"Invalid database type: {config.database.type}",
+                    rule.get("severity", "error"),
+                )
+            )
+
+        # required secret keys
+        for path in ["app.secret_key", "security.secret_key"]:
+            rule = rules.get(path)
+            if rule and rule.get("required"):
+                section, attr = path.split(".")
+                value = getattr(getattr(config, section), attr, "")
+                if not value:
+                    results.append(
+                        cls.ValidationResult(
+                            f"{path} is required", rule.get("severity", "warning")
+                        )
+                    )
+
+        # simple numeric checks
+        if config.app.port <= 0:
+            results.append(cls.ValidationResult("app.port must be positive", "error"))
+        if config.database.port <= 0:
+            results.append(
+                cls.ValidationResult("database.port must be positive", "error")
+            )
+
+        return results
+
+    @classmethod
+    def validate_environment_specific(
+        cls, config: "Config"
+    ) -> List["ConfigValidator.ValidationResult"]:
+        """Checks that depend on the current environment."""
+        results: List[ConfigValidator.ValidationResult] = []
+        env = getattr(config, "environment", "development")
+
+        if env == "production":
+            if config.app.secret_key in {
+                "dev-key-change-in-production",
+                "change-me",
+                "",
+            }:
+                results.append(
+                    cls.ValidationResult(
+                        "SECRET_KEY must be set for production", "error"
+                    )
+                )
+            if not config.database.password and config.database.type != "sqlite":
+                results.append(
+                    cls.ValidationResult(
+                        "Production database requires password", "warning"
+                    )
+                )
+            if config.app.host == "127.0.0.1":
+                results.append(
+                    cls.ValidationResult(
+                        "Production should not run on localhost", "warning"
+                    )
+                )
+
+        if config.app.debug and config.app.host == "0.0.0.0":
+            results.append(
+                cls.ValidationResult(
+                    "Debug mode with host 0.0.0.0 is a security risk", "warning"
+                )
+            )
+        if config.database.type == "postgresql" and not config.database.password:
+            results.append(
+                cls.ValidationResult("PostgreSQL requires a password", "warning")
+            )
+
+        return results


### PR DESCRIPTION
## Summary
- expand `ConfigValidator` with ValidationResult dataclass
- add default rule setup and new validation routines
- expose `ConfigManager.validate_current_config` for structured checks

## Testing
- `black config/config.py config/config_validator.py`
- `isort config/config.py config/config_validator.py`
- `flake8 config/config.py config/config_validator.py`
- `mypy config/config.py config/config_validator.py` *(fails: many unrelated errors)*
- `pytest -q` *(fails: missing optional test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e23e9db1c83208a8a811b0e89605c