### PR TITLE
Add alt text and ARIA attributes to navbar images

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -38,7 +38,7 @@ except ImportError:
 def get_simple_icon(name: str):
     """Return an icon for the navbar tests."""
     img_src = f"/assets/{name}.png"
-    return html.Img(src=img_src, className="nav-icon")
+    return html.Img(src=img_src, className="nav-icon", alt=f"{name} icon")
 
 
 def create_navbar_layout() -> Any:
@@ -57,6 +57,7 @@ def create_navbar_layout() -> Any:
                             src="/assets/yosai_logo_name_white.png",
                             height="40px",
                             style={"filter": "brightness(1)"},
+                            alt="Yōsai logo",
                         ),
                         href="/",
                         className="navbar-brand-link d-flex align-items-center",
@@ -72,13 +73,18 @@ def create_navbar_layout() -> Any:
                                     ],
                                     href="/analytics",
                                     className="nav-link px-3",
+                                    aria_label="Analytics page",
                                 )
                             ),
                             dbc.NavItem(
                                 dcc.Link(
-                                    [html.I(className="fas fa-chart-line me-2"), "Graphs"],
+                                    [
+                                        html.I(className="fas fa-chart-line me-2"),
+                                        "Graphs",
+                                    ],
                                     href="/graphs",
                                     className="nav-link px-3",
+                                    aria_label="Graphs page",
                                 )
                             ),
                             dbc.NavItem(
@@ -86,6 +92,7 @@ def create_navbar_layout() -> Any:
                                     [html.I(className="fas fa-upload me-2"), "Upload"],
                                     href="/upload",
                                     className="nav-link px-3",
+                                    aria_label="Upload page",
                                 )
                             ),
                             dbc.NavItem(
@@ -96,6 +103,7 @@ def create_navbar_layout() -> Any:
                                     ],
                                     href="/export",
                                     className="nav-link px-3",
+                                    aria_label="Export page",
                                 )
                             ),
                             dbc.NavItem(
@@ -103,6 +111,7 @@ def create_navbar_layout() -> Any:
                                     [html.I(className="fas fa-cog me-2"), "Settings"],
                                     href="/settings",
                                     className="nav-link px-3",
+                                    aria_label="Settings page",
                                 )
                             ),
                         ],
@@ -138,34 +147,55 @@ def create_fallback_navbar():
                         [
                             dbc.NavItem(
                                 dbc.NavLink(
-                                    "Analytics", href="/analytics", external_link=False
+                                    "Analytics",
+                                    href="/analytics",
+                                    external_link=False,
+                                    aria_label="Analytics page",
                                 )
                             ),
                             dbc.NavItem(
-                                dbc.NavLink("Graphs", href="/graphs", external_link=False)
+                                dbc.NavLink(
+                                    "Graphs",
+                                    href="/graphs",
+                                    external_link=False,
+                                    aria_label="Graphs page",
+                                )
                             ),
                             dbc.NavItem(
-                                dbc.NavLink("Upload", href="/upload", external_link=False)
+                                dbc.NavLink(
+                                    "Upload",
+                                    href="/upload",
+                                    external_link=False,
+                                    aria_label="Upload page",
+                                )
                             ),
                             dbc.NavItem(
-                                dbc.NavLink("Export", href="/export", external_link=False)
-                        ),
-                        dbc.NavItem(
-                            dbc.NavLink(
-                                "Settings", href="/settings", external_link=False
-                            )
-                        ),
-                    ],
-                    navbar=True,
-                    className="ms-auto",
-                ),
-            ],
-            fluid=True,
-        ),
-        color="dark",
-        dark=True,
-        className="fixed-top",
-    )
+                                dbc.NavLink(
+                                    "Export",
+                                    href="/export",
+                                    external_link=False,
+                                    aria_label="Export page",
+                                )
+                            ),
+                            dbc.NavItem(
+                                dbc.NavLink(
+                                    "Settings",
+                                    href="/settings",
+                                    external_link=False,
+                                    aria_label="Settings page",
+                                )
+                            ),
+                        ],
+                        navbar=True,
+                        className="ms-auto",
+                    ),
+                ],
+                fluid=True,
+            ),
+            color="dark",
+            dark=True,
+            className="fixed-top",
+        )
 
 
 def register_navbar_callbacks(callback_manager, service: Optional[Any] = None) -> None:

--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -2,24 +2,28 @@
 """Enhanced navbar component with logo and improved navigation."""
 
 import logging
-from typing import Optional, Any
+from typing import Any, Optional
+
+from core.callback_registry import handle_register_with_deduplication
 
 try:
+    import dash
     import dash_bootstrap_components as dbc
     from dash import html
+
     DBC_AVAILABLE = True
 except ImportError:
     DBC_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
-from core.callback_registry import handle_register_with_deduplication
+
 
 def create_navbar_layout() -> Any:
     """Create enhanced navbar with logo and proper navigation."""
-    
+
     if not DBC_AVAILABLE:
         return html.Div("Navbar unavailable")
