### PR TITLE
Add memory override bounds

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -104,7 +104,14 @@ class DynamicConfigManager(BaseConfigLoader):
 
         mem_thresh = os.getenv("MEMORY_THRESHOLD_MB")
         if mem_thresh is not None:
-            self.performance.memory_usage_threshold_mb = int(mem_thresh)
+            value = int(mem_thresh)
+            if value > 500:
+                logger.warning(
+                    "MEMORY_THRESHOLD_MB=%s is too high. Using 500MB maximum.",
+                    value,
+                )
+                value = 500
+            self.performance.memory_usage_threshold_mb = value
 
         db_timeout = os.getenv("DB_TIMEOUT")
         if db_timeout is not None:
@@ -136,7 +143,14 @@ class DynamicConfigManager(BaseConfigLoader):
 
         max_memory = os.getenv("ANALYTICS_MAX_MEMORY_MB")
         if max_memory is not None:
-            self.analytics.max_memory_mb = int(max_memory)
+            value = int(max_memory)
+            if value > 500:
+                logger.warning(
+                    "ANALYTICS_MAX_MEMORY_MB=%s is too high. Using 500MB maximum.",
+                    value,
+                )
+                value = 500
+            self.analytics.max_memory_mb = value
 
         upload_chunk = os.getenv("UPLOAD_CHUNK_SIZE")
         if upload_chunk is not None:

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -54,3 +54,14 @@ These classes have been COMPLETELY REMOVED:
 - ❌ `BusinessLogicValidator`
 
 Use `SecurityValidator` for all validation needs.
+
+## Environment Limits
+
+When overriding configuration with environment variables, memory related values
+are clamped to a maximum of **500 MB**. The following variables are affected:
+
+- `MEMORY_THRESHOLD_MB`
+- `ANALYTICS_MAX_MEMORY_MB`
+
+If a higher value is provided, a warning will be logged and the value will be
+reduced to 500 MB.


### PR DESCRIPTION
## Summary
- clamp memory-based env overrides in config
- warn and reduce value if greater than 500
- document the new environment limits

## Testing
- `pre-commit run --files config/dynamic_config.py docs/validation_overview.md` *(fails: mypy errors)*
- `SKIP=mypy pre-commit run --files config/dynamic_config.py docs/validation_overview.md`

------
https://chatgpt.com/codex/tasks/task_e_6871bcd2d904832080a425340d1073d8