### PR TITLE
Introduce UnifiedUploadValidator

### DIFF
--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -19,6 +19,7 @@ from .core.exceptions import (
     FileValidationError,
 )
 from .unified_file_validator import UnifiedFileValidator
+from .unified_upload_validator import UnifiedUploadValidator
 
 # Analytics helpers are intentionally loaded lazily in environments where the
 # full analytics stack is unavailable. ``AI_SUGGESTIONS_AVAILABLE`` defaults to
@@ -65,6 +66,7 @@ __all__ = [
     "FileHandler",
     "AsyncFileProcessor",
     "UnifiedFileValidator",
+    "UnifiedUploadValidator",
     "process_file_simple",
     "FileProcessingError",
     "FileValidationError",

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -20,7 +20,7 @@ from core.protocols import ConfigurationProtocol
 from core.unicode import UnicodeProcessor, sanitize_dataframe
 from core.unicode_utils import sanitize_for_utf8
 from upload_types import ValidationResult
-from upload_validator import UploadValidator
+from .unified_upload_validator import UnifiedUploadValidator
 
 
 def _lazy_string_validator() -> Any:
@@ -218,7 +218,7 @@ class UnifiedFileValidator:
             self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb
         )
         self._string_validator = _lazy_string_validator()
-        self._basic_validator = UploadValidator(self.max_size_mb, config=self.config)
+        self._basic_validator = UnifiedUploadValidator(self.max_size_mb, config=self.config)
 
     def _sanitize_string(self, value: str) -> str:
         cleaned = sanitize_for_utf8(str(value))

