### PR TITLE
Add placeholder deep analytics page

### DIFF
--- a/pages/deep_analytics/analysis.py
+++ b/pages/deep_analytics/analysis.py
@@ -1,419 +1,64 @@
-#!/usr/bin/env python3
-"""
-REPLACE pages/deep_analytics.py entirely
-Restored analytics functionality without navigation flash
-"""
-from __future__ import annotations
-
-import logging
-from typing import Any, Dict, List, Optional
-
-import dash_bootstrap_components as dbc
-from dash import Input, Output, State, callback, dcc, html, no_update
-from dash import register_page as dash_register_page
-from dash.exceptions import PreventUpdate
-
-logger = logging.getLogger(__name__)
-
-
-def register_page() -> None:
-    """Register the analytics page with Dash."""
-    dash_register_page(
-        __name__, 
-        path="/analytics", 
-        name="Analytics", 
-        aliases=["/", "/dashboard"]
-    )
-
-
-def layout() -> dbc.Container:
-    """Complete analytics layout with working functionality."""
-    
-    return dbc.Container([
-        # Status alert for feedback
-        dbc.Alert(
-            id="analytics-status-alert", 
-            is_open=False, 
-            className="mb-3"
-        ),
-        
-        # Main analytics card
-        dbc.Card([
-            dbc.CardHeader([
-                html.H4("📊 Analytics Dashboard", className="mb-0")
-            ]),
-            dbc.CardBody([
-                # Data source selection
-                dbc.Row([
-                    dbc.Col([
-                        html.Label("Data Source:", className="fw-bold"),
-                        dcc.Dropdown(
-                            id="analytics-data-source",
-                            options=[
-                                {"label": "📁 Uploaded Files", "value": "uploaded"},
-                                {"label": "🔗 Sample Data", "value": "sample"},
-                                {"label": "📊 Demo Dataset", "value": "demo"}
-                            ],
-                            value="uploaded",
-                            placeholder="Select data source...",
-                            className="mb-3"
-                        )
-                    ], md=6),
-                    
-                    dbc.Col([
-                        html.Label("Analysis Type:", className="fw-bold"),
-                        dcc.Dropdown(
-                            id="analytics-type",
-                            options=[
-                                {"label": "📈 Data Quality", "value": "quality"},
-                                {"label": "🔍 Summary Stats", "value": "summary"},
-                                {"label": "📊 Visualizations", "value": "charts"},
-                                {"label": "🎯 Pattern Analysis", "value": "patterns"}
-                            ],
-                            value="quality",
-                            className="mb-3"
-                        )
-                    ], md=6)
-                ]),
-                
-                # Action buttons
-                dbc.Row([
-                    dbc.Col([
-                        dbc.ButtonGroup([
-                            dbc.Button(
-                                "🚀 Run Analysis", 
-                                id="run-analysis-btn",
-                                color="primary",
-                                size="lg"
-                            ),
-                            dbc.Button(
-                                "🔄 Refresh Data", 
-                                id="refresh-data-btn",
-                                color="secondary",
-                                outline=True
-                            ),
-                            dbc.Button(
-                                "📥 Export Results", 
-                                id="export-results-btn",
-                                color="success",
-                                outline=True,
-                                disabled=True
-                            )
-                        ], className="w-100")
-                    ])
-                ], className="mb-4"),
-                
-                html.Hr(),
-                
-                # Results area
-                dcc.Loading(
-                    id="analytics-loading",
-                    type="circle",
-                    children=[
-                        html.Div(
-                            id="analytics-results",
-                            children=[
-                                dbc.Alert([
-                                    html.H6("👋 Welcome to Analytics"),
-                                    html.P("Select a data source and analysis type, then click 'Run Analysis' to begin.")
-                                ], color="info")
-                            ]
-                        )
-                    ]
-                )
-            ])
-        ], className="mb-4"),
-        
-        # Hidden stores
-        dcc.Store(id="analytics-data-store", data={}),
-        dcc.Store(id="analytics-results-store", data={})
-        
-    ], fluid=True)
-
-
-def register_callbacks(manager: Any) -> None:
-    """Register analytics callbacks using the unified system."""
-    
-    if manager is None:
-        logger.warning("No callback manager provided")
-        return
-    
-    try:
-        @manager.unified_callback(
-            [
-                Output("analytics-results", "children"),
-                Output("analytics-status-alert", "children"),
-                Output("analytics-status-alert", "is_open"),
-                Output("analytics-status-alert", "color"),
-                Output("export-results-btn", "disabled")
-            ],
-            Input("run-analysis-btn", "n_clicks"),
-            [
-                State("analytics-data-source", "value"),
-                State("analytics-type", "value")
-            ],
-            callback_id="run_analytics_analysis",
-            component_name="deep_analytics",
-            prevent_initial_call=True
-        )
-        def run_analysis(n_clicks, data_source, analysis_type):
-            """Run the selected analysis type."""
-            
-            if not n_clicks or not data_source or not analysis_type:
-                raise PreventUpdate
-            
-            try:
-                # Generate analysis based on type
-                if analysis_type == "quality":
-                    results = _create_quality_analysis(data_source)
-                elif analysis_type == "summary":
-                    results = _create_summary_analysis(data_source)
-                elif analysis_type == "charts":
-                    results = _create_chart_analysis(data_source)
-                elif analysis_type == "patterns":
-                    results = _create_pattern_analysis(data_source)
-                else:
-                    results = _create_default_analysis()
-                
-                status_msg = f"✅ {analysis_type.title()} analysis completed successfully!"
-                return results, status_msg, True, "success", False
-                
-            except Exception as e:
-                error_msg = f"❌ Analysis failed: {str(e)}"
-                error_results = dbc.Alert(
-                    f"Analysis error: {str(e)}", 
-                    color="danger"
-                )
-                return error_results, error_msg, True, "danger", True
-        
-        @manager.unified_callback(
-            [
-                Output("analytics-data-source", "options"),
-                Output("analytics-status-alert", "children", allow_duplicate=True),
-                Output("analytics-status-alert", "is_open", allow_duplicate=True),
-                Output("analytics-status-alert", "color", allow_duplicate=True)
-            ],
-            Input("refresh-data-btn", "n_clicks"),
-            callback_id="refresh_analytics_data",
-            component_name="deep_analytics",
-            prevent_initial_call=True
-        )
-        def refresh_data(n_clicks):
-            """Refresh available data sources."""
-            
-            if not n_clicks:
-                raise PreventUpdate
-            
-            # Get updated data source options
-            updated_options = _get_data_source_options()
-            status_msg = "🔄 Data sources refreshed!"
-            
-            return updated_options, status_msg, True, "info"
-        
-        logger.info("✅ Deep analytics callbacks registered successfully")
-        
-    except Exception as e:
-        logger.error(f"❌ Failed to register deep analytics callbacks: {e}")
-
-
-def _get_data_source_options() -> List[Dict[str, str]]:
-    """Get available data source options."""
-    options = [
-        {"label": "📊 Demo Dataset", "value": "demo"},
-        {"label": "🔗 Sample Data", "value": "sample"}
-    ]
-    
-    # Try to add uploaded files
-    try:
-        from pages.file_upload import get_uploaded_data
-        uploaded_data = get_uploaded_data()
-        
-        if uploaded_data:
-            for filename in uploaded_data.keys():
-                options.insert(0, {
-                    "label": f"📁 {filename}", 
-                    "value": f"upload:{filename}"
-                })
-    except Exception:
-        logger.debug("Could not load uploaded files")
-    
-    return options
-
-
-def _create_quality_analysis(data_source: str) -> dbc.Card:
-    """Create data quality analysis display."""
-    return dbc.Card([
-        dbc.CardHeader("📈 Data Quality Analysis"),
-        dbc.CardBody([
-            dbc.Row([
-                dbc.Col([
-                    html.H6("Data Completeness"),
-                    dbc.Progress(value=85, color="success", className="mb-2"),
-                    html.Small("85% complete")
-                ], md=4),
-                dbc.Col([
-                    html.H6("Data Consistency"),
-                    dbc.Progress(value=92, color="info", className="mb-2"),
-                    html.Small("92% consistent")
-                ], md=4),
-                dbc.Col([
-                    html.H6("Data Accuracy"),
-                    dbc.Progress(value=78, color="warning", className="mb-2"),
-                    html.Small("78% accurate")
-                ], md=4)
-            ])
-        ])
-    ])
-
-
-def _create_summary_analysis(data_source: str) -> dbc.Card:
-    """Create summary statistics analysis."""
-    return dbc.Card([
-        dbc.CardHeader("🔍 Summary Statistics"),
-        dbc.CardBody([
-            dbc.Table([
-                html.Thead([
-                    html.Tr([
-                        html.Th("Metric"),
-                        html.Th("Value"),
-                        html.Th("Status")
-                    ])
-                ]),
-                html.Tbody([
-                    html.Tr([html.Td("Total Records"), html.Td("15,432"), html.Td("✅")]),
-                    html.Tr([html.Td("Columns"), html.Td("12"), html.Td("✅")]),
-                    html.Tr([html.Td("Missing Values"), html.Td("234"), html.Td("⚠️")]),
-                    html.Tr([html.Td("Duplicates"), html.Td("0"), html.Td("✅")])
-                ])
-            ], striped=True, bordered=True, hover=True)
-        ])
-    ])
-
-
-def _create_chart_analysis(data_source: str) -> dbc.Card:
-    """Create visualization analysis placeholder."""
-    return dbc.Card([
-        dbc.CardHeader("📊 Data Visualizations"),
-        dbc.CardBody([
-            dbc.Alert([
-                html.H6("📈 Charts Coming Soon"),
-                html.P("Interactive charts and graphs will be added in the next update."),
-                html.P("Features planned:"),
-                html.Ul([
-                    html.Li("Distribution plots"),
-                    html.Li("Correlation matrices"),
-                    html.Li("Time series analysis"),
-                    html.Li("Scatter plots")
-                ])
-            ], color="info")
-        ])
-    ])
-
-
-def _create_pattern_analysis(data_source: str) -> dbc.Card:
-    """Create pattern analysis display."""
-    return dbc.Card([
-        dbc.CardHeader("🎯 Pattern Analysis"),
-        dbc.CardBody([
-            dbc.Alert([
-                html.H6("🔍 Pattern Detection"),
-                html.P("Advanced pattern analysis capabilities coming soon."),
-                html.P("Will include:"),
-                html.Ul([
-                    html.Li("Anomaly detection"),
-                    html.Li("Trend analysis"), 
-                    html.Li("Clustering"),
-                    html.Li("Behavioral patterns")
-                ])
-            ], color="primary")
-        ])
-    ])
-
-
-def _create_default_analysis() -> dbc.Alert:
-    """Create default analysis message."""
-    return dbc.Alert(
-        "Please select an analysis type and click 'Run Analysis'",
-        color="info"
-    )
-
-
-# Backward compatibility
-def deep_analytics_layout():
-    """Compatibility function for app_factory."""
-    return layout()
-
+from dash import html, dcc
+from dash.dependencies import Input, Output
 
 __all__ = [
-    "layout", 
-    "register_page", 
-    "register_callbacks", 
-    "deep_analytics_layout"
+    "deep_analytics_layout",
+    "register_page",
+    "register_callbacks",
+    "create_analysis_results_display",
+    "create_data_quality_display",
+    "create_suggests_display",
+    "create_limited_analysis_display",
+    "get_analysis_buttons_section",
 ]
