### PR TITLE
Add metadata to navbar callback

### DIFF
--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -135,6 +135,8 @@ def register_navbar_callbacks(callback_manager, service: Optional[Any] = None) -
             [dash.dependencies.Output("navbar-collapse", "is_open")],
             [dash.dependencies.Input("navbar-toggler", "n_clicks")],
             [dash.dependencies.State("navbar-collapse", "is_open")],
+            callback_id="navbar_toggle",
+            component_name="navbar",
         )
         def toggle_navbar_collapse(n, is_open):
             if n:


### PR DESCRIPTION
## Summary
- register navbar callback with explicit `callback_id` and `component_name`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68709d1c32c88320bc706424f48212b5