### PR TITLE
Fix custom field toggler callback

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -677,6 +677,7 @@ def register_callbacks(
     manager.register_handler(
         Output({"type": "custom-field", "index": MATCH}, "style"),
         Input({"type": "column-mapping", "index": MATCH}, "value"),
+        prevent_initial_call=True,
         callback_id="toggle_custom_field",
         component_name="column_verification",
     )(toggle_custom_field)


### PR DESCRIPTION
## Summary
- enable `prevent_initial_call` for the custom field toggle callback in `column_verification`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6870a646c14c8320972bc837d0b77b9e