### PR TITLE
Fix page registration timing

### DIFF
--- a/pages/export.py
+++ b/pages/export.py
@@ -1,6 +1,3 @@
-from dash import register_page
-register_page(__name__, path="/export", name="Export")
-
 #!/usr/bin/env python3
 """Export page providing download instructions."""
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -20,12 +20,10 @@ from dash import (
     dcc,
     html,
     no_update,
-    register_page,
+    register_page as dash_register_page,
 )
 from dash.exceptions import PreventUpdate
 
-# Register this page with Dash when imported
-register_page(__name__, path="/upload", name="Upload")
 
 # Core imports that should always work
 try:
@@ -291,6 +289,12 @@ def load_page(**kwargs) -> UploadPage:
     return UploadPage(**kwargs)
 
 
+def register_page() -> None:
+    """Register the upload page with Dash."""
+
+    dash_register_page(__name__, path="/upload", name="Upload")
+
+
 def layout() -> dbc.Container:
     """Compatibility wrapper returning the default component layout."""
 
@@ -536,6 +540,7 @@ register_upload_callbacks = register_callbacks
 __all__ = [
     "UploadPage",
     "load_page",
+    "register_page",
     "layout",
     "safe_upload_layout",
     "register_callbacks",


### PR DESCRIPTION
## Summary
- remove early `dash.register_page` calls from export and upload pages
- add registration helper for upload page
- verify minimal Dash Pages test runs

## Testing
- `python minimal_dash_pages_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68736fa3e0d08320b7b0afe28e70ba9d