### PR TITLE
Fix scipy_compat merge conflict

### DIFF
--- a/utils/scipy_compat.py
+++ b/utils/scipy_compat.py
@@ -9,12 +9,13 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from utils.scipy_compat import stats
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "detect_frequency_anomalies",
     "detect_statistical_anomalies", 
     "calculate_severity_from_zscore",
+    "get_stats_module",
     "sanitize_unicode_data",
 ]
 
@@ -40,7 +41,6 @@ def sanitize_unicode_data(data: Any) -> Any:
     return data
 
 
-<<<<<<< HEAD
 class StatisticalAnomalyDetector:
     """Modular statistical anomaly detector with Unicode safety."""
     
@@ -203,8 +203,6 @@ class StatisticalAnomalyDetector:
             self.logger.warning(f"Statistical anomaly detection failed: {exc}")
         
         return anomalies
-=======
-import numpy as np
 
 
 class FallbackStats:
@@ -230,10 +228,7 @@ def get_stats_module():
         logger.warning("scipy.stats unavailable: %s", exc)
         return FallbackStats()
 
-
-__all__ = ["get_wrap_callback", "get_stats_module"]
->>>>>>> 2c57eafc043f5a7f39764fc0c57c57c9210a234f
-
+stats = get_stats_module()
 
 def calculate_severity_from_zscore(z_score: float) -> str:
     """Calculate severity level from Z-score with input validation."""


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in `scipy_compat.py`
- remove self-import and add logger
- expose `get_stats_module` and initialize `stats`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68720fa583048320b59742968c204f31