### PR TITLE
Remove deprecated InputValidator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ The factory builds the container, which then instantiates services. Services ope
 
 - **Unified Validator** – Input and file validation are now handled by the
   `SecurityValidator` together with `UnifiedFileValidator`. The deprecated
-  `InputValidator` and `SecureFileValidator` classes have been removed.
+  `SecureFileValidator` class has been removed.
 - **Separated Analytics Modules** – The previously monolithic
   `AnalyticsService` has been broken into smaller modules under
 `services/data_processing/` and `analytics/`.  `UnifiedFileValidator`,
@@ -34,8 +34,8 @@ container. Register them during application startup and retrieve them where
 needed:
 
 ```python
-from core.container import Container
 from config import create_config_manager
+from core.container import Container
 from services.analytics_service import create_analytics_service
 
 container = Container()

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -11,12 +11,12 @@ from core.security_validator import SecurityValidator
 
 validator = SecurityValidator()
 
-# Input validation (replaces InputValidator, SQLInjectionPrevention, XSSPrevention)
+# Input validation
 result = validator.validate_input(user_input, "field_name")
 if not result['valid']:
     raise ValidationError(result['issues'])
 
-# File upload validation (replaces SecureFileValidator, DataFrameSecurityValidator)
+# File upload validation (replaces SecureFileValidator)
 result = validator.validate_file_upload(filename, file_bytes)
 if not result['valid']:
     raise ValidationError(result['issues'])
@@ -34,38 +34,23 @@ SecurityValidator provides comprehensive validation including:
 
 ## Migration from Deprecated Classes
 
-All deprecated validator classes have been REMOVED. Update your code:
+All legacy validators have been removed. Update your code to use
+`SecurityValidator` for both input and file checks:
 
 ```python
-# OLD (REMOVED):
-from security.dataframe_validator import DataFrameSecurityValidator
-validator = DataFrameSecurityValidator()
-result = validator.validate_for_upload(df)
-
-# NEW (CURRENT):
 from core.security_validator import SecurityValidator
+
 validator = SecurityValidator()
-csv_bytes = df.to_csv(index=False).encode('utf-8')
+csv_bytes = df.to_csv(index=False).encode("utf-8")
 result = validator.validate_file_upload("data.csv", csv_bytes)
-
-# OLD (REMOVED):
-from security.sql_validator import SQLInjectionPrevention  
-SQLInjectionPrevention.validate_query_parameter(user_input)
-
-# NEW (CURRENT):
-from core.security_validator import SecurityValidator
-validator = SecurityValidator()
 result = validator.validate_input(user_input, "query_parameter")
 ```
 
 ## Removed Classes
 
 These classes have been COMPLETELY REMOVED:
-- ❌ `InputValidator` 
-- ❌ `DataFrameSecurityValidator`
-- ❌ `SQLInjectionPrevention`
 - ❌ `XSSPrevention`
-- ❌ `SecureFileValidator` 
+- ❌ `SecureFileValidator`
 - ❌ `BusinessLogicValidator`
 
 Use `SecurityValidator` for all validation needs.

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -14,22 +14,21 @@ from typing import Any, Dict, Optional, Tuple
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
-from core.protocols import ConfigurationProtocol
+from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
+from core.protocols import ConfigurationProtocol
 from core.unicode import UnicodeProcessor, sanitize_dataframe
 from core.unicode_utils import sanitize_for_utf8
 from upload_types import ValidationResult
 from upload_validator import UploadValidator
 
 
-def _lazy_string_validator() -> "StringValidator":
-    """Import ``InputValidator`` from :mod:`core.security` lazily."""
-    from core.security import InputValidator as StringValidator
+def _lazy_string_validator() -> Any:
+    """Import :class:`SecurityValidator` lazily."""
+    from core.security_validator import SecurityValidator as StringValidator
 
     return StringValidator()
 
-
-from core.exceptions import ValidationError
 
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
 ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
@@ -215,7 +214,9 @@ class UnifiedFileValidator:
         config: ConfigurationProtocol = dynamic_config,
     ) -> None:
         self.config = config
-        self.max_size_mb = max_size_mb or getattr(self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb)
+        self.max_size_mb = max_size_mb or getattr(
+            self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb
+        )
         self._string_validator = _lazy_string_validator()
         self._basic_validator = UploadValidator(self.max_size_mb, config=self.config)
 


### PR DESCRIPTION
## Summary
- delete `InputValidator` from `core/security.py`
- switch lazy import in `UnifiedFileValidator` to `SecurityValidator`
- update docs to drop references to removed classes

## Testing
- `pre-commit run --files core/security.py docs/architecture.md docs/validation_overview.md services/data_processing/unified_file_validator.py` *(mypy skipped)*
- `pytest -q` *(failed: Missing module 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6871361a52e48320a468413226ccecdc