### PR TITLE
Add UI monitor and navigation manager

### DIFF
--- a/core/navigation/__init__.py
+++ b/core/navigation/__init__.py
@@ -1,0 +1,8 @@
+"""Enterprise navigation utilities."""
+
+from .enterprise_navigation_manager import (
+    EnterpriseNavigationManager,
+    NavigationLoopError,
+)
+
+__all__ = ["EnterpriseNavigationManager", "NavigationLoopError"]

--- a/core/navigation/enterprise_navigation_manager.py
+++ b/core/navigation/enterprise_navigation_manager.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Navigation state management with loop detection."""
+
+from collections import deque
+from typing import Deque, List
+
+
+class NavigationLoopError(Exception):
+    """Raised when a navigation loop is detected."""
+
+
+class EnterpriseNavigationManager:
+    """Track navigation history and detect loops."""
+
+    def __init__(self, max_history: int = 50, loop_threshold: int = 5) -> None:
+        self.history: Deque[str] = deque(maxlen=max_history)
+        self.loop_threshold = loop_threshold
+
+    # ------------------------------------------------------------------
+    def record_navigation(self, page: str) -> None:
+        """Record navigation to ``page`` and check for loops."""
+        self.history.append(page)
+        if self._check_loop(page):
+            raise NavigationLoopError(f"Navigation loop detected on {page}")
+
+    # ------------------------------------------------------------------
+    def _check_loop(self, page: str) -> bool:
+        count = 0
+        for entry in reversed(self.history):
+            if entry != page:
+                break
+            count += 1
+        return count >= self.loop_threshold
+
+    # ------------------------------------------------------------------
+    def get_history(self) -> List[str]:
+        """Return list of visited pages."""
+        return list(self.history)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        """Clear stored navigation history."""
+        self.history.clear()

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -53,3 +53,17 @@ email settings to receive alerts.
 
 A basic dashboard is available in `dashboards/performance/` for quick visual
 checks of recent activity.
+
+### UI Monitoring
+
+Client side frame times and callback runtimes can be captured using
+`monitoring.ui_monitor.RealTimeUIMonitor`. The metrics are forwarded to the
+shared `PerformanceMonitor` instance.
+
+```python
+from monitoring.ui_monitor import get_ui_monitor
+
+ui = get_ui_monitor()
+ui.record_frame_time(16.7)
+ui.record_callback_duration("update_chart", 0.05)
+```

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,11 +1,19 @@
 """Monitoring utilities package."""
 
 from core.performance import PerformanceMonitor
-from .data_quality_monitor import DataQualityMonitor, DataQualityMetrics, get_data_quality_monitor
+
+from .data_quality_monitor import (
+    DataQualityMetrics,
+    DataQualityMonitor,
+    get_data_quality_monitor,
+)
+from .ui_monitor import RealTimeUIMonitor, get_ui_monitor
 
 __all__ = [
     "PerformanceMonitor",
     "DataQualityMonitor",
     "DataQualityMetrics",
     "get_data_quality_monitor",
+    "RealTimeUIMonitor",
+    "get_ui_monitor",
 ]

--- a/monitoring/ui_monitor.py
+++ b/monitoring/ui_monitor.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Real-time UI metrics monitoring."""
+
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from core.performance import MetricType, get_performance_monitor
+
+
+@dataclass
+class FrameTiming:
+    duration_ms: float
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass
+class CallbackTiming:
+    name: str
+    duration_ms: float
+    timestamp: float = field(default_factory=time.time)
+
+
+class RealTimeUIMonitor:
+    """Record UI frame render times and callback durations."""
+
+    def __init__(self) -> None:
+        self.frame_times: List[FrameTiming] = []
+        self.callback_times: List[CallbackTiming] = []
+        self._frame_start: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    def start_frame(self) -> None:
+        """Mark the beginning of a frame."""
+        self._frame_start = time.perf_counter()
+
+    # ------------------------------------------------------------------
+    def end_frame(self) -> None:
+        """Record frame duration from the last :meth:`start_frame` call."""
+        if self._frame_start is None:
+            return
+        duration = (time.perf_counter() - self._frame_start) * 1000.0
+        self.record_frame_time(duration)
+        self._frame_start = None
+
+    # ------------------------------------------------------------------
+    def record_frame_time(self, duration_ms: float) -> None:
+        """Record a single frame render time in milliseconds."""
+        self.frame_times.append(FrameTiming(duration_ms))
+        get_performance_monitor().record_metric(
+            "ui.frame_time_ms", duration_ms, MetricType.USER_INTERACTION
+        )
+
+    # ------------------------------------------------------------------
+    def record_callback_duration(self, callback_name: str, duration_sec: float) -> None:
+        """Record the execution time of a Dash callback."""
+        duration_ms = duration_sec * 1000.0
+        self.callback_times.append(CallbackTiming(callback_name, duration_ms))
+        get_performance_monitor().record_metric(
+            f"ui.callback.{callback_name}", duration_sec, MetricType.EXECUTION_TIME
+        )
+
+
+_ui_monitor: Optional[RealTimeUIMonitor] = None
+
+
+def get_ui_monitor() -> RealTimeUIMonitor:
+    """Return the global :class:`RealTimeUIMonitor` instance."""
+    global _ui_monitor
+    if _ui_monitor is None:
+        _ui_monitor = RealTimeUIMonitor()
+    return _ui_monitor
+
+
+__all__ = ["RealTimeUIMonitor", "get_ui_monitor"]

--- a/tests/test_navigation_manager.py
+++ b/tests/test_navigation_manager.py
@@ -1,0 +1,20 @@
+from core.navigation.enterprise_navigation_manager import (
+    EnterpriseNavigationManager,
+    NavigationLoopError,
+)
+
+
+def test_navigation_loop_detection():
+    manager = EnterpriseNavigationManager(loop_threshold=3)
+    manager.record_navigation("A")
+    manager.record_navigation("A")
+
+    try:
+        manager.record_navigation("A")
+    except NavigationLoopError:
+        loop_detected = True
+    else:
+        loop_detected = False
+
+    assert loop_detected
+    assert manager.get_history()[-1] == "A"

--- a/tests/test_ui_monitor.py
+++ b/tests/test_ui_monitor.py
@@ -1,0 +1,26 @@
+import importlib.util
+import sys
+
+from core import performance
+from core.performance import PerformanceMonitor
+
+spec = importlib.util.spec_from_file_location(
+    "monitoring.ui_monitor", "monitoring/ui_monitor.py"
+)
+ui_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ui_module
+spec.loader.exec_module(ui_module)  # type: ignore
+RealTimeUIMonitor = ui_module.RealTimeUIMonitor
+
+
+def test_ui_monitor_records(monkeypatch):
+    monitor = PerformanceMonitor(max_metrics=10)
+    monkeypatch.setattr(performance, "_performance_monitor", monitor)
+
+    ui = RealTimeUIMonitor()
+    ui.record_frame_time(10.0)
+    ui.record_callback_duration("cb", 0.02)
+
+    names = [m.name for m in monitor.metrics]
+    assert "ui.frame_time_ms" in names
+    assert "ui.callback.cb" in names


### PR DESCRIPTION
## Summary
- implement `RealTimeUIMonitor` for UI frame and callback metrics
- integrate monitor exports via `monitoring.__init__`
- add `EnterpriseNavigationManager` for loop detection
- document UI monitoring usage
- test new modules

## Testing
- `pytest -q tests/test_ui_monitor.py tests/test_navigation_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6871e208eb6883208dc5b6fa96f05234