### PR TITLE
Rename analytics protocol method

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -28,7 +28,7 @@ class AnalyticsProviderProtocol(Protocol):
     """Perform analytics operations and retrieve metrics."""
 
     @abstractmethod
-    def process_data(self, data: Any) -> Any:
+    def process_dataframe(self, data: Any) -> Any:
         """Process raw analytics data and return a result."""
         ...
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -41,7 +41,7 @@ class ConfigProviderProtocol(Protocol):
 class AnalyticsProviderProtocol(Protocol):
     """Basic analytics provider interface."""
 
-    def process_data(self, df: pd.DataFrame) -> Dict[str, Any]:
+    def process_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Process ``df`` and return analytics metrics."""
         ...
 
@@ -557,6 +557,10 @@ class AnalyticsService(AnalyticsServiceProtocol):
     # ------------------------------------------------------------------
     # AnalyticsProviderProtocol implementation
     # ------------------------------------------------------------------
+    def process_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Alias for :meth:`process_data` required by ``AnalyticsProviderProtocol``."""
+        return self.process_data(df)
+
     def process_data(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Process ``df`` and return a metrics dictionary."""
         cleaned = self.clean_uploaded_dataframe(df)


### PR DESCRIPTION
## Summary
- rename `process_data` method to `process_dataframe` in `AnalyticsProviderProtocol`
- provide alias method in `AnalyticsService` to keep `process_data` intact

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_6871f6241ea883208ce38ce8647b2e33