### PR TITLE
Add safe text encode/decode helpers

### DIFF
--- a/core/unicode.py
+++ b/core/unicode.py
@@ -172,6 +172,20 @@ class UnicodeProcessor:
 
     # ------------------------------------------------------------------
     @staticmethod
+    def safe_encode_text(value: Any) -> str:
+        """Alias for :meth:`safe_encode`."""
+
+        return UnicodeProcessor.safe_encode(value)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def safe_decode_text(data: bytes, encoding: str = "utf-8") -> str:
+        """Alias for :meth:`safe_decode`."""
+
+        return UnicodeProcessor.safe_decode(data, encoding)
+
+    # ------------------------------------------------------------------
+    @staticmethod
     def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         """Return ``df`` with all columns and object data sanitized."""
 
@@ -332,6 +346,12 @@ def safe_decode(data: bytes, encoding: str = "utf-8") -> str:
     """Alias for :func:`safe_decode_bytes`."""
 
     return safe_decode_bytes(data, encoding)
+
+
+def safe_decode_text(data: bytes, encoding: str = "utf-8") -> str:
+    """Safely decode byte data to text."""
+
+    return UnicodeProcessor.safe_decode_text(data, encoding)
 
 
 def safe_encode_text(value: Any) -> str:
@@ -503,6 +523,7 @@ __all__ = [
     "clean_unicode_text",
     "safe_decode_bytes",
     "safe_decode",
+    "safe_decode_text",
     "safe_encode_text",
     "safe_encode",
     "sanitize_dataframe",


### PR DESCRIPTION
## Summary
- implement `UnicodeProcessor.safe_encode_text` and `UnicodeProcessor.safe_decode_text`
- expose new `safe_decode_text` helper at the module level
- export new helper in `__all__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686f0db30228832089bad6d9e8e97d2d