### PR TITLE
Fix file_info.json UTF-8 reading

### DIFF
--- a/investigate_data.py
+++ b/investigate_data.py
@@ -33,7 +33,7 @@ def investigate_data():
     info_file = upload_dir / "file_info.json"
     if info_file.exists():
         print(f"\n📋 file_info.json contents:")
-        with open(info_file, "r") as f:
+        with open(info_file, "r", encoding="utf-8") as f:
             info = json.load(f)
         for filename, details in info.items():
             print(f"  {filename}:")

--- a/tests/test_investigate_data.py
+++ b/tests/test_investigate_data.py
@@ -1,0 +1,29 @@
+import json
+import os
+from pathlib import Path
+import builtins
+
+import pytest
+
+import investigate_data
+
+
+def test_file_info_reading_uses_utf8(monkeypatch, tmp_path):
+    os.environ["UPLOAD_FOLDER"] = str(tmp_path)
+    info = {"föö.csv": {"rows": 1, "columns": 2, "size_mb": 0.1}}
+    info_file = tmp_path / "file_info.json"
+    info_file.write_text(json.dumps(info, ensure_ascii=False), encoding="utf-8")
+
+    called_encodings = []
+    original_open = builtins.open
+
+    def fake_open(file, mode="r", *args, **kwargs):
+        if Path(file).name == "file_info.json":
+            called_encodings.append(kwargs.get("encoding"))
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    # Should not raise and should call open with utf-8 encoding
+    investigate_data.investigate_data()
+    assert "utf-8" in called_encodings


### PR DESCRIPTION
## Summary
- ensure file_info.json is opened with UTF-8 encoding
- add regression test for UTF-8 handling in investigate_data

## Testing
- `pytest tests/test_investigate_data.py::test_file_info_reading_uses_utf8 -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f62047f48320ba52320a6cc9d008