### PR TITLE
Fix missing imports in config

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -3,13 +3,18 @@
 Simplified Configuration System
 Replaces: config/yaml_config.py, config/unified_config.py, config/validator.py
 """
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
+import logging
+import os
+import yaml
 
 from core.exceptions import ConfigurationError
 from core.protocols import ConfigurationProtocol
 from core.secrets_manager import SecretsManager
 from core.secrets_validator import SecretsValidator
+
+from .config_transformer import ConfigTransformer
 
 from .base import (
     AnalyticsConfig,
@@ -237,7 +242,7 @@ class ConfigManager(ConfigurationProtocol):
 
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides"""
-        config_transformer.apply(self)
+        self.config = self.transformer.transform(self.config)
 
     def _apply_validated_secrets(self) -> None:
         """Apply secrets validated by SecretsValidator."""
@@ -364,7 +369,6 @@ class ConfigManager(ConfigurationProtocol):
             return {"valid": False, "error": str(exc)}
 
 
-
 # Global configuration instance
 _config_manager: Optional[ConfigManager] = None
 
@@ -433,6 +437,7 @@ def get_secret_validation_config() -> SecretValidationConfig:
 def get_plugin_config(name: str) -> Dict[str, Any]:
     """Get configuration for a specific plugin"""
     return get_config().get_plugin_config(name)
+
 
 # Export main classes and functions
 


### PR DESCRIPTION
## Summary
- import logging, os, yaml and typing types in `config/config.py`
- apply environment overrides using the existing transformer instance

## Testing
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: found errors)*
- `pytest -q` *(fails: missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e4790b29883208b3b16348407e941