### PR TITLE
Fix training data encoding

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -642,7 +642,7 @@ def save_verified_mappings(
             today = datetime.now().strftime("%Y%m%d")
             training_file = f"data/training/column_mappings_{today}.jsonl"
 
-            with open(training_file, "a") as f:
+            with open(training_file, "a", encoding="utf-8") as f:
                 f.write(json.dumps(training_data) + "\n")
 
             logger.info(f"Training data appended to {training_file}")


### PR DESCRIPTION
## Summary
- ensure utf-8 encoding when saving training data for column mappings

## Testing
- `pytest tests/components/test_verification_modals.py tests/components/test_ui_callback_helpers.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6871bc7d2dbc8320a8b202bd2fa111fe