### PR TITLE
Introduce BaseConfigLoader and refactor loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ This project uses **`config/config.py`** for all application settings. The
 `create_config_manager()` helper builds a `ConfigManager` composed of modular
 dataclasses like `AppConfig`, `DatabaseConfig` and `SecurityConfig`. It loads a
 YAML file from `config/` based on `YOSAI_ENV` or `YOSAI_CONFIG_FILE`, then
-applies environment variable overrides. Earlier versions used separate modules
+applies environment variable overrides.
+The underlying loading logic lives in `config/base_loader.py` as `BaseConfigLoader`.
+It handles YAML `!include` expansion, JSON files and environment variable substitution. Earlier versions used separate modules
 such as `app_config.py` and `simple_config.py`; these have been replaced by this
 unified loader. Register the configuration with the DI container so it can be
 resolved from anywhere:

--- a/config/base_loader.py
+++ b/config/base_loader.py
@@ -1,0 +1,77 @@
+import io
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from .unicode_sql_processor import UnicodeSQLProcessor
+
+
+class BaseConfigLoader:
+    """Generic loader for YAML or JSON configuration files."""
+
+    log = logging.getLogger(__name__)
+
+    def load_file(self, path: Path) -> Dict[str, Any]:
+        """Load and sanitize configuration from ``path``."""
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            data = self._load_yaml(path)
+        elif path.suffix.lower() == ".json":
+            data = self._load_json(path)
+        else:
+            data = {}
+        return self._sanitize(data)
+
+    # ------------------------------------------------------------------
+    def _load_yaml(self, path: Path) -> Dict[str, Any]:
+        def _recursive_load(file_path: Path) -> Any:
+            class Loader(yaml.SafeLoader):
+                pass
+
+            def _include(loader: Loader, node: yaml.Node) -> Any:
+                filename = loader.construct_scalar(node)
+                inc_path = (loader._root / filename).resolve()
+                return _recursive_load(inc_path)
+
+            Loader.add_constructor("!include", _include)
+
+            text = self._substitute_env_vars(file_path.read_text(encoding="utf-8"))
+            loader = Loader(io.StringIO(text))
+            loader._root = file_path.parent
+            try:
+                return loader.get_single_data() or {}
+            finally:
+                loader.dispose()
+
+        return _recursive_load(path)
+
+    def _load_json(self, path: Path) -> Dict[str, Any]:
+        text = self._substitute_env_vars(path.read_text(encoding="utf-8"))
+        return json.loads(text)
+
+    def _substitute_env_vars(self, text: str) -> str:
+        import re
+
+        def repl(match: re.Match[str]) -> str:
+            key = match.group(1)
+            return os.getenv(key, match.group(0))
+
+        return re.sub(r"\$\{([^}]+)\}", repl, text)
+
+    def _sanitize(self, obj: Any) -> Any:
+        if isinstance(obj, str):
+            try:
+                return UnicodeSQLProcessor.encode_query(obj)
+            except Exception:
+                return obj
+        if isinstance(obj, dict):
+            return {k: self._sanitize(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._sanitize(v) for v in obj]
+        return obj
+
+
+__all__ = ["BaseConfigLoader"]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -2,21 +2,19 @@
 
 from __future__ import annotations
 
-import io
 import json
 import logging
 import os
-from pathlib import Path
 from typing import Any, Dict, Optional
 
-import yaml
+from pathlib import Path
 
 from .environment import select_config_file
 from .protocols import ConfigLoaderProtocol
-from .unicode_sql_processor import UnicodeSQLProcessor
+from .base_loader import BaseConfigLoader
 
 
-class ConfigLoader(ConfigLoaderProtocol):
+class ConfigLoader(BaseConfigLoader, ConfigLoaderProtocol):
     """Load configuration from YAML/JSON files or environment.
 
     The loader understands a custom ``!include`` YAML tag which allows other
@@ -33,10 +31,7 @@ class ConfigLoader(ConfigLoaderProtocol):
         data: Dict[str, Any] = {}
         if path and path.exists():
             try:
-                if path.suffix.lower() in {".yaml", ".yml"}:
-                    data = self._load_yaml(path)
-                elif path.suffix.lower() == ".json":
-                    data = self._load_json(path)
+                data = self.load_file(path)
             except Exception as exc:  # pragma: no cover - defensive
                 self.log.warning("Failed to load %s: %s", path, exc)
 
@@ -47,54 +42,6 @@ class ConfigLoader(ConfigLoaderProtocol):
             except Exception as exc:  # pragma: no cover - defensive
                 self.log.warning("Failed to parse YOSAI_CONFIG_JSON: %s", exc)
         return self._sanitize(data)
-
-    # ------------------------------------------------------------------
-    def _load_yaml(self, path: Path) -> Dict[str, Any]:
-        def _recursive_load(file_path: Path) -> Any:
-            class Loader(yaml.SafeLoader):
-                pass
-
-            def _include(loader: Loader, node: yaml.Node) -> Any:
-                filename = loader.construct_scalar(node)
-                inc_path = (loader._root / filename).resolve()
-                return _recursive_load(inc_path)
-
-            Loader.add_constructor("!include", _include)
-
-            text = self._substitute_env_vars(file_path.read_text(encoding="utf-8"))
-            loader = Loader(io.StringIO(text))
-            loader._root = file_path.parent
-            try:
-                return loader.get_single_data() or {}
-            finally:
-                loader.dispose()
-
-        return _recursive_load(path)
-
-    def _load_json(self, path: Path) -> Dict[str, Any]:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-
-    def _substitute_env_vars(self, text: str) -> str:
-        import re
-
-        def repl(match: re.Match[str]) -> str:
-            key = match.group(1)
-            return os.getenv(key, match.group(0))
-
-        return re.sub(r"\$\{([^}]+)\}", repl, text)
-
-    def _sanitize(self, obj: Any) -> Any:
-        if isinstance(obj, str):
-            try:
-                return UnicodeSQLProcessor.encode_query(obj)
-            except Exception:
-                return obj
-        if isinstance(obj, dict):
-            return {k: self._sanitize(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [self._sanitize(v) for v in obj]
-        return obj
 
 
 __all__ = ["ConfigLoader", "ConfigLoaderProtocol"]


### PR DESCRIPTION
## Summary
- implement generic `BaseConfigLoader`
- reuse new loader in `ConfigLoader`
- refactor `DynamicConfigManager` to extend `BaseConfigLoader`
- document loader in README

## Testing
- `pytest tests/test_config_loader.py::test_yaml_and_env_loading -q`
- `pytest tests/test_config_loader.py::test_json_env_rules_parsed -q`
- `pytest tests/test_max_display_rows.py::test_config_manager_loads_max_display_rows -q`


------
https://chatgpt.com/codex/tasks/task_e_686f7ae5af5c8320ae25f744ecf8af25