### PR TITLE
Add ConfigTransformer export

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -19,6 +19,7 @@ from .config import (
 )
 from .config_manager import ConfigManager, get_config, reload_config
 from .config_loader import ConfigLoader
+from .config_transformer import ConfigTransformer
 from .connection_pool import DatabaseConnectionPool
 from .connection_retry import ConnectionRetryManager, RetryConfig
 from .constants import CSSConstants, PerformanceConstants, SecurityConstants


### PR DESCRIPTION
## Summary
- import ConfigTransformer in `config.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e30bda0308320b7fa01cd299c3753