### PR TITLE
Improve Unicode sanitization

### DIFF
--- a/tests/stubs/redis/__init__.py
+++ b/tests/stubs/redis/__init__.py
@@ -1,0 +1,7 @@
+class FakeRedis:
+    async def get(self, key):
+        return None
+
+
+class asyncio:
+    Redis = FakeRedis

--- a/tests/test_sanitize_dataframe_memory.py
+++ b/tests/test_sanitize_dataframe_memory.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import psutil
+import pytest
+
+from services.data_processing.file_processor import UnicodeFileProcessor
+
+
+@pytest.mark.slow
+@pytest.mark.performance
+def test_sanitize_dataframe_unicode_memory_usage():
+    rows = 10_000
+    df = pd.DataFrame({"text": ["bad\ud83d\ude00"] * rows})
+
+    proc = UnicodeFileProcessor()
+    process = psutil.Process()
+    start_mem = process.memory_info().rss / (1024 * 1024)
+    total = 0
+    for chunk in proc.sanitize_dataframe_unicode(df, chunk_size=5_000, stream=True):
+        assert not chunk["text"].str.contains("\\ud83d").any()
+        total += len(chunk)
+    end_mem = process.memory_info().rss / (1024 * 1024)
+    assert total == rows
+    assert end_mem - start_mem < 100


### PR DESCRIPTION
## Summary
- stream sanitize_dataframe_unicode and avoid large DataFrame apply
- add redis stub to satisfy tests
- add memory usage performance test

## Testing
- `pre-commit run black --files tests/stubs/redis/__init__.py tests/test_sanitize_dataframe_memory.py services/data_processing/file_processor.py`
- `pre-commit run isort --files tests/stubs/redis/__init__.py tests/test_sanitize_dataframe_memory.py services/data_processing/file_processor.py`
- `pre-commit run flake8 --files tests/stubs/redis/__init__.py tests/test_sanitize_dataframe_memory.py services/data_processing/file_processor.py`
- `pytest tests/test_sanitize_dataframe_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871361db9ac83209101c1e26047501d