### PR TITLE
Add SecureConfigManager with Vault secrets

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -16,6 +16,7 @@ from .config_validator import ConfigValidator, ValidationResult
 from .constants import CSSConstants, PerformanceConstants, SecurityConstants
 from .dynamic_config import DynamicConfigManager, dynamic_config
 from .config_manager import ConfigManager, get_config, reload_config
+from .secure_config_manager import SecureConfigManager
 from .protocols import (
     ConfigLoaderProtocol,
     ConfigTransformerProtocol,
@@ -93,6 +94,7 @@ __all__ = [
     "SecurityConfig",
     "UploadConfig",
     "ConfigManager",
+    "SecureConfigManager",
     "ConfigValidator",
     "ValidationResult",
     "ConfigLoader",

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -12,7 +12,7 @@ database:
   port: ${DB_PORT:5432}
   name: ${DB_NAME}
   user: ${DB_USER}
-  password: ${DB_PASSWORD}
+  password: vault:secret/data/db#password
   url: ${DATABASE_URL:}
   initial_pool_size: ${DB_INITIAL_POOL_SIZE:10}
   max_pool_size: ${DB_MAX_POOL_SIZE:20}
@@ -31,7 +31,7 @@ cache:
   max_memory_mb: ${CACHE_MAX_MEMORY_MB:100}
 
 security:
-  secret_key: ${SECRET_KEY}
+  secret_key: vault:secret/data/app#secret_key
   session_timeout_minutes: ${SESSION_TIMEOUT:30}
   max_file_size_mb: ${MAX_FILE_SIZE:50}
   max_upload_mb: ${MAX_UPLOAD_MB:500}

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -13,11 +13,11 @@ database:
   port: 5432
   name: "yosai_db"
   user: "yosai_user"
-  password: "${DB_PASSWORD}"
+  password: "vault:secret/data/db#password"
   url: ""
 
 security:
-  secret_key: "${SECRET_KEY}"
+  secret_key: "vault:secret/data/app#secret_key"
   session_timeout_minutes: 120
   max_file_size_mb: 250
   max_upload_mb: 500

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,11 +11,11 @@ database:
   port: 5432
   name: "yosai_db"
   user: "yosai_user"
-  password: "${DB_PASSWORD}"
+  password: "vault:secret/data/db#password"
   url: ""
 
 security:
-  secret_key: "${SECRET_KEY}"
+  secret_key: "vault:secret/data/app#secret_key"
   session_timeout: 3600
   max_upload_mb: 50
   allowed_file_types:

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -46,6 +46,37 @@ fetch the secret with a name matching the requested key. With the
 `VAULT_ADDR` and `VAULT_TOKEN` environment variables. Keys may include a
 field selector like `secret/data/db#password` to read specific values.
 
+### Vault Configuration
+
+The optional `SecureConfigManager` resolves any string starting with
+`"vault:"` in the YAML configuration. Install the `hvac` and
+`cryptography` packages and set the following environment variables:
+
+```
+VAULT_ADDR=https://vault.example.com
+VAULT_TOKEN=s.xxxxxx
+FERNET_KEY=<base64-fernet-key>
+```
+
+`VAULT_ADDR` and `VAULT_TOKEN` authenticate the Vault client. `FERNET_KEY`
+is used to decrypt any encrypted values returned from Vault.
+Update `production.yaml` to reference secrets like:
+
+```yaml
+database:
+  password: vault:secret/data/db#password
+security:
+  secret_key: vault:secret/data/app#secret_key
+```
+
+Create the manager with:
+
+```python
+from config import SecureConfigManager
+
+cfg = SecureConfigManager()
+```
+
 ## Incident Handling
 
 If you suspect a secret has been exposed:

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,6 @@ SQLAlchemy>=2.0
 prefect>=2.0
 click>=8.0
 pytest-cov>=2.12.0
+hvac>=2.3.0
+cryptography>=45.0.0
 

--- a/tests/test_secure_config_manager.py
+++ b/tests/test_secure_config_manager.py
@@ -1,0 +1,39 @@
+import types
+
+from cryptography.fernet import Fernet
+
+from config.secure_config_manager import SecureConfigManager
+
+
+def test_vault_secret_resolution(monkeypatch, tmp_path):
+    key = Fernet.generate_key()
+    f = Fernet(key)
+    encrypted = f.encrypt(b"super-secret").decode()
+
+    class DummyKV:
+        def read_secret_version(self, path):
+            assert path == "secret/data/db"
+            return {"data": {"data": {"password": encrypted}}}
+
+    class DummyClient:
+        def __init__(self, url=None, token=None):  # noqa: D401 - stub
+            self.secrets = types.SimpleNamespace(kv=types.SimpleNamespace(v2=DummyKV()))
+
+    monkeypatch.setattr("config.secure_config_manager.hvac.Client", DummyClient)
+
+    cfg_yaml = """
+database:
+  password: vault:secret/data/db#password
+security:
+  secret_key: vault:secret/data/db#password
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_yaml, encoding="utf-8")
+
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
+    monkeypatch.setenv("FERNET_KEY", key.decode())
+
+    mgr = SecureConfigManager()
+
+    assert mgr.get_database_config().password == "super-secret"
+    assert mgr.get_security_config().secret_key == "super-secret"


### PR DESCRIPTION
## Summary
- introduce `SecureConfigManager` for pulling encrypted secrets from HashiCorp Vault
- reference Vault secrets in YAML configs
- document Vault access configuration
- add dependencies
- test secret decryption logic

## Testing
- `pip install -q hvac cryptography` *(fails: ModuleNotFoundError: No module named 'dash')*
- `pytest tests/test_secure_config_manager.py::test_vault_secret_resolution -q` *(failed to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871361c29e8832089c21a49500348db