### PR TITLE
Link threats to MITRE ATT&CK techniques

### DIFF
--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -147,6 +147,7 @@ class SecurityPatternsAnalyzer:
                         "threat_type": threat.threat_type,
                         "description": threat.description,
                         "confidence": threat.confidence,
+                        "attack": threat.attack,
                     },
                 )
                 self._emit_anomaly_detected(threat)
@@ -422,6 +423,7 @@ class SecurityPatternsAnalyzer:
                 "threat_type": threat.threat_type,
                 "severity": threat.severity,
                 "confidence": threat.confidence,
+                "attack": threat.attack,
             },
         )
 
@@ -451,6 +453,7 @@ class SecurityPatternsAnalyzer:
                     "confidence": t.confidence,
                     "description": t.description,
                     "affected_entities": t.affected_entities,
+                    "attack": t.attack,
                 }
                 for t in result.threat_indicators
             ],

--- a/analytics/security_patterns/statistical_detection.py
+++ b/analytics/security_patterns/statistical_detection.py
@@ -9,6 +9,7 @@ import pandas as pd
 from scipy import stats
 
 from .types import ThreatIndicator
+from .pattern_detection import _attack_info
 
 __all__ = [
     "detect_failure_rate_anomalies",
@@ -52,6 +53,7 @@ def detect_failure_rate_anomalies(df: pd.DataFrame, logger: Optional[logging.Log
                         },
                         timestamp=datetime.now(),
                         affected_entities=[str(user_id)],
+                        attack=_attack_info("unusual_failure_rate"),
                     )
                 )
     except Exception as exc:  # pragma: no cover - log and continue
@@ -87,6 +89,7 @@ def detect_frequency_anomalies(df: pd.DataFrame, logger: Optional[logging.Logger
                         },
                         timestamp=datetime.now(),
                         affected_entities=[str(user_id)],
+                        attack=_attack_info("excessive_access_frequency"),
                     )
                 )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/types.py
+++ b/analytics/security_patterns/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 __all__ = ["ThreatIndicator"]
 
@@ -15,3 +15,4 @@ class ThreatIndicator:
     evidence: Dict[str, Any]
     timestamp: datetime
     affected_entities: List[str]
+    attack: Optional[Dict[str, str]] = None

--- a/resources/attack_techniques.yaml
+++ b/resources/attack_techniques.yaml
@@ -1,0 +1,16 @@
+rapid_access_attempts:
+  id: T1110
+  name: Brute Force
+  url: https://attack.mitre.org/techniques/T1110/
+excessive_after_hours_access:
+  id: T1078
+  name: Valid Accounts
+  url: https://attack.mitre.org/techniques/T1078/
+unusual_failure_rate:
+  id: T1059
+  name: Command and Scripting Interpreter
+  url: https://attack.mitre.org/techniques/T1059/
+excessive_access_frequency:
+  id: T1021
+  name: Remote Services
+  url: https://attack.mitre.org/techniques/T1021/


### PR DESCRIPTION
## Summary
- map threat indicators to MITRE ATT&CK techniques
- store ATT&CK mapping in `resources/attack_techniques.yaml`
- include ATT&CK info when emitting threat alerts and logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_6871d8133dfc8320bb53c53bc63337b6