### PR TITLE
Introduce config manager factory

### DIFF
--- a/config/complete_service_registration.py
+++ b/config/complete_service_registration.py
@@ -34,7 +34,13 @@ def register_all_services(container: ServiceContainer) -> None:
 
 
 def register_core_infrastructure(container: ServiceContainer) -> None:
-    from config.config import ConfigManager
+    from config import (
+        ConfigLoader,
+        ConfigManager,
+        ConfigTransformer,
+        ConfigValidator,
+        create_config_manager,
+    )
     from config.database_manager import DatabaseConfig, DatabaseManager
     from core.logging import LoggingService
     from services.configuration_service import (
@@ -42,10 +48,14 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         DynamicConfigurationService,
     )
 
+    container.register_singleton("config_loader", ConfigLoader)
+    container.register_singleton("config_validator", ConfigValidator)
+    container.register_singleton("config_transformer", ConfigTransformer)
     container.register_singleton(
         "config_manager",
         ConfigManager,
         protocol=ConfigurationProtocol,
+        factory=lambda c: create_config_manager(container=c),
     )
     container.register_singleton(
         "configuration_service",
@@ -87,19 +97,27 @@ def register_analytics_services(container: ServiceContainer) -> None:
         def get_dashboard_summary(self, time_range: str = "30d") -> Dict[str, Any]:
             return {"status": "stub", "message": "Analytics not configured"}
 
-        def analyze_access_patterns(self, days: int, user_id: str | None = None) -> Dict[str, Any]:
+        def analyze_access_patterns(
+            self, days: int, user_id: str | None = None
+        ) -> Dict[str, Any]:
             return {"status": "stub"}
 
         def detect_anomalies(self, data, sensitivity: float = 0.5):
             return []
 
-        def generate_report(self, report_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        def generate_report(
+            self, report_type: str, params: Dict[str, Any]
+        ) -> Dict[str, Any]:
             return {"status": "stub"}
 
-        def get_user_activity_summary(self, user_id: str, days: int = 30) -> Dict[str, Any]:
+        def get_user_activity_summary(
+            self, user_id: str, days: int = 30
+        ) -> Dict[str, Any]:
             return {"status": "stub"}
 
-        def get_facility_statistics(self, facility_id: str | None = None) -> Dict[str, Any]:
+        def get_facility_statistics(
+            self, facility_id: str | None = None
+        ) -> Dict[str, Any]:
             return {"status": "stub"}
 
         def health_check(self) -> Dict[str, Any]:

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -1,0 +1,54 @@
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .environment import select_config_file
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigLoader:
+    """Load configuration data from YAML files."""
+
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self.config_path = config_path
+
+    def load(self) -> Dict[str, Any]:
+        """Return configuration dictionary from YAML or empty dict."""
+        config_file = select_config_file(self.config_path)
+        if not config_file or not Path(config_file).exists():
+            logger.info("No YAML config file found, using defaults")
+            return {}
+        try:
+            with open(config_file, "r", encoding="utf-8") as fh:
+                content = fh.read()
+                # simple env substitution
+                import re
+
+                def replacer(match: re.Match[str]) -> str:
+                    var = match.group(1)
+                    return os.getenv(var, match.group(0))
+
+                content = re.sub(r"\$\{([^}]+)\}", replacer, content)
+
+                class IncludeLoader(yaml.SafeLoader):
+                    pass
+
+                base_dir = Path(config_file).parent
+
+                def _include(loader: IncludeLoader, node: yaml.Node) -> Any:
+                    filename = loader.construct_scalar(node)
+                    inc_path = base_dir / filename
+                    with open(inc_path, "r", encoding="utf-8") as inc:
+                        return yaml.load(inc, Loader=IncludeLoader)
+
+                IncludeLoader.add_constructor("!include", _include)
+
+                data = yaml.load(content, Loader=IncludeLoader)
+                return data or {}
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("Error loading config file %s: %s", config_file, exc)
+            return {}

--- a/config/config_transformer.py
+++ b/config/config_transformer.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+
+class ConfigTransformer:
+    """Optional hook to transform the final Config object."""
+
+    def transform(self, config: Any) -> Any:
+        """Return transformed configuration."""
+        return config

--- a/core/plugins/auto_config.py
+++ b/core/plugins/auto_config.py
@@ -1,11 +1,12 @@
 """Utility helpers for automatic plugin setup."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from dash import Dash
 
-from config.config import ConfigManager
+from config import ConfigManager, create_config_manager
 from core.service_container import ServiceContainer
 
 from .unified_registry import UnifiedPluginRegistry
@@ -26,7 +27,7 @@ class PluginAutoConfiguration:
         self.container = container or ServiceContainer()
         # Expose container on the app for decorators like ``safe_callback``
         cast(Any, self.app)._yosai_container = self.container
-        self.config_manager = config_manager or ConfigManager()
+        self.config_manager = config_manager or create_config_manager()
         self.package = package
         self.registry = UnifiedPluginRegistry(
             app,
@@ -80,7 +81,10 @@ class PluginAutoConfiguration:
             methods=["GET"],
         )
         self.registry.plugin_manager.register_performance_endpoint(self.app)
-        return {"/health/plugins": plugin_health, "/health/plugins/performance": self.registry.plugin_manager.get_plugin_performance_metrics}
+        return {
+            "/health/plugins": plugin_health,
+            "/health/plugins/performance": self.registry.plugin_manager.get_plugin_performance_metrics,
+        }
 
 
 def setup_plugins(


### PR DESCRIPTION
## Summary
- add `ConfigLoader` and `ConfigTransformer` helpers
- allow `ConfigManager` to accept loader/validator/transformer dependencies
- provide `create_config_manager` factory
- register config components in service registration
- use factory in plugin auto configuration

## Testing
- `black config/config_loader.py config/config_transformer.py config/config.py config/__init__.py config/complete_service_registration.py core/plugins/auto_config.py`
- `isort config/config_loader.py config/config_transformer.py config/config.py config/__init__.py config/complete_service_registration.py core/plugins/auto_config.py`
- `flake8 config/config_loader.py config/config_transformer.py config/config.py config/__init__.py config/complete_service_registration.py core/plugins/auto_config.py`
- `pytest tests/test_config_validator.py::test_missing_sections -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e23eadac48320a203bf243381fb75