### PR TITLE
Fix UnicodeProcessor import paths

### DIFF
--- a/core/protocols.py
+++ b/core/protocols.py
@@ -446,7 +446,7 @@ def get_unicode_processor(
     c = _get_container(container)
     if c and c.has("unicode_processor"):
         return c.get("unicode_processor")
-    from .unicode_processor import UnicodeProcessor
+    from core.unicode import UnicodeProcessor
 
     return UnicodeProcessor()
 

--- a/tests/threading/test_unicode_threading.py
+++ b/tests/threading/test_unicode_threading.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from unicode_handler import ChunkedUnicodeProcessor, UnicodeProcessor
+from core.unicode import ChunkedUnicodeProcessor, UnicodeProcessor
 
 
 def test_clean_surrogate_chars_threaded():


### PR DESCRIPTION
## Summary
- point get_unicode_processor at `core.unicode` module
- tweak import in unicode threading tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686f0db4ed888320aa04ebc9594feb1a