### PR TITLE
Fix migration docs

### DIFF
--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -23,16 +23,17 @@ no longer shipped with the project.
 
 ## Cleanup Utility Example
 
-The repository ships a small helper script that removes any remaining
-references to the legacy controller. It can be run from the project root:
+The repository provides `legacy_callback_migrator.py` which rewrites any
+remaining references to `callback_controller` and verifies that the unified
+callback system works correctly. Run it from the project root:
 
 ```bash
-python tools/complete_callback_cleanup.py
+python legacy_callback_migrator.py --dry-run
 ```
 
-The script scans for deprecated imports, rewrites them to use
-`TrulyUnifiedCallbacks`, validates that `services/data_processing/callback_controller.py`
-is absent and performs a simple runtime check of the new system.
+Omit `--dry-run` to apply the changes. The script scans for deprecated imports,
+adds the required `TrulyUnifiedCallbacks` import if missing and performs a
+simple runtime validation of the new system.
 
 ## Best Practices for Migration
 
@@ -47,4 +48,4 @@ is absent and performs a simple runtime check of the new system.
   `UnicodeAwareTrulyUnifiedCallbacks`. Surrogate pairs and non‑printable
   characters are sanitized automatically to avoid UTF‑8 errors.
 - **Remove legacy imports** after migration and verify that tests pass. The
-  `tools/complete_callback_cleanup.py` helper can assist with large refactors.
+  `legacy_callback_migrator.py` script can assist with large refactors.


### PR DESCRIPTION
## Summary
- update migration instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68736caf70488320b8f43b4f3f460989