### PR TITLE
Fix Dash page registration

### DIFF
--- a/minimal_dash_pages_test.py
+++ b/minimal_dash_pages_test.py
@@ -10,8 +10,13 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Create minimal app
-app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+# Create minimal app with Dash Pages enabled but without scanning the main pages
+app = dash.Dash(
+    __name__,
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
+    use_pages=True,
+    pages_folder="__test_pages__",
+)
 
 # Register minimal test pages
 dash.register_page("home", path="/", name="Home", layout=lambda: html.H1("🏠 HOME PAGE WORKS!"))

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -131,5 +131,3 @@ def __getattr__(name: str):
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-# Register this page when module is imported
-register_page()

--- a/pages/export.py
+++ b/pages/export.py
@@ -75,5 +75,3 @@ def __getattr__(name: str):
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-# Register this page when module is imported
-register_page()

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -552,5 +552,3 @@ def __getattr__(name: str):
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-# Register this page when module is imported
-register_page()

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -126,5 +126,3 @@ def __getattr__(name: str):
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-# Register this page when module is imported
-register_page()

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -123,5 +123,3 @@ def __getattr__(name: str):
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-# Register this page when module is imported
-register_page()


### PR DESCRIPTION
## Summary
- prevent auto page registration before the Dash app exists
- update minimal Dash Pages test to set up pages correctly

## Testing
- `python project_dash_diagnosis.py > diagnosis_output.txt && tail -n 20 diagnosis_output.txt` *(fails: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_687339387e548320969168de651a8400