### PR TITLE
Fix import errors and unicode safety

### DIFF
--- a/analytics/access_trends.py
+++ b/analytics/access_trends.py
@@ -12,7 +12,14 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from scipy import stats
-from sklearn.linear_model import LinearRegression
+from utils.sklearn_compat import optional_import
+
+LinearRegression = optional_import("sklearn.linear_model.LinearRegression")
+
+if LinearRegression is None:  # pragma: no cover - fallback
+    class LinearRegression:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for LinearRegression")
 
 # Suppress pandas deprecation warnings regarding legacy frequency strings.
 warnings.filterwarnings(

--- a/analytics/anomaly_detection/analyzer.py
+++ b/analytics/anomaly_detection/analyzer.py
@@ -12,9 +12,28 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import IsolationForest
-from sklearn.exceptions import DataConversionWarning
-from sklearn.preprocessing import StandardScaler
+from utils.sklearn_compat import optional_import
+
+IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
+DataConversionWarning = optional_import("sklearn.exceptions.DataConversionWarning")
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if IsolationForest is None:  # pragma: no cover - fallback
+    class IsolationForest:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for IsolationForest")
+
+if DataConversionWarning is None:  # pragma: no cover
+    class DataConversionWarning(RuntimeWarning):
+        pass
+
+if StandardScaler is None:  # pragma: no cover
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X):
+            return X
+
+        def transform(self, X):
+            return X
 
 from security_callback_controller import (
     SecurityEvent,

--- a/analytics/anomaly_detection/ml_inference.py
+++ b/analytics/anomaly_detection/ml_inference.py
@@ -6,10 +6,35 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import IsolationForest
-from sklearn.cluster import DBSCAN
-from sklearn.neural_network import MLPRegressor
-from sklearn.preprocessing import StandardScaler
+from utils.sklearn_compat import optional_import
+
+IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
+DBSCAN = optional_import("sklearn.cluster.DBSCAN")
+MLPRegressor = optional_import("sklearn.neural_network.MLPRegressor")
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if IsolationForest is None:
+    class IsolationForest:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for IsolationForest")
+
+if DBSCAN is None:
+    class DBSCAN:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for DBSCAN")
+
+if MLPRegressor is None:
+    class MLPRegressor:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for MLPRegressor")
+
+if StandardScaler is None:
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X):
+            return X
+
+        def transform(self, X):
+            return X
 
 __all__ = ["detect_ml_anomalies"]
 

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -19,9 +19,28 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import IsolationForest
-from sklearn.exceptions import DataConversionWarning
-from sklearn.preprocessing import StandardScaler
+from utils.sklearn_compat import optional_import
+
+IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
+DataConversionWarning = optional_import("sklearn.exceptions.DataConversionWarning")
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if IsolationForest is None:  # pragma: no cover - fallback definitions
+    class IsolationForest:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for IsolationForest")
+
+if DataConversionWarning is None:  # pragma: no cover
+    class DataConversionWarning(RuntimeWarning):
+        pass
+
+if StandardScaler is None:  # pragma: no cover
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X):
+            return X
+
+        def transform(self, X):
+            return X
 
 from core.callback_manager import CallbackManager as SecurityCallbackController
 from security_callback_controller import (

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -11,10 +11,33 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.cluster import KMeans
-from sklearn.exceptions import DataConversionWarning
-from sklearn.metrics import silhouette_score
-from sklearn.preprocessing import StandardScaler
+from utils.sklearn_compat import optional_import
+
+KMeans = optional_import("sklearn.cluster.KMeans")
+DataConversionWarning = optional_import("sklearn.exceptions.DataConversionWarning")
+silhouette_score = optional_import("sklearn.metrics.silhouette_score")
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if KMeans is None:  # pragma: no cover - fallback definitions
+    class KMeans:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for KMeans")
+
+if DataConversionWarning is None:  # pragma: no cover
+    class DataConversionWarning(RuntimeWarning):
+        pass
+
+if silhouette_score is None:  # pragma: no cover
+    def silhouette_score(*args, **kwargs):  # type: ignore
+        raise ImportError("scikit-learn is required for silhouette_score")
+
+if StandardScaler is None:  # pragma: no cover
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X):
+            return X
+
+        def transform(self, X):
+            return X
 
 # Ignore the upcoming default change warning for KMeans ``n_init`` and
 # suppress type conversion warnings when non-float data is passed.

--- a/core/callback_controller.py
+++ b/core/callback_controller.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Protocol
 
