### PR TITLE
Implement device verification modal toggle

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -282,6 +282,29 @@ def mark_device_as_edited(floor, access, special, security):
     return True  # Simplified - any change marks as edited
 
 
+def toggle_device_verification_modal(confirm_clicks, cancel_clicks, is_open):
+    """Toggle the device verification modal open/close state."""
+    if confirm_clicks or cancel_clicks:
+        return not is_open
+    return is_open
+
+
+def register_modal_callback(manager: "TrulyUnifiedCallbacks") -> None:
+    """Register callbacks controlling the verification modal."""
+
+    manager.register_callback(
+        Output("device-verification-modal", "is_open"),
+        [
+            Input("device-verify-confirm", "n_clicks"),
+            Input("device-verify-cancel", "n_clicks"),
+        ],
+
+        [State("device-verification-modal", "is_open")],
+        prevent_initial_call=True,
+        callback_id="toggle_device_verification_modal",
+        component_name="device_verification",
+    )(toggle_device_verification_modal)
+
 def register_callbacks(
     manager: "TrulyUnifiedCallbacks",
     controller: UnifiedAnalyticsController | None = None,
@@ -308,4 +331,4 @@ def register_callbacks(
         )
 
 
-__all__ = ["create_device_verification_modal", "register_callbacks"]
+__all__ = ["create_device_verification_modal", "register_callbacks", "register_modal_callback"]

--- a/components/file_upload_component.py
+++ b/components/file_upload_component.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 
+from components.device_verification import register_modal_callback
 from components.upload import UploadArea
 from upload_callbacks import UploadCallbackManager
 
@@ -97,6 +98,7 @@ class FileUploadComponent:
 
     def register_callbacks(self, manager, controller=None) -> None:
         """Register upload callbacks with the given manager."""
+        register_modal_callback(manager)
         self.callback_manager.register(manager, controller)
 
 

--- a/tests/components/test_verification_modals.py
+++ b/tests/components/test_verification_modals.py
@@ -5,7 +5,10 @@ from dash import dcc, html
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
 from components.column_verification import create_column_verification_modal
-from components.device_verification import create_device_verification_modal
+from components.device_verification import (
+    create_device_verification_modal,
+    toggle_device_verification_modal,
+)
 
 
 def _collect(component, cls):
@@ -61,3 +64,10 @@ def test_create_device_verification_modal_basic():
 def test_create_device_verification_modal_empty():
     modal = create_device_verification_modal({}, "sess")
     assert isinstance(modal, html.Div)
+
+
+def test_toggle_device_verification_modal():
+    # Opens when triggered from a closed state
+    assert toggle_device_verification_modal(1, None, False) is True
+    # Closes when either button is pressed while open
+    assert toggle_device_verification_modal(None, 1, True) is False


### PR DESCRIPTION
## Summary
- control the device verification modal via new callback
- register toggle callback in `FileUploadComponent`
- test modal toggle behaviour

## Testing
- `pytest tests/components/test_verification_modals.py -q` *(fails: ModuleNotFoundError: No module named 'dash.testing')*

------
https://chatgpt.com/codex/tasks/task_e_6871f61c5f08832095ffe80a38bcea3f