### PR TITLE
Refactor config imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ resolved from anywhere:
 
 ```python
 from core.container import Container
-from config.config import create_config_manager
+from config import create_config_manager
 
 container = Container()
 container.register("config", create_config_manager())
@@ -358,7 +358,7 @@ config = container.get("config")
 A short example without the container:
 
 ```python
-from config.config import create_config_manager
+from config import create_config_manager
 
 config = create_config_manager()
 db_cfg = config.get_database_config()
@@ -481,7 +481,7 @@ the new unified configuration through it instead:
 
 ```python
 from core.container import Container
-from config.config import create_config_manager
+from config import create_config_manager
 
 container = Container()
 container.register("config", create_config_manager())

--- a/app.py
+++ b/app.py
@@ -239,7 +239,7 @@ def main():
             raw_cfg = loader.load()
             logger.debug("Loaded raw config with keys: %s", list(raw_cfg.keys()))
 
-            from config.config import get_config
+            from config import get_config
             config = get_config()
             app_config = config.get_app_config()
             logger.info("✅ Configuration loaded successfully")

--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -97,7 +97,7 @@ from flask_caching import Cache
 
 from components.ui.navbar import create_navbar_layout
 from config.complete_service_registration import register_all_application_services
-from config.config import get_config
+from config import get_config
 from core.callback_registry import GlobalCallbackRegistry, _callback_registry
 from core.performance_monitor import DIPerformanceMonitor
 from core.service_container import ServiceContainer

--- a/core/auth.py
+++ b/core/auth.py
@@ -26,7 +26,7 @@ from flask_login import (
 from jose import jwt
 
 from .secrets_manager import SecretsManager
-from config.config import get_security_config
+from config import get_security_config
 
 auth_bp = Blueprint("auth", __name__)
 login_manager = LoginManager()

--- a/core/plugins/config/__init__.py
+++ b/core/plugins/config/__init__.py
@@ -1,7 +1,7 @@
 """Minimal plugin config compatibility"""
 
 # Re-export from unified configuration for compatibility
-from config.config import ConfigManager, get_config
+from config import ConfigManager, get_config
 from config.database_manager import DatabaseManager
 
 

--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import Any, Dict, List
 
-from config.config import ConfigManager
+from config import ConfigManager
 from core.callback_manager import CallbackManager
 from core.service_container import ServiceContainer
 from services.data_processing.core.protocols import (

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from dash import Dash
 
-from config.config import ConfigManager
+from config import ConfigManager
 from core.callback_manager import CallbackManager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager

--- a/core/secrets_manager.py
+++ b/core/secrets_manager.py
@@ -63,7 +63,7 @@ class SecretsManager:
 
 def validate_secrets(manager: Optional[SecretsManager] = None) -> dict[str, Any]:
     """Return summary of required secrets presence using the provided manager."""
-    from config.config import get_config
+    from config import get_config
 
     manager = manager or SecretsManager()
     config = get_config()

--- a/database/connection.py
+++ b/database/connection.py
@@ -26,7 +26,7 @@ class DatabaseConnection(Protocol):
 def create_database_connection() -> DatabaseConnection:
     """Create database connection using existing DatabaseManager"""
     # Use your existing database manager
-    from config.config import get_config
+    from config import get_config
 
     config_manager = get_config()
     db_config = config_manager.get_database_config()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ needed:
 
 ```python
 from core.container import Container
-from config.config import create_config_manager
+from config import create_config_manager
 from services.analytics_service import create_analytics_service
 
 container = Container()
