### PR TITLE
Fix Dash startup & analytics service

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -253,7 +253,8 @@ def _create_full_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
-            use_pages=True,
+            use_pages=False,
+            pages_folder="",
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)
@@ -423,7 +424,8 @@ def _create_simple_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
-            use_pages=True,
+            use_pages=False,
+            pages_folder="",
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)
@@ -524,7 +526,8 @@ def _create_json_safe_app(assets_folder: str) -> "Dash":
             suppress_callback_exceptions=True,
             assets_folder=assets_folder,
             assets_ignore=assets_ignore,
-            use_pages=True,
+            use_pages=False,
+            pages_folder="",
         )
         fix_flask_mime_types(app)
         ensure_icon_cache_headers(app)

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -551,6 +551,36 @@ class AnalyticsService(AnalyticsServiceProtocol):
         """Return current analytics metrics."""
         return self.get_analytics_status()
 
+    # ------------------------------------------------------------------
+    # Placeholder implementations for abstract methods
+    # ------------------------------------------------------------------
+    def analyze_access_patterns(
+        self, days: int, user_id: str | None = None
+    ) -> Dict[str, Any]:
+        """Analyze access patterns over the given timeframe."""
+        logger.debug(
+            "analyze_access_patterns called with days=%s user_id=%s",
+            days,
+            user_id,
+        )
+        return {"patterns": [], "days": days, "user_id": user_id}
+
+    def detect_anomalies(
+        self, data: pd.DataFrame, sensitivity: float = 0.5
+    ) -> List[Dict[str, Any]]:
+        """Detect anomalies in the provided data."""
+        logger.debug("detect_anomalies called with sensitivity=%s", sensitivity)
+        return []
+
+    def generate_report(self, report_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate an analytics report."""
+        logger.debug(
+            "generate_report called with report_type=%s params=%s",
+            report_type,
+            params,
+        )
+        return {"report_type": report_type, "params": params}
+
 
 # Global service instance
 _analytics_service: Optional[AnalyticsService] = None


### PR DESCRIPTION
## Summary
- disable automatic page discovery and register manually
- add placeholder analytics methods to satisfy abstract class

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python -c "from config import get_config; print('✅ Config loads')"` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -c "from services.analytics_service import get_analytics_service; print('✅ Analytics service works')"` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e8158ced48320b6f20d9f4086b930