### PR TITLE
Improve Unicode SQL encoding

### DIFF
--- a/tests/test_unicode_handling.py
+++ b/tests/test_unicode_handling.py
@@ -1,16 +1,17 @@
 import pytest
 
-from core.unicode import UnicodeSQLProcessor
+from config.database_exceptions import UnicodeEncodingError
+from config.unicode_sql_processor import UnicodeSQLProcessor
 
 
 def test_surrogate_pair_encoding():
     emoji = chr(0xD83D) + chr(0xDC36)  # dog face
     result = UnicodeSQLProcessor.encode_query(emoji)
-    assert result == emoji
+    assert result == "🐶"
 
 
 def test_invalid_surrogate_handling():
     text = "bad" + chr(0xD800)
-    result = UnicodeSQLProcessor.encode_query(text)
-    assert "\ufffd" in result
-    assert chr(0xD800) not in result
+    with pytest.raises(UnicodeEncodingError) as exc_info:
+        UnicodeSQLProcessor.encode_query(text)
+    assert exc_info.value.original_value == text


### PR DESCRIPTION
## Summary
- use `contains_surrogates` in the SQL processor
- raise `UnicodeEncodingError` if surrogates detected
- keep valid surrogate pairs intact while encoding
- tighten tests for the revised behaviour

## Testing
- `pytest tests/test_unicode_handling.py tests/test_unicode_handler.py tests/test_unicode_wrappers.py -q -k 'not performance'`

------
https://chatgpt.com/codex/tasks/task_e_686e4079bd1883208ebdfbec2dbc860e