@@ -51,7 +51,7 @@ analytics_service = container.get("analytics")  # AnalyticsServiceProtocol
 
 
 ```python
-from config.config import create_config_manager
+from config import create_config_manager
 
 config = create_config_manager()
 db_cfg = config.get_database_config()

--- a/scripts/production_setup.py
+++ b/scripts/production_setup.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from config.config import ConfigManager
+from config import ConfigManager
 from database.connection import create_database_connection
 
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -126,7 +126,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
 
             from config.database_manager import DatabaseConfig as ManagerConfig
             from config.database_manager import DatabaseManager
-            from config.config import get_database_config
+            from config import get_database_config
 
             cfg = get_database_config()
             manager_cfg = ManagerConfig(

--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,6 +1,6 @@
 from core.container import Container
 
-from config.config import create_config_manager
+from config import create_config_manager
 from services.analytics_service import AnalyticsService
 
 

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -3,7 +3,7 @@ import pytest
 
 from dash import Dash, html
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.auto_config import setup_plugins
 from tests.test_auto_configuration import _set_env

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -1,6 +1,6 @@
 import sys
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -4,7 +4,7 @@ import pytest
 
 from dash import Dash, Input, Output
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.json_serialization_plugin import JsonSerializationPlugin
 from core.plugins.auto_config import setup_plugins

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from config.config import create_config_manager
+from config import create_config_manager
 from config.dynamic_config import DynamicConfigManager
 
 

--- a/tests/test_config_production_secrets.py
+++ b/tests/test_config_production_secrets.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.config import create_config_manager
+from config import create_config_manager
 
 REQUIRED_AUTH_VARS = [
     "AUTH0_CLIENT_ID",

--- a/tests/test_config_transformer.py
+++ b/tests/test_config_transformer.py
@@ -1,6 +1,6 @@
 import os
 
-from config.config import create_config_manager
+from config import create_config_manager
 
 
 def test_environment_overrides(monkeypatch):

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.exceptions import ConfigurationError
 from config.config_validator import ConfigValidator
 

--- a/tests/test_csrf_plugin.py
+++ b/tests/test_csrf_plugin.py
@@ -1,6 +1,6 @@
 import os
 
-from config.config import reload_config
+from config import reload_config
 from core import app_factory
 
 

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.config import DatabaseConfig
+from config import DatabaseConfig
 from tests.fake_configuration import FakeConfiguration
 from config.connection_pool import DatabaseConnectionPool
 from config.database_manager import MockConnection

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -4,7 +4,7 @@ import sys
 from core.plugins.dependency_resolver import PluginDependencyResolver
 from core.plugins.manager import PluginManager
 from core.service_container import ServiceContainer
-from config.config import create_config_manager
+from config import create_config_manager
 from services.data_processing.core.protocols import PluginMetadata
 
 

--- a/tests/test_display_rows_limit.py
+++ b/tests/test_display_rows_limit.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from config.config import get_config
+from config import get_config
 from services.data_processing.file_processor import create_file_preview
 
 

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 from flask import Flask
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.json_serialization_plugin import (
     JsonCallbackService,

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from config.config import create_config_manager
+from config import create_config_manager
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2,7 +2,7 @@ import sys
 import time
 from pathlib import Path
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginMetadata

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -3,7 +3,7 @@ import sys
 import types
 from pathlib import Path
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginMetadata, PluginStatus

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -1,6 +1,6 @@
 import time
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -1,6 +1,6 @@
 import sys
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from services.data_processing.core.protocols import PluginPriority

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -162,7 +162,7 @@ def env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestProtocolCompliance:
     def test_configuration_service_compliance(self):
-        from config.config import create_config_manager
+        from config import create_config_manager
 
         cfg = create_config_manager()
         assert isinstance(cfg, ConfigurationProtocol)

--- a/tests/test_sample_paths.py
+++ b/tests/test_sample_paths.py
@@ -1,6 +1,6 @@
 import os
 
-from config.config import get_config, reload_config
+from config import get_config, reload_config
 from services import AnalyticsService
 
 

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -1,7 +1,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager
 from services.data_processing.core.protocols import PluginMetadata

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -12,7 +12,7 @@ class EnumJSONProvider(DefaultJSONProvider):
         return super().default(o)
 import sys
 
-from config.config import create_config_manager
+from config import create_config_manager
 from core.service_container import ServiceContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.plugins.unified_registry import UnifiedPluginRegistry


### PR DESCRIPTION
## Summary
- switch imports from submodules to package-level API for ConfigManager and helper functions
- update documentation to use the new package-level imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e30bf35c88320af11f5ce4f8fabdc