### PR TITLE
Add DB_PASSWORD note for dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ with this Python release and newer.
    python scripts/generate_dev_secrets.py >> .env
    # Edit .env with your configuration (e.g. set HOST and database info)
    ```
+   `setup_dev_mode` checks for the `DB_PASSWORD` variable. The sample
+   `.env.example` includes a placeholder value. If this variable is
+   missing only a warning is emitted on startup, but database features
+   may not function.
 6. **Build the CSS bundle:**
    Ensure `node` and `npm` are available if you use the npm command.
    ```bash

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -45,6 +45,10 @@ This guide walks new contributors through setting up a local development environ
    cp .env.example .env
    # Edit .env as needed
    ```
+   The development helper `setup_dev_mode` expects `DB_PASSWORD` to be
+   defined. The placeholder value in `.env.example` is sufficient for a
+   local setup. If you omit it the app only emits a warning but database
+   features may not be available.
 
 7. **(Optional) Initialize the database or load sample data.**
    Prepare your PostgreSQL database and populate it with any example data if desired.

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -69,6 +69,9 @@ Copy the sample environment file and adjust any values you need:
 ```bash
 cp .env.example .env
 ```
+`setup_dev_mode` expects `DB_PASSWORD` to be set. The example `.env.example`
+already defines a placeholder. If you skip this variable the tests will only
+show a warning but any database-dependent checks may fail.
 
 If the CSS bundle has not been built yet, generate it:
 ```bash


### PR DESCRIPTION
## Summary
- mention DB_PASSWORD requirement in README
- explain same in developer onboarding guide
- add note to test setup docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687363575a6c8320aaae62b1fbbb0876