### PR TITLE
Add YAML include support to ConfigLoader and integrate

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,8 @@ from core.unicode import unicode_safe_callback
 import traceback
 from pathlib import Path
 
+from config import ConfigLoader
+
 # This import is handled inside the main() function now
 
 # Add Unicode handling
@@ -233,6 +235,10 @@ def main():
 
         # Import configuration
         try:
+            loader = ConfigLoader()
+            raw_cfg = loader.load()
+            logger.debug("Loaded raw config with keys: %s", list(raw_cfg.keys()))
+
             from config.config import get_config
             config = get_config()
             app_config = config.get_app_config()

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -18,6 +18,7 @@ from .config import (
     get_security_config,
 )
 from .config_manager import ConfigManager, get_config, reload_config
+from .config_loader import ConfigLoader
 from .connection_pool import DatabaseConnectionPool
 from .connection_retry import ConnectionRetryManager, RetryConfig
 from .constants import CSSConstants, PerformanceConstants, SecurityConstants


### PR DESCRIPTION
## Summary
- implement YAML `!include` recursion in `config/config_loader.py`
- expose `ConfigLoader` from `config` package
- load raw config with `ConfigLoader` in `app.py`

## Testing
- `python -m py_compile config/config_loader.py`
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686e2c117f28832094f96403424dc059