### PR TITLE
Implement upload callback registration

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -1,6 +1,8 @@
 from dash import html
 import dash_bootstrap_components as dbc
 
+_upload_component = None
+
 # Import your existing upload component function
 try:
     from components import create_upload_card  # Use existing function
@@ -24,10 +26,57 @@ def safe_upload_layout():
     return layout()
 
 def register_callbacks(manager):
-    pass
+    """Register upload callbacks with the provided manager."""
+
+    global _upload_component
+
+    try:
+        from components.upload import UnifiedUploadComponent
+        from services.upload.controllers.upload_controller import (
+            UnifiedUploadController,
+        )
+    except Exception as exc:  # pragma: no cover - optional imports
+        import logging
+
+        logging.getLogger(__name__).error("Failed to import upload modules: %s", exc)
+        return
+
+    _upload_component = UnifiedUploadComponent()
+    controller = UnifiedUploadController(callbacks=manager)
+
+    for defs in [
+        controller.upload_callbacks(),
+        controller.progress_callbacks(),
+        controller.validation_callbacks(),
+    ]:
+        for func, outputs, inputs, states, cid, extra in defs:
+            manager.register_callback(
+                outputs,
+                inputs,
+                states,
+                callback_id=cid,
+                component_name="file_upload",
+                **extra,
+            )(func)
+
+
+
+def get_uploaded_filenames(service=None, container=None):
+    from services.upload_data_service import get_uploaded_filenames as _get
+
+    return _get(service=service, container=container)
 
 def register_page():
     from dash import register_page as dash_register_page
     dash_register_page(__name__, path="/upload", name="Upload")
 
-__all__ = ["layout", "safe_upload_layout", "register_page", "register_callbacks"]
+register_upload_callbacks = register_callbacks
+
+__all__ = [
+    "layout",
+    "safe_upload_layout",
+    "register_page",
+    "register_callbacks",
+    "register_upload_callbacks",
+    "get_uploaded_filenames",
+]


### PR DESCRIPTION
## Summary
- wire up upload callbacks using UnifiedUploadController
- expose `register_upload_callbacks` alias and helper for uploaded filenames

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68709d1d18f0832096eba77d21cafb50