### PR TITLE
Remove redundant preview output from upload controller

### DIFF
--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -33,20 +33,19 @@ class UnifiedUploadController:
                     df = pd.read_csv(io.StringIO(decoded.decode("utf-8")))
             except Exception as exc:
                 logger.error("Failed to parse uploaded file: %s", exc)
-                return [], False, {}
+                return False, {}
 
-            preview = dash_table.DataTable(
+            dash_table.DataTable(
                 data=df.head().to_dict("records"),
                 columns=[{"name": c, "id": c} for c in df.columns],
                 page_size=5,
             )
-            return preview, False, df.to_json(date_format="iso", orient="split")
+            return False, df.to_json(date_format="iso", orient="split")
 
         return [
             (
                 handle_upload,
                 [
-                    Output("preview-area", "children"),
                     Output("to-column-map-btn", "disabled"),
                     Output("uploaded-df-store", "data"),
                 ],


### PR DESCRIPTION
## Summary
- avoid duplicate `preview-area` outputs in `UnifiedUploadController`
- return only progress and data from the controller upload handler

## Testing
- `python -m py_compile services/upload/controllers/upload_controller.py`
- `python - <<'PY'
from core.callback_registry import _callback_registry
_callback_registry.registered_callbacks.clear()
_callback_registry.registration_sources.clear()
_callback_registry.registration_attempts.clear()
_callback_registry.registration_order.clear()
_callback_registry.register('file_upload_handle', 'module')
print('result', _callback_registry.validate_registration_integrity())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6871bc68042c8320aed5003bc99255ed