### PR TITLE
Fix dependencies endpoint

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -1005,6 +1005,8 @@ def _add_nuclear_dependencies_route(app: "Dash") -> None:
     def nuclear_dependencies() -> Any:
         return jsonify([])
 
+    logger.info("\u2705 Nuclear dependencies route installed")
+
 
 # Export the main function
 __all__ = ["create_app"]


### PR DESCRIPTION
## Summary
- log when the fallback /_dash-dependencies route is registered
- keep using the route in each app creation path

## Testing
- `pytest -k nuclear -q` *(fails: ModuleNotFoundError: No module named 'authlib')*

------
https://chatgpt.com/codex/tasks/task_e_687306db4000832083bfc8ac79cae615