--- a/services/data_processing/unified_upload_validator.py
+++ b/services/data_processing/unified_upload_validator.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Basic upload validation utilities."""
+
+import base64
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from config.dynamic_config import dynamic_config
+from upload_types import ValidationResult
+
+
+class UnifiedUploadValidator:
+    """Validate basic properties of uploaded files."""
+
+    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
+
+    def __init__(
+        self,
+        max_size_mb: Optional[int] = None,
+        config: Any = dynamic_config,
+    ) -> None:
+        self.config = config
+        if max_size_mb is not None:
+            self.max_size_mb = max_size_mb
+        elif hasattr(config, "get_max_upload_size_mb"):
+            self.max_size_mb = config.get_max_upload_size_mb()
+        else:
+            self.max_size_mb = getattr(
+                getattr(config, "security", config),
+                "max_upload_mb",
+                dynamic_config.security.max_upload_mb,
+            )
+
+    # ------------------------------------------------------------------
+    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
+        """Validate an uploaded file-like object."""
+        if file_obj is None:
+            return ValidationResult(False, "No file provided")
+
+        try:
+            import pandas as pd
+
+            if isinstance(file_obj, pd.DataFrame):
+                if file_obj.empty:
+                    return ValidationResult(False, "Empty dataframe")
+                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
+                if size_mb > self.max_size_mb:
+                    return ValidationResult(
+                        False,
+                        f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                    )
+                return ValidationResult(True, "ok")
+        except Exception:
+            pass
+
+        if isinstance(file_obj, (str, Path)):
+            text = str(file_obj)
+            if self._DATA_URI_RE.match(text):
+                try:
+                    _, b64 = text.split(",", 1)
+                    decoded = base64.b64decode(b64)
+                except Exception:
+                    return ValidationResult(False, "Invalid base64 contents")
+                return self.validate_file_upload(decoded)
+
+            if isinstance(file_obj, Path) or Path(text).exists():
+                path = Path(file_obj)
+                if not path.exists():
+                    return ValidationResult(False, "File not found")
+                size_mb = path.stat().st_size / (1024 * 1024)
+                if size_mb == 0:
+                    return ValidationResult(False, "File is empty")
+                if size_mb > self.max_size_mb:
+                    return ValidationResult(
+                        False,
+                        f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                    )
+                return ValidationResult(True, "ok")
+            return ValidationResult(False, "File not found")
+
+        if isinstance(file_obj, (bytes, bytearray)):
+            size_mb = len(file_obj) / (1024 * 1024)
+            if size_mb == 0:
+                return ValidationResult(False, "File is empty")
+            if size_mb > self.max_size_mb:
+                return ValidationResult(
+                    False,
+                    f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                )
+            return ValidationResult(True, "ok")
+
+        return ValidationResult(False, "Unsupported file type")
+
+
+__all__ = ["UnifiedUploadValidator", "ValidationResult"]

--- a/services/input_validator.py
+++ b/services/input_validator.py
@@ -1,114 +1,27 @@
-"""Input validation helpers for uploaded files.
-
-This module provides a small helper used by :class:`AnalyticsService`
-to validate uploaded files before any processing occurs.  Each file is
-checked for presence, non-empty content and that its size does not
-exceed configured limits.  The validator returns a simple dataclass
-:class:`ValidationResult` summarizing the outcome.
-"""
+"""Input validation helpers for uploaded files."""
 
 from __future__ import annotations
 
-import base64
-import re
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from services.configuration_service import (
     ConfigurationServiceProtocol,
     DynamicConfigurationService,
 )
+from upload_types import ValidationResult
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
-@dataclass
-class ValidationResult:
-    """Result of validating an uploaded file."""
-
-    valid: bool
-    message: str = ""
-
-
-class InputValidator:
-    """Validate basic properties of uploaded files."""
+class InputValidator(UnifiedUploadValidator):
+    """Thin wrapper around :class:`UnifiedUploadValidator`."""
 
     def __init__(
         self,
         max_size_mb: Optional[int] = None,
         config: ConfigurationServiceProtocol | None = None,
     ) -> None:
-        self.config = config or DynamicConfigurationService()
-        self.max_size_mb = max_size_mb or self.config.get_max_upload_size_mb()
+        cfg = config or DynamicConfigurationService()
+        super().__init__(max_size_mb=max_size_mb, config=cfg)
 
-    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
 
-    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        """Validate an uploaded file-like object.
-
-        Parameters
-        ----------
-        file_obj:
-            The uploaded object which may be a :class:`~pandas.DataFrame`, a path
-            to a file or bytes-like data.
-        """
-        if file_obj is None:
-            return ValidationResult(False, "No file provided")
-
-        # If it's a pandas DataFrame
-        try:
-            import pandas as pd
-
-            if isinstance(file_obj, pd.DataFrame):
-                if file_obj.empty:
-                    return ValidationResult(False, "Empty dataframe")
-                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(
-                        False,
-                        f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                    )
-                return ValidationResult(True, "ok")
-        except Exception:
-            pass
-
-        # If it's a path on disk or base64 encoded string
-        if isinstance(file_obj, (str, Path)):
-            text = str(file_obj)
-            if self._DATA_URI_RE.match(text):
-                try:
-                    _, b64 = text.split(",", 1)
-                    decoded = base64.b64decode(b64)
-                except Exception:
-                    return ValidationResult(False, "Invalid base64 contents")
-                return self.validate_file_upload(decoded)
-
-            if isinstance(file_obj, Path) or Path(text).exists():
-                path = Path(file_obj)
-                if not path.exists():
-                    return ValidationResult(False, "File not found")
-                size_mb = path.stat().st_size / (1024 * 1024)
-                if size_mb == 0:
-                    return ValidationResult(False, "File is empty")
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(
-                        False,
-                        f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                    )
-                return ValidationResult(True, "ok")
-
-            return ValidationResult(False, "File not found")
-
-        # Raw bytes
-        if isinstance(file_obj, (bytes, bytearray)):
-            size_mb = len(file_obj) / (1024 * 1024)
-            if size_mb == 0:
-                return ValidationResult(False, "File is empty")
-            if size_mb > self.max_size_mb:
-                return ValidationResult(
-                    False,
-                    f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                )
-            return ValidationResult(True, "ok")
-
-        # Unknown type - treat as invalid
-        return ValidationResult(False, "Unsupported file type")
+__all__ = ["InputValidator", "ValidationResult"]

--- a/tests/test_upload_validator.py
+++ b/tests/test_upload_validator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from upload_validator import UploadValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator as UploadValidator
 
 
 def test_validate_file_upload_dataframe():

--- a/upload_core.py
+++ b/upload_core.py
@@ -23,7 +23,7 @@ from services.upload import (
     get_trigger_id,
 )
 from services.upload.upload_queue_manager import UploadQueueManager
-from upload_validator import UploadValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from services.upload.protocols import (
     DeviceLearningServiceProtocol,
     UploadProcessingServiceProtocol,
@@ -50,7 +50,7 @@ class UploadCore:
         self.ai = AISuggestionService()
         self.modal = ModalService()
         self.client_validator = ClientSideValidator()
-        self.validator = UploadValidator()
+        self.validator = UnifiedUploadValidator()
         self.chunked = ChunkedUploadManager()
         self.queue = UploadQueueManager()
         self.task_queue = task_queue or TaskQueue()

--- a/upload_validator.py
+++ b/upload_validator.py
@@ -1,73 +1,10 @@
 """Validation helpers for uploaded files."""
+
 from __future__ import annotations
 
-import base64
-import re
-from pathlib import Path
-from typing import Any, Optional
-
-from config.dynamic_config import dynamic_config
-from core.protocols import ConfigurationProtocol
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from upload_types import ValidationResult
 
+UploadValidator = UnifiedUploadValidator
 
-class UploadValidator:
-    """Validate basic properties of uploaded files."""
-
-    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
-
-    def __init__(
-        self,
-        max_size_mb: Optional[int] = None,
-        config: ConfigurationProtocol = dynamic_config,
-    ) -> None:
-        self.config = config
-        self.max_size_mb = max_size_mb or getattr(self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb)
-
-    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        if file_obj is None:
-            return ValidationResult(False, "No file provided")
-
-        try:
-            import pandas as pd
-            if isinstance(file_obj, pd.DataFrame):
-                if file_obj.empty:
-                    return ValidationResult(False, "Empty dataframe")
-                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(False, f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-                return ValidationResult(True, "ok")
-        except Exception:
-            pass
-
-        if isinstance(file_obj, (str, Path)):
-            text = str(file_obj)
-            if self._DATA_URI_RE.match(text):
-                try:
-                    _, b64 = text.split(',', 1)
-                    decoded = base64.b64decode(b64)
-                except Exception:
-                    return ValidationResult(False, "Invalid base64 contents")
-                return self.validate_file_upload(decoded)
-
-            if isinstance(file_obj, Path) or Path(text).exists():
-                path = Path(file_obj)
-                if not path.exists():
-                    return ValidationResult(False, "File not found")
-                size_mb = path.stat().st_size / (1024 * 1024)
-                if size_mb == 0:
-                    return ValidationResult(False, "File is empty")
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-                return ValidationResult(True, "ok")
-            return ValidationResult(False, "File not found")
-
-        if isinstance(file_obj, (bytes, bytearray)):
-            size_mb = len(file_obj) / (1024 * 1024)
-            if size_mb == 0:
-                return ValidationResult(False, "File is empty")
-            if size_mb > self.max_size_mb:
-                return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-            return ValidationResult(True, "ok")
-
-        return ValidationResult(False, "Unsupported file type")
+__all__ = ["UploadValidator", "ValidationResult"]


### PR DESCRIPTION
## Summary
- implement `UnifiedUploadValidator` with upload validation logic
- turn `InputValidator` and `UploadValidator` into wrappers
- reference the new validator from `UnifiedFileValidator` and `UploadCore`
- export in package init and update tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6871bc7b66e08320b36f2b69c5386df7