### PR TITLE
Refactor remaining legacy callback usage

### DIFF
--- a/callback_audit_results/audit_report.txt
+++ b/callback_audit_results/audit_report.txt
@@ -2,19 +2,15 @@
 ==================================================
 
 📊 SUMMARY:
-  Total Callbacks: 1
-  Files with Callbacks: 1
-  Pattern Types: 1
+  Total Callbacks: 0
+  Files with Callbacks: 0
+  Pattern Types: 0
   Conflicts: 0 (0 critical)
 
-📈 PATTERN DISTRIBUTION:
-  🔥 Legacy Dash: 1 (100.0%)
-
 🚀 RECOMMENDATIONS:
-  1. 🔥 HIGH PRIORITY: Migrate 1 legacy @app.callback patterns
+  1. 🔍 Consider expanding search or checking different directories
 
 📋 NEXT STEPS:
-  1. Review pattern distribution above
-  2. Address any high-priority recommendations
-  3. Resolve conflicts if present
-  4. Consider implementing Unicode safety wrappers
+  1. Check if callbacks are in other directories
+  2. Verify callback registration patterns
+  3. Consider running audit on broader scope

--- a/test_app_factory.py
+++ b/test_app_factory.py
@@ -1,36 +1,50 @@
+from dash import Input, Output, dcc, html
+
 from core.app_factory import create_app
-from dash import html, dcc, Input, Output
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from ui_callback_controller import UIEvent, ui_callback_controller
 
 # Create app using YOUR app factory
 app = create_app()
+callbacks = TrulyUnifiedCallbacks(app)
 
-# Override the upload page to bypass TrulyUnifiedCallbacks
-@app.callback(
+
+# Override the upload page using TrulyUnifiedCallbacks
+@callbacks.handle_register(
     Output("page-content", "children"),
     Input("url", "pathname"),
-    prevent_initial_call=True
+    callback_id="factory_router",
+    component_name="app_factory",
+    prevent_initial_call=True,
 )
 def simple_router(pathname):
     if pathname == "/upload":
-        return html.Div([
-            html.H1("App Factory Upload Test"),
-            dcc.Upload(
-                id="factory-upload",
-                children="Drop files here (via app factory)",
-                style={'border': '2px dashed green', 'padding': '20px'}
-            ),
-            html.Div("Ready", id="factory-output")
-        ])
+        return html.Div(
+            [
+                html.H1("App Factory Upload Test"),
+                dcc.Upload(
+                    id="factory-upload",
+                    children="Drop files here (via app factory)",
+                    style={"border": "2px dashed green", "padding": "20px"},
+                ),
+                html.Div("Ready", id="factory-output"),
+            ]
+        )
     return html.Div(f"Page: {pathname}")
 
-# Simple callback using standard Dash (not TrulyUnifiedCallbacks)
-@app.callback(
+
+# Simple callback using TrulyUnifiedCallbacks
+@callbacks.handle_register(
     Output("factory-output", "children"),
     Input("factory-upload", "contents"),
-    prevent_initial_call=True
+    callback_id="factory_upload",
+    component_name="app_factory",
+    prevent_initial_call=True,
 )
 def handle_factory_upload(contents):
+    ui_callback_controller.trigger(UIEvent.UI_UPDATE, "upload", {})
     return "File detected via app factory!" if contents else "No file"
+
 
 if __name__ == "__main__":
     app.run_server(debug=True, port=8052)

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -1,5 +1,5 @@
-import pytest
 import dash
+import pytest
 from dash import Input, Output
 
 from core.callback_registry import CallbackRegistry
@@ -46,7 +46,8 @@ def test_unified_decorator_method():
 
 def test_unified_with_registry():
     app = dash.Dash(__name__)
-    registry = CallbackRegistry(app)
+    coord = TrulyUnifiedCallbacks(app)
+    registry = CallbackRegistry(coord)
 
     @unified_callback(
         registry,

--- a/ui_callback_controller.py
+++ b/ui_callback_controller.py
@@ -1,0 +1,8 @@
+from core.callback_events import CallbackEvent
+from core.callback_manager import CallbackManager
+
+UIEvent = CallbackEvent
+UICallbackController = CallbackManager
+ui_callback_controller = CallbackManager()
+
+__all__ = ["UIEvent", "UICallbackController", "ui_callback_controller"]


### PR DESCRIPTION
## Summary
- create `UICallbackController` alias for UI events
- refactor `CallbackRegistry` to rely on `TrulyUnifiedCallbacks`
- update app factory test to register callbacks through the new system
- adjust callback unifier test
- update callback audit results

## Testing
- `bash callback_audit.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_6871ced377588320bb1ffd484d1240c8