### PR TITLE
Add config manager factory and tests

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -586,6 +586,11 @@ class ConfigManager(ConfigurationProtocol):
             return {"valid": False, "error": str(exc)}
 
 
+def create_config_manager(config_path: Optional[str] = None) -> "ConfigManager":
+    """Factory helper to instantiate :class:`ConfigManager`."""
+    return ConfigManager(config_path)
+
+
 # Global configuration instance
 _config_manager: Optional[ConfigManager] = None
 
@@ -663,6 +668,7 @@ __all__ = [
     "CacheConfig",
     "SecretValidationConfig",
     "ConfigManager",
+    "create_config_manager",
     "get_config",
     "reload_config",
     "get_app_config",

--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,12 +1,12 @@
 from core.container import Container
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from services.analytics_service import AnalyticsService
 
 
 def test_container_initializes_without_circular_dependencies():
     container = Container()
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     analytics = AnalyticsService()
 
     container.register("config", cfg)

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -3,7 +3,7 @@ import pytest
 
 from dash import Dash, html
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.auto_config import setup_plugins
 from tests.test_auto_configuration import _set_env
@@ -19,7 +19,7 @@ def test_plugin_discovery_and_callback_registration(monkeypatch, tmp_path):
         try:
             app = Dash(__name__)
             app.layout = html.Div()
-            cfg = ConfigManager()
+            cfg = create_config_manager()
             cfg.config.plugin_settings[builder.plugin_name] = {"enabled": True}
             registry = setup_plugins(
                 app,

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -1,6 +1,6 @@
 import sys
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 
@@ -53,7 +53,7 @@ def test_load_all_plugins_registers_services(tmp_path):
     pkg_dir = create_package(tmp_path)
     sys.path.insert(0, str(tmp_path))
     try:
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["test_plugin"] = {"enabled": True}
         manager = PluginManager(
             ServiceContainer(),

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -4,7 +4,7 @@ import pytest
 
 from dash import Dash, Input, Output
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.json_serialization_plugin import JsonSerializationPlugin
 from core.plugins.auto_config import setup_plugins
@@ -93,7 +93,7 @@ def test_setup_uses_provided_dependencies(monkeypatch, tmp_path):
     try:
         app = Dash(__name__)
         container = ServiceContainer()
-        config = ConfigManager()
+        config = create_config_manager()
         config.config.plugin_settings["auto_plugin"] = {"enabled": True}
         registry = setup_plugins(app, container=container, config_manager=config, package="auto_pkg")
         assert registry.container is container

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+import pytest
+
+from config.config import create_config_manager
+from config.dynamic_config import DynamicConfigManager
+
+
+def test_yaml_and_env_loading(monkeypatch, tmp_path):
+    yaml_text = """
+app:
+  title: "Demo ${APP_EXTRA}"
+database:
+  name: demo.db
+security:
+  secret_key: ${SECRET_VAR}
+"""
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
+    monkeypatch.setenv("APP_EXTRA", "\u0394")
+    monkeypatch.setenv("SECRET_VAR", "secret")
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    # required env vars
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("AUTH0_DOMAIN", "domain")
+    monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
+
+    cfg = create_config_manager()
+    assert cfg.get_app_config().title == "Demo \u0394"
+
+
+def test_json_env_rules_parsed(monkeypatch):
+    monkeypatch.setenv("VALIDATOR_RULES", '{"xss": false, "sql_injection": false}')
+    dynamic = DynamicConfigManager()
+    assert dynamic.uploads.VALIDATOR_RULES["xss"] is False
+    assert dynamic.uploads.VALIDATOR_RULES["sql_injection"] is False

--- a/tests/test_config_production_secrets.py
+++ b/tests/test_config_production_secrets.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 
 REQUIRED_AUTH_VARS = [
     "AUTH0_CLIENT_ID",
@@ -21,4 +21,4 @@ def set_env(monkeypatch, secret: str) -> None:
 def test_invalid_secrets_raise(monkeypatch):
     set_env(monkeypatch, "change-me")
     with pytest.raises(ValueError):
-        ConfigManager()
+        create_config_manager()

--- a/tests/test_config_transformer.py
+++ b/tests/test_config_transformer.py
@@ -1,0 +1,20 @@
+import os
+
+from config.config import create_config_manager
+
+
+def test_environment_overrides(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "db.example.com")
+    monkeypatch.setenv("DB_PORT", "1234")
+    # required vars
+    monkeypatch.setenv("SECRET_KEY", "s")
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("AUTH0_DOMAIN", "dom")
+    monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
+
+    cfg = create_config_manager()
+    db = cfg.get_database_config()
+    assert db.host == "db.example.com"
+    assert db.port == 1234

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -4,7 +4,7 @@ import sys
 from core.plugins.dependency_resolver import PluginDependencyResolver
 from core.plugins.manager import PluginManager
 from core.service_container import ServiceContainer
-from config.config import ConfigManager
+from config.config import create_config_manager
 from services.data_processing.core.protocols import PluginMetadata
 
 
@@ -122,7 +122,7 @@ def create_plugin():
 """
     )
     sys.path.insert(0, str(tmp_path))
-    manager = PluginManager(ServiceContainer(), ConfigManager(), package="cyclepkg", health_check_interval=1)
+    manager = PluginManager(ServiceContainer(), create_config_manager(), package="cyclepkg", health_check_interval=1)
     try:
         caplog.set_level("ERROR")
         result = manager.load_all_plugins()
@@ -163,7 +163,7 @@ def create_plugin():
 """
     )
     sys.path.insert(0, str(tmp_path))
-    manager = PluginManager(ServiceContainer(), ConfigManager(), package="unkpkg", health_check_interval=1)
+    manager = PluginManager(ServiceContainer(), create_config_manager(), package="unkpkg", health_check_interval=1)
     try:
         caplog.set_level("ERROR")
         result = manager.load_all_plugins()

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 from flask import Flask
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.json_serialization_plugin import (
     JsonCallbackService,
@@ -143,7 +143,7 @@ class TestPluginManager(unittest.TestCase):
 
     def setUp(self):
         self.container = ServiceContainer()
-        cfg_mgr = ConfigManager()
+        cfg_mgr = create_config_manager()
         cfg_mgr.config.plugin_settings["json_serialization"] = {
             "max_dataframe_rows": 5,
             "auto_wrap_callbacks": True,
@@ -174,7 +174,7 @@ class TestPluginManager(unittest.TestCase):
 
     def test_periodic_health_snapshot(self):
         """Plugin manager updates health snapshot periodically"""
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["json_serialization"] = {"max_dataframe_rows": 5}
         manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
         plugin = JsonSerializationPlugin()
@@ -187,7 +187,7 @@ class TestPluginManager(unittest.TestCase):
     def test_health_endpoint_registration(self):
         """Ensure /health/plugins endpoint is registered"""
         app = Flask(__name__)
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["json_serialization"] = {"max_dataframe_rows": 5}
         manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
         manager.register_health_endpoint(app)

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
@@ -35,7 +35,7 @@ analytics:
     }
     for k, v in envs.items():
         monkeypatch.setenv(k, v)
-    cfg = ConfigManager(str(path))
+    cfg = create_config_manager(str(path))
     assert cfg.get_analytics_config().max_display_rows == 123
 
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2,7 +2,7 @@ import sys
 import time
 from pathlib import Path
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginMetadata
@@ -39,7 +39,7 @@ class SimplePlugin:
 
 
 def test_load_plugin_registers_plugin(tmp_path):
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["simple"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = SimplePlugin()
@@ -83,7 +83,7 @@ def create_plugin():
     )
     sys.path.insert(0, str(tmp_path))
     try:
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["auto"] = {"enabled": True}
         manager = PluginManager(
             ServiceContainer(),
@@ -100,7 +100,7 @@ def create_plugin():
 
 
 def test_get_plugin_health_snapshot():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["simple"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = SimplePlugin()

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -3,7 +3,7 @@ import sys
 import types
 from pathlib import Path
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginMetadata, PluginStatus
@@ -66,7 +66,7 @@ class NoHealthPlugin:
 
 
 def test_load_plugin_success(tmp_path):
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["dummy"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
@@ -80,7 +80,7 @@ def test_load_plugin_success(tmp_path):
 
 
 def test_load_plugin_failure_missing_health():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["nohealth"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = NoHealthPlugin()
@@ -92,7 +92,7 @@ def test_load_plugin_failure_missing_health():
 
 
 def test_get_plugin_health(monkeypatch):
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["dummy"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
@@ -137,7 +137,7 @@ def create_plugin():
     )
     sys.path.insert(0, str(tmp_path))
     try:
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["plug_a"] = {"enabled": True}
         manager = PluginManager(
             ServiceContainer(),
@@ -154,7 +154,7 @@ def create_plugin():
 
 
 def test_stop_all_plugins_calls_stop():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["dummy"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = DummyPlugin()
@@ -177,7 +177,7 @@ class FailingStopPlugin(DummyPlugin):
 
 
 def test_stop_all_plugins_handles_errors():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["failstop"] = {"enabled": True}
     manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
     plugin = FailingStopPlugin()

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -1,12 +1,12 @@
 import time
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 
 
 def test_health_thread_stops_on_exit():
-    mgr = PluginManager(ServiceContainer(), ConfigManager(), health_check_interval=1)
+    mgr = PluginManager(ServiceContainer(), create_config_manager(), health_check_interval=1)
     assert mgr._health_thread.is_alive()
     mgr.stop_health_monitor()
     time.sleep(0.1)
@@ -14,7 +14,7 @@ def test_health_thread_stops_on_exit():
 
 
 def test_context_manager_stops_thread():
-    with PluginManager(ServiceContainer(), ConfigManager(), health_check_interval=1) as mgr:
+    with PluginManager(ServiceContainer(), create_config_manager(), health_check_interval=1) as mgr:
         assert mgr._health_thread.is_alive()
     time.sleep(0.1)
     assert not mgr._health_thread.is_alive()

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -1,6 +1,6 @@
 import sys
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginPriority
@@ -51,7 +51,7 @@ def create_plugin():
 
     sys.path.insert(0, str(tmp_path))
     try:
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         cfg.config.plugin_settings["a"] = {}
         cfg.config.plugin_settings["b"] = {}
         manager = PluginManager(

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -162,9 +162,9 @@ def env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestProtocolCompliance:
     def test_configuration_service_compliance(self):
-        from config.config import ConfigManager
+        from config.config import create_config_manager
 
-        cfg = ConfigManager()
+        cfg = create_config_manager()
         assert isinstance(cfg, ConfigurationProtocol)
         assert_type(cfg, ConfigurationProtocol)
 

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -1,7 +1,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager
 from services.data_processing.core.protocols import PluginMetadata
@@ -36,7 +36,7 @@ class ConcurrencyPlugin:
 
 
 def test_concurrent_load_plugin():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["concurrent"] = {"enabled": True}
     manager = ThreadSafePluginManager(ServiceContainer(), cfg, health_check_interval=0.1)
     plugin = ConcurrencyPlugin()
@@ -51,7 +51,7 @@ def test_concurrent_load_plugin():
 
 
 def test_concurrent_health_checks():
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["concurrent"] = {"enabled": True}
     manager = ThreadSafePluginManager(ServiceContainer(), cfg, health_check_interval=0.1)
     plugin = ConcurrencyPlugin()

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -12,7 +12,7 @@ class EnumJSONProvider(DefaultJSONProvider):
         return super().default(o)
 import sys
 
-from config.config import ConfigManager
+from config.config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.plugins.unified_registry import UnifiedPluginRegistry
@@ -56,7 +56,7 @@ class DummyPlugin:
 def test_registry_registration_and_service():
     app = Dash(__name__)
     container = ServiceContainer()
-    cfg = ConfigManager()
+    cfg = create_config_manager()
     cfg.config.plugin_settings["dummy"] = {"enabled": True}
     registry = UnifiedPluginRegistry(app, container, cfg)
     plugin = DummyPlugin()


### PR DESCRIPTION
## Summary
- implement `create_config_manager` helper in configuration module
- update tests to use the new factory
- test config loader, validator and transformer behaviour

## Testing
- `pytest tests/test_config_loader.py tests/test_config_validator.py tests/test_config_transformer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e23eef2f083208df04dfc6834c014