### PR TITLE
Add advanced Redis cache type

### DIFF
--- a/core/plugins/config/factories.py
+++ b/core/plugins/config/factories.py
@@ -73,7 +73,11 @@ class CacheManagerFactory:
     def create_manager(cls, cache_config) -> ICacheManager:
         """Create cache manager based on configuration"""
         # Import here to avoid circular imports
-        from .cache_manager import MemoryCacheManager, RedisCacheManager
+        from .cache_manager import (
+            MemoryCacheManager,
+            RedisCacheManager,
+            AdvancedRedisCacheManager,
+        )
 
         # Register default managers if not already registered
         if not cls._managers:
@@ -81,6 +85,7 @@ class CacheManagerFactory:
                 {
                     "memory": MemoryCacheManager,
                     "redis": RedisCacheManager,
+                    "advanced_redis": AdvancedRedisCacheManager,
                 }
             )
 

--- a/core/plugins/config/production.yaml
+++ b/core/plugins/config/production.yaml
@@ -22,7 +22,7 @@ database:
   retry_attempts: ${DB_RETRY_ATTEMPTS:3}
 
 cache:
-  type: redis
+  type: advanced_redis
   host: ${REDIS_HOST:localhost}
   port: ${REDIS_PORT:6379}
   database: ${REDIS_DB:0}


### PR DESCRIPTION
## Summary
- allow specifying an `advanced_redis` cache backend via `CacheManagerFactory`
- implement `AdvancedRedisCacheManager` with configurable default TTL
- document advanced redis in production config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f80279b708320bc7a403c4ab0b81c