### PR TITLE
Fix upload change loop

### DIFF
--- a/assets/js/upload-handlers.js
+++ b/assets/js/upload-handlers.js
@@ -108,6 +108,9 @@
 
 
     input.addEventListener('change', async function(e){
+      // Ignore synthetic events to avoid recursion when we
+      // redispatch the event after validation.
+      if(!e.isTrusted){ return; }
       e.stopImmediatePropagation();
       e.preventDefault();
       if(area){ area.classList.add('drag-drop-upload--uploading'); }


### PR DESCRIPTION
## Summary
- guard against synthetic change events in upload handlers

## Testing
- `pre-commit run --files assets/js/upload-handlers.js`
- `pytest -k ''` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e3008429c8320b5aa24c8f6675d11