### PR TITLE
Add async Redis cache manager and decorator

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Any
 
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
+from .advanced_cache import AdvancedCacheManager, create_advanced_cache_manager, cache_with_lock
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .truly_unified_callbacks import (
@@ -11,5 +12,11 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
 else:  # pragma: no cover - fallback at runtime
     TrulyUnifiedCallbacksType = Any  # type: ignore[misc]
 
-__all__ = ["TrulyUnifiedCallbacks", "TrulyUnifiedCallbacksType"]
+__all__ = [
+    "TrulyUnifiedCallbacks",
+    "TrulyUnifiedCallbacksType",
+    "AdvancedCacheManager",
+    "cache_with_lock",
+    "create_advanced_cache_manager",
+]
 

--- a/core/advanced_cache.py
+++ b/core/advanced_cache.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+"""Asynchronous cache manager with optional Redis backend."""
+
+import asyncio
+import logging
+import pickle
+import time
+from functools import wraps
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import redis.asyncio as redis
+
+from config.config import get_cache_config
+from config.base import CacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedCacheManager:
+    """Async cache manager using Redis with in-memory fallback."""
+
+    def __init__(self, cache_config: CacheConfig) -> None:
+        self.config = cache_config
+        self.key_prefix = getattr(cache_config, "key_prefix", "yosai:")
+        self.default_ttl = getattr(cache_config, "timeout_seconds", 300)
+        self._redis: Optional[redis.Redis] = None
+        self._memory: Dict[str, tuple[Any, Optional[float]]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    async def start(self) -> None:
+        """Initialize Redis connection."""
+        if self._redis is None:
+            self._redis = redis.Redis(
+                host=getattr(self.config, "host", "localhost"),
+                port=getattr(self.config, "port", 6379),
+                db=getattr(self.config, "database", 0),
+            )
+        try:
+            await self._redis.ping()
+            logger.info("Advanced cache manager connected to Redis")
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Failed to connect to Redis: %s", exc)
+            self._redis = None
+
+    # ------------------------------------------------------------------
+    async def stop(self) -> None:
+        """Close Redis connection."""
+        if self._redis is not None:
+            try:
+                await self._redis.close()
+            finally:
+                self._redis = None
+        self._memory.clear()
+        self._locks.clear()
+
+    # ------------------------------------------------------------------
+    def _make_key(self, key: str) -> str:
+        return f"{self.key_prefix}{key}"
+
+    # ------------------------------------------------------------------
+    async def get(self, key: str) -> Optional[Any]:
+        full_key = self._make_key(key)
+        if self._redis is not None:
+            try:
+                data = await self._redis.get(full_key)
+                return pickle.loads(data) if data is not None else None
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis GET failed for %s: %s", full_key, exc)
+                return None
+        # Fallback to memory
+        if key not in self._memory:
+            return None
+        value, expiry = self._memory[key]
+        if expiry is not None and time.time() > expiry:
+            del self._memory[key]
+            return None
+        return value
+
+    # ------------------------------------------------------------------
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        full_key = self._make_key(key)
+        expire = ttl if ttl is not None else self.default_ttl
+        if self._redis is not None:
+            try:
+                payload = pickle.dumps(value)
+                if expire:
+                    await self._redis.setex(full_key, expire, payload)
+                else:
+                    await self._redis.set(full_key, payload)
+                return
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis SET failed for %s: %s", full_key, exc)
+        # Fallback to memory
+        expiry = time.time() + expire if expire else None
+        self._memory[key] = (value, expiry)
+
+    # ------------------------------------------------------------------
+    async def delete(self, key: str) -> bool:
+        full_key = self._make_key(key)
+        if self._redis is not None:
+            try:
+                removed = await self._redis.delete(full_key)
+                if removed:
+                    return True
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis DEL failed for %s: %s", full_key, exc)
+        return self._memory.pop(key, None) is not None
+
+    # ------------------------------------------------------------------
+    async def clear(self) -> None:
+        if self._redis is not None:
+            try:
+                await self._redis.flushdb()
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis FLUSHDB failed: %s", exc)
+        self._memory.clear()
+
+    # ------------------------------------------------------------------
+    def get_lock(self, key: str, timeout: int = 10):
+        """Return an async context manager lock for the key."""
+        if self._redis is not None:
+            return self._redis.lock(self._make_key(f"lock:{key}"), timeout=timeout)
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+
+# ----------------------------------------------------------------------
+
+def cache_with_lock(
+    manager: AdvancedCacheManager,
+    ttl: Optional[int] = None,
+    key_func: Optional[Callable[..., str]] = None,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Cache async function results with a per-key lock."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            cache_key = (
+                key_func(*args, **kwargs)
+                if key_func
+                else f"{func.__module__}.{func.__name__}:{hash(str(args) + str(sorted(kwargs.items())))}"
+            )
+            async with manager.get_lock(cache_key):
+                cached = await manager.get(cache_key)
+                if cached is not None:
+                    return cached
+                result = await func(*args, **kwargs)
+                await manager.set(cache_key, result, ttl)
+                return result
+
+        return wrapper
+
+    return decorator
+
+
+# ----------------------------------------------------------------------
+
+async def create_advanced_cache_manager() -> AdvancedCacheManager:
+    """Initialize :class:`AdvancedCacheManager` using application config."""
+    cfg = get_cache_config()
+    manager = AdvancedCacheManager(cfg)
+    await manager.start()
+    return manager
+
+
+__all__ = [
+    "AdvancedCacheManager",
+    "cache_with_lock",
+    "create_advanced_cache_manager",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ scikit-learn==1.3.0
 joblib==1.3.2
 psutil>=5.9.0
 psycopg2-binary==2.9.7
+redis>=4.6.0
 requests>=2.32.0
 sqlparse>=0.5.0
 bleach==6.0.0

--- a/tests/test_advanced_cache.py
+++ b/tests/test_advanced_cache.py
@@ -1,0 +1,23 @@
+import pytest
+
+from core.advanced_cache import AdvancedCacheManager, cache_with_lock
+from config.base import CacheConfig
+
+
+@pytest.mark.asyncio
+async def test_cache_with_lock_basic():
+    manager = AdvancedCacheManager(CacheConfig(timeout_seconds=1))
+    await manager.start()
+
+    calls = {"n": 0}
+
+    @cache_with_lock(manager, ttl=1)
+    async def compute(val: int) -> int:
+        calls["n"] += 1
+        return val * 2
+
+    assert await compute(2) == 4
+    assert await compute(2) == 4
+    assert calls["n"] == 1
+
+    await manager.stop()


### PR DESCRIPTION
## Summary
- introduce `AdvancedCacheManager` with async redis backend and memory fallback
- add `cache_with_lock` decorator for TTL-aware locking
- expose cache manager exports via `core.__init__`
- add redis dependency
- test advanced cache functionality

## Testing
- `pytest tests/test_advanced_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f802701b483208e570103b5fe44d5