### PR TITLE
Clamp MAX_UPLOAD_MB env override

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -91,6 +91,12 @@ class DynamicConfigManager(BaseConfigLoader):
                     value,
                 )
                 value = 50
+            elif value > 500:
+                logger.warning(
+                    "MAX_UPLOAD_MB=%s is too large. Using 500MB maximum.",
+                    value,
+                )
+                value = 500
             self.security.max_upload_mb = value
             self.security.max_file_size_mb = value  # Keep them in sync
 

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -54,3 +54,10 @@ These classes have been COMPLETELY REMOVED:
 - ❌ `BusinessLogicValidator`
 
 Use `SecurityValidator` for all validation needs.
+
+## Upload Limits
+
+The dashboard allows the maximum upload size to be overridden with the
+`MAX_UPLOAD_MB` environment variable. Values below **50&nbsp;MB** or above
+**500&nbsp;MB** are clamped to those limits and a warning is logged when the
+configuration is loaded.


### PR DESCRIPTION
## Summary
- cap `MAX_UPLOAD_MB` environment override to 500MB
- warn and clamp when value is out of bounds
- document upload size limits in validation overview

## Testing
- `pytest -k dynamic_config -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_6871bc84209483208cbfe1f1c3176099