### PR TITLE
Introduce Redis caching with invalidation

### DIFF
--- a/advanced_cache.py
+++ b/advanced_cache.py
@@ -1,10 +1,84 @@
+"""Simple caching helpers with optional Redis backend."""
+
+from __future__ import annotations
+
 import functools
-from typing import Any, Callable
+import os
+import pickle
 from threading import RLock
+from typing import Any, Callable, Optional
+
+import redis
 
 from core.cache import cache
 
 _locks: dict[str, RLock] = {}
+_redis_client: Optional[redis.Redis] = None
+
+
+def get_redis_client() -> Optional[redis.Redis]:
+    """Return a lazily initialized Redis client."""
+    global _redis_client
+    if _redis_client is None:
+        try:
+            _redis_client = redis.Redis(
+                host=os.getenv("REDIS_HOST", "localhost"),
+                port=int(os.getenv("REDIS_PORT", "6379")),
+                db=int(os.getenv("REDIS_DB", "0")),
+            )
+            _redis_client.ping()
+        except Exception:
+            _redis_client = None
+    return _redis_client
+
+
+def get_cache_value(key: str) -> Any:
+    client = get_redis_client()
+    if client is not None:
+        try:
+            data = client.get(key)
+            if data is not None:
+                return pickle.loads(data)
+        except Exception:
+            pass
+    return cache.get(key)
+
+
+def set_cache_value(key: str, value: Any, ttl: int | None = None) -> None:
+    client = get_redis_client()
+    if client is not None:
+        try:
+            payload = pickle.dumps(value)
+            if ttl:
+                client.setex(key, ttl, payload)
+            else:
+                client.set(key, payload)
+        except Exception:
+            pass
+    try:
+        cache.set(key, value, timeout=ttl)
+    except TypeError:
+        cache.set(key, value, ttl=ttl)
+
+
+def delete_cache_key(key: str) -> None:
+    client = get_redis_client()
+    if client is not None:
+        try:
+            client.delete(key)
+        except Exception:
+            pass
+    cache.delete(key)
+
+
+def clear_cache() -> None:
+    client = get_redis_client()
+    if client is not None:
+        try:
+            client.flushdb()
+        except Exception:
+            pass
+    cache.clear()
 
 
 def _get_lock(name: str) -> RLock:
@@ -23,26 +97,31 @@ def cache_with_lock(ttl_seconds: int = 300) -> Callable[[Callable[..., Any]], Ca
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            key = f"{func.__name__}:{hash(str(args) + str(sorted(kwargs.items())))}"
-            result = cache.get(key)
+            key = (
+                f"{func.__module__}.{func.__name__}:"
+                f"{hash(str(args) + str(sorted(kwargs.items())))}"
+            )
+            result = get_cache_value(key)
             if result is not None:
                 return result
 
             with lock:
-                result = cache.get(key)
+                result = get_cache_value(key)
                 if result is not None:
                     return result
 
                 result = func(*args, **kwargs)
-                try:
-                    cache.set(key, result, timeout=ttl_seconds)
-                except TypeError:
-                    # Some cache implementations might use 'ttl'
-                    cache.set(key, result, ttl=ttl_seconds)
+                set_cache_value(key, result, ttl_seconds)
                 return result
 
         return wrapper
 
     return decorator
 
-__all__ = ["cache_with_lock"]
+__all__ = [
+    "cache_with_lock",
+    "get_cache_value",
+    "set_cache_value",
+    "delete_cache_key",
+    "clear_cache",
+]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -16,6 +16,7 @@ import pandas as pd
 from services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.analytics_summary import generate_sample_analytics
 from services.data_processing.processor import Processor
+from advanced_cache import cache_with_lock
 from core.security_validator import SecurityValidator
 from services.db_analytics_helper import DatabaseAnalyticsHelper
 from services.summary_reporting import SummaryReporter
@@ -214,10 +215,12 @@ class AnalyticsService(AnalyticsServiceProtocol):
         """Get analytics using the sample file processor."""
         return self.upload_processor._get_analytics_with_fixed_processor()
 
+    @cache_with_lock(ttl_seconds=600)
     def _get_database_analytics(self) -> Dict[str, Any]:
         """Get analytics from database."""
         return self.db_helper.get_analytics()
 
+    @cache_with_lock(ttl_seconds=300)
     def get_dashboard_summary(self) -> Dict[str, Any]:
         """Get a basic dashboard summary"""
         try:
@@ -436,6 +439,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
             "recommendations": [],
         }
 
+    @cache_with_lock(ttl_seconds=600)
     def get_unique_patterns_analysis(self, data_source: str | None = None):
         """Get unique patterns analysis for the requested source."""
         logger = logging.getLogger(__name__)

--- a/services/consolidated_learning_service.py
+++ b/services/consolidated_learning_service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
+from advanced_cache import clear_cache
 
 class ConsolidatedLearningService:
     """Unified learning service for all mapping types."""
@@ -49,6 +50,7 @@ class ConsolidatedLearningService:
 
         self.learned_data[fingerprint] = mapping_data
         self._persist_learned_data()
+        clear_cache()
         self.logger.info(f"Saved mapping {fingerprint[:8]} for {filename}")
         return fingerprint
 

--- a/services/database_analytics_service.py
+++ b/services/database_analytics_service.py
@@ -6,6 +6,8 @@ from typing import Any, Dict
 
 import pandas as pd
 
+from advanced_cache import cache_with_lock
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,6 +17,7 @@ class DatabaseAnalyticsService:
     def __init__(self, database_manager: Any):
         self.database_manager = database_manager
 
+    @cache_with_lock(ttl_seconds=600)
     def get_analytics(self) -> Dict[str, Any]:
         if not self.database_manager:
             return {"status": "error", "message": "Database not available"}

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -14,6 +14,7 @@ from file_conversion.file_converter import FileConverter
 from services.upload.protocols import UploadStorageProtocol
 from typing import Protocol
 from config.app_config import UploadConfig
+from advanced_cache import clear_cache
 
 
 class UploadStoreProtocol(Protocol):
@@ -161,6 +162,7 @@ class UploadedDataStore(UploadStorageProtocol):
         """Persist ``df`` to disk and record its metadata."""
         # save synchronously to ensure metadata exists immediately
         self._save_to_disk(filename, df)
+        clear_cache()
 
     def load_dataframe(self, filename: str) -> pd.DataFrame:
         """Load a previously saved dataframe."""
@@ -194,6 +196,7 @@ class UploadedDataStore(UploadStorageProtocol):
                     self._info_path().unlink()
             except Exception as e:  # pragma: no cover - best effort
                 logger.error(f"Error clearing uploaded data: {e}")
+        clear_cache()
 
     def wait_for_pending_saves(self) -> None:
         """Block until all background save tasks have completed."""


### PR DESCRIPTION
## Summary
- add Redis helpers in `advanced_cache.py`
- cache heavy analytics queries
- invalidate cache on data ingest and model training

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_6871d817f6d88320a6780afa8650ca67