-# Stub flag for whether the analytics service is available
-ANALYTICS_SERVICE_AVAILABLE = False
 
-# Stub for missing display factory
-def create_analysis_results_display(*args, **kwargs):
-    """Placeholder for missing create_analysis_results_display"""
-    return None
 
-# Stub for missing safe display factory
-def create_analysis_results_display_safe(*args, **kwargs):
-    """Placeholder for missing create_analysis_results_display_safe"""
-    return None
-
-# Stub for missing data-quality display factory
-def create_data_quality_display(*args, **kwargs):
-    """Placeholder for missing create_data_quality_display"""
-    return None
-
-# Stub for missing corrected data-quality display factory
-def create_data_quality_display_corrected(*args, **kwargs):
-    """Placeholder for missing create_data_quality_display_corrected"""
-    return None
-
-# Stub for missing limited analysis display factory
-def create_limited_analysis_display(*args, **kwargs):
-    """Placeholder for missing create_limited_analysis_display"""
-    return None
-
-# ─────── Auto-generated stubs for all __all__ symbols ───────
 def deep_analytics_layout(*args, **kwargs):
-    """Stub for deep_analytics_layout"""
-    return None
+    return html.Div([
+        html.H1("Deep Analytics"),
+        html.P("This is a placeholder for the Deep Analytics page."),
+    ], id="deep-analytics-page")
 
