### PR TITLE
Fix callbacks and unify registration

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -300,6 +300,21 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
     )
 
 
+def create_device_mapping_section(devices: List[str] | None = None) -> html.Div:
+    """Return button and modal for device mapping."""
+
+    open_button = dbc.Button(
+        "Map Devices",
+        id="open-device-mapping",
+        color="primary",
+        className="mb-3",
+    )
+
+    modal = create_simple_device_modal_with_ai(devices or [])
+
+    return html.Div([open_button, modal])
+
+
 def create_simple_device_modal(devices: List[str]) -> dbc.Modal:
     """Create simple device mapping modal"""
 
@@ -621,4 +636,4 @@ def register_callbacks(
         )
 
 
-__all__ = ["register_callbacks"]
+__all__ = ["register_callbacks", "create_device_mapping_section"]

--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -14,12 +14,9 @@ from analytics.controllers import UnifiedAnalyticsController
 from core.callback_registry import _callback_registry
 from core.dash_profile import profile_callback
 from core.state import CentralizedStateManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-
 logger = logging.getLogger(__name__)
 import dash_bootstrap_components as dbc
 
-callback_manager = TrulyUnifiedCallbacks()
 analytics_state = CentralizedStateManager()
 
 from services.data_processing.analytics_engine import (
@@ -524,7 +521,7 @@ def register_callbacks(
     def _do_registration() -> None:
         cb = Callbacks()
 
-        callback_manager.register_operation(
+        manager.register_operation(
             "analysis_buttons",
             lambda s, t, b, a, sug, q, u, ds: cb.handle_analysis_buttons(
                 s, t, b, a, sug, q, u, ds
@@ -532,12 +529,12 @@ def register_callbacks(
             name="handle_analysis_buttons",
             timeout=5,
         )
-        callback_manager.register_operation(
+        manager.register_operation(
             "refresh_sources",
             lambda n: cb.refresh_data_sources_callback(n),
             name="refresh_data_sources",
         )
-        callback_manager.register_operation(
+        manager.register_operation(
             "status_alert",
             lambda val: cb.update_status_alert(val),
             name="update_status_alert",
@@ -568,7 +565,7 @@ def register_callbacks(
         def analytics_operations(
             sec, trn, beh, anom, sug, qual, uniq, refresh, trigger, data_source
         ):
-            display = callback_manager.execute_group(
+            display = manager.execute_group(
                 "analysis_buttons",
                 sec,
                 trn,
@@ -580,9 +577,9 @@ def register_callbacks(
                 data_source,
             )[0]
 
-            options = callback_manager.execute_group("refresh_sources", refresh)[0]
+            options = manager.execute_group("refresh_sources", refresh)[0]
 
-            alert = callback_manager.execute_group("status_alert", trigger)[0]
+            alert = manager.execute_group("status_alert", trigger)[0]
 
             analytics_state.dispatch(
                 "UPDATE", {"display": display, "options": options, "alert": alert}

--- a/upload_callbacks.py
+++ b/upload_callbacks.py
@@ -20,7 +20,13 @@ class UploadCallbackManager:
 
         uc = UnifiedUploadController(callbacks=manager)
 
-        for defs in [uc.upload_callbacks(), uc.progress_callbacks(), uc.validation_callbacks()]:
+        callback_sources = [
+            getattr(uc, "upload_callbacks", lambda: [])(),
+            getattr(uc, "progress_callbacks", lambda: [])(),
+            getattr(uc, "validation_callbacks", lambda: [])(),
+        ]
+
+        for defs in callback_sources:
             for func, outputs, inputs, states, cid, extra in defs:
                 manager.register_callback(
                     outputs,


### PR DESCRIPTION
## Summary
- remove standalone callback manager in deep analytics callbacks
- add device mapping section with open button
- deduplicate navbar callback via global registry
- ensure legacy upload callback ids register once
- improve UploadCallbackManager to handle missing methods

## Testing
- `pytest -q tests/test_upload_end_to_end.py::test_callback_connectivity -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e3c6ac7c83209cfc226b04032e69