### PR TITLE
Temporary fallback for scipy import

### DIFF
--- a/analytics/anomaly_detection/statistical_detection.py
+++ b/analytics/anomaly_detection/statistical_detection.py
@@ -6,8 +6,23 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from utils.scipy_compat import get_stats_module
-stats = get_stats_module()
+# from utils.scipy_compat import get_stats_module
+# stats = get_stats_module()
+
+try:
+    from scipy import stats  # pragma: no cover - use SciPy if available
+except ImportError:  # pragma: no cover - fallback implementation
+    import numpy as np
+
+    class FallbackStats:
+        @staticmethod
+        def zscore(a, axis=0, ddof=0, nan_policy="propagate"):
+            a = np.asarray(a)
+            mean = np.mean(a, axis=axis, keepdims=True)
+            std = np.std(a, axis=axis, ddof=ddof, keepdims=True)
+            return np.where(std == 0, 0, (a - mean) / std)
+
+    stats = FallbackStats()
 
 __all__ = [
     "detect_frequency_anomalies",


### PR DESCRIPTION
## Summary
- avoid failing import if scipy missing in `statistical_detection`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68720fdecc7c8320ba999b6eb4a61215