### PR TITLE
Add DBSCAN & autoencoder ensemble anomaly detection

### DIFF
--- a/analytics/anomaly_detection/ml_inference.py
+++ b/analytics/anomaly_detection/ml_inference.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import IsolationForest
+from sklearn.cluster import DBSCAN
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
 
 __all__ = ["detect_ml_anomalies"]
 
@@ -15,35 +18,66 @@ def detect_ml_anomalies(
     df: pd.DataFrame,
     sensitivity: float,
     isolation_forest: IsolationForest,
+    dbscan_model: Optional[DBSCAN] = None,
+    autoencoder_model: Optional[MLPRegressor] = None,
+    dbscan_scaler: Optional[StandardScaler] = None,
+    autoencoder_scaler: Optional[StandardScaler] = None,
     logger: Optional[logging.Logger] = None,
 ) -> List[Dict[str, Any]]:
-    """Detect anomalies using an IsolationForest model."""
+    """Detect anomalies using an ensemble of ML models."""
     logger = logger or logging.getLogger(__name__)
     anomalies: List[Dict[str, Any]] = []
     try:
-        features = ['hour', 'day_of_week', 'is_weekend', 'is_after_hours', 'access_granted']
-        # Shallow copy of just the features needed for inference to keep
-        # memory usage low
+        features = ["hour", "day_of_week", "is_weekend", "is_after_hours", "access_granted"]
         feature_df = df[features].copy(deep=False)
         if len(feature_df) < 10:
             return anomalies
+
+        scores: List[np.ndarray] = []
+
+        # Isolation Forest score (normalized)
         isolation_forest.set_params(contamination=1 - sensitivity)
-        outliers = isolation_forest.fit_predict(feature_df)
-        anomaly_indices = np.where(outliers == -1)[0]
+        iso_scores = -isolation_forest.fit(feature_df).decision_function(feature_df)
+        iso_scores = (iso_scores - iso_scores.min()) / (iso_scores.ptp() + 1e-9)
+        scores.append(iso_scores)
+
+        # DBSCAN score if model provided
+        if dbscan_model is not None:
+            db_data = feature_df if dbscan_scaler is None else dbscan_scaler.transform(feature_df)
+            db_labels = dbscan_model.fit_predict(db_data)
+            db_scores = (db_labels == -1).astype(float)
+            scores.append(db_scores)
+
+        # Autoencoder reconstruction error if model provided
+        if autoencoder_model is not None:
+            ae_data = feature_df if autoencoder_scaler is None else autoencoder_scaler.transform(feature_df)
+            ae_recon = autoencoder_model.predict(ae_data)
+            if ae_recon.ndim == 1:
+                ae_recon = ae_recon.reshape(-1, 1)
+            ae_scores = np.mean((ae_data - ae_recon) ** 2, axis=1)
+            ae_scores = (ae_scores - ae_scores.min()) / (ae_scores.ptp() + 1e-9)
+            scores.append(ae_scores)
+
+        aggregated_scores = np.mean(np.column_stack(scores), axis=1)
+        threshold = np.quantile(aggregated_scores, sensitivity)
+        anomaly_indices = np.where(aggregated_scores >= threshold)[0]
+
         for idx in anomaly_indices:
             original_row = df.iloc[idx]
-            anomalies.append({
-                "type": "ml_anomaly",
-                "details": {
-                    "person_id": original_row["person_id"],
-                    "door_id": original_row["door_id"],
-                    "timestamp": original_row["timestamp"].isoformat(),
-                    "features": feature_df.iloc[idx].to_dict(),
-                },
-                "severity": "medium",
-                "confidence": 0.6,
-                "timestamp": datetime.now(),
-            })
+            anomalies.append(
+                {
+                    "type": "ml_anomaly",
+                    "details": {
+                        "person_id": original_row["person_id"],
+                        "door_id": original_row["door_id"],
+                        "timestamp": original_row["timestamp"].isoformat(),
+                        "features": feature_df.iloc[idx].to_dict(),
+                    },
+                    "severity": "medium",
+                    "confidence": float(aggregated_scores[idx]),
+                    "timestamp": datetime.now(),
+                }
+            )
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("ML anomaly detection failed: %s", exc)
     return anomalies

--- a/analytics/anomaly_detection/tests/test_anomaly_modules.py
+++ b/analytics/anomaly_detection/tests/test_anomaly_modules.py
@@ -1,8 +1,34 @@
+import sys
+import types
 import pandas as pd
 from sklearn.ensemble import IsolationForest
 