-    
+
     try:
         return dbc.Navbar(
             dbc.Container(
@@ -29,18 +33,14 @@ def create_navbar_layout() -> Any:
                         html.Img(
                             src="/assets/yosai_logo_name_white.png",
                             height="40px",
-                            style={
-                                "margin-right": "10px",
-                                "filter": "brightness(1)"
-                            }
+                            style={"margin-right": "10px", "filter": "brightness(1)"},
+                            alt="Yōsai logo",
                         ),
                         href="/",
-                        className="navbar-brand-link d-flex align-items-center"
+                        className="navbar-brand-link d-flex align-items-center",
                     ),
-                    
                     # Navbar Toggler for Mobile
                     dbc.NavbarToggler(id="navbar-toggler", n_clicks=0),
-                    
                     # Collapsible Navigation
                     dbc.Collapse(
                         dbc.Nav(
@@ -49,102 +49,140 @@ def create_navbar_layout() -> Any:
                                     dbc.NavLink(
                                         [
                                             html.I(className="fas fa-chart-bar me-2"),
-                                            "Analytics"
+                                            "Analytics",
                                         ],
                                         href="/analytics",
                                         external_link=False,
                                         className="nav-link px-3",
-                                        id="nav-analytics"
+                                        id="nav-analytics",
+                                        aria_label="Analytics page",
                                     )
                                 ),
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
                                             html.I(className="fas fa-chart-line me-2"),
-                                            "Graphs"
+                                            "Graphs",
                                         ],
                                         href="/graphs",
                                         external_link=False,
                                         className="nav-link px-3",
-                                        id="nav-graphs"
+                                        id="nav-graphs",
+                                        aria_label="Graphs page",
                                     )
                                 ),
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
                                             html.I(className="fas fa-upload me-2"),
-                                            "Upload"
+                                            "Upload",
                                         ],
                                         href="/upload",
                                         external_link=False,
                                         className="nav-link px-3",
-                                        id="nav-upload"
+                                        id="nav-upload",
+                                        aria_label="Upload page",
                                     )
                                 ),
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
                                             html.I(className="fas fa-download me-2"),
-                                            "Export"
+                                            "Export",
                                         ],
                                         href="/export",
                                         external_link=False,
                                         className="nav-link px-3",
-                                        id="nav-export"
+                                        id="nav-export",
+                                        aria_label="Export page",
                                     )
                                 ),
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
                                             html.I(className="fas fa-cog me-2"),
-                                            "Settings"
+                                            "Settings",
                                         ],
                                         href="/settings",
                                         external_link=False,
                                         className="nav-link px-3",
-                                        id="nav-settings"
+                                        id="nav-settings",
+                                        aria_label="Settings page",
                                     )
                                 ),
                             ],
                             navbar=True,
-                            className="ms-auto"
+                            className="ms-auto",
                         ),
                         id="navbar-collapse",
                         is_open=False,
                         navbar=True,
-                    )
+                    ),
                 ],
                 fluid=True,
-                className="px-4"
+                className="px-4",
             ),
             color="dark",
             dark=True,
             expand="lg",
             className="navbar navbar-expand-lg fixed-top shadow-sm",
-            style={"background-color": "#000000"}
+            style={"background-color": "#000000"},
         )
-        
+
     except Exception as e:
         logger.error(f"Enhanced navbar creation failed: {e}")
         return create_fallback_navbar()
 
+
 def create_fallback_navbar():
     """Simple fallback navbar."""
     return dbc.Navbar(
-        dbc.Container([
-            dbc.NavbarBrand("Dashboard", href="/"),
-            dbc.Nav([
-                dbc.NavItem(dbc.NavLink("Analytics", href="/analytics", external_link=False)),
-                dbc.NavItem(dbc.NavLink("Graphs", href="/graphs", external_link=False)),
-                dbc.NavItem(dbc.NavLink("Upload", href="/upload", external_link=False)),
-            ], navbar=True, className="ms-auto")
-        ], fluid=True),
-        color="dark", dark=True, className="fixed-top"
+        dbc.Container(
+            [
+                dbc.NavbarBrand("Dashboard", href="/"),
+                dbc.Nav(
+                    [
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                "Analytics",
+                                href="/analytics",
+                                external_link=False,
+                                aria_label="Analytics page",
+                            )
+                        ),
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                "Graphs",
+                                href="/graphs",
+                                external_link=False,
+                                aria_label="Graphs page",
+                            )
+                        ),
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                "Upload",
+                                href="/upload",
+                                external_link=False,
+                                aria_label="Upload page",
+                            )
+                        ),
+                    ],
+                    navbar=True,
+                    className="ms-auto",
+                ),
+            ],
+            fluid=True,
+        ),
+        color="dark",
+        dark=True,
+        className="fixed-top",
     )
+
 
 def register_navbar_callbacks(callback_manager, service: Optional[Any] = None) -> None:
     """Register navbar toggle callback for mobile."""
     try:
+
         @handle_register_with_deduplication(
             callback_manager,
             dash.dependencies.Output("navbar-collapse", "is_open"),
@@ -159,7 +197,9 @@ def register_navbar_callbacks(callback_manager, service: Optional[Any] = None) -
             if n:
                 return not is_open
             return is_open
+
     except Exception as e:
         logger.warning(f"Navbar callback registration failed: {e}")
+
 
 __all__ = ["create_navbar_layout", "register_navbar_callbacks"]


### PR DESCRIPTION
## Summary
- improve accessibility for navbars by providing alt text
- add `aria-label` attributes to each navigation link
- clean up import ordering in `navbar_enhanced.py`

## Testing
- `pre-commit run --files components/ui/navbar_enhanced.py components/ui/navbar.py` *(fails: mypy/bandit errors in unrelated files)*
- `pytest` *(fails: 123 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68736d216dcc8320bd56191d4a908dbd