### PR TITLE
Add Advanced SQL validator

### DIFF
--- a/tests/test_security_validator.py
+++ b/tests/test_security_validator.py
@@ -1,6 +1,12 @@
+import types
 import pytest
 
-from core.security_validator import SecurityLevel, SecurityValidator
+from core.security_validator import (
+    AdvancedSQLValidator,
+    SecurityLevel,
+    SecurityValidator,
+)
+import security_callback_controller
 
 
 def test_sql_injection_validation():
@@ -10,7 +16,17 @@ def test_sql_injection_validation():
     assert issues[0].level == SecurityLevel.CRITICAL
 
 
+def test_valid_sql_passes():
+    validator = AdvancedSQLValidator()
+    assert not validator.is_malicious("SELECT * FROM users WHERE id = 1")
+
+
 def test_main_validation_orchestration():
+    # Stub security callback handling for isolated testing
+    security_callback_controller.security_unified_callbacks = types.SimpleNamespace(
+        trigger=lambda *args, **kwargs: None
+    )
+
     validator = SecurityValidator()
     result = validator.validate_input("<script>alert('xss')</script>", "comment")
     assert not result["valid"]


### PR DESCRIPTION
## Summary
- add `AdvancedSQLValidator` using sqlparse and integrate with `SecurityValidator`
- replace regex-based SQL injection check with parser-based validation
- extend security validator tests to cover valid and malicious SQL
- stub security callbacks in tests for isolation

## Testing
- `pytest -q tests/test_security_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_6871361b65c08320a556359ccc7de6d0