+from .error_handling import ErrorCategory, ErrorSeverity, error_handler
+
 logger = logging.getLogger(__name__)
 
 
@@ -215,6 +217,16 @@ class CallbackController:
         logger.error(
             f"Callback error for {context.event_type.name}: {exc}",
             exc_info=True,
+        )
+        # Consolidated error handling
+        error_handler.handle_error(
+            exc,
+            category=ErrorCategory.USER_INPUT,
+            severity=ErrorSeverity.HIGH,
+            context={
+                "event": context.event_type.name,
+                "callback": getattr(callback, "__name__", str(callback)),
+            },
         )
         for handler in self._error_handlers:
             try:

--- a/core/unicode.py
+++ b/core/unicode.py
@@ -379,6 +379,18 @@ def safe_encode(value: Any) -> str:
     return safe_encode_text(value)
 
 
+def utf8_safe_encode(value: Any) -> bytes:
+    """Return UTF-8 encoded bytes handling surrogate pairs."""
+
+    return safe_encode_text(value).encode("utf-8", errors="surrogatepass")
+
+
+def utf8_safe_decode(data: bytes) -> str:
+    """Decode UTF-8 bytes while preserving surrogate pairs."""
+
+    return data.decode("utf-8", errors="surrogatepass")
+
+
 def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Deprecated alias for :func:`sanitize_dataframe`."""
 
@@ -607,4 +619,6 @@ __all__ = [
     "UnicodeSecurityProcessor",
     "object_count",
     "unicode_safe_callback",
+    "utf8_safe_encode",
+    "utf8_safe_decode",
 ]

--- a/models/anomaly_models.py
+++ b/models/anomaly_models.py
@@ -2,9 +2,29 @@ from __future__ import annotations
 
 import pandas as pd
 import numpy as np
-from sklearn.cluster import DBSCAN
-from sklearn.neural_network import MLPRegressor
-from sklearn.preprocessing import StandardScaler
+from utils.sklearn_compat import optional_import
+
+DBSCAN = optional_import("sklearn.cluster.DBSCAN")
+MLPRegressor = optional_import("sklearn.neural_network.MLPRegressor")
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if DBSCAN is None:  # pragma: no cover - fallback definitions
+    class DBSCAN:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for DBSCAN")
+
+if MLPRegressor is None:  # pragma: no cover - fallback definitions
+    class MLPRegressor:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for MLPRegressor")
+
+if StandardScaler is None:  # pragma: no cover - fallback definitions
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X):
+            return X
+
+        def transform(self, X):
+            return X
 
 __all__ = [
     "train_dbscan_model",

--- a/plugins/ai_classification/database/ai_models.py
+++ b/plugins/ai_classification/database/ai_models.py
@@ -6,13 +6,20 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import joblib
+from utils.sklearn_compat import optional_import
 
-try:
-    from sklearn.feature_extraction.text import TfidfVectorizer
-    from sklearn.linear_model import LogisticRegression
-except Exception:  # pragma: no cover - sklearn optional
-    LogisticRegression = None  # type: ignore
-    TfidfVectorizer = None  # type: ignore
+TfidfVectorizer = optional_import("sklearn.feature_extraction.text.TfidfVectorizer")
+LogisticRegression = optional_import("sklearn.linear_model.LogisticRegression")
+
+if LogisticRegression is None:  # pragma: no cover - fallback
+    class LogisticRegression:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for LogisticRegression")
+
+if TfidfVectorizer is None:  # pragma: no cover - fallback
+    class TfidfVectorizer:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("scikit-learn is required for TfidfVectorizer")
 
 
 class ColumnClassifier:

--- a/tools/robust_file_reader.py
+++ b/tools/robust_file_reader.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 from pathlib import Path
 from typing import Union
-try: import chardet
-except: chardet = None
+from core.unicode import safe_decode
+
+try:  # Optional dependency
+    import chardet
+except Exception:  # pragma: no cover - optional
+    chardet = None
 
 class RobustFileReader:
     ENCODING_PRIORITY = ["utf-8", "latin-1", "cp1252", "iso-8859-1"]
@@ -15,13 +19,17 @@ class RobustFileReader:
         if chardet:
             detected = chardet.detect(raw_bytes)
             if detected.get("encoding"):
-                try: return raw_bytes.decode(detected["encoding"])
-                except: pass
+                try:
+                    return safe_decode(raw_bytes, detected["encoding"])
+                except Exception:
+                    pass
         
         for encoding in RobustFileReader.ENCODING_PRIORITY:
-            try: return raw_bytes.decode(encoding)
-            except: continue
-        return raw_bytes.decode('utf-8', errors='replace')
+            try:
+                return safe_decode(raw_bytes, encoding)
+            except Exception:
+                continue
+        return safe_decode(raw_bytes, "utf-8")
 
 def safe_read_text(file_path: Union[str, Path]) -> str:
     return RobustFileReader.read_text_with_detection(file_path)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -16,6 +16,8 @@ from core.unicode import (
     sanitize_dataframe,
     sanitize_unicode_input,
     secure_unicode_sanitization,
+    utf8_safe_encode,
+    utf8_safe_decode,
 )
 
 from .assets_debug import (
@@ -46,6 +48,8 @@ __all__ = [
     "sanitize_dataframe",
     "contains_surrogates",
     "secure_unicode_sanitization",
+    "utf8_safe_encode",
+    "utf8_safe_decode",
     "process_large_csv_content",
     "safe_format_number",
     "object_count",

--- a/utils/scipy_compat.py
+++ b/utils/scipy_compat.py
@@ -1,0 +1,36 @@
+"""Compatibility helpers for SciPy internals."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def get_wrap_callback() -> Callable[..., Any]:
+    """Return SciPy's private ``_wrap_callback`` implementation.
+
+    Handles different module locations across SciPy versions.
+    """
+    try:
+        from scipy.optimize._optimize import _wrap_callback
+        return _wrap_callback
+    except Exception:
+        try:
+            from scipy.optimize.optimize import _wrap_callback  # type: ignore
+            return _wrap_callback
+        except Exception as exc:  # pragma: no cover - fallback
+            logger.warning("_wrap_callback unavailable: %s", exc)
+
+            def _wrap_callback(f: Callable[..., Any], c: Any) -> Callable[..., Any]:
+                def wrapper(xk: Any, *a: Any, **kw: Any) -> Any:
+                    return f(xk, *a, **kw)
+
+                return wrapper
+
+            return _wrap_callback
+
+
+__all__ = ["get_wrap_callback"]
+

