### PR TITLE
Reduce unnecessary DataFrame copies

### DIFF
--- a/analytics/access_trends.py
+++ b/analytics/access_trends.py
@@ -95,7 +95,7 @@ class AccessTrendsAnalyzer:
 
     def _prepare_time_series(self, df: pd.DataFrame) -> pd.DataFrame:
         """Prepare time series data for analysis"""
-        df_clean = df.copy()
+        df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
         from security.unicode_security_handler import UnicodeSecurityHandler

--- a/analytics/anomaly_detection/data_prep.py
+++ b/analytics/anomaly_detection/data_prep.py
@@ -11,7 +11,7 @@ __all__ = ["prepare_anomaly_data"]
 def prepare_anomaly_data(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> pd.DataFrame:
     """Prepare and clean data for anomaly detection."""
     logger = logger or logging.getLogger(__name__)
-    df_clean = df.copy()
+    df_clean = df.copy(deep=False)
 
     from security.unicode_security_handler import UnicodeSecurityHandler
 

--- a/analytics/chunked_analytics_controller.py
+++ b/analytics/chunked_analytics_controller.py
@@ -153,7 +153,7 @@ class ChunkedAnalyticsController:
         if column not in df.columns:
             return df
 
-        df = df.copy()
+        df = df.copy(deep=False)
         df[column] = pd.to_datetime(df[column], errors="coerce")
 
         invalid_mask = df[column].isna()

--- a/analytics/interactive_charts.py
+++ b/analytics/interactive_charts.py
@@ -55,8 +55,8 @@ class SecurityChartsGenerator:
             return self._empty_charts()
 
     def _prepare_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Prepare data for chart generation"""
-        df = df.copy()
+        """Prepare data for chart generation with minimal copying"""
+        df = df.copy(deep=False)
         df["timestamp"] = pd.to_datetime(df["timestamp"])
         df["date"] = df["timestamp"].dt.date
         df["hour"] = df["timestamp"].dt.hour

--- a/analytics/security_patterns/data_prep.py
+++ b/analytics/security_patterns/data_prep.py
@@ -11,7 +11,7 @@ __all__ = ["prepare_security_data"]
 def prepare_security_data(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -> pd.DataFrame:
     """Prepare and clean data for security analysis."""
     logger = logger or logging.getLogger(__name__)
-    df_clean = df.copy()
+    df_clean = df.copy(deep=False)
 
     # Handle Unicode issues
     from security.unicode_security_handler import UnicodeSecurityHandler

--- a/analytics/unique_patterns_analyzer.py
+++ b/analytics/unique_patterns_analyzer.py
@@ -69,8 +69,8 @@ class UniquePatternAnalyzer:
         }
 
     def _prepare_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Prepare data for analysis"""
-        prepared_df = df.copy()
+        """Prepare data for analysis with minimal memory usage"""
+        prepared_df = df.copy(deep=False)
 
         # Ensure timestamp is datetime
         if "timestamp" in prepared_df.columns:

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -114,7 +114,7 @@ class UserBehaviorAnalyzer:
 
     def _prepare_behavior_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Prepare and clean data for behavior analysis"""
-        df_clean = df.copy()
+        df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
         from security.unicode_security_handler import UnicodeSecurityHandler

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Return a copy of ``df`` with any datetime-like columns parsed."""
-    df = df.copy()
+    """Return a shallow copy of ``df`` with any datetime-like columns parsed."""
+    df = df.copy(deep=False)
     timestamp_columns = [
         "timestamp",
         "datetime",

--- a/tests/test_memory_profile.py
+++ b/tests/test_memory_profile.py
@@ -1,0 +1,18 @@
+import importlib.util
+import pandas as pd
+
+
+spec = importlib.util.spec_from_file_location('unique_patterns_analyzer', 'analytics/unique_patterns_analyzer.py')
+upa = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(upa)
+
+
+def test_prepare_data_memory_usage():
+    df = pd.DataFrame({
+        'timestamp': pd.date_range('2024-01-01', periods=1000, freq='h'),
+        'door_id': ['x'] * 1000
+    })
+    base = df.memory_usage(deep=True).sum()
+    prepared = upa.UniquePatternAnalyzer()._prepare_data(df)
+    diff = prepared.memory_usage(deep=True).sum() - base
+    assert diff < 200_000


### PR DESCRIPTION
## Summary
- avoid deep dataframe copies in analytics utilities
- add simple memory profiling test

## Testing
- `pytest tests/test_memory_profile.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6871bc7fc928832091a744afbbf70a5a