### PR TITLE
Fix training file encoding and ensure column tests pass

### DIFF
--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -642,7 +642,7 @@ def save_verified_mappings(
             today = datetime.now().strftime("%Y%m%d")
             training_file = f"data/training/column_mappings_{today}.jsonl"
 
-            with open(training_file, "a") as f:
+            with open(training_file, "a", encoding="utf-8") as f:
                 f.write(json.dumps(training_data) + "\n")
 
             logger.info(f"Training data appended to {training_file}")
@@ -674,7 +674,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the coordinator."""
 
-    manager.register_handler(
+    manager.register_callback(
         Output({"type": "custom-field", "index": MATCH}, "style"),
         Input({"type": "column-mapping", "index": MATCH}, "value"),
         prevent_initial_call=True,

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -288,7 +288,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.register_handler(
+    manager.register_callback(
         Output({"type": "device-edited", "index": MATCH}, "data"),
         [
             Input({"type": "device-floor", "index": MATCH}, "value"),

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -580,7 +580,7 @@ def register_callbacks(
 ) -> None:
     """Register component callbacks using the provided coordinator."""
 
-    manager.register_handler(
+    manager.register_callback(
         Output("simple-device-modal", "children"),
         Input("simple-device-modal", "is_open"),
         prevent_initial_call=True,
@@ -588,7 +588,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(populate_simple_device_modal)
 
-    manager.register_handler(
+    manager.register_callback(
         Output("simple-device-modal", "is_open"),
         [
             Input("open-device-mapping", "n_clicks"),
@@ -601,7 +601,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(toggle_simple_device_modal)
 
-    manager.register_handler(
+    manager.register_callback(
         Output("device-save-status", "children"),
         [
             Input({"type": "device-floor", "index": ALL}, "value"),
@@ -615,7 +615,7 @@ def register_callbacks(
         component_name="simple_device_mapping",
     )(save_user_inputs)
 
-    manager.register_handler(
+    manager.register_callback(
         [
             Output({"type": "device-floor", "index": ALL}, "value"),
             Output({"type": "device-access", "index": ALL}, "value"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def fake_dash(monkeypatch: pytest.MonkeyPatch, request):
         "dash.exceptions",
         types.SimpleNamespace(PreventUpdate=Exception),
     )
-    dash_stub.no_update = None
+    dash_stub.no_update = dash_stub._callback.NoUpdate()
 
     attrs = {
         "dash": dash_stub,
@@ -249,6 +249,17 @@ def fake_dash(monkeypatch: pytest.MonkeyPatch, request):
         if hasattr(request.module, name):
             monkeypatch.setattr(request.module, name, val, raising=False)
 
+    for mod_name in (
+        "components.column_verification",
+        "components.device_verification",
+        "components.simple_device_mapping",
+    ):
+        if mod_name in sys.modules:
+            mod = sys.modules[mod_name]
+            for name, val in attrs.items():
+                if hasattr(mod, name):
+                    monkeypatch.setattr(mod, name, val, raising=False)
+
     yield dash_stub
 
 
@@ -263,6 +274,9 @@ def fake_dbc(monkeypatch: pytest.MonkeyPatch, request):
     monkeypatch.setitem(sys.modules, "dash_bootstrap_components", dbc_stub)
     if hasattr(request.module, "dbc"):
         monkeypatch.setattr(request.module, "dbc", dbc_stub, raising=False)
+    for mod_name in ("components.column_verification", "components.device_verification"):
+        if mod_name in sys.modules:
+            monkeypatch.setattr(sys.modules[mod_name], "dbc", dbc_stub, raising=False)
 
     yield dbc_stub
 

--- a/tests/stubs/dash/__init__.py
+++ b/tests/stubs/dash/__init__.py
@@ -14,7 +14,8 @@ from . import html
 from . import dcc
 from . import dependencies
 from . import _callback
-no_update = None
+no_update = _callback.NoUpdate()
+__version__ = "0.0.0"
 
 
 __all__ = [

--- a/tests/stubs/dash/_callback.py
+++ b/tests/stubs/dash/_callback.py
@@ -1,1 +1,4 @@
 callback = lambda *a, **k: (lambda f: f)
+
+class NoUpdate:
+    pass

--- a/tests/stubs/dash/dcc.py
+++ b/tests/stubs/dash/dcc.py
@@ -7,5 +7,13 @@ class Download:
         pass
 
 class Dropdown:
-    def __init__(self, *a, **k):
-        pass
+    def __init__(self, *args, **kwargs):
+        self.children = list(args)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+class Store:
+    def __init__(self, *args, **kwargs):
+        self.children = list(args)
+        for k, v in kwargs.items():
+            setattr(self, k, v)

--- a/tests/stubs/dash/html.py
+++ b/tests/stubs/dash/html.py
@@ -1,11 +1,46 @@
 class _Base:
     def __init__(self, *args, **kwargs):
-        self.args = args
+        if "children" in kwargs:
+            self.children = kwargs.pop("children")
+        elif len(args) == 1:
+            self.children = args[0]
+        else:
+            self.children = list(args)
         for k, v in kwargs.items():
             setattr(self, k, v)
 
 
 class Div(_Base):
+    pass
+
+class H5(_Base):
+    pass
+
+class H6(_Base):
+    pass
+
+class Tr(_Base):
+    pass
+
+class Td(_Base):
+    pass
+
+class Th(_Base):
+    pass
+
+class Thead(_Base):
+    pass
+
+class Tbody(_Base):
+    pass
+
+class Br(_Base):
+    pass
+
+class Small(_Base):
+    pass
+
+class Strong(_Base):
     pass
 
 

--- a/tests/stubs/dash_bootstrap_components.py
+++ b/tests/stubs/dash_bootstrap_components.py
@@ -1,22 +1,70 @@
-class Card:
-    def __init__(self, *a, **k):
-        pass
+class _Base:
+    def __init__(self, *args, **kwargs):
+        if "children" in kwargs:
+            self.children = kwargs.pop("children")
+        elif len(args) == 1:
+            self.children = args[0]
+        else:
+            self.children = list(args)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
-class Navbar:
-    def __init__(self, *a, **k):
-        pass
+class Card(_Base):
+    pass
 
-class Container:
-    def __init__(self, *a, **k):
-        pass
+class Navbar(_Base):
+    pass
 
-class Row:
-    def __init__(self, *a, **k):
-        pass
+class Container(_Base):
+    pass
 
-class Col:
-    def __init__(self, *a, **k):
-        pass
+class Row(_Base):
+    pass
+
+class Col(_Base):
+    pass
+
+class Modal(_Base):
+    pass
+
+class ModalHeader(_Base):
+    pass
+
+class ModalBody(_Base):
+    pass
+
+class ModalFooter(_Base):
+    pass
+
+class ModalTitle(_Base):
+    pass
+
+class Alert(_Base):
+    pass
+
+class Button(_Base):
+    pass
+
+class Table(_Base):
+    pass
+
+class CardHeader(_Base):
+    pass
+
+class CardBody(_Base):
+    pass
+
+class Label(_Base):
+    pass
+
+class Input(_Base):
+    pass
+
+class Badge(_Base):
+    pass
+
+class Checklist(_Base):
+    pass
 
 NavbarToggler = Collapse = DropdownMenu = lambda *a, **k: None
 DropdownMenuItem = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- write training data using UTF-8
- align callback registration helpers with tests
- extend test stubs so they mimic required dash APIs
- adjust fixtures to patch component modules correctly

## Testing
- `pytest tests/components/test_ui_callback_helpers.py tests/components/test_verification_modals.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871bccdadf8832089cd9bc09ab8155a