### PR TITLE
Add risk scoring module with API endpoint

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "unique_patterns_analyzer",
     "security_metrics",
     "security_score_calculator",
+    "risk_scoring",
     "db_interface",
     "file_processing_utils",
     "utils",
@@ -18,6 +19,7 @@ __all__ = [
 
 import logging
 
+from . import risk_scoring
 from .business_service import AnalyticsBusinessService
 from .data_repository import AnalyticsDataRepository
 from .ui_controller import AnalyticsUIController

--- a/analytics/risk_scoring.py
+++ b/analytics/risk_scoring.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Aggregate risk scoring utilities."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .anomaly_detection.types import AnomalyAnalysis
+from .security_patterns.analyzer import SecurityAssessment
+from .user_behavior import BehaviorAnalysis
+
+
+@dataclass
+class RiskScoreResult:
+    """Result returned by :func:`combine_risk_factors`."""
+
+    score: float  # 0-100 scale
+    level: str  # low, medium, high, critical
+
+
+def _determine_level(score: float) -> str:
+    if score >= 75:
+        return "critical"
+    if score >= 50:
+        return "high"
+    if score >= 25:
+        return "medium"
+    return "low"
+
+
+def calculate_risk_score(
+    anomaly_component: float = 0.0,
+    pattern_component: float = 0.0,
+    behavior_component: float = 0.0,
+) -> RiskScoreResult:
+    """Combine numeric risk components into a final score."""
+    components = [
+        max(0.0, min(anomaly_component, 100.0)),
+        max(0.0, min(pattern_component, 100.0)),
+        max(0.0, min(behavior_component, 100.0)),
+    ]
+    score = sum(components) / len(components)
+    return RiskScoreResult(score=round(score, 2), level=_determine_level(score))
+
+
+def combine_risk_factors(
+    anomaly: Optional[AnomalyAnalysis] = None,
+    patterns: Optional[SecurityAssessment] = None,
+    behavior: Optional[BehaviorAnalysis] = None,
+) -> RiskScoreResult:
+    """Combine analysis results from different modules into one score."""
+    anomaly_score = 0.0
+    if anomaly is not None:
+        anomaly_score = float(anomaly.risk_assessment.get("risk_score", 0.0)) * 100
+
+    pattern_score = 0.0
+    if patterns is not None:
+        pattern_score = max(0.0, 100.0 - float(patterns.overall_score))
+
+    behavior_score = 0.0
+    if behavior is not None and behavior.total_users_analyzed:
+        ratio = behavior.high_risk_users / behavior.total_users_analyzed
+        behavior_score = max(0.0, min(ratio * 100, 100.0))
+
+    return calculate_risk_score(anomaly_score, pattern_score, behavior_score)
+
+
+__all__ = ["RiskScoreResult", "calculate_risk_score", "combine_risk_factors"]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,6 @@
+"""Expose API routes used by the dashboard."""
+
+from . import plugin_performance  # noqa: F401
+from . import risk_scoring  # noqa: F401
+
+__all__ = ["plugin_performance", "risk_scoring"]

--- a/api/risk_scoring.py
+++ b/api/risk_scoring.py
@@ -1,0 +1,20 @@
+"""REST endpoints exposing risk scoring utilities."""
+
+from __future__ import annotations
+
+from flask import jsonify, request
+
+from analytics.risk_scoring import calculate_risk_score
+from app import app
+
+
+@app.route("/api/v1/risk/score", methods=["POST"])
+def calculate_score_endpoint():
+    """Return aggregated risk score from provided values."""
+    payload = request.get_json(silent=True) or {}
+    anomaly = float(payload.get("anomaly_score", 0))
+    patterns = float(payload.get("pattern_score", 0))
+    behavior = float(payload.get("behavior_deviation", 0))
+
+    result = calculate_risk_score(anomaly, patterns, behavior)
+    return jsonify({"score": result.score, "level": result.level})

--- a/tests/test_risk_scoring.py
+++ b/tests/test_risk_scoring.py
@@ -1,0 +1,64 @@
+# Provide minimal dash stub if dash is unavailable
+import sys
+
+if "dash" not in sys.modules:
+    from tests.stubs import dash as dash_stub
+
+    sys.modules["dash"] = dash_stub  # type: ignore
+    sys.modules["dash.html"] = dash_stub.html  # type: ignore
+    sys.modules["dash.dcc"] = dash_stub.dcc  # type: ignore
+    sys.modules["dash.dependencies"] = dash_stub.dependencies  # type: ignore
+    sys.modules["dash._callback"] = dash_stub._callback  # type: ignore
+
+from analytics.anomaly_detection.types import AnomalyAnalysis
+from analytics.risk_scoring import (
+    RiskScoreResult,
+    calculate_risk_score,
+    combine_risk_factors,
+)
+from analytics.security_patterns.analyzer import SecurityAssessment
+from analytics.user_behavior import BehaviorAnalysis
+
+# Provide minimal dash stub if dash is unavailable
+if "dash" not in sys.modules:
+    from tests.stubs import dash as dash_stub
+
+    sys.modules["dash"] = dash_stub  # type: ignore
+    sys.modules["dash.html"] = dash_stub.html  # type: ignore
+    sys.modules["dash.dcc"] = dash_stub.dcc  # type: ignore
+    sys.modules["dash.dependencies"] = dash_stub.dependencies  # type: ignore
+    sys.modules["dash._callback"] = dash_stub._callback  # type: ignore
+
+
+def test_calculate_risk_score_numeric():
+    result = calculate_risk_score(50, 20, 30)
+    assert isinstance(result, RiskScoreResult)
+    assert result.score == 33.33
+    assert result.level == "medium"
+
+
+def test_combine_risk_factors():
+    anomaly = AnomalyAnalysis(
+        total_anomalies=2,
+        severity_distribution={"high": 1, "medium": 1},
+        detection_summary={},
+        risk_assessment={"risk_level": "high", "risk_score": 0.6},
+        recommendations=[],
+    )
+    patterns = SecurityAssessment(
+        overall_score=70,
+        risk_level="medium",
+        confidence_interval=(50.0, 90.0),
+        threat_indicators=[],
+        pattern_analysis={},
+        recommendations=[],
+    )
+    behavior = BehaviorAnalysis(
+        total_users_analyzed=10,
+        high_risk_users=2,
+        global_patterns={},
+        insights=[],
+        recommendations=[],
+    )
+    result = combine_risk_factors(anomaly, patterns, behavior)
+    assert result.level in {"low", "medium", "high", "critical"}


### PR DESCRIPTION
## Summary
- create `risk_scoring` utilities for aggregating analytics results
- expose `/api/v1/risk/score` endpoint for computing risk score
- import new module in analytics and API packages
- add basic tests for risk scoring

## Testing
- `black analytics/risk_scoring.py api/risk_scoring.py api/__init__.py analytics/__init__.py tests/test_risk_scoring.py`
- `isort tests/test_risk_scoring.py analytics/risk_scoring.py api/risk_scoring.py api/__init__.py analytics/__init__.py`
- `flake8 analytics/risk_scoring.py api/risk_scoring.py api/__init__.py analytics/__init__.py tests/test_risk_scoring.py`
- `pytest tests/test_risk_scoring.py -q` *(fails: ModuleNotFoundError: No module named 'hvac')*

------
https://chatgpt.com/codex/tasks/task_e_6871d81473288320afe7132034659357