### PR TITLE
Add configurable limits

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from .app_config import UploadConfig
 from .constants import (
     DEFAULT_APP_HOST,
     DEFAULT_APP_PORT,
@@ -15,7 +16,6 @@ from .constants import (
     DEFAULT_DB_PORT,
 )
 from .dynamic_config import dynamic_config
-from .app_config import UploadConfig
 
 
 @dataclass
@@ -42,7 +42,7 @@ class DatabaseConfig:
     password: str = ""
     # Database connection URL. If empty, generated from other fields.
     url: str = ""
-    connection_timeout: int = 30
+    connection_timeout: int = dynamic_config.get_db_connection_timeout()
     initial_pool_size: int = dynamic_config.get_db_pool_size()
     max_pool_size: int = dynamic_config.get_db_pool_size() * 2
     shrink_timeout: int = 60

--- a/config/constants.py
+++ b/config/constants.py
@@ -74,7 +74,7 @@ class SecurityConstants:
 
     pbkdf2_iterations: int = 100000
     salt_bytes: int = 32
-    rate_limit_requests: int = 100
+    rate_limit_requests: int = 200
     rate_limit_window_minutes: int = 1
     max_upload_mb: int = 500  # Changed from 100 to 500
     max_file_size_mb: int = 500  # Added for consistency
@@ -88,6 +88,13 @@ class PerformanceConstants:
     db_pool_size: int = 10
     ai_confidence_threshold: int = 75
     memory_usage_threshold_mb: int = 1024
+
+
+@dataclass
+class DatabaseConstants:
+    """Database related defaults."""
+
+    connection_timeout_seconds: int = 30
 
 
 @dataclass
@@ -119,7 +126,6 @@ class AnalyticsConstants:
     query_timeout_seconds: int = 300
     max_memory_mb: int = 1024
     max_display_rows: int = 10000
-
 
 
 @dataclass

--- a/config/env_overrides.py
+++ b/config/env_overrides.py
@@ -43,6 +43,11 @@ def apply_env_overrides(config: Any) -> None:
                 db.port = int(db_port)
             except ValueError:
                 logger.warning("Invalid DB_PORT value: %s", db_port)
+        if db_timeout := os.getenv("DB_TIMEOUT"):
+            try:
+                db.connection_timeout = int(db_timeout)
+            except ValueError:
+                logger.warning("Invalid DB_TIMEOUT value: %s", db_timeout)
         if db_user := os.getenv("DB_USER"):
             db.user = db_user
         if db_pass := os.getenv("DB_PASSWORD"):
@@ -51,11 +56,15 @@ def apply_env_overrides(config: Any) -> None:
     # --- Security overrides -------------------------------------------
     if hasattr(config, "security"):
         sec = config.security
-        if hasattr(sec, "pbkdf2_iterations") and (val := os.getenv("PBKDF2_ITERATIONS")):
+        if hasattr(sec, "pbkdf2_iterations") and (
+            val := os.getenv("PBKDF2_ITERATIONS")
+        ):
             sec.pbkdf2_iterations = int(val)
         if hasattr(sec, "rate_limit_requests") and (val := os.getenv("RATE_LIMIT_API")):
             sec.rate_limit_requests = int(val)
-        if hasattr(sec, "rate_limit_window_minutes") and (val := os.getenv("RATE_LIMIT_WINDOW")):
+        if hasattr(sec, "rate_limit_window_minutes") and (
+            val := os.getenv("RATE_LIMIT_WINDOW")
+        ):
             sec.rate_limit_window_minutes = int(val)
         if (max_upload := os.getenv("MAX_UPLOAD_MB")) is not None:
             try:

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -2,8 +2,10 @@
 """Settings management page with placeholders."""
 
 import dash_bootstrap_components as dbc
-from dash import html, register_page as dash_register_page
+from dash import dcc, html
+from dash import register_page as dash_register_page
 
+from config.dynamic_config import dynamic_config
 from security.unicode_security_processor import sanitize_unicode_input
 
 
@@ -26,12 +28,64 @@ def _settings_section(title: str) -> dbc.Card:
     )
 
 
+def _system_config_section() -> dbc.Card:
+    """Return system configuration with dropdowns for key settings."""
+
+    rate_options = [60, 120, 200, 500, 1000]
+    timeout_options = [5, 10, 20, 30, 60]
+    batch_options = [1000, 2000, 5000, 10000, 25000]
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H5("System Configuration", className="card-title"),
+                dbc.Label(
+                    "Rate Limit (per minute)",
+                    html_for="setting-rate-limit",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-rate-limit",
+                    options=[{"label": str(o), "value": o} for o in rate_options],
+                    value=dynamic_config.security.rate_limit_requests,
+                    clearable=False,
+                    className="mb-3",
+                ),
+                dbc.Label(
+                    "DB Connection Timeout",
+                    html_for="setting-db-timeout",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-db-timeout",
+                    options=[{"label": str(o), "value": o} for o in timeout_options],
+                    value=dynamic_config.database.connection_timeout_seconds,
+                    clearable=False,
+                    className="mb-3",
+                ),
+                dbc.Label(
+                    "Analytics Batch Size",
+                    html_for="setting-batch-size",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-batch-size",
+                    options=[{"label": str(o), "value": o} for o in batch_options],
+                    value=dynamic_config.analytics.batch_size,
+                    clearable=False,
+                ),
+            ]
+        ),
+        className="mb-4 settings-section",
+    )
+
+
 def layout() -> dbc.Container:
     """Settings page layout."""
     sections = dbc.Row(
         [
             dbc.Col(_settings_section("User Preferences"), md=6),
-            dbc.Col(_settings_section("System Configuration"), md=6),
+            dbc.Col(_system_config_section(), md=6),
         ]
     )
 


### PR DESCRIPTION
## Summary
- centralize default limits in `constants`
- allow env overrides of DB timeout and expose helper
- pull values into the settings page
- support new database constant in base configuration

## Testing
- `pre-commit run --files config/base.py config/constants.py config/dynamic_config.py config/env_overrides.py pages/settings.py` *(mypy skipped)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_6870f88e95488320b7237d17752eb2b8