### PR TITLE
Fix config imports and unicode handler

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -20,6 +20,7 @@ from .config import (
 )
 from .config_manager import ConfigManager, get_config, reload_config
 from .config_loader import ConfigLoader
+from .config_validator import ConfigValidator
 from .config_transformer import ConfigTransformer
 from .connection_pool import DatabaseConnectionPool
 from .connection_retry import ConnectionRetryManager, RetryConfig

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -32,8 +32,11 @@ class ConfigLoader(ConfigLoaderProtocol):
 
     log = logging.getLogger(__name__)
 
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self.config_path = config_path
+
     def load(self, config_path: Optional[str] = None) -> Dict[str, Any]:
-        path = select_config_file(config_path)
+        path = select_config_file(config_path or self.config_path)
         data: Dict[str, Any] = {}
         if path and path.exists():
             try:

--- a/config/unicode_sql_processor.py
+++ b/config/unicode_sql_processor.py
@@ -16,7 +16,7 @@ class UnicodeSQLProcessor:
         if not isinstance(query, str):
             query = str(query)
         try:
-            data = query.encode("utf-8", "surrogateescape")
+            data = query.encode("utf-8", "surrogatepass")
             return data.decode("utf-8", "replace")
         except Exception as exc:  # pragma: no cover - defensive
             raise UnicodeEncodingError(str(exc)) from exc


### PR DESCRIPTION
## Summary
- export `ConfigValidator` from `config`
- allow `ConfigLoader` to persist a default path
- use surrogatepass in `UnicodeSQLProcessor`

## Testing
- `python3 -c 'from config import ConfigValidator; print("✅ ConfigValidator import successful")'`
- `python3 -c 'from config import create_config_manager; print("✅ create_config_manager import successful")'`
- `python3 app.py` *(fails: No module named 'flask_babel')*
- `python3 - <<'EOF'
from config.config_validator import ConfigValidator
from core.exceptions import ConfigurationError
try:
    validator = ConfigValidator()
    test_config = {"app": {"title": "Test"}, "database": {"name": "test.db"}, "security": {"secret_key": "test-key"}}
    result = validator.validate(test_config)
    print("✅ ConfigValidator working correctly")
except Exception as e:
    print(f"❌ ConfigValidator error: {e}")
EOF`
- `python3 - <<'EOF'
from config import create_config_manager
try:
    config_manager = create_config_manager()
    app_config = config_manager.get_app_config()
    print(f"✅ ConfigManager working - App title: {app_config.title}")
except Exception as e:
    print(f"❌ ConfigManager error: {e}")
EOF`
- `python3 - <<'EOF'
from config.unicode_sql_processor import UnicodeSQLProcessor
try:
    test_query = "SELECT * FROM test" + chr(0xD800)
    safe_query = UnicodeSQLProcessor.encode_query(test_query)
    print("✅ Unicode processing working correctly")
except Exception as e:
    print(f"❌ Unicode processing error: {e}")
EOF`
- `pytest -k config_loader -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_686e38a6da848320ba18cdcc0b639915