### PR TITLE
Fix vectorized tests imports

### DIFF
--- a/tests/test_vectorized_functions_additional.py
+++ b/tests/test_vectorized_functions_additional.py
@@ -1,62 +1,47 @@
 """Additional tests for vectorized functions."""
 
 import pandas as pd
-import pytest
 
-# Fixed imports
-try:
-    from analytics.anomaly_detection import AnomalyDetector
-    from analytics.security_patterns import SecurityPatternsAnalyzer
-except ImportError as e:
-    pytest.skip(f"Required modules not available: {e}", allow_module_level=True)
+from analytics.anomaly_detection import AnomalyDetector
+from analytics.security_patterns import SecurityPatternsAnalyzer
 
 
 class TestVectorizedFunctionsFixed:
     """Fixed tests for vectorized functions"""
-    
+
     def test_extract_failure_patterns_vectorized(self):
         """Test failure pattern extraction"""
         analyzer = SecurityPatternsAnalyzer()
-        df = pd.DataFrame({
-            "event_id": range(6),
-            "timestamp": pd.date_range("2024-01-01", periods=6, freq="H"),
-            "person_id": ["u1", "u1", "u1", "u2", "u3", "u1"],
-            "door_id": ["d1"] * 6,
-            "access_result": ["Denied"] * 6,
-        })
-        
-        if hasattr(analyzer, '_prepare_data'):
-            df = analyzer._prepare_data(df)
-            
-        if hasattr(analyzer, '_extract_failure_patterns'):
-            patterns = analyzer._extract_failure_patterns(df)
-            # Check that patterns are found
-            assert isinstance(patterns, list)
-        else:
-            pytest.skip("_extract_failure_patterns method not available")
-    
+        df = pd.DataFrame(
+            {
+                "event_id": range(6),
+                "timestamp": pd.date_range("2024-01-01", periods=6, freq="H"),
+                "person_id": ["u1", "u1", "u1", "u2", "u3", "u1"],
+                "door_id": ["d1"] * 6,
+                "access_result": ["Denied"] * 6,
+            }
+        )
+
+        df = analyzer._prepare_data(df)
+        patterns = analyzer._detect_statistical_threats(df)
+        assert isinstance(patterns, list)
+
     def test_anomaly_detection_with_new_class(self):
         """Test anomaly detection with corrected class name"""
         detector = AnomalyDetector()
-        
-        df = pd.DataFrame({
-            "event_id": range(15),
-            "timestamp": pd.date_range("2024-01-01 08:00:00", periods=15, freq="3min"),
-            "person_id": ["u1"] * 12 + ["u2", "u2", "u2"],
-            "door_id": ["d1"] * 15,
-            "access_result": ["Granted"] * 15,
-        })
-        
-        if hasattr(detector, '_prepare_data'):
-            df = detector._prepare_data(df)
-        elif hasattr(detector, '_prepare_anomaly_data'):
-            df = detector._prepare_anomaly_data(df)
-            
-        if hasattr(detector, '_detect_frequency_anomalies'):
-            anomalies = detector._detect_frequency_anomalies(df)
-            assert isinstance(anomalies, list)
-        elif hasattr(detector, 'detect_anomalies'):
-            result = detector.detect_anomalies(df)
-            assert isinstance(result, dict)
-        else:
-            pytest.skip("Anomaly detection methods not available")
+
+        df = pd.DataFrame(
+            {
+                "event_id": range(15),
+                "timestamp": pd.date_range(
+                    "2024-01-01 08:00:00", periods=15, freq="3min"
+                ),
+                "person_id": ["u1"] * 12 + ["u2", "u2", "u2"],
+                "door_id": ["d1"] * 15,
+                "access_result": ["Granted"] * 15,
+            }
+        )
+
+        df = detector._prepare_anomaly_data(df)
+        anomalies = detector._detect_frequency_anomalies(df)
+        assert isinstance(anomalies, list)


### PR DESCRIPTION
## Summary
- ensure `tests/test_vectorized_functions_additional.py` imports packages directly
- rely on explicit API calls for data preparation and detection

## Testing
- `pre-commit run --files tests/test_vectorized_functions_additional.py` *(fails: mypy)*
- `pytest tests/test_vectorized_functions_additional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871361ed268832097031b551465e237