-def register_callbacks(*args, **kwargs):
-    """Stub for register_callbacks"""
-    return None
 
-def create_analysis_results_display_safe(*args, **kwargs):
-    """Stub for create_analysis_results_display_safe"""
-    return None
+def register_page(app):
+    app.register_page(
+        __name__,
+        path="/deep-analytics",
+        layout=deep_analytics_layout,
+    )
+
+
+def register_callbacks(app):
+    # no dynamic callbacks yet
+    pass
+
+
+def create_analysis_results_display(*args, **kwargs):
+    return html.Div("Analysis Results Placeholder")
+
 
 def create_data_quality_display(*args, **kwargs):
-    """Stub for create_data_quality_display"""
-    return None
+    return html.Div("Data Quality Placeholder")
 
-def create_limited_analysis_display(*args, **kwargs):
-    """Stub for create_limited_analysis_display"""
-    return None
 
 def create_suggests_display(*args, **kwargs):
-    """Stub for create_suggests_display"""
-    return None
-# ────────────────────────────────────────────────────────────────
+    return html.Div("Suggestions Placeholder")
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Dynamic stub handler: any missing create_/get_ attribute returns a no-op
-def __getattr__(name: str):
-    """
-    Provide stub functions dynamically for any missing
-    create_* or get_* attributes to satisfy imports.
-    """
-    if name.startswith(("create_", "get_")):
-        def _stub(*args, **kwargs):
-            return None
-        return _stub
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-# ─────────────────────────────────────────────────────────────────────────────
+
+def create_limited_analysis_display(*args, **kwargs):
+    return html.Div("Limited Analysis Placeholder")
+
+
+def get_analysis_buttons_section(*args, **kwargs):
+    return html.Div("Analysis Buttons Placeholder")
+
+
+# Integrate with the main app when imported
+try:
+    from app import app  # type: ignore
+except Exception:
+    app = None
+
+if app is not None:
+    register_page(app)
+    register_callbacks(app)


### PR DESCRIPTION
## Summary
- rewrite `pages/deep_analytics/analysis.py` with a simple placeholder layout
- include dummy factories so the page renders basic content
- register page and callbacks if the main app is present

## Testing
- `python3 -m py_compile pages/deep_analytics/analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6873252e21088320ac33fc5e8280665c