### PR TITLE
Fix scipy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ numpy>=1.24.0
 authlib==1.2.1
 python-jose==3.3.0
 cssutils==2.8.0
-scipy>=1.12.0
+scipy>=1.11.0
 scikit-learn==1.3.0
 joblib==1.3.2
 psutil>=5.9.0


### PR DESCRIPTION
## Summary
- set `scipy` minimum version to 1.11.0 in `requirements.txt`

## Testing
- `pytest -k "scipy" -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e4de8a2988320b9074c9bbd00346c