### PR TITLE
Fix missing dask dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,5 @@ hvac>=2.3.0
 cryptography>=45.0.0
 kafka-python>=2.0.2
 pulsar-client>=3.2.0
+dask[distributed]==2024.4.1
 


### PR DESCRIPTION
## Summary
- add missing `dask` dependency to `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6871e6c9ed148320a59d6e8df2457332