### PR TITLE
Fix dash pages navigation

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -1,5 +1,11 @@
 """Entry point for the deep analytics Dash page."""
 
+from dash import register_page
+
 from .deep_analytics import layout
+
+register_page(
+    __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
+)
 
 __all__ = ["layout"]

--- a/pages/export.py
+++ b/pages/export.py
@@ -2,9 +2,11 @@
 """Export page providing download instructions."""
 
 import dash_bootstrap_components as dbc
-from dash import dcc, html
+from dash import dcc, html, register_page
 
 from security.unicode_security_processor import sanitize_unicode_input
+
+register_page(__name__, path="/export", name="Export")
 
 
 def _instructions() -> dbc.Card:

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -6,7 +6,7 @@ import logging
 import types
 from typing import TYPE_CHECKING, Any
 
-from dash import html
+from dash import html, register_page
 
 from core.callback_registry import _callback_registry
 from core.unicode import safe_encode_text
@@ -18,6 +18,8 @@ except Exception:  # pragma: no cover - fallback when unavailable
 
 logger = logging.getLogger(__name__)
 
+register_page(__name__, path="/file-upload", name="File Upload", aliases=["/upload"])
+
 _import_error: Exception | None = None
 
 
@@ -26,6 +28,7 @@ def _safe_import_upload_component():
     global _import_error
     try:
         from components.upload import UnifiedUploadComponent as UUC
+
         logger.debug("UnifiedUploadComponent imported successfully")
         _import_error = None
         return UUC

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -17,9 +17,12 @@ except Exception as e:  # pragma: no cover - optional plotting deps
     px = None
     go = None
 
+from dash import dcc, html, register_page
+
 from core.cache import cache
-from dash import dcc, html
 from security.unicode_security_processor import sanitize_unicode_input
+
+register_page(__name__, path="/graphs", name="Graphs")
 
 
 @cache.memoize()
@@ -29,14 +32,18 @@ def _create_figures() -> Dict[str, Any]:
         return {k: (go.Figure() if go else None) for k in ("line", "bar", "other")}
 
     try:
-        df = pd.DataFrame({
-            "date": pd.date_range(end=pd.Timestamp.today(), periods=30),
-            "door": [f"Door {i%3+1}" for i in range(30)],
-            "count": [int(i * 1.5) % 50 + 10 for i in range(30)],
-        })
+        df = pd.DataFrame(
+            {
+                "date": pd.date_range(end=pd.Timestamp.today(), periods=30),
+                "door": [f"Door {i%3+1}" for i in range(30)],
+                "count": [int(i * 1.5) % 50 + 10 for i in range(30)],
+            }
+        )
         line_fig = px.line(df, x="date", y="count", title="Access Count Over Time")
         bar_fig = px.bar(df, x="door", y="count", title="Access Count by Door")
-        scatter_fig = px.scatter(df, x="date", y="count", color="door", title="Door Activity")
+        scatter_fig = px.scatter(
+            df, x="date", y="count", color="door", title="Door Activity"
+        )
         for fig in (line_fig, bar_fig, scatter_fig):
             fig.update_layout(height=300, margin=dict(l=20, r=20, t=40, b=20))
         return {"line": line_fig, "bar": bar_fig, "other": scatter_fig}
@@ -57,9 +64,21 @@ def layout() -> dbc.Container:
 
     tabs = dbc.Tabs(
         [
-            dbc.Tab(dcc.Graph(figure=_FIGURES.get("line") if _FIGURES else None), label=sanitize_unicode_input("Line"), tab_id="line"),
-            dbc.Tab(dcc.Graph(figure=_FIGURES.get("bar") if _FIGURES else None), label=sanitize_unicode_input("Bar"), tab_id="bar"),
-            dbc.Tab(dcc.Graph(figure=_FIGURES.get("other") if _FIGURES else None), label=sanitize_unicode_input("Other"), tab_id="other"),
+            dbc.Tab(
+                dcc.Graph(figure=_FIGURES.get("line") if _FIGURES else None),
+                label=sanitize_unicode_input("Line"),
+                tab_id="line",
+            ),
+            dbc.Tab(
+                dcc.Graph(figure=_FIGURES.get("bar") if _FIGURES else None),
+                label=sanitize_unicode_input("Bar"),
+                tab_id="bar",
+            ),
+            dbc.Tab(
+                dcc.Graph(figure=_FIGURES.get("other") if _FIGURES else None),
+                label=sanitize_unicode_input("Other"),
+                tab_id="other",
+            ),
         ],
         id="graphs-tabs",
         active_tab="line",

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -2,9 +2,11 @@
 """Settings management page with placeholders."""
 
 import dash_bootstrap_components as dbc
-from dash import html
+from dash import html, register_page
 
 from security.unicode_security_processor import sanitize_unicode_input
+
+register_page(__name__, path="/settings", name="Settings")
 
 
 def _settings_section(title: str) -> dbc.Card:


### PR DESCRIPTION
## Summary
- register Dash pages and use `page_container`
- simplify router callback to only handle transition classes

## Testing
- `isort pages/file_upload.py pages/export.py pages/graphs.py pages/settings.py pages/deep_analytics.py core/app_factory/__init__.py`
- `black pages/file_upload.py pages/export.py pages/graphs.py pages/settings.py pages/deep_analytics.py core/app_factory/__init__.py`
- `flake8 pages/file_upload.py pages/export.py pages/graphs.py pages/settings.py pages/deep_analytics.py core/app_factory/__init__.py`
- `mypy --strict pages/file_upload.py pages/export.py pages/graphs.py pages/settings.py pages/deep_analytics.py core/app_factory/__init__.py` *(fails: 712 errors)*
- `bandit -r pages/file_upload.py pages/export.py pages/graphs.py pages/settings.py pages/deep_analytics.py core/app_factory/__init__.py`
- `pytest tests/di/test_app_factory_helpers.py::test_configure_swagger -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c5396f08320801e6e98f25581a9