### PR TITLE
Add docs for blank Dash pages

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,13 @@ python tools/generate_openapi.py
 The script writes `docs/openapi.json`. Once generated, this file can be served
 by Swagger UI to display the complete API reference.
 
+### Regenerating after changes
+
+`docs/openapi.json` is not committed to the repository. Whenever you modify any
+API routes or schemas, run `python tools/generate_openapi.py` and verify the
+file in `docs/` updates. This keeps the interactive documentation in sync with
+the code.
+
 ## Database Manager
 
 ### `DatabaseManager`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,3 +17,36 @@ pip install --force-reinstall "Flask>=2.2.5"
 ```
 
 This restores the missing function in `flask/cli.py` and allows the dashboard to start normally.
+
+## Blank Dash page / missing content
+
+If the application starts without errors but the browser only shows a blank page,
+verify that the Dash layout and callbacks are registered correctly and that
+static assets are being served.
+
+1. **Check the layout**: ensure `app.layout` is set to either a Dash component
+   tree or a function returning one.
+
+2. **Confirm callbacks**: page content often relies on callbacks. Register a
+   simple routing callback to populate the page:
+
+   ```python
+   from dash import Input, Output, html, dcc
+
+   app.layout = html.Div([
+       dcc.Location(id="url"),
+       html.Div(id="page-content")
+   ])
+
+   @app.callback(Output("page-content", "children"), Input("url", "pathname"))
+   def display_page(pathname):
+       if pathname == "/":
+           return html.H1("Dashboard Home")
+       return html.Div([html.H1("404"), html.P(f"No page '{pathname}'")])
+   ```
+
+3. **Validate assets**: check that the `assets/` directory exists and that the
+   browser DevTools console does not show failed CSS or JavaScript requests.
+
+Following these steps resolves most cases where the Dash server runs but no
+content appears in the browser.


### PR DESCRIPTION
## Summary
- document steps for blank Dash pages when app layout is empty or callbacks are missing
- explain that OpenAPI spec must be regenerated locally after API changes

## Testing
- `pre-commit run --files docs/troubleshooting.md docs/api.md`

------
https://chatgpt.com/codex/tasks/task_e_686e8ce3f7348320a148e0813d3a5221