### PR TITLE
Fix internal Dash navigation links

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -112,7 +112,13 @@ def create_navbar_layout() -> dbc.Navbar:
                         dbc.NavbarBrand("Dashboard", href="/"),
                         dbc.Nav(
                             [
-                                dbc.NavItem(dbc.NavLink("Upload", href="/file-upload")),
+                                dbc.NavItem(
+                                    dbc.NavLink(
+                                        "Upload",
+                                        href="/file-upload",
+                                        external_link=False,
+                                    )
+                                ),
                             ],
                             navbar=True,
                         ),

--- a/utils/safe_components.py
+++ b/utils/safe_components.py
@@ -32,7 +32,7 @@ def safe_navbar():
                                 dbc.NavLink(
                                     navbar_icon("upload.png", "Upload", "⬆️"),
                                     href="/file-upload",
-                                    external_link=True,
+                                    external_link=False,
                                     title="Upload",
                                 )
                             ),
@@ -42,7 +42,7 @@ def safe_navbar():
                                         "analytics.png", "Deep Analytics Page", "📊"
                                     ),
                                     href="/analytics",
-                                    external_link=True,
+                                    external_link=False,
                                     title="Deep Analytics Page",
                                 )
                             ),


### PR DESCRIPTION
## Summary
- update fallback navbar nav link to keep navigation internal
- ensure safe_navbar uses `external_link=False` on NavLinks

## Testing
- `pytest -k navbar -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686e63f926dc8320a9a79deaab71041d