### PR TITLE
Introduce UIComponent and page classes

### DIFF
--- a/components/ui_component.py
+++ b/components/ui_component.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Base UI component with DI and Unicode helpers."""
+
+from typing import Any, Optional
+
+from core.container import container as _global_container
+from core.protocols import ServiceContainer, UnicodeProcessorProtocol, get_unicode_processor
+from security.unicode_security_processor import sanitize_unicode_input
+
+
+class UIComponent:
+    """Base class for UI components with DI and Unicode helpers."""
+
+    def __init__(
+        self,
+        *,
+        container: Optional[ServiceContainer] = None,
+        unicode_processor: Optional[UnicodeProcessorProtocol] = None,
+    ) -> None:
+        self.container = container or _global_container
+        self.unicode_processor = unicode_processor or get_unicode_processor(self.container)
+
+    # ------------------------------------------------------------------
+    def sanitize(self, text: Any) -> str:
+        """Return ``text`` sanitized for safe display."""
+        try:
+            return sanitize_unicode_input(text)
+        except Exception:
+            return str(text)
+
+    # ------------------------------------------------------------------
+    def layout(self) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    def register_callbacks(self, manager: Any, controller: Any | None = None) -> None:  # pragma: no cover - interface
+        return None
+
+
+__all__ = ["UIComponent"]

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -11,48 +11,108 @@ from typing import Any
 import dash_bootstrap_components as dbc
 from dash import html, register_page as dash_register_page
 
+from components.ui_component import UIComponent
+
 logger = logging.getLogger(__name__)
+
+class AnalyticsPage(UIComponent):
+    """Simple analytics page component."""
+
+    def layout(self) -> html.Div:  # type: ignore[override]
+        return dbc.Container(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                dbc.Card(
+                                    [
+                                        dbc.CardBody(
+                                            [
+                                                html.H5(
+                                                    "📊 Analytics Dashboard",
+                                                    className="card-title",
+                                                ),
+                                                html.P(
+                                                    "Advanced analytics restored without navigation flash.",
+                                                    className="card-text",
+                                                ),
+                                                html.Hr(),
+                                                html.I(
+                                                    className="fas fa-chart-line fa-3x mb-3",
+                                                    style={"color": "#007bff"},
+                                                ),
+                                                html.H6("✅ Navigation Flash: FIXED"),
+                                                html.H6("🔧 Advanced Analytics: Coming Next"),
+                                                html.P(
+                                                    "Page loads stable like Settings/Export",
+                                                    className="text-muted",
+                                                ),
+                                                html.Hr(),
+                                                html.H6("📋 Planned Features:"),
+                                                html.Ul(
+                                                    [
+                                                        html.Li("Data source selection"),
+                                                        html.Li("Interactive charts and graphs"),
+                                                        html.Li("Device pattern analysis"),
+                                                        html.Li("Anomaly detection"),
+                                                        html.Li("Behavior analysis"),
+                                                    ]
+                                                ),
+                                            ]
+                                        )
+                                    ],
+                                    className="mb-4",
+                                )
+                            ]
+                        , md=8)
+                    ]
+                )
+            ],
+            fluid=True,
+        )
+
+    def register_callbacks(self, manager: Any, controller: Any | None = None) -> None:  # type: ignore[override]
+        pass
+
+
+_analytics_component = AnalyticsPage()
+
+
+def load_page(**kwargs) -> AnalyticsPage:
+    """Return a new :class:`AnalyticsPage` instance."""
+
+    return AnalyticsPage(**kwargs)
+
 
 def register_page() -> None:
     """Register the analytics page with Dash."""
-    dash_register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+    dash_register_page(
+        __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
+    )
+
 
 def layout() -> html.Div:
-    """Simple stable analytics layout - no Dropdown, no Loading, no flash."""
-    return dbc.Container([
-        dbc.Row([
-            dbc.Col([
-                dbc.Card([
-                    dbc.CardBody([
-                        html.H5("📊 Analytics Dashboard", className="card-title"),
-                        html.P("Advanced analytics restored without navigation flash.", className="card-text"),
-                        html.Hr(),
-                        html.I(className="fas fa-chart-line fa-3x mb-3", style={"color": "#007bff"}),
-                        html.H6("✅ Navigation Flash: FIXED"),
-                        html.H6("🔧 Advanced Analytics: Coming Next"),
-                        html.P("Page loads stable like Settings/Export", className="text-muted"),
-                        html.Hr(),
-                        html.H6("📋 Planned Features:"),
-                        html.Ul([
-                            html.Li("Data source selection"),
-                            html.Li("Interactive charts and graphs"),
-                            html.Li("Device pattern analysis"),
-                            html.Li("Anomaly detection"),
-                            html.Li("Behavior analysis")
-                        ])
-                    ])
-                ], className="mb-4")
-            ], md=8)
-        ])
-    ], fluid=True)
+    """Compatibility wrapper returning the default component layout."""
+
+    return _analytics_component.layout()
+
 
 def register_callbacks(manager: Any) -> None:
-    """No callbacks needed yet."""
-    pass
+    """Compatibility wrapper using the default component."""
+
+    _analytics_component.register_callbacks(manager)
 
 # For backward compatibility with app_factory
 def deep_analytics_layout():
     """Compatibility function for app_factory."""
     return layout()
 
-__all__ = ["layout", "register_page", "register_callbacks", "deep_analytics_layout"]
+__all__ = [
+    "AnalyticsPage",
+    "load_page",
+    "layout",
+    "register_page",
+    "register_callbacks",
+    "deep_analytics_layout",
+]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -17,10 +17,188 @@ from dash import Input, Output, State, dcc, html, no_update
 from dash.exceptions import PreventUpdate
 from dash import register_page as dash_register_page
 
+from components.ui_component import UIComponent
+
 logger = logging.getLogger(__name__)
 
 # Global storage for uploaded files
 _uploaded_files: Dict[str, pd.DataFrame] = {}
+
+
+class UploadPage(UIComponent):
+    """Upload page component."""
+
+    def layout(self) -> dbc.Container:  # type: ignore[override]
+        """Modern file upload layout with working drag-and-drop functionality."""
+
+        return dbc.Container([
+            # Header
+            dbc.Row([
+                dbc.Col([
+                    html.H2("📁 File Upload", className="mb-3"),
+                    html.P(
+                        "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
+                        className="text-muted mb-4",
+                    ),
+                ])
+            ]),
+
+            # Upload area
+            dbc.Row([
+                dbc.Col([
+                    dcc.Upload(
+                        id="drag-drop-upload",
+                        children=html.Div(
+                            [
+                                html.I(
+                                    className="fas fa-cloud-upload-alt fa-3x mb-3",
+                                    style={"color": "#6c757d"},
+                                ),
+                                html.H5("Drag & Drop Files Here"),
+                                html.P("or click to select files", className="text-muted"),
+                                html.P(
+                                    "Supports: .csv, .xlsx, .xls, .json",
+                                    className="small text-muted",
+                                ),
+                            ],
+                            style={
+                                "textAlign": "center",
+                                "padding": "60px",
+                                "border": "2px dashed #dee2e6",
+                                "borderRadius": "10px",
+                                "cursor": "pointer",
+                            },
+                        ),
+                        style={"width": "100%", "minHeight": "200px", "marginBottom": "20px"},
+                        multiple=True,
+                        accept=".csv,.xlsx,.xls,.json",
+                        max_size=50 * 1024 * 1024,  # 50MB
+                        className="upload-dropzone",
+                    )
+                ], lg=8, md=10, sm=12, className="mx-auto")
+            ], className="mb-4"),
+
+            # Upload status and progress
+            dbc.Row([
+                dbc.Col([
+                    html.Div(id="upload-status", className="mb-3"),
+                    dbc.Progress(
+                        id="upload-progress",
+                        value=0,
+                        striped=True,
+                        animated=False,
+                        color="success",
+                        style={"display": "none", "height": "8px"},
+                        className="mb-3",
+                    ),
+                ], lg=8, md=10, sm=12, className="mx-auto")
+            ]),
+
+            # File preview area
+            dbc.Row([
+                dbc.Col([html.Div(id="preview-area")], lg=10, md=12, sm=12, className="mx-auto")
+            ]),
+
+            # Navigation area
+            dbc.Row([
+                dbc.Col([html.Div(id="upload-navigation")], lg=8, md=10, sm=12, className="mx-auto")
+            ], className="mt-4"),
+
+            # Data stores
+            dcc.Store(id="uploaded-files-store", data={}),
+            dcc.Store(id="upload-session-store", data={}),
+        ], fluid=True, className="py-4")
+
+    # ------------------------------------------------------------------
+    def register_callbacks(self, manager, controller=None) -> None:  # type: ignore[override]
+        """Register upload callbacks - simplified and working."""
+
+        if manager is None:
+            logger.warning("No callback manager provided to file_upload")
+            return
+
+        try:
+            @manager.unified_callback(
+                [
+                    Output("preview-area", "children"),
+                    Output("upload-progress", "value"),
+                    Output("upload-progress", "style"),
+                    Output("upload-status", "children"),
+                    Output("uploaded-files-store", "data"),
+                ],
+                Input("drag-drop-upload", "contents"),
+                [
+                    State("drag-drop-upload", "filename"),
+                    State("uploaded-files-store", "data"),
+                ],
+                callback_id="file_upload_handler_simple",
+                component_name="file_upload",
+                prevent_initial_call=True,
+            )
+            def handle_upload(contents, filenames, existing_data):
+                if not contents:
+                    raise PreventUpdate
+
+                try:
+                    if not isinstance(contents, list):
+                        contents = [contents]
+                    if not isinstance(filenames, list):
+                        filenames = [filenames]
+
+                    results = []
+                    updated_store = existing_data or {}
+
+                    for content, filename in zip(contents, filenames):
+                        if content and filename:
+                            result = _process_single_file(content, filename)
+                            if result:
+                                results.append(result)
+                                _uploaded_files[filename] = result["dataframe"]
+                                updated_store[filename] = filename
+
+                    if results:
+                        preview = _create_file_preview(results)
+                        status = _create_success_status(len(results))
+                        progress_style = {"display": "block", "height": "8px"}
+
+                        return preview, 100, progress_style, status, updated_store
+                    else:
+                        error_status = _create_error_status("No valid files processed")
+                        progress_style = {"display": "none"}
+                        return no_update, 0, progress_style, error_status, no_update
+
+                except Exception as e:
+                    logger.error(f"Upload processing error: {e}")
+                    error_status = _create_error_status(f"Upload failed: {str(e)}")
+                    progress_style = {"display": "none"}
+                    return no_update, 0, progress_style, error_status, no_update
+
+            @manager.unified_callback(
+                Output("upload-navigation", "children"),
+                Input("uploaded-files-store", "data"),
+                callback_id="file_upload_navigation_simple",
+                component_name="file_upload",
+                prevent_initial_call=True,
+            )
+            def update_navigation(uploaded_files):
+                if not uploaded_files:
+                    return ""
+
+                return _create_navigation_buttons(uploaded_files)
+
+            logger.info("✅ File upload callbacks registered successfully")
+
+        except Exception as e:
+            logger.error(f"❌ Failed to register file upload callbacks: {e}")
+
+
+_upload_component = UploadPage()
+
+
+def load_page(**kwargs) -> UploadPage:
+    """Return a new :class:`UploadPage` instance."""
+
+    return UploadPage(**kwargs)
 
 
 def register_page() -> None:
@@ -33,172 +211,15 @@ def register_page() -> None:
 
 
 def layout() -> dbc.Container:
-    """Modern file upload layout with working drag-and-drop functionality."""
-    
-    return dbc.Container([
-        # Header
-        dbc.Row([
-            dbc.Col([
-                html.H2("📁 File Upload", className="mb-3"),
-                html.P("Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.", 
-                       className="text-muted mb-4")
-            ])
-        ]),
-        
-        # Upload area
-        dbc.Row([
-            dbc.Col([
-                dcc.Upload(
-                    id="drag-drop-upload",
-                    children=html.Div([
-                        html.I(className="fas fa-cloud-upload-alt fa-3x mb-3", 
-                               style={"color": "#6c757d"}),
-                        html.H5("Drag & Drop Files Here"),
-                        html.P("or click to select files", className="text-muted"),
-                        html.P("Supports: .csv, .xlsx, .xls, .json", className="small text-muted")
-                    ], style={
-                        "textAlign": "center",
-                        "padding": "60px",
-                        "border": "2px dashed #dee2e6",
-                        "borderRadius": "10px",
-                        "cursor": "pointer"
-                    }),
-                    style={
-                        "width": "100%",
-                        "minHeight": "200px",
-                        "marginBottom": "20px"
-                    },
-                    multiple=True,
-                    accept='.csv,.xlsx,.xls,.json',
-                    max_size=50 * 1024 * 1024,  # 50MB
-                    className="upload-dropzone"
-                )
-            ], lg=8, md=10, sm=12, className="mx-auto")
-        ], className="mb-4"),
-        
-        # Upload status and progress
-        dbc.Row([
-            dbc.Col([
-                html.Div(id="upload-status", className="mb-3"),
-                dbc.Progress(
-                    id="upload-progress",
-                    value=0,
-                    striped=True,
-                    animated=False,
-                    color="success",
-                    style={'display': 'none', 'height': '8px'},
-                    className="mb-3"
-                )
-            ], lg=8, md=10, sm=12, className="mx-auto")
-        ]),
-        
-        # File preview area
-        dbc.Row([
-            dbc.Col([
-                html.Div(id="preview-area")
-            ], lg=10, md=12, sm=12, className="mx-auto")
-        ]),
-        
-        # Navigation area
-        dbc.Row([
-            dbc.Col([
-                html.Div(id="upload-navigation")
-            ], lg=8, md=10, sm=12, className="mx-auto")
-        ], className="mt-4"),
-        
-        # Data stores
-        dcc.Store(id="uploaded-files-store", data={}),
-        dcc.Store(id="upload-session-store", data={}),
-        
-    ], fluid=True, className="py-4")
+    """Compatibility wrapper returning the default component layout."""
+
+    return _upload_component.layout()
 
 
 def register_callbacks(manager):
-    """Register upload callbacks - simplified and working."""
+    """Compatibility wrapper using the default component."""
 
-    if manager is None:
-        logger.warning("No callback manager provided to file_upload")
-        return
-
-    try:
-        @manager.unified_callback(
-            [
-                Output("preview-area", "children"),
-                Output("upload-progress", "value"),
-                Output("upload-progress", "style"),
-                Output("upload-status", "children"),
-                Output("uploaded-files-store", "data")
-            ],
-            Input("drag-drop-upload", "contents"),
-            [
-                State("drag-drop-upload", "filename"),
-                State("uploaded-files-store", "data")
-            ],
-            callback_id="file_upload_handler_simple",
-            component_name="file_upload",
-            prevent_initial_call=True,
-        )
-        def handle_upload(contents, filenames, existing_data):
-            """Handle file uploads with proper error handling."""
-            
-            if not contents:
-                raise PreventUpdate
-            
-            try:
-                # Ensure inputs are lists
-                if not isinstance(contents, list):
-                    contents = [contents]
-                if not isinstance(filenames, list):
-                    filenames = [filenames]
-                
-                results = []
-                updated_store = existing_data or {}
-                
-                for content, filename in zip(contents, filenames):
-                    if content and filename:
-                        result = _process_single_file(content, filename)
-                        if result:
-                            results.append(result)
-                            # Store in global and component store
-                            _uploaded_files[filename] = result['dataframe']
-                            updated_store[filename] = filename
-                
-                if results:
-                    preview = _create_file_preview(results)
-                    status = _create_success_status(len(results))
-                    progress_style = {'display': 'block', 'height': '8px'}
-                    
-                    return preview, 100, progress_style, status, updated_store
-                else:
-                    error_status = _create_error_status("No valid files processed")
-                    progress_style = {'display': 'none'}
-                    return no_update, 0, progress_style, error_status, no_update
-                    
-            except Exception as e:
-                logger.error(f"Upload processing error: {e}")
-                error_status = _create_error_status(f"Upload failed: {str(e)}")
-                progress_style = {'display': 'none'}
-                return no_update, 0, progress_style, error_status, no_update
-
-        @manager.unified_callback(
-            Output("upload-navigation", "children"),
-            Input("uploaded-files-store", "data"),
-            callback_id="file_upload_navigation_simple",
-            component_name="file_upload",
-            prevent_initial_call=True
-        )
-        def update_navigation(uploaded_files):
-            """Update navigation options after successful upload."""
-            
-            if not uploaded_files:
-                return ""
-            
-            return _create_navigation_buttons(uploaded_files)
-
-        logger.info("✅ File upload callbacks registered successfully")
-        
-    except Exception as e:
-        logger.error(f"❌ Failed to register file upload callbacks: {e}")
+    _upload_component.register_callbacks(manager)
 
 
 def _process_single_file(content: str, filename: str) -> Optional[Dict[str, Any]]:
@@ -370,8 +391,10 @@ def safe_upload_layout():
 register_upload_callbacks = register_callbacks
 
 __all__ = [
+    "UploadPage",
+    "load_page",
     "layout",
-    "safe_upload_layout", 
+    "safe_upload_layout",
     "register_page",
     "register_callbacks",
     "register_upload_callbacks",

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -8,88 +8,106 @@ from dash import register_page as dash_register_page
 from config.dynamic_config import dynamic_config
 from security.unicode_security_processor import sanitize_unicode_input
 
+from components.ui_component import UIComponent
+
+
+class SettingsPage(UIComponent):
+    """Settings page component."""
+
+    def layout(self) -> dbc.Container:  # type: ignore[override]
+        sections = dbc.Row(
+            [
+                dbc.Col(self._settings_section("User Preferences"), md=6),
+                dbc.Col(self._system_config_section(), md=6),
+            ]
+        )
+
+        return dbc.Container([sections], fluid=True)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _settings_section(title: str) -> dbc.Card:
+        title = sanitize_unicode_input(title)
+        return dbc.Card(
+            dbc.CardBody(
+                [
+                    html.H5(title, className="card-title"),
+                    html.P("Configuration options coming soon.", className="card-text"),
+                ]
+            ),
+            className="mb-4 settings-section",
+        )
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _system_config_section() -> dbc.Card:
+        rate_options = [60, 120, 200, 500, 1000]
+        timeout_options = [5, 10, 20, 30, 60]
+        batch_options = [1000, 2000, 5000, 10000, 25000]
+
+        return dbc.Card(
+            dbc.CardBody(
+                [
+                    html.H5("System Configuration", className="card-title"),
+                    dbc.Label(
+                        "Rate Limit (per minute)",
+                        html_for="setting-rate-limit",
+                        className="fw-bold",
+                    ),
+                    dcc.Dropdown(
+                        id="setting-rate-limit",
+                        options=[{"label": str(o), "value": o} for o in rate_options],
+                        value=dynamic_config.security.rate_limit_requests,
+                        clearable=False,
+                        className="mb-3",
+                    ),
+                    dbc.Label(
+                        "DB Connection Timeout",
+                        html_for="setting-db-timeout",
+                        className="fw-bold",
+                    ),
+                    dcc.Dropdown(
+                        id="setting-db-timeout",
+                        options=[{"label": str(o), "value": o} for o in timeout_options],
+                        value=dynamic_config.database.connection_timeout_seconds,
+                        clearable=False,
+                        className="mb-3",
+                    ),
+                    dbc.Label(
+                        "Analytics Batch Size",
+                        html_for="setting-batch-size",
+                        className="fw-bold",
+                    ),
+                    dcc.Dropdown(
+                        id="setting-batch-size",
+                        options=[{"label": str(o), "value": o} for o in batch_options],
+                        value=dynamic_config.analytics.batch_size,
+                        clearable=False,
+                    ),
+                ]
+            ),
+            className="mb-4 settings-section",
+        )
+
+
+_settings_component = SettingsPage()
+
+
+def load_page(**kwargs) -> SettingsPage:
+    """Return a new :class:`SettingsPage` instance."""
+
+    return SettingsPage(**kwargs)
+
 
 def register_page() -> None:
     """Register the settings page with Dash."""
     dash_register_page(__name__, path="/settings", name="Settings")
 
 
-def _settings_section(title: str) -> dbc.Card:
-    """Return a placeholder settings section."""
-    title = sanitize_unicode_input(title)
-    return dbc.Card(
-        dbc.CardBody(
-            [
-                html.H5(title, className="card-title"),
-                html.P("Configuration options coming soon.", className="card-text"),
-            ]
-        ),
-        className="mb-4 settings-section",
-    )
-
-
-def _system_config_section() -> dbc.Card:
-    """Return system configuration with dropdowns for key settings."""
-
-    rate_options = [60, 120, 200, 500, 1000]
-    timeout_options = [5, 10, 20, 30, 60]
-    batch_options = [1000, 2000, 5000, 10000, 25000]
-
-    return dbc.Card(
-        dbc.CardBody(
-            [
-                html.H5("System Configuration", className="card-title"),
-                dbc.Label(
-                    "Rate Limit (per minute)",
-                    html_for="setting-rate-limit",
-                    className="fw-bold",
-                ),
-                dcc.Dropdown(
-                    id="setting-rate-limit",
-                    options=[{"label": str(o), "value": o} for o in rate_options],
-                    value=dynamic_config.security.rate_limit_requests,
-                    clearable=False,
-                    className="mb-3",
-                ),
-                dbc.Label(
-                    "DB Connection Timeout",
-                    html_for="setting-db-timeout",
-                    className="fw-bold",
-                ),
-                dcc.Dropdown(
-                    id="setting-db-timeout",
-                    options=[{"label": str(o), "value": o} for o in timeout_options],
-                    value=dynamic_config.database.connection_timeout_seconds,
-                    clearable=False,
-                    className="mb-3",
-                ),
-                dbc.Label(
-                    "Analytics Batch Size",
-                    html_for="setting-batch-size",
-                    className="fw-bold",
-                ),
-                dcc.Dropdown(
-                    id="setting-batch-size",
-                    options=[{"label": str(o), "value": o} for o in batch_options],
-                    value=dynamic_config.analytics.batch_size,
-                    clearable=False,
-                ),
-            ]
-        ),
-        className="mb-4 settings-section",
-    )
-
-
 def layout() -> dbc.Container:
-    """Settings page layout."""
-    sections = dbc.Row(
-        [
-            dbc.Col(_settings_section("User Preferences"), md=6),
-            dbc.Col(_system_config_section(), md=6),
-        ]
-    )
+    """Compatibility wrapper returning the default component layout."""
 
-    return dbc.Container([sections], fluid=True)
+    return _settings_component.layout()
 
 
-__all__ = ["layout", "register_page"]
+__all__ = ["SettingsPage", "load_page", "layout", "register_page"]

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -14,8 +14,9 @@ pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 def _create_upload_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
     coord = TrulyUnifiedCallbacks(app)
-    file_upload.register_upload_callbacks(coord)
-    app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
+    comp = file_upload.load_page()
+    comp.register_callbacks(coord)
+    app.layout = html.Div([dcc.Location(id="url"), comp.layout()])
     return app
 
 

--- a/tests/test_dash_pages.py
+++ b/tests/test_dash_pages.py
@@ -12,8 +12,7 @@ from dash import dcc, html
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 from pages import file_upload
-from pages.deep_analytics import layout as analytics_layout
-from pages.deep_analytics import register_callbacks as register_analytics_callbacks
+from pages.deep_analytics import AnalyticsPage
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
@@ -21,16 +20,18 @@ pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 def _create_upload_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
     coord = TrulyUnifiedCallbacks(app)
-    file_upload.register_upload_callbacks(coord)
-    app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
+    upload_comp = file_upload.load_page()
+    upload_comp.register_callbacks(coord)
+    app.layout = html.Div([dcc.Location(id="url"), upload_comp.layout()])
     return app
 
 
 def _create_analytics_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
     coord = TrulyUnifiedCallbacks(app)
-    register_analytics_callbacks(coord)
-    app.layout = html.Div([dcc.Location(id="url"), analytics_layout()])
+    analytics_comp = AnalyticsPage()
+    analytics_comp.register_callbacks(coord)
+    app.layout = html.Div([dcc.Location(id="url"), analytics_comp.layout()])
     return app
 
 

--- a/tests/test_upload_end_to_end.py
+++ b/tests/test_upload_end_to_end.py
@@ -190,7 +190,8 @@ def test_callback_connectivity(fake_dash):
     _callback_registry.registration_order.clear()
     _callback_registry.registration_attempts.clear()
 
-    file_upload.register_upload_callbacks(coord)
+    comp = file_upload.load_page()
+    comp.register_callbacks(coord)
 
     expected = {
         "file_upload_handle",
@@ -200,5 +201,5 @@ def test_callback_connectivity(fake_dash):
     assert expected.issubset(_callback_registry.registered_callbacks)
     first = len(_callback_registry.registered_callbacks)
 
-    file_upload.register_upload_callbacks(coord)
+    comp.register_callbacks(coord)
     assert len(_callback_registry.registered_callbacks) == first

--- a/tests/test_upload_fix.py
+++ b/tests/test_upload_fix.py
@@ -42,8 +42,10 @@ def create_sample_files(tmp_path: Path) -> dict[str, Path]:
 def _create_app() -> dash.Dash:
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
     coord = TrulyUnifiedCallbacks(app)
-    file_upload.register_upload_callbacks(coord)
-    app.layout = html.Div([dcc.Location(id="url"), file_upload.layout()])
+    comp = file_upload.load_page()
+    comp.register_callbacks(coord)
+    app.layout = html.Div([dcc.Location(id="url"), comp.layout()])
+    app._component = comp
     return app
 
 
@@ -62,7 +64,7 @@ def test_file_upload_component_integration(_skip_if_no_chromedriver, dash_duo, t
 
     uploaded = file_upload.get_uploaded_filenames()
     assert sorted(uploaded) == sorted(p.name for p in files.values())
-    assert isinstance(file_upload._upload_component, UnifiedUploadComponent)
+    assert isinstance(app._component, UnifiedUploadComponent)
 
 
 def test_safe_encode_text_edge_cases():


### PR DESCRIPTION
## Summary
- add `UIComponent` base class handling DI and Unicode sanitization
- implement `UploadPage`, `AnalyticsPage`, and `SettingsPage` classes
- delegate existing page modules to component instances
- update tests to construct components directly

## Testing
- `pytest -k 'dash_pages or upload_progress_sse or upload_fix or upload_end_to_end or file_upload_import_failure' -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_6871ced4c2688320be9e631d13dfc384