### PR TITLE
Update SecurityConfig with upload limits

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -66,6 +66,14 @@ class SecurityConfig:
     cors_origins: List[str] = field(default_factory=list)
     csrf_enabled: bool = True
     max_failed_attempts: int = 5
+    max_upload_mb: int = 50
+    allowed_file_types: List[str] = field(
+        default_factory=lambda: [".csv", ".json", ".xlsx"]
+    )
+    max_file_size_bytes: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.max_file_size_bytes = self.max_upload_mb * 1024 * 1024
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- extend `SecurityConfig` with upload settings
- calculate maximum file size from MB limit

## Testing
- `pytest -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e44b9651c8320b76fde01f5fa0cc7