### PR TITLE
Refactor config service accessors

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,8 +3,6 @@
 import logging
 from typing import Any, Dict, Optional
 
-from services.registry import get_service
-
 from .base import (
     AppConfig,
     Config,
@@ -21,31 +19,6 @@ from .protocols import (
     ConfigTransformerProtocol,
     ConfigValidatorProtocol,
 )
-
-
-def _get_service(name: str):
-    """Safely retrieve optional services from registry."""
-    return get_service(name)
-
-
-def get_database_manager():
-    """Return the optional ``DatabaseManager`` service."""
-    return _get_service("DatabaseManager")
-
-
-def get_database_connection():
-    """Return the optional ``DatabaseConnection`` service."""
-    return _get_service("DatabaseConnection")
-
-
-def get_mock_connection():
-    """Return the optional ``MockConnection`` service."""
-    return _get_service("MockConnection")
-
-
-def get_enhanced_postgresql_manager():
-    """Return the optional ``EnhancedPostgreSQLManager`` service."""
-    return _get_service("EnhancedPostgreSQLManager")
 
 
 def create_config_manager(
@@ -133,11 +106,6 @@ __all__ = [
     "get_database_config",
     "get_security_config",
     "get_plugin_config",
-    # Optional service getters
-    "get_database_manager",
-    "get_database_connection",
-    "get_mock_connection",
-    "get_enhanced_postgresql_manager",
     # Dynamic configuration
     "dynamic_config",
     "DynamicConfigManager",

--- a/config/service_integration.py
+++ b/config/service_integration.py
@@ -1,0 +1,37 @@
+"""Optional service accessors for integration with the service registry."""
+
+from __future__ import annotations
+
+from services.registry import get_service
+
+__all__ = [
+    "get_database_manager",
+    "get_database_connection",
+    "get_mock_connection",
+    "get_enhanced_postgresql_manager",
+]
+
+
+def _get_service(name: str):
+    """Safely retrieve optional services from registry."""
+    return get_service(name)
+
+
+def get_database_manager():
+    """Return the optional ``DatabaseManager`` service."""
+    return _get_service("DatabaseManager")
+
+
+def get_database_connection():
+    """Return the optional ``DatabaseConnection`` service."""
+    return _get_service("DatabaseConnection")
+
+
+def get_mock_connection():
+    """Return the optional ``MockConnection`` service."""
+    return _get_service("MockConnection")
+
+
+def get_enhanced_postgresql_manager():
+    """Return the optional ``EnhancedPostgreSQLManager`` service."""
+    return _get_service("EnhancedPostgreSQLManager")

--- a/docs/import_dependency_map.md
+++ b/docs/import_dependency_map.md
@@ -20,8 +20,8 @@ app.py
 Key points:
 
 * Configuration no longer resolves optional services at import time.  Functions
-  such as `get_database_manager()` retrieve services from the registry when
-  called, preventing early imports.
+  such as `config.service_integration.get_database_manager()` retrieve services
+  from the registry when called, preventing early imports.
 * `security_callback_controller` imports `CallbackEvent` from the lightweight
   `core.callback_events` module.  This removes a link in the chain that used to
   pull in the entire callback controller during start-up.


### PR DESCRIPTION
## Summary
- remove registry import from `config.__init__`
- add `config.service_integration` module for optional service getters
- update docs with new import path

## Testing
- `pip install -q -r requirements-test.txt`
- `pip install -q pandas`
- `pip install -q dash==2.14.1 dash-bootstrap-components==1.6.0`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e49b705c08320a2fdf9ab8f9ed9a7