### PR TITLE
Fix DatabaseConfig url support

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,7 @@ database:
   echo: false
   pool_size: 10
   max_overflow: 20
+  url: ""
 
 security:
   session_timeout: 3600

--- a/config/config_transformer.py
+++ b/config/config_transformer.py
@@ -62,13 +62,9 @@ class ConfigTransformer(ConfigTransformerProtocol):
                 logger.warning("Invalid MAX_UPLOAD_MB value: %s", max_upload)
         if max_upload_bytes := os.getenv("MAX_UPLOAD_BYTES"):
             try:
-                config.security.max_upload_mb = int(max_upload_bytes) // (
-                    1024 * 1024
-                )
+                config.security.max_upload_mb = int(max_upload_bytes) // (1024 * 1024)
             except ValueError:
-                logger.warning(
-                    "Invalid MAX_UPLOAD_BYTES value: %s", max_upload_bytes
-                )
+                logger.warning("Invalid MAX_UPLOAD_BYTES value: %s", max_upload_bytes)
 
     def _apply_security_defaults(self, config: "Config") -> None:
         """Apply security-related defaults."""

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -13,6 +13,7 @@ database:
   name: ${DB_NAME}
   user: ${DB_USER}
   password: ${DB_PASSWORD}
+  url: ${DATABASE_URL:}
   initial_pool_size: ${DB_INITIAL_POOL_SIZE:10}
   max_pool_size: ${DB_MAX_POOL_SIZE:20}
   connection_timeout: ${DB_TIMEOUT:30}

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -14,6 +14,7 @@ database:
   name: "yosai_db"
   user: "yosai_user"
   password: "${DB_PASSWORD}"
+  url: ""
 
 security:
   secret_key: "${SECRET_KEY}"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -12,6 +12,7 @@ database:
   name: "yosai_db"
   user: "yosai_user"
   password: "${DB_PASSWORD}"
+  url: ""
 
 security:
   secret_key: "${SECRET_KEY}"


### PR DESCRIPTION
## Summary
- add missing `url` attribute and auto-generation logic to `DatabaseConfig`
- allow `DATABASE_URL` env var to override database URL
- update YAML configs with `url` field
- run formatting

## Testing
- `black config/base.py config/config_transformer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686e4e76950c832099f2ec7741f50834