### PR TITLE
Introduce UnifiedUploadValidator

### DIFF
--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -15,8 +15,8 @@ from services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,
 )
-from services.data_processing.unified_file_validator import (
-    UnifiedFileValidator,
+from services.data_processing.unified_upload_validator import (
+    UnifiedUploadValidator,
     safe_decode_with_unicode_handling,
 )
 from upload_types import ValidationResult
@@ -75,13 +75,13 @@ class FileHandler:
         config: ConfigurationProtocol = dynamic_config,
     ) -> None:
         self.config = config
-        self.validator = UnifiedFileValidator(max_size_mb, config=self.config)
+        self.validator = UnifiedUploadValidator(max_size_mb, config=self.config)
 
     def sanitize_filename(self, filename: str) -> str:
         return self.validator.sanitize_filename(filename)
 
     def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        """Run basic checks on ``file_obj`` using :class:`UnifiedFileValidator`."""
+        """Run basic checks on ``file_obj`` using :class:`UnifiedUploadValidator`."""
         if file_obj is None:
             return ValidationResult(False, "No file provided")
         try:

--- a/services/data_processing/unified_upload_validator.py
+++ b/services/data_processing/unified_upload_validator.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+"""Unified upload validation utilities consolidating legacy validators."""
+
+import base64
+import io
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import pandas as pd
+
+from config.dynamic_config import dynamic_config
+from core.exceptions import ValidationError
+from core.performance import get_performance_monitor
+from core.protocols import ConfigurationProtocol
+from core.unicode import UnicodeProcessor, sanitize_dataframe
+from core.unicode_utils import sanitize_for_utf8
+from upload_types import ValidationResult
+
+
+def _lazy_string_validator() -> Any:
+    """Import :class:`SecurityValidator` lazily."""
+    from core.security_validator import SecurityValidator as StringValidator
+
+    return StringValidator()
+
+
+SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
+ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
+
+
+logger = logging.getLogger(__name__)
+
+
+def safe_decode_with_unicode_handling(data: bytes, enc: str) -> str:
+    from core.unicode_decode import safe_unicode_decode
+
+    text = safe_unicode_decode(data, enc)
+
+    cleaned = sanitize_for_utf8(text)
+    return cleaned.replace("\ufffd", "")
+
+
+def safe_decode_file(contents: str) -> Optional[bytes]:
+    try:
+        if "," not in contents:
+            return None
+        _, content_string = contents.split(",", 1)
+        decoded = base64.b64decode(content_string)
+        if not decoded:
+            return None
+        return decoded
+    except (base64.binascii.Error, ValueError):
+        return None
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Unexpected error decoding file", exc_info=exc)
+        raise
+
+
+def process_dataframe(
+    decoded: bytes,
+    filename: str,
+    *,
+    config: ConfigurationProtocol = dynamic_config,
+) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
+    try:
+        filename_lower = filename.lower()
+        monitor = get_performance_monitor()
+        chunk_size = getattr(config.analytics, "chunk_size", 50000)
+
+        if filename_lower.endswith(".csv"):
+            for encoding in ["utf-8", "latin-1", "cp1252"]:
+                try:
+                    text = safe_decode_with_unicode_handling(decoded, encoding)
+                    reader = pd.read_csv(
+                        io.StringIO(text),
+                        on_bad_lines="skip",
+                        encoding="utf-8",
+                        low_memory=False,
+                        dtype=str,
+                        keep_default_na=False,
+                        chunksize=chunk_size,
+                    )
+                    chunks = []
+                    for chunk in reader:
+                        monitor.throttle_if_needed()
+                        chunks.append(chunk)
+                    df = (
+                        pd.concat(chunks, ignore_index=True)
+                        if chunks
+                        else pd.DataFrame()
+                    )
+                    return df, None
+                except UnicodeDecodeError:
+                    continue
+            return None, "Could not decode CSV with any standard encoding"
+        elif filename_lower.endswith(".json"):
+            for encoding in ["utf-8", "latin-1", "cp1252"]:
+                try:
+                    text = safe_decode_with_unicode_handling(decoded, encoding)
+                    reader = pd.read_json(
+                        io.StringIO(text),
+                        lines=True,
+                        chunksize=chunk_size,
+                    )
+                    chunks = []
+                    for chunk in reader:
+                        monitor.throttle_if_needed()
+                        chunks.append(chunk)
+                    df = (
+                        pd.concat(chunks, ignore_index=True)
+                        if chunks
+                        else pd.DataFrame()
+                    )
+                    return df, None
+                except UnicodeDecodeError:
+                    continue
+            return None, "Could not decode JSON with any standard encoding"
+        elif filename_lower.endswith((".xlsx", ".xls")):
+            df = pd.read_excel(io.BytesIO(decoded))
+            return df, None
+        else:
+            return None, f"Unsupported file type: {filename}"
+    except (
+        UnicodeDecodeError,
+        ValueError,
+        pd.errors.ParserError,
+        json.JSONDecodeError,
+    ) as e:
+        return None, f"Error processing file: {str(e)}"
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Unexpected error processing file", exc_info=exc)
+        raise
+
+
+def validate_dataframe_content(df: pd.DataFrame) -> Dict[str, Any]:
+    if df.empty:
+        return {
+            "valid": False,
+            "error": "DataFrame is empty",
+            "issues": ["empty_dataframe"],
+        }
+
+    issues = []
+    warnings = []
+
+    if len(df.columns) == 0:
+        return {
+            "valid": False,
+            "error": "DataFrame has no columns",
+            "issues": ["no_columns"],
+        }
+
+    if len(df.columns) != len(set(df.columns)):
+        issues.append("duplicate_columns")
+        warnings.append("DataFrame contains duplicate column names")
+
+    empty_columns = df.columns[df.isnull().all()].tolist()
+    if empty_columns:
+        issues.append("empty_columns")
+        warnings.append(f"Columns with no data: {empty_columns}")
+
+    total_cells = len(df) * len(df.columns)
+    null_cells = df.isnull().sum().sum()
+    empty_string_cells = (df == "").sum().sum()
+    null_ratio = null_cells / total_cells if total_cells > 0 else 0
+    empty_ratio = (
+        (null_cells + empty_string_cells) / total_cells if total_cells > 0 else 0
+    )
+
+    if empty_ratio > 0.5:
+        issues.append("high_empty_ratio")
+        warnings.append(f"High percentage of empty cells: {empty_ratio:.1%}")
+
+    suspicious_cols = [
+        col
+        for col in df.columns
+        if any(
+            prefix in str(col).lower()
+            for prefix in ["=", "+", "-", "@", "cmd", "system"]
+        )
+    ]
+    if suspicious_cols:
+        issues.append("suspicious_column_names")
+        warnings.append(f"Suspicious column names detected: {suspicious_cols}")
+
+    return {
+        "valid": len(issues) == 0
+        or all(issue in ["empty_columns", "high_empty_ratio"] for issue in issues),
+        "rows": len(df),
+        "columns": len(df.columns),
+        "null_ratio": null_ratio,
+        "empty_ratio": empty_ratio,
+        "issues": issues,
+        "warnings": warnings,
+        "column_names": list(df.columns),
+        "memory_usage": df.memory_usage(deep=True).sum(),
+    }
+
+
+class UnifiedUploadValidator:
+    """Combine all upload validation responsibilities into a single class."""
+
+    ALLOWED_EXTENSIONS = ALLOWED_EXTENSIONS
+    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
+
+    def __init__(
+        self,
+        max_size_mb: Optional[int] = None,
+        config: ConfigurationProtocol = dynamic_config,
+    ) -> None:
+        self.config = config
+        self.max_size_mb = max_size_mb or getattr(
+            self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb
+        )
+        self._string_validator = _lazy_string_validator()
+
+    def _sanitize_string(self, value: str) -> str:
+        cleaned = sanitize_for_utf8(str(value))
+        if re.search(
+            r"(<script.*?>.*?</script>|<.*?on\w+\s*=|javascript:|data:text/html|[<>])",
+            cleaned,
+            re.IGNORECASE | re.DOTALL,
+        ):
+            raise ValidationError("Potentially dangerous characters detected")
+        result = self._string_validator.validate_input(cleaned, "input")
+        if not result["valid"]:
+            raise ValidationError("; ".join(result["issues"]))
+        import bleach
+
+        return bleach.clean(result["sanitized"], strip=True)
+
+    # ------------------------------------------------------------------
+    # Filename helpers
+    # ------------------------------------------------------------------
+    def sanitize_filename(self, filename: str) -> str:
+        """Validate and sanitize a filename."""
+        cleaned = self._sanitize_string(filename)
+        cleaned = UnicodeProcessor.safe_encode_text(cleaned)
+
+        if os.path.basename(cleaned) != cleaned:
+            raise ValidationError("Path separators not allowed in filename")
+        if len(cleaned) > 100:
+            raise ValidationError("Filename too long")
+        if not SAFE_FILENAME_RE.fullmatch(cleaned):
+            raise ValidationError("Invalid filename")
+
+        ext = Path(cleaned).suffix.lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            raise ValidationError(f"Unsupported file type: {ext}")
+        return cleaned
+
+    # ------------------------------------------------------------------
+    # DataFrame helpers
+    # ------------------------------------------------------------------
+    def validate_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Validate a :class:`~pandas.DataFrame` and return metrics."""
+        metrics = validate_dataframe_content(df)
+        if not metrics.get("valid", False):
+            return metrics
+
+        size_mb = df.memory_usage(deep=True).sum() / (1024 * 1024)
+        if size_mb > self.max_size_mb:
+            return {
+                "valid": False,
+                "error": f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                "issues": ["too_large"],
+            }
+        metrics["memory_usage_mb"] = size_mb
+        return metrics
+
+    def validate_file_meta(self, filename: str, size: int) -> Dict[str, Any]:
+        """Validate filename and file size without inspecting contents."""
+        issues: list[str] = []
+        max_bytes = self.max_size_mb * 1024 * 1024
+        if size > max_bytes:
+            issues.append("File too large")
+        if not SAFE_FILENAME_RE.fullmatch(filename):
+            issues.append("Invalid filename")
+        ext = Path(filename).suffix.lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            issues.append(f"Unsupported file type: {ext}")
+        return {"valid": len(issues) == 0, "issues": issues}
+
+    # ------------------------------------------------------------------
+    # File helpers
+    # ------------------------------------------------------------------
+    def validate_file(self, contents: str, filename: str) -> pd.DataFrame:
+        """Decode ``contents`` and return a validated :class:`~pandas.DataFrame`."""
+        sanitized_name = self.sanitize_filename(filename)
+
+        file_bytes = safe_decode_file(contents)
+        if file_bytes is None:
+            raise ValidationError("Invalid base64 contents")
+
+        sec_result = self.validate_file_meta(sanitized_name, len(file_bytes))
+        if not sec_result["valid"]:
+            raise ValidationError("; ".join(sec_result["issues"]))
+
+        df, err = process_dataframe(file_bytes, sanitized_name, config=self.config)
+        if df is None:
+            raise ValidationError(err or "Unable to parse file")
+
+        metrics = self.validate_dataframe(df)
+        if not metrics.get("valid", False):
+            raise ValidationError(metrics.get("error", "Invalid dataframe"))
+
+        df = sanitize_dataframe(df)
+        return df
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
+        """Validate ``file_obj`` mimicking the legacy :class:`UploadValidator`."""
+        if file_obj is None:
+            return ValidationResult(False, "No file provided")
+
+        try:
+            import pandas as pd
+
+            if isinstance(file_obj, pd.DataFrame):
+                if file_obj.empty:
+                    return ValidationResult(False, "Empty dataframe")
+                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
+                if size_mb > self.max_size_mb:
+                    return ValidationResult(
+                        False,
+                        f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                    )
+                return ValidationResult(True, "ok")
+        except Exception:
+            pass
+
+        if isinstance(file_obj, (str, Path)):
+            text = str(file_obj)
+            if self._DATA_URI_RE.match(text):
+                try:
+                    _, b64 = text.split(",", 1)
+                    decoded = base64.b64decode(b64)
+                except Exception:
+                    return ValidationResult(False, "Invalid base64 contents")
+                return self.validate_file_upload(decoded)
+
+            if isinstance(file_obj, Path) or Path(text).exists():
+                path = Path(file_obj)
+                if not path.exists():
+                    return ValidationResult(False, "File not found")
+                size_mb = path.stat().st_size / (1024 * 1024)
+                if size_mb == 0:
+                    return ValidationResult(False, "File is empty")
+                if size_mb > self.max_size_mb:
+                    return ValidationResult(
+                        False,
+                        f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                    )
+                return ValidationResult(True, "ok")
+            return ValidationResult(False, "File not found")
+
+        if isinstance(file_obj, (bytes, bytearray)):
+            size_mb = len(file_obj) / (1024 * 1024)
+            if size_mb == 0:
+                return ValidationResult(False, "File is empty")
+            if size_mb > self.max_size_mb:
+                return ValidationResult(
+                    False,
+                    f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
+                )
+            return ValidationResult(True, "ok")
+
+        return ValidationResult(False, "Unsupported file type")
+
+    def process_base64_contents(self, contents: str, filename: str) -> pd.DataFrame:
+        """Backward compatible wrapper for :meth:`validate_file`."""
+        return self.validate_file(contents, filename)
+
+
+__all__ = [
+    "UnifiedUploadValidator",
+    "ValidationResult",
+    "safe_decode_with_unicode_handling",
+    "safe_decode_file",
+    "process_dataframe",
+    "validate_dataframe_content",
+]

--- a/services/input_validator.py
+++ b/services/input_validator.py
@@ -1,114 +1,23 @@
-"""Input validation helpers for uploaded files.
-
-This module provides a small helper used by :class:`AnalyticsService`
-to validate uploaded files before any processing occurs.  Each file is
-checked for presence, non-empty content and that its size does not
-exceed configured limits.  The validator returns a simple dataclass
-:class:`ValidationResult` summarizing the outcome.
-"""
-
+"""Backward compatibility wrapper for :class:`UnifiedUploadValidator`."""
 from __future__ import annotations
 
-import base64
-import re
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Optional
 
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from upload_types import ValidationResult
 from services.configuration_service import (
     ConfigurationServiceProtocol,
     DynamicConfigurationService,
 )
 
 
-@dataclass
-class ValidationResult:
-    """Result of validating an uploaded file."""
-
-    valid: bool
-    message: str = ""
-
-
-class InputValidator:
-    """Validate basic properties of uploaded files."""
+class InputValidator(UnifiedUploadValidator):
+    """Thin wrapper around :class:`UnifiedUploadValidator`."""
 
     def __init__(
         self,
         max_size_mb: Optional[int] = None,
         config: ConfigurationServiceProtocol | None = None,
     ) -> None:
-        self.config = config or DynamicConfigurationService()
-        self.max_size_mb = max_size_mb or self.config.get_max_upload_size_mb()
-
-    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
-
-    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        """Validate an uploaded file-like object.
-
-        Parameters
-        ----------
-        file_obj:
-            The uploaded object which may be a :class:`~pandas.DataFrame`, a path
-            to a file or bytes-like data.
-        """
-        if file_obj is None:
-            return ValidationResult(False, "No file provided")
-
-        # If it's a pandas DataFrame
-        try:
-            import pandas as pd
-
-            if isinstance(file_obj, pd.DataFrame):
-                if file_obj.empty:
-                    return ValidationResult(False, "Empty dataframe")
-                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(
-                        False,
-                        f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                    )
-                return ValidationResult(True, "ok")
-        except Exception:
-            pass
-
-        # If it's a path on disk or base64 encoded string
-        if isinstance(file_obj, (str, Path)):
-            text = str(file_obj)
-            if self._DATA_URI_RE.match(text):
-                try:
-                    _, b64 = text.split(",", 1)
-                    decoded = base64.b64decode(b64)
-                except Exception:
-                    return ValidationResult(False, "Invalid base64 contents")
-                return self.validate_file_upload(decoded)
-
-            if isinstance(file_obj, Path) or Path(text).exists():
-                path = Path(file_obj)
-                if not path.exists():
-                    return ValidationResult(False, "File not found")
-                size_mb = path.stat().st_size / (1024 * 1024)
-                if size_mb == 0:
-                    return ValidationResult(False, "File is empty")
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(
-                        False,
-                        f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                    )
-                return ValidationResult(True, "ok")
-
-            return ValidationResult(False, "File not found")
-
-        # Raw bytes
-        if isinstance(file_obj, (bytes, bytearray)):
-            size_mb = len(file_obj) / (1024 * 1024)
-            if size_mb == 0:
-                return ValidationResult(False, "File is empty")
-            if size_mb > self.max_size_mb:
-                return ValidationResult(
-                    False,
-                    f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB",
-                )
-            return ValidationResult(True, "ok")
-
-        # Unknown type - treat as invalid
-        return ValidationResult(False, "Unsupported file type")
+        config = config or DynamicConfigurationService()
+        super().__init__(max_size_mb=max_size_mb, config=config)

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,11 +1,11 @@
 import pytest
 
 from core.exceptions import ValidationError
-from services.data_processing.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_validator_methods_basic():
-    validator = UnifiedFileValidator()
+    validator = UnifiedUploadValidator()
     meta = validator.validate_file_meta("test.csv", 10)
     assert meta["valid"] is True
     with pytest.raises(ValidationError):
@@ -13,10 +13,10 @@ def test_validator_methods_basic():
 
 
 def test_filename_sanitization_surrogates_removed():
-    validator = UnifiedFileValidator()
+    validator = UnifiedUploadValidator()
     assert validator.sanitize_filename("good\ud800.csv") == "good.csv"
 
 
 def test_filename_sanitization_valid():
-    validator = UnifiedFileValidator()
+    validator = UnifiedUploadValidator()
     assert validator.sanitize_filename("my_file.csv") == "my_file.csv"

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -3,7 +3,7 @@ import base64
 import pandas as pd
 import pytest
 
-from services.data_processing.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 @pytest.mark.parametrize("sep", [";", "\t"])
@@ -19,7 +19,7 @@ def test_parse_csv_with_various_delimiters(tmp_path, sep):
     csv_path = tmp_path / "sample.csv"
     df.to_csv(csv_path, index=False, sep=sep)
 
-    processor = UnifiedFileValidator()
+    processor = UnifiedUploadValidator()
     with open(csv_path, "rb") as f:
         data_b64 = base64.b64encode(f.read()).decode()
     contents = f"data:text/csv;base64,{data_b64}"

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -11,7 +11,7 @@ from services.data_enhancer import (
     get_mapping_suggestions,
 )
 from services.data_processing.file_processor import process_uploaded_file
-from services.data_processing.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from core.security_validator import SecurityValidator
 
 
@@ -27,7 +27,7 @@ def test_enhanced_processor(tmp_path):
     csv_path = tmp_path / "sample.csv"
     df.to_csv(csv_path, index=False)
 
-    processor = UnifiedFileValidator()
+    processor = UnifiedUploadValidator()
 
     df_loaded = pd.read_csv(csv_path)
     suggestions = get_mapping_suggestions(df_loaded)

--- a/tests/test_file_validator_errors.py
+++ b/tests/test_file_validator_errors.py
@@ -1,4 +1,4 @@
-from services.data_processing.unified_file_validator import (
+from services.data_processing.unified_upload_validator import (
     process_dataframe,
     safe_decode_file,
 )

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,23 +1,23 @@
 import pandas as pd
 
-from services.data_processing.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_none_upload_rejected():
-    validator = UnifiedFileValidator(max_size_mb=1)
+    validator = UnifiedUploadValidator(max_size_mb=1)
     res = validator.validate_file_upload(None)
     assert not res.valid
 
 
 def test_empty_dataframe_rejected():
-    validator = UnifiedFileValidator(max_size_mb=1)
+    validator = UnifiedUploadValidator(max_size_mb=1)
     df = pd.DataFrame()
     res = validator.validate_file_upload(df)
     assert not res.valid
 
 
 def test_valid_dataframe_allowed():
-    validator = UnifiedFileValidator(max_size_mb=1)
+    validator = UnifiedUploadValidator(max_size_mb=1)
     df = pd.DataFrame({"a": [1, 2]})
     res = validator.validate_file_upload(df)
     assert res.valid

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -6,7 +6,7 @@ from tests.fake_configuration import FakeConfiguration
 fake_cfg = FakeConfiguration()
 from core.performance import get_performance_monitor
 from services.data_processing.file_handler import process_file_simple
-from services.data_processing.unified_file_validator import process_dataframe
+from services.data_processing.unified_upload_validator import process_dataframe
 
 
 def test_memory_limit_abort_csv(monkeypatch, tmp_path):

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -3,18 +3,18 @@ import pytest
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
-from services.data_processing.unified_file_validator import UnifiedFileValidator
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_malicious_filename_is_invalid():
-    validator = UnifiedFileValidator()
+    validator = UnifiedUploadValidator()
     result = validator.validate_file_meta("../../evil.csv", 10)
     assert result["valid"] is False
     assert any("Invalid filename" in issue for issue in result["issues"])
 
 
 def test_oversized_upload_is_invalid():
-    validator = UnifiedFileValidator()
+    validator = UnifiedUploadValidator()
     too_big = fake_cfg.security.max_upload_mb * 1024 * 1024 + 1
     result = validator.validate_file_meta("big.csv", too_big)
     assert result["valid"] is False

--- a/tests/test_surrogate_handling.py
+++ b/tests/test_surrogate_handling.py
@@ -2,7 +2,7 @@ import json
 
 import pandas as pd
 
-from services.data_processing.unified_file_validator import process_dataframe
+from services.data_processing.unified_upload_validator import process_dataframe
 
 
 def test_process_dataframe_csv_with_surrogate(tmp_path):

--- a/upload_validator.py
+++ b/upload_validator.py
@@ -1,73 +1,20 @@
-"""Validation helpers for uploaded files."""
+"""Compatibility wrapper around :class:`UnifiedUploadValidator`."""
 from __future__ import annotations
 
-import base64
-import re
-from pathlib import Path
-from typing import Any, Optional
+from typing import Optional, Any
 
 from config.dynamic_config import dynamic_config
 from core.protocols import ConfigurationProtocol
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from upload_types import ValidationResult
 
 
-class UploadValidator:
-    """Validate basic properties of uploaded files."""
-
-    _DATA_URI_RE = re.compile(r"^data:.*;base64,", re.IGNORECASE)
+class UploadValidator(UnifiedUploadValidator):
+    """Thin wrapper preserving the old ``UploadValidator`` API."""
 
     def __init__(
         self,
         max_size_mb: Optional[int] = None,
         config: ConfigurationProtocol = dynamic_config,
     ) -> None:
-        self.config = config
-        self.max_size_mb = max_size_mb or getattr(self.config.security, "max_upload_mb", dynamic_config.security.max_upload_mb)
-
-    def validate_file_upload(self, file_obj: Any) -> ValidationResult:
-        if file_obj is None:
-            return ValidationResult(False, "No file provided")
-
-        try:
-            import pandas as pd
-            if isinstance(file_obj, pd.DataFrame):
-                if file_obj.empty:
-                    return ValidationResult(False, "Empty dataframe")
-                size_mb = file_obj.memory_usage(deep=True).sum() / (1024 * 1024)
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(False, f"Dataframe too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-                return ValidationResult(True, "ok")
-        except Exception:
-            pass
-
-        if isinstance(file_obj, (str, Path)):
-            text = str(file_obj)
-            if self._DATA_URI_RE.match(text):
-                try:
-                    _, b64 = text.split(',', 1)
-                    decoded = base64.b64decode(b64)
-                except Exception:
-                    return ValidationResult(False, "Invalid base64 contents")
-                return self.validate_file_upload(decoded)
-
-            if isinstance(file_obj, Path) or Path(text).exists():
-                path = Path(file_obj)
-                if not path.exists():
-                    return ValidationResult(False, "File not found")
-                size_mb = path.stat().st_size / (1024 * 1024)
-                if size_mb == 0:
-                    return ValidationResult(False, "File is empty")
-                if size_mb > self.max_size_mb:
-                    return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-                return ValidationResult(True, "ok")
-            return ValidationResult(False, "File not found")
-
-        if isinstance(file_obj, (bytes, bytearray)):
-            size_mb = len(file_obj) / (1024 * 1024)
-            if size_mb == 0:
-                return ValidationResult(False, "File is empty")
-            if size_mb > self.max_size_mb:
-                return ValidationResult(False, f"File too large: {size_mb:.1f}MB > {self.max_size_mb}MB")
-            return ValidationResult(True, "ok")
-
-        return ValidationResult(False, "Unsupported file type")
+        super().__init__(max_size_mb=max_size_mb, config=config)


### PR DESCRIPTION
## Summary
- add `UnifiedUploadValidator` with combined validation logic
- make `InputValidator` and `UploadValidator` thin wrappers
- update `FileHandler` and tests to use the new validator

## Testing
- `pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871bcc88d7c8320a6db85d8bcfb237f