### PR TITLE
Improve page loading error handling

### DIFF
--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -3,6 +3,16 @@
 Page registration system - simplified to prevent routing conflicts
 """
 
+# Expected page modules bundled with the application. Each listed module must
+# provide at least a ``layout`` function and may optionally expose a
+# ``register_page`` hook for Dash integration.
+#
+# - ``deep_analytics``
+# - ``file_upload``
+# - ``graphs``
+# - ``export``
+# - ``settings``
+
 import importlib
 import logging
 from types import ModuleType
@@ -39,8 +49,8 @@ def _load_page(name: str) -> Optional[ModuleType]:
         _loaded[name] = module
         logger.debug(f"✅ Loaded page module: {name}")
         return module
-    except Exception as e:
-        logger.warning(f"❌ Failed to import page {name}: {e}")
+    except Exception:
+        logger.exception(f"❌ Failed to import page {name}")
         _loaded[name] = None
         return None
 

--- a/tests/pages/test_page_loading.py
+++ b/tests/pages/test_page_loading.py
@@ -1,0 +1,15 @@
+import logging
+
+import pages
+
+
+def test_missing_page_logs_error(monkeypatch, caplog):
+    monkeypatch.setitem(pages.PAGE_MODULES, "missing", "pages.missing_page")
+    pages.clear_page_cache()
+    with caplog.at_level("ERROR"):
+        module = pages._load_page("missing")
+    assert module is None
+    assert any(
+        "Failed to import page missing" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- document which pages are expected
- log traceback when page import fails
- test logging for missing pages

## Testing
- `pytest tests/pages/test_page_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f62164888320b9ec00deb0730a40