+dash_stub = types.ModuleType("dash")
+setattr(dash_stub, "Dash", object)
+deps_stub = types.ModuleType("dependencies")
+for attr in ["Input", "Output", "State"]:
+    setattr(deps_stub, attr, object)
+setattr(dash_stub, "dependencies", deps_stub)
+setattr(dash_stub, "no_update", object())
+sys.modules.setdefault("dash", dash_stub)
+sys.modules.setdefault("dash.dependencies", deps_stub)
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))
+sys.modules.setdefault("hvac", types.ModuleType("hvac"))
+
 from analytics.anomaly_detection.data_prep import prepare_anomaly_data
 from analytics.anomaly_detection.ml_inference import detect_ml_anomalies
+import importlib.util
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parents[3] / "models"
+spec = importlib.util.spec_from_file_location(
+    "anomaly_models", MODULE_DIR / "anomaly_models.py"
+)
+anomaly_models = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(anomaly_models)
+train_dbscan_model = anomaly_models.train_dbscan_model
+train_autoencoder_model = anomaly_models.train_autoencoder_model
 
 
 def test_prepare_anomaly_data_basic():
@@ -27,4 +53,27 @@ def test_detect_ml_anomalies_runs():
     cleaned = prepare_anomaly_data(df)
     model = IsolationForest(random_state=42, n_estimators=10, contamination=0.1)
     anomalies = detect_ml_anomalies(cleaned, 0.9, model)
+    assert isinstance(anomalies, list)
+
+
+def test_train_models_and_ensemble():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=30, freq="min"),
+        "person_id": ["u1"] * 30,
+        "door_id": ["d1"] * 30,
+        "access_result": ["Granted"] * 30,
+    })
+    cleaned = prepare_anomaly_data(df)
+    iso = IsolationForest(random_state=42, n_estimators=10, contamination=0.1)
+    db_model, db_scaler = train_dbscan_model(cleaned, eps=0.5, min_samples=3)
+    ae_model, ae_scaler = train_autoencoder_model(cleaned, hidden_layer_sizes=(5, 2, 5), max_iter=100)
+    anomalies = detect_ml_anomalies(
+        cleaned,
+        0.9,
+        iso,
+        dbscan_model=db_model,
+        autoencoder_model=ae_model,
+        dbscan_scaler=db_scaler,
+        autoencoder_scaler=ae_scaler,
+    )
     assert isinstance(anomalies, list)

--- a/models/anomaly_models.py
+++ b/models/anomaly_models.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from sklearn.cluster import DBSCAN
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+__all__ = [
+    "train_dbscan_model",
+    "train_autoencoder_model",
+    "autoencoder_reconstruction_error",
+]
+
+_FEATURES = ["hour", "day_of_week", "is_weekend", "is_after_hours", "access_granted"]
+
+
+def _extract_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Return feature subset used for model training."""
+    return df[_FEATURES].copy(deep=False)
+
+
+def train_dbscan_model(
+    df: pd.DataFrame,
+    eps: float = 0.5,
+    min_samples: int = 5,
+) -> tuple[DBSCAN, StandardScaler]:
+    """Train a DBSCAN clustering model."""
+    features = _extract_features(df)
+    scaler = StandardScaler()
+    data = scaler.fit_transform(features)
+    model = DBSCAN(eps=eps, min_samples=min_samples)
+    model.fit(data)
+    return model, scaler
+
+
+def train_autoencoder_model(
+    df: pd.DataFrame,
+    hidden_layer_sizes: tuple[int, ...] = (8, 4, 8),
+    max_iter: int = 200,
+) -> tuple[MLPRegressor, StandardScaler]:
+    """Train an autoencoder using ``MLPRegressor``."""
+    features = _extract_features(df)
+    scaler = StandardScaler()
+    data = scaler.fit_transform(features)
+    model = MLPRegressor(
+        hidden_layer_sizes=hidden_layer_sizes,
+        random_state=42,
+        max_iter=max_iter,
+    )
+    model.fit(data, data)
+    return model, scaler
+
+
+def autoencoder_reconstruction_error(
+    df: pd.DataFrame, model: MLPRegressor, scaler: StandardScaler
+) -> np.ndarray:
+    """Compute reconstruction error for each row."""
+    features = _extract_features(df)
+    data = scaler.transform(features)
+    reconstructed = model.predict(data)
+    if reconstructed.ndim == 1:
+        reconstructed = reconstructed.reshape(-1, 1)
+    return np.mean((data - reconstructed) ** 2, axis=1)


### PR DESCRIPTION
## Summary
- add `models/anomaly_models.py` with DBSCAN and autoencoder utilities
- extend ML inference to support Isolation Forest, DBSCAN and autoencoder ensemble
- adjust anomaly detection tests to exercise new models

## Testing
- `pytest analytics/anomaly_detection/tests/test_anomaly_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d8113e148320bb6b6556610cd97d