### PR TITLE
Refactor callbacks to register_handler

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -288,7 +288,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.unified_callback(
+    manager.register_handler(
         Output({"type": "device-edited", "index": MATCH}, "data"),
         [
             Input({"type": "device-floor", "index": MATCH}, "value"),

--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -131,7 +131,7 @@ def create_fallback_navbar():
 def register_navbar_callbacks(callback_manager, service: Optional[Any] = None) -> None:
     """Register navbar toggle callback for mobile."""
     try:
-        @callback_manager.unified_callback(
+        @callback_manager.register_handler(
             [dash.dependencies.Output("navbar-collapse", "is_open")],
             [dash.dependencies.Input("navbar-toggler", "n_clicks")],
             [dash.dependencies.State("navbar-collapse", "is_open")],

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -52,7 +52,7 @@ def register_callbacks(manager):
         controller.validation_callbacks(),
     ]:
         for func, outputs, inputs, states, cid, extra in defs:
-            manager.register_callback(
+            manager.register_handler(
                 outputs,
                 inputs,
                 states,

--- a/pages/file_upload_before_learning_fix.py
+++ b/pages/file_upload_before_learning_fix.py
@@ -192,7 +192,7 @@ class StableFileUploadComponent:
         """Register all callbacks in a consolidated manner."""
 
         # Main upload handler callback - listens to dcc.Upload contents
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("preview-area", "children"),
                 Output("to-column-map-btn", "disabled"),
@@ -216,7 +216,7 @@ class StableFileUploadComponent:
             return [], False, {"task_id": task_id}, False
 
         # Progress update callback (unchanged)
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("upload-progress", "value"),
                 Output("upload-progress", "label"),
@@ -242,7 +242,7 @@ class StableFileUploadComponent:
                 return 0, "0%", [], True
 
         # Finalization callback (unchanged)
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("upload-progress-interval", "disabled", allow_duplicate=True),
                 Output("upload-progress", "style", allow_duplicate=True),

--- a/pages/file_upload_current_backup.py
+++ b/pages/file_upload_current_backup.py
@@ -192,7 +192,7 @@ class StableFileUploadComponent:
         """Register all callbacks in a consolidated manner."""
 
         # Main upload handler callback - listens to dcc.Upload contents
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("preview-area", "children"),
                 Output("to-column-map-btn", "disabled"),
@@ -216,7 +216,7 @@ class StableFileUploadComponent:
             return [], False, {"task_id": task_id}, False
 
         # Progress update callback (unchanged)
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("upload-progress", "value"),
                 Output("upload-progress", "label"),
@@ -242,7 +242,7 @@ class StableFileUploadComponent:
                 return 0, "0%", [], True
 
         # Finalization callback (unchanged)
-        @manager.register_callback(
+        @manager.register_handler(
             [
                 Output("upload-progress-interval", "disabled", allow_duplicate=True),
                 Output("upload-progress", "style", allow_duplicate=True),

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -370,7 +370,7 @@ def create_device_learning_service() -> DeviceLearningService:
 def create_learning_callbacks(manager: "TrulyUnifiedCallbacks") -> None:
     """Register device learning callback with coordinator."""
 
-    @manager.unified_callback(
+    @manager.register_handler(
         Output("device-learning-status", "children"),
         [
             Input("file-upload-store", "data"),


### PR DESCRIPTION
## Summary
- standardize callback registration on `register_handler`
- remove deprecated decorator usage

## Testing
- `pytest tests/test_callbacks_alias.py -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870a64a766c8320b21127d37d909b96