### PR TITLE
Add upload limits to security configs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,12 @@ security:
     admin: 7200
     basic: 1800
   csrf_enabled: false
+  max_upload_mb: 50
+  allowed_file_types:
+    - .csv
+    - .json
+    - .xlsx
+    - .xls
 
 sample_files:
   csv_path: "data/sample_data.csv"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -16,6 +16,12 @@ database:
 security:
   secret_key: "${SECRET_KEY}"
   session_timeout: 3600
+  max_upload_mb: 50
+  allowed_file_types:
+    - .csv
+    - .json
+    - .xlsx
+    - .xls
 
 sample_files:
   csv_path: "data/sample_data.csv"


### PR DESCRIPTION
## Summary
- add `max_upload_mb` and `allowed_file_types` under `security:` in `config/config.yaml`
- mirror the same settings in `config/test.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ConfigManager and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e44bc2ec88320b716c8003076e4bb