### PR TITLE
Fix uploads config defaults

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -17,10 +17,10 @@ from .base_loader import BaseConfigLoader
 def validate_uploads_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Validate uploads configuration with defaults."""
     defaults = {
-            "max_file_size": 104857600,
-            "allowed_extensions": [".csv", ".xlsx", ".json"],
-            "scan_for_malware": True,
-        },
+        "max_file_size": 104857600,
+        "allowed_extensions": [".csv", ".xlsx", ".json"],
+        "scan_for_malware": True,
+    }
 
     if "uploads" not in config:
         config["uploads"] = defaults


### PR DESCRIPTION
## Summary
- fix dictionary initialization in `validate_uploads_config`
- run tests (fail due to environment)

## Testing
- `pytest -q` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873664e2e908320a53b2e418ce1b575