### PR TITLE
Fix upload page to use unified component

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -1,33 +1,50 @@
+"""File upload page wired to the unified upload component."""
+
 from dash import html
 import dash_bootstrap_components as dbc
 
-# Import your existing upload component function
-try:
-    from components import create_upload_card  # Use existing function
-    HAS_UPLOAD_COMPONENT = True
-except ImportError:
-    HAS_UPLOAD_COMPONENT = False
+from components.upload import UnifiedUploadComponent
+from services.upload_data_service import get_uploaded_filenames as _get_uploaded_filenames
 
-def layout():
-    if HAS_UPLOAD_COMPONENT:
-        return dbc.Container([
-            html.H2("File Upload"),
-            create_upload_card()  # Use existing upload component
-        ])
-    else:
-        return dbc.Container([
-            html.H2("File Upload"),
-            html.P("Upload component not available")
-        ])
 
-def safe_upload_layout():
+# Instantiate the shared upload component once
+_upload_component = UnifiedUploadComponent()
+
+
+def layout() -> html.Div:
+    """Render the upload page using the unified component."""
+    return _upload_component.layout()
+
+
+def safe_upload_layout() -> html.Div:
+    """Compatibility wrapper used by legacy routing."""
     return layout()
 
-def register_callbacks(manager):
-    pass
+
+def register_callbacks(manager) -> None:
+    """Delegate callback registration to the component."""
+    _upload_component.register_callbacks(manager)
+
+
+# Dash tests expect this alias
+register_upload_callbacks = register_callbacks
+
+
+def get_uploaded_filenames():
+    """Expose helper for tests to query uploaded files."""
+    return _get_uploaded_filenames()
 
 def register_page():
     from dash import register_page as dash_register_page
     dash_register_page(__name__, path="/upload", name="Upload")
 
-__all__ = ["layout", "safe_upload_layout", "register_page", "register_callbacks"]
+
+__all__ = [
+    "layout",
+    "safe_upload_layout",
+    "register_page",
+    "register_callbacks",
+    "register_upload_callbacks",
+    "get_uploaded_filenames",
+    "_upload_component",
+]


### PR DESCRIPTION
## Summary
- rework the `/upload` page to use the existing `UnifiedUploadComponent`
- expose `register_upload_callbacks` and `get_uploaded_filenames` helpers

## Testing
- `pytest -k "file_upload" -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_68708bface5c8320ae006ec0baa85336