### PR TITLE
Automate sys.modules stub migration

### DIFF
--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -130,3 +130,12 @@ container.register_singleton("analytics_service", DummyAnalytics())
 
 Pass the container to the unit under test and drop the `sys.modules` setup.
 
+The `tools/migrate_tests.py` helper automates this refactor. Running
+
+```bash
+python tools/migrate_tests.py --apply path/to/test_file.py
+```
+
+comments out the old `sys.modules` lines and imports protocol test doubles from
+`tests.stubs` so tests run against the lightweight implementations.
+


### PR DESCRIPTION
## Summary
- automatically import protocol test doubles when patching `sys.modules`
- document the new behaviour in `docs/test_architecture.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6871cecdb6b883208114adeb3ad9b707