### PR TITLE
Handle async loops when reading uploads

### DIFF
--- a/services/data_processing/async_file_processor.py
+++ b/services/data_processing/async_file_processor.py
@@ -124,11 +124,15 @@ class AsyncFileProcessor(FileProcessorProtocol):
                 pass
         return df
 
-    def read_uploaded_file(
+    async def read_uploaded_file(
         self, contents: str, filename: str
     ) -> Tuple[pd.DataFrame, str]:
-        """Synchronously read uploaded file using async helper."""
-        df = asyncio.run(self.process_file(contents, filename))
+        """Read uploaded file handling both async and sync contexts."""
+        try:
+            asyncio.get_running_loop()
+            df = await asyncio.create_task(self.process_file(contents, filename))
+        except RuntimeError:  # pragma: no cover - run outside event loop
+            df = asyncio.run(self.process_file(contents, filename))
         return df, ""
 
     @staticmethod

--- a/tests/test_async_file_processor.py
+++ b/tests/test_async_file_processor.py
@@ -1,10 +1,56 @@
 import asyncio
 import time
+import pytest
 
 import pandas as pd
+import importlib.util
+import importlib
+import types
+import sys
+from pathlib import Path
 
-from services.data_processing.async_file_processor import AsyncFileProcessor
-from services.task_queue import clear_task, create_task, get_status
+services_root = Path(__file__).resolve().parents[1] / "services"
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(services_root)]
+sys.modules.setdefault("services", services_pkg)
+
+upload_pkg = types.ModuleType("services.upload")
+upload_pkg.__path__ = [str(services_root / "upload")]
+sys.modules.setdefault("services.upload", upload_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "services.upload.protocols", services_root / "upload" / "protocols.py"
+)
+protocols_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(protocols_mod)
+sys.modules.setdefault("services.upload.protocols", protocols_mod)
+
+data_processing_pkg = types.ModuleType("services.data_processing")
+data_processing_pkg.__path__ = [str(services_root / "data_processing")]
+sys.modules.setdefault("services.data_processing", data_processing_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "services.task_queue", services_root / "task_queue.py"
+)
+task_queue_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(task_queue_module)
+sys.modules.setdefault("services.task_queue", task_queue_module)
+clear_task = task_queue_module.clear_task
+create_task = task_queue_module.create_task
+get_status = task_queue_module.get_status
+
+spec = importlib.util.spec_from_file_location(
+    "services.data_processing.async_file_processor",
+    services_root / "data_processing" / "async_file_processor.py",
+)
+async_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(async_module)
+AsyncFileProcessor = async_module.AsyncFileProcessor
+
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 
 def test_async_file_processor_progress(tmp_path):
@@ -33,4 +79,27 @@ def test_async_file_processor_progress(tmp_path):
     assert len(result) == len(df)
     assert last == 100
     clear_task(tid)
+
+
+def test_read_uploaded_file_outside_loop(tmp_path):
+    df = DataFrameBuilder().add_column("a", range(2)).build()
+    content = UploadFileBuilder().with_dataframe(df).as_base64()
+
+    processor = AsyncFileProcessor()
+    loaded, err = asyncio.run(processor.read_uploaded_file(content, "sample.csv"))
+
+    assert err == ""
+    assert len(loaded) == len(df)
+
+
+@pytest.mark.asyncio
+async def test_read_uploaded_file_inside_loop(tmp_path):
+    df = DataFrameBuilder().add_column("a", range(2)).build()
+    content = UploadFileBuilder().with_dataframe(df).as_base64()
+
+    processor = AsyncFileProcessor()
+    loaded, err = await processor.read_uploaded_file(content, "sample.csv")
+
+    assert err == ""
+    assert len(loaded) == len(df)
 


### PR DESCRIPTION
## Summary
- make `AsyncFileProcessor.read_uploaded_file` awaitable
- dynamically import `AsyncFileProcessor` in tests to avoid heavy deps
- add tests for reading files inside/outside event loops

## Testing
- `pytest tests/test_async_file_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f61dff7c8320953f3d54d5c53e8a