### PR TITLE
Centralize upload data helpers

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -539,7 +539,7 @@ def populate_simple_device_modal(is_open):
         logger.warning(f"Failed to get devices from global store: {e}")
 
     # Fallback: Get devices from uploaded data
-    from pages.file_upload import get_uploaded_data
+    from services.upload_data_service import get_uploaded_data
 
     uploaded_data = get_uploaded_data()
 

--- a/examples/debug_deep_analytics.py
+++ b/examples/debug_deep_analytics.py
@@ -71,7 +71,7 @@ def test_complete_pipeline():
     # Step 3: Test file upload module
     print("📤 STEP 3: Testing file upload module")
     try:
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_files = get_uploaded_data()
         print(f"✅ File upload module found {len(uploaded_files)} files")

--- a/examples/deep_analytics_specific_debug.py
+++ b/examples/deep_analytics_specific_debug.py
@@ -189,7 +189,7 @@ def test_deep_analytics_specific_path():
     # Step 7: Test file upload detection
     print("📁 STEP 7: Testing file upload detection")
     try:
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_files = get_uploaded_data()
 

--- a/examples/diagnostic_script.py
+++ b/examples/diagnostic_script.py
@@ -71,7 +71,7 @@ def test_complete_pipeline():
     # Step 3: Test file upload module
     print("📤 STEP 3: Testing file upload module")
     try:
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_files = get_uploaded_data()
         print(f"✅ File upload module found {len(uploaded_files)} files")

--- a/examples/unique_patterns_debug.py
+++ b/examples/unique_patterns_debug.py
@@ -52,7 +52,7 @@ def test_unique_patterns_specific():
     # Step 2: Test get_uploaded_data directly
     print("📁 STEP 2: Testing get_uploaded_data()")
     try:
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_data = get_uploaded_data()
 
@@ -151,7 +151,7 @@ def test_unique_patterns_specific():
     print("🔍 STEP 6: Manual step-by-step test of unique patterns logic")
     try:
         print("   6a. Getting uploaded data...")
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_data = get_uploaded_data()
         print(f"      Found {len(uploaded_data)} files")

--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -292,7 +292,7 @@ def create_data_quality_display_corrected(
             else:
                 filename = None
 
-            from pages.file_upload import get_uploaded_data
+            from services.upload_data_service import get_uploaded_data
 
             uploaded_files = get_uploaded_data()
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -39,6 +39,11 @@ except ImportError:
 
 
 from components.ui_component import UIComponent
+from services.upload_data_service import (
+    get_uploaded_data as _svc_get_uploaded_data,
+    get_uploaded_filenames as _svc_get_uploaded_filenames,
+    clear_uploaded_data as _svc_clear_uploaded_data,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -398,14 +403,18 @@ def safe_upload_layout():
 
 
 def clear_uploaded_data() -> None:
-    """Clear uploaded data."""
-    global _uploaded_files
-    _uploaded_files.clear()
+    """Clear uploaded data via the service layer."""
+    _svc_clear_uploaded_data()
 
 
 def get_uploaded_filenames() -> List[str]:
-    """Get list of uploaded filenames."""
-    return list(_uploaded_files.keys())
+    """Return list of uploaded filenames via the service layer."""
+    return _svc_get_uploaded_filenames()
+
+
+def get_uploaded_data() -> Dict[str, pd.DataFrame]:
+    """Return all uploaded data via the service layer."""
+    return _svc_get_uploaded_data()
 
 
 # Backward compatibility

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -146,7 +146,7 @@ def process_suggests_analysis(data_source: str) -> Dict[str, Any]:
             else:
                 filename = None
 
-            from pages.file_upload import get_uploaded_data  # lazy import
+            from services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:
@@ -220,7 +220,7 @@ def process_quality_analysis(data_source: str) -> Dict[str, Any]:
             else:
                 filename = None
 
-            from pages.file_upload import get_uploaded_data  # lazy import
+            from services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:
@@ -266,7 +266,7 @@ def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str,
             return {"error": "Analytics service not available"}
 
         if data_source.startswith("upload:") or data_source == "service:uploaded":
-            from pages.file_upload import get_uploaded_data  # lazy import
+            from services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:

--- a/services/data_processing/processor.py
+++ b/services/data_processing/processor.py
@@ -115,7 +115,7 @@ class Processor:
 
     def _get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
         try:
-            from pages.file_upload import get_uploaded_data
+            from services.upload_data_service import get_uploaded_data
 
             data = get_uploaded_data()
             if not data:

--- a/tests/test_upload_data_service_interface.py
+++ b/tests/test_upload_data_service_interface.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from services.upload_data_service import (
+    get_uploaded_data,
+    get_uploaded_filenames,
+    clear_uploaded_data,
+    load_dataframe,
+    get_file_info,
+    UploadDataService,
+)
+from utils.upload_store import UploadedDataStore
+
+
+def test_service_helpers(tmp_path):
+    store = UploadedDataStore(storage_dir=tmp_path)
+    service = UploadDataService(store)
+
+    df = pd.DataFrame({"a": [1, 2]})
+    store.add_file("a.csv", df)
+
+    assert get_uploaded_filenames(service) == ["a.csv"]
+    data = get_uploaded_data(service)
+    assert list(data.keys()) == ["a.csv"]
+    assert load_dataframe("a.csv", service).equals(df)
+
+    info = get_file_info(service)
+    assert info["a.csv"]["rows"] == 2
+
+    clear_uploaded_data(service)
+    assert get_uploaded_filenames(service) == []

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -13,7 +13,7 @@ from services import AnalyticsService
 def test_load_uploaded_data(monkeypatch):
     sample = {"file.csv": DataFrameBuilder().add_column("A", [1]).build()}
     monkeypatch.setattr(
-        "pages.file_upload.get_uploaded_data", lambda: sample, raising=False
+        "services.upload_data_service.get_uploaded_data", lambda service=None, container=None: sample
     )
     service = AnalyticsService()
     assert service.load_uploaded_data() == sample

--- a/ui_tracker.py
+++ b/ui_tracker.py
@@ -153,7 +153,7 @@ def check_ui_data_source():
 
     # Check uploaded data
     try:
-        from pages.file_upload import get_uploaded_data
+        from services.upload_data_service import get_uploaded_data
 
         uploaded_data = get_uploaded_data()
 


### PR DESCRIPTION
## Summary
- expose helper functions in `upload_data_service`
- call upload data service from `file_upload` page
- replace imports from `pages.file_upload` with service helper
- add tests for the service interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6871e2080b00832098fd6dfebb890916