### PR TITLE
Fix early page registration for Dash

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -253,6 +253,7 @@ def _create_full_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
+            use_pages=True,
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)
@@ -356,6 +357,7 @@ def _create_full_app(assets_folder: str) -> "Dash":
         initialize_csrf(app, config_manager)
 
         _initialize_plugins(app, config_manager, container=service_container)
+        _register_pages()
         _setup_layout(app)
         _register_callbacks(app, config_manager, container=service_container)
 
@@ -421,6 +423,7 @@ def _create_simple_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
+            use_pages=True,
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)
@@ -463,6 +466,8 @@ def _create_simple_app(assets_folder: str) -> "Dash":
             ):
                 resp.headers["Cache-Control"] = "public,max-age=31536000,immutable"
             return resp
+
+        _register_pages()
 
         app.title = "Yōsai Intel Dashboard"
 
@@ -519,6 +524,7 @@ def _create_json_safe_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
+            use_pages=True,
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)
@@ -561,6 +567,8 @@ def _create_json_safe_app(assets_folder: str) -> "Dash":
             ):
                 resp.headers["Cache-Control"] = "public,max-age=31536000,immutable"
             return resp
+
+        _register_pages()
 
         app.title = "🏯 Yōsai Intel Dashboard"
 
@@ -801,6 +809,17 @@ def _register_global_callbacks(manager: TrulyUnifiedCallbacksType) -> None:
         # Don't raise in test mode
         if "pytest" not in sys.modules:
             raise
+
+
+def _register_pages() -> None:
+    """Register all pages once the Dash app is ready."""
+    try:
+        from pages import register_pages
+
+        register_pages()
+        logger.info("✅ Pages registered successfully")
+    except Exception as e:
+        logger.warning(f"Page registration failed: {e}")
 
 
 def _setup_layout(app: "Dash") -> None:

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -60,4 +60,14 @@ def get_page_layout(page_name: str) -> Optional[Callable]:
     return None
 
 
-__all__ = ["get_page_layout"]
+def register_pages() -> None:
+    """Register all available pages with Dash."""
+    for name, module in _pages.items():
+        if module and hasattr(module, "register_page"):
+            try:
+                module.register_page()
+            except Exception as exc:
+                logger.warning(f"Failed to register page {name}: {exc}")
+
+
+__all__ = ["get_page_layout", "register_pages"]

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -1,11 +1,13 @@
 """Entry point for the deep analytics Dash page."""
 
-from dash import register_page
+from dash import register_page as dash_register_page
 
 from .deep_analytics import layout
 
-register_page(
-    __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
-)
+def register_page() -> None:
+    """Register the analytics page after Dash initialization."""
+    dash_register_page(
+        __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
+    )
 
-__all__ = ["layout"]
+__all__ = ["layout", "register_page"]

--- a/pages/export.py
+++ b/pages/export.py
@@ -2,11 +2,14 @@
 """Export page providing download instructions."""
 
 import dash_bootstrap_components as dbc
-from dash import dcc, html, register_page
+from dash import dcc, html, register_page as dash_register_page
 
 from security.unicode_security_processor import sanitize_unicode_input
 
-register_page(__name__, path="/export", name="Export")
+
+def register_page() -> None:
+    """Register this page with Dash after app creation."""
+    dash_register_page(__name__, path="/export", name="Export")
 
 
 def _instructions() -> dbc.Card:
@@ -63,4 +66,4 @@ def layout() -> dbc.Container:
     return dbc.Container([_instructions()], fluid=True)
 
 
-__all__ = ["layout"]
+__all__ = ["layout", "register_page"]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -6,7 +6,7 @@ import logging
 import types
 from typing import TYPE_CHECKING, Any
 
-from dash import html, register_page
+from dash import html, register_page as dash_register_page
 
 from core.callback_registry import _callback_registry
 from core.unicode import safe_encode_text
@@ -18,7 +18,10 @@ except Exception:  # pragma: no cover - fallback when unavailable
 
 logger = logging.getLogger(__name__)
 
-register_page(__name__, path="/file-upload", name="File Upload", aliases=["/upload"])
+
+def register_page() -> None:
+    """Register the file upload page with Dash."""
+    dash_register_page(__name__, path="/file-upload", name="File Upload", aliases=["/upload"])
 
 _import_error: Exception | None = None
 
@@ -208,6 +211,7 @@ def check_upload_system_health() -> dict:
 __all__ = [
     "layout",
     "safe_upload_layout",
+    "register_page",
     "register_upload_callbacks",
     "register_callbacks",
     "check_upload_system_health",

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -17,12 +17,15 @@ except Exception as e:  # pragma: no cover - optional plotting deps
     px = None
     go = None
 
-from dash import dcc, html, register_page
+from dash import dcc, html, register_page as dash_register_page
 
 from core.cache import cache
 from security.unicode_security_processor import sanitize_unicode_input
 
-register_page(__name__, path="/graphs", name="Graphs")
+
+def register_page() -> None:
+    """Register the graphs page with Dash."""
+    dash_register_page(__name__, path="/graphs", name="Graphs")
 
 
 @cache.memoize()
@@ -87,4 +90,4 @@ def layout() -> dbc.Container:
     return dbc.Container([tabs], fluid=True)
 
 
-__all__ = ["layout"]
+__all__ = ["layout", "register_page"]

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -2,11 +2,14 @@
 """Settings management page with placeholders."""
 
 import dash_bootstrap_components as dbc
-from dash import html, register_page
+from dash import html, register_page as dash_register_page
 
 from security.unicode_security_processor import sanitize_unicode_input
 
-register_page(__name__, path="/settings", name="Settings")
+
+def register_page() -> None:
+    """Register the settings page with Dash."""
+    dash_register_page(__name__, path="/settings", name="Settings")
 
 
 def _settings_section(title: str) -> dbc.Card:
@@ -35,4 +38,4 @@ def layout() -> dbc.Container:
     return dbc.Container([sections], fluid=True)
 
 
-__all__ = ["layout"]
+__all__ = ["layout", "register_page"]


### PR DESCRIPTION
## Summary
- refactor page registration into callable functions
- add `register_pages` helper to run after Dash instantiation
- enable `use_pages=True` when creating Dash apps
- register all pages after app creation

## Testing
- `pytest -k dash_pages -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686e77789f308320ba3cb72e8ff70c6e