### PR TITLE
Add upload component validation helpers

### DIFF
--- a/components/upload/unified_upload_component.py
+++ b/components/upload/unified_upload_component.py
@@ -1,12 +1,73 @@
 from __future__ import annotations
 
+from dash import dcc
+
 from components.file_upload_component import FileUploadComponent
+
+
+def _find_upload_components(component) -> list[dcc.Upload]:
+    """Recursively collect any ``dcc.Upload`` components."""
+
+    found: list[dcc.Upload] = []
+    if isinstance(component, dcc.Upload):
+        found.append(component)
+
+    children = getattr(component, "children", None)
+    if isinstance(children, (list, tuple)):
+        for child in children:
+            found.extend(_find_upload_components(child))
+    elif children is not None:
+        found.extend(_find_upload_components(children))
+
+    return found
 
 
 class UnifiedUploadComponent(FileUploadComponent):
     """Unified upload component wrapping :class:`FileUploadComponent`."""
 
-    pass
+    def validate_component_state(self, manager=None) -> bool:
+        """Verify required attributes and callback registration."""
+
+        required = ["callback_manager", "layout", "register_callbacks"]
+        if any(not hasattr(self, attr) for attr in required):
+            return False
+
+        try:
+            layout = self.layout()
+        except Exception:
+            return False
+
+        uploads = _find_upload_components(layout)
+        if not uploads:
+            return False
+
+        class DummyManager:
+            def __init__(self) -> None:
+                self.ids: list[str] = []
+
+            def register_handler(self, *_, callback_id=None, **__):  # type: ignore[override]
+                self.ids.append(callback_id)
+
+                def decorator(func):
+                    return func
+
+                return decorator
+
+        mgr = manager or DummyManager()
+
+        try:
+            self.register_callbacks(mgr)
+        except Exception:
+            return False
+
+        expected = {
+            "file_upload_handle",
+            "file_upload_progress",
+            "file_upload_finalize",
+        }
+
+        ids = getattr(mgr, "ids", [])
+        return expected.issubset(set(ids))
 
 
 __all__ = ["UnifiedUploadComponent"]

--- a/tests/components/test_unified_upload_component.py
+++ b/tests/components/test_unified_upload_component.py
@@ -1,0 +1,37 @@
+from dash import dcc
+
+from components.upload import UnifiedUploadComponent
+
+
+class DummyManager:
+    def __init__(self) -> None:
+        self.ids = []
+
+    def register_handler(self, *_, callback_id=None, **__):
+        self.ids.append(callback_id)
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def test_find_upload_components():
+    comp = UnifiedUploadComponent()
+    from components.upload.unified_upload_component import _find_upload_components
+
+    layout = comp.layout()
+    uploads = _find_upload_components(layout)
+    assert uploads
+    assert all(isinstance(u, dcc.Upload) for u in uploads)
+
+
+def test_validate_component_state():
+    comp = UnifiedUploadComponent()
+    mgr = DummyManager()
+    assert comp.validate_component_state(mgr)
+    assert {
+        "file_upload_handle",
+        "file_upload_progress",
+        "file_upload_finalize",
+    }.issubset(set(mgr.ids))


### PR DESCRIPTION
## Summary
- implement `_find_upload_components` helper
- add `validate_component_state()` to ensure upload component integrity
- test upload component validation logic

## Testing
- `pytest tests/components/test_unified_upload_component.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3009a8548320aa0302038e4957de