### PR TITLE
Add distributed chunked analysis

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -158,6 +158,10 @@ class DynamicConfigManager(BaseConfigLoader):
                 value = 500
             self.analytics.max_memory_mb = value
 
+        max_workers = os.getenv("ANALYTICS_MAX_WORKERS")
+        if max_workers is not None:
+            self.analytics.max_workers = int(max_workers)
+
         upload_chunk = os.getenv("UPLOAD_CHUNK_SIZE")
         if upload_chunk is not None:
             self.uploads.DEFAULT_CHUNK_SIZE = int(upload_chunk)

--- a/config/env_overrides.py
+++ b/config/env_overrides.py
@@ -118,6 +118,8 @@ def apply_env_overrides(config: Any) -> None:
             analytics.batch_size = int(val)
         if val := os.getenv("ANALYTICS_MAX_MEMORY_MB"):
             analytics.max_memory_mb = int(val)
+        if val := os.getenv("ANALYTICS_MAX_WORKERS"):
+            analytics.max_workers = int(val)
 
     # --- Uploads overrides -------------------------------------------
     if hasattr(config, "uploads"):

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -54,6 +54,7 @@ analytics:
   enable_real_time: ${ENABLE_REAL_TIME:true}
   batch_size: ${BATCH_SIZE:5000}
   chunk_size: ${ANALYTICS_CHUNK_SIZE:100000}
+  max_workers: ${ANALYTICS_MAX_WORKERS:4}
   enable_chunked_analysis: ${ENABLE_CHUNKED_ANALYSIS:true}
   anomaly_detection_enabled: ${ENABLE_ANOMALY_DETECTION:true}
   ml_models_path: ${ML_MODELS_PATH:models/ml}


### PR DESCRIPTION
## Summary
- enable max worker override and update config
- allow env overrides to tune chunk worker count
- process analysis chunks with Dask and cache results

## Testing
- `pre-commit run --files services/chunked_analysis.py config/dynamic_config.py config/env_overrides.py config/production.yaml`
- `pytest -q` *(fails: 122 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6871d8104cb88320b9ab1000e5a7fcfd