### PR TITLE
Update SciPy integrations and fallback support

### DIFF
--- a/analytics/access_trends.py
+++ b/analytics/access_trends.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy import stats
+from utils.scipy_compat import get_stats_module
+stats = get_stats_module()
 from utils.sklearn_compat import optional_import
 
 LinearRegression = optional_import("sklearn.linear_model.LinearRegression")

--- a/analytics/anomaly_detection/statistical_detection.py
+++ b/analytics/anomaly_detection/statistical_detection.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from scipy import stats
+from utils.scipy_compat import get_stats_module
+stats = get_stats_module()
 
 __all__ = [
     "detect_frequency_anomalies",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.24.0
 authlib==1.2.1
 python-jose==3.3.0
 cssutils==2.8.0
-scipy>=1.11.0
+scipy==1.11.4
 scikit-learn==1.3.0
 joblib==1.3.2
 psutil>=5.9.0


### PR DESCRIPTION
## Summary
- use `get_stats_module` for anomaly detection and trend analysis
- provide fallback stats implementation in `scipy_compat`
- pin scipy to version 1.11.4 in requirements

## Testing
- `pytest analytics/anomaly_detection/tests/test_statistical_detection.py::test_detect_statistical_anomalies -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_6871fc5e98ec83208ab20423da4a0ea9