--- a/utils/sklearn_compat.py
+++ b/utils/sklearn_compat.py
@@ -1,0 +1,22 @@
+"""Optional scikit-learn imports with graceful fallbacks."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Type
+
+logger = logging.getLogger(__name__)
+
+
+def optional_import(name: str, fallback: Type | None = None) -> Any:
+    """Attempt to import ``name`` returning ``fallback`` if unavailable."""
+    try:
+        module = __import__(name, fromlist=["*"])  # type: ignore
+        return module
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.warning("Optional dependency '%s' unavailable: %s", name, exc)
+        return fallback
+
+
+__all__ = ["optional_import"]
+

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -4,6 +4,8 @@ Text utilities for safe text handling
 
 from typing import Any, Union
 
+from core.unicode import clean_surrogate_chars
+
 
 def safe_text(text: Union[str, Any]) -> str:
     """
@@ -20,10 +22,10 @@ def safe_text(text: Union[str, Any]) -> str:
 
     # Handle different types safely
     if hasattr(text, "__str__"):
-        return str(text)
+        return clean_surrogate_chars(str(text))
 
     # Fallback for any other type
-    return repr(text)
+    return clean_surrogate_chars(repr(text))
 
 
 def sanitize_text_for_dash(text: Union[str, Any]) -> str:
@@ -37,6 +39,7 @@ def sanitize_text_for_dash(text: Union[str, Any]) -> str:
         str: Dash-safe text
     """
     safe_str = safe_text(text)
+    safe_str = clean_surrogate_chars(safe_str)
 
     # Remove any problematic characters that might cause JSON issues
     safe_str = safe_str.replace("\x00", "")  # Remove null bytes
@@ -86,3 +89,4 @@ def truncate_text(text: str, max_length: int = 100, suffix: str = "...") -> str:
 
 
 __all__ = ["safe_text", "sanitize_text_for_dash", "format_file_size", "truncate_text"]
+


### PR DESCRIPTION
## Summary
- add helper for safe sklearn imports
- add SciPy wrap callback compatibility layer
- handle surrogate pairs in text utilities and robust reader
- use optional sklearn imports in analytics models
- unify callback error handling through global error handler
- expose UTF-8 safe encode/decode helpers

## Testing
- `pytest -k unicode -q` *(fails: ModuleNotFoundError: No module named 'hvac')*

------
https://chatgpt.com/codex/tasks/task_e_6871f057b434832086ccd7ee1100f8f1