### PR TITLE
Fix missing callback wrapper in file_upload

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -226,7 +226,8 @@ def register_callbacks(manager):
         allow_duplicate=True,
 
     )
-
+    def callback_wrapper(*args, **kwargs):
+        return handle_file_upload(*args, **kwargs)
 
 
 def _process_upload_safe(contents, filename):


### PR DESCRIPTION
## Summary
- restore the callback wrapper for the upload dropzone

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6870f297f0908320b09061c6bcceb971