### PR TITLE
Use cache_with_lock for analytics generator

### DIFF
--- a/advanced_cache.py
+++ b/advanced_cache.py
@@ -1,0 +1,48 @@
+import functools
+from typing import Any, Callable
+from threading import RLock
+
+from core.cache import cache
+
+_locks: dict[str, RLock] = {}
+
+
+def _get_lock(name: str) -> RLock:
+    lock = _locks.get(name)
+    if lock is None:
+        lock = RLock()
+        _locks[name] = lock
+    return lock
+
+
+def cache_with_lock(ttl_seconds: int = 300) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Cache function results with a per-function lock."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        lock = _get_lock(func.__name__)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            key = f"{func.__name__}:{hash(str(args) + str(sorted(kwargs.items())))}"
+            result = cache.get(key)
+            if result is not None:
+                return result
+
+            with lock:
+                result = cache.get(key)
+                if result is not None:
+                    return result
+
+                result = func(*args, **kwargs)
+                try:
+                    cache.set(key, result, timeout=ttl_seconds)
+                except TypeError:
+                    # Some cache implementations might use 'ttl'
+                    cache.set(key, result, ttl=ttl_seconds)
+                return result
+
+        return wrapper
+
+    return decorator
+
+__all__ = ["cache_with_lock"]

--- a/api/plugin_performance.py
+++ b/api/plugin_performance.py
@@ -5,12 +5,14 @@ from flask import jsonify, request
 
 from app import app
 from core.plugins.performance_manager import EnhancedThreadSafePluginManager
+from advanced_cache import cache_with_lock
 
 
 class PluginPerformanceAPI:
     """Expose plugin performance metrics via REST endpoints."""
 
     @app.route('/api/v1/plugins/performance', methods=['GET'])
+    @cache_with_lock(ttl_seconds=10)
     def get_plugin_performance():
         manager: EnhancedThreadSafePluginManager = app._yosai_plugin_manager  # type: ignore[attr-defined]
         name = request.args.get('plugin')
@@ -18,6 +20,7 @@ class PluginPerformanceAPI:
         return jsonify(data)
 
     @app.route('/api/v1/plugins/performance/alerts', methods=['GET', 'POST'])
+    @cache_with_lock(ttl_seconds=30)
     def manage_performance_alerts():
         manager: EnhancedThreadSafePluginManager = app._yosai_plugin_manager  # type: ignore[attr-defined]
         if request.method == 'POST':

--- a/services/analytics_generator.py
+++ b/services/analytics_generator.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from core.cache import cache
+from advanced_cache import cache_with_lock
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 class AnalyticsGenerator:
     """Generate summaries and sample analytics."""
 
-    @cache.memoize()
+    @cache_with_lock(ttl_seconds=600)
     def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
         total_events = len(df)
         active_users = df["person_id"].nunique() if "person_id" in df.columns else 0
@@ -61,7 +62,7 @@ class AnalyticsGenerator:
             "top_doors": top_doors,
         }
 
-    @cache.memoize()
+    @cache_with_lock(ttl_seconds=3600)
     def create_sample_data(self, n_events: int = 1000) -> pd.DataFrame:
         np.random.seed(42)
         end_date = datetime.now()
@@ -95,7 +96,7 @@ class AnalyticsGenerator:
         df = pd.DataFrame(data).sort_values("timestamp").reset_index(drop=True)
         return df
 
-    @cache.memoize()
+    @cache_with_lock(ttl_seconds=600)
     def analyze_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
         if df.empty:
             return {"total_events": 0}
@@ -130,7 +131,7 @@ class AnalyticsGenerator:
             "daily_distribution": daily_dist,
         }
 
-    @cache.memoize()
+    @cache_with_lock(ttl_seconds=600)
     def generate_basic_analytics(self, df: pd.DataFrame) -> Dict[str, Any]:
         try:
             analytics: Dict[str, Any] = {
@@ -163,7 +164,7 @@ class AnalyticsGenerator:
             logger.error("Error generating basic analytics: %s", exc)
             return {"status": "error", "message": str(exc)}
 
-    @cache.memoize()
+    @cache_with_lock(ttl_seconds=3600)
     def generate_sample_analytics(self) -> Dict[str, Any]:
         df = self.create_sample_data()
         basic = self.generate_basic_analytics(df)


### PR DESCRIPTION
## Summary
- add `advanced_cache.cache_with_lock` decorator
- use `cache_with_lock` in AnalyticsGenerator methods instead of `cache.memoize`
- cache heavy plugin performance API endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_686f80285c888320b85def2854359cbf