### PR TITLE
Remove unused upload card flag

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -35,14 +35,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Try to import your existing components - graceful fallback
-try:
-    from components import create_upload_card
-    HAS_UPLOAD_COMPONENT = True
-    logger.info("✅ Found existing upload component")
-except ImportError:
-    HAS_UPLOAD_COMPONENT = False
-    logger.info("ℹ️ No existing upload component - using built-in")
+
 
 # Try to import advanced services - graceful fallback
 try:
@@ -473,4 +466,19 @@ __all__ = [
     "get_uploaded_filenames",
 ]
 
-logger.info(f"🚀 File upload loaded - Controller: {CONTROLLER_AVAILABLE}, Component: {HAS_UPLOAD_COMPONENT}")
+import importlib
+
+_component_available = False
+try:
+    spec = importlib.util.find_spec("components")
+    if spec:
+        module = importlib.import_module("components")
+        _component_available = hasattr(module, "create_upload_card")
+except Exception:
+    _component_available = False
+
+logger.info(
+    "🚀 File upload loaded - Controller: %s, Upload component available: %s",
+    CONTROLLER_AVAILABLE,
+    _component_available,
+)


### PR DESCRIPTION
## Summary
- drop `create_upload_card` fallback import
- compute upload component availability at runtime

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_6870f2a1c8f08320969425328006fb1c