### PR TITLE
Add pre-commit security checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     hooks:
       - id: mypy
 
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.8
+    hooks:
+      - id: bandit
+        args: ["-r", "."]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,13 @@ pip install pre-commit
 pre-commit install
 ```
 
+The hook will automatically run each time you commit. To verify all files at
+once execute:
+
+```bash
+pre-commit run --all-files
+```
+
 These additional packages provide linting, type checking, security scanning and testing tools used in our CI pipeline.
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- add bandit to the pre-commit configuration
- document how to run the pre-commit hook in CONTRIBUTING

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6871ced7939c83209605c8c39b74be42