### PR TITLE
Update upload component IDs

### DIFF
--- a/components/upload/ui/upload_area.py
+++ b/components/upload/ui/upload_area.py
@@ -9,7 +9,7 @@ from dash import dcc, html
 class UploadArea:
     """Drag and drop upload area without business logic."""
 
-    def __init__(self, upload_handler: Callable | None = None, upload_id: str = "file-upload-area") -> None:
+    def __init__(self, upload_handler: Callable | None = None, upload_id: str = "drag-drop-upload") -> None:
         self.upload_handler = upload_handler
         self.upload_id = upload_id
         self.status_id = f"{upload_id}-status"

--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -59,8 +59,8 @@ class UnifiedUploadController(UploadControllerProtocol):
                     Output("uploaded-df-store", "data"),
                 ],
                 [
-                    Input("file-uploader", "contents"),
-                    Input("file-uploader", "filename"),
+                    Input("drag-drop-upload", "contents"),
+                    Input("drag-drop-upload", "filename"),
                 ],
                 None,
                 "file_upload_handle",


### PR DESCRIPTION
## Summary
- change default UploadArea ID to `drag-drop-upload`
- update UnifiedUploadController callback inputs to match the new ID

## Testing
- `pytest tests/test_upload_fix.py::test_file_upload_component_integration -q` *(fails: Missing required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e3007cd388320b79bcd25d0dc83b7