### PR TITLE
Enable file upload callbacks

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -901,7 +901,7 @@ def _register_callbacks(
     if coordinator is not None:
         coordinator._callback_registry = _callback_registry
         registration_modules = [
-            # ("pages.file_upload", "register_callbacks"), # DISABLED
+            ("pages.file_upload", "register_callbacks"),
             ("pages.deep_analytics", "register_callbacks"),
             ("components.ui.navbar", "register_navbar_callbacks"),
         ]


### PR DESCRIPTION
## Summary
- enable callback registration for file upload

## Testing
- `pytest -k 'app_factory and not slow and not database' -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_6870c69c8d588320a703f5dd456b8788