### PR TITLE
Fix Pylance import warnings

### DIFF
--- a/core/unicode.py
+++ b/core/unicode.py
@@ -15,7 +15,7 @@ import unicodedata
 from functools import wraps
 from typing import Any, Callable, Iterable, Optional, Union
 
-import pandas as pd
+import pandas as pd  # type: ignore[import]
 
 from .exceptions import SecurityError
 from .security_patterns import (

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -11,8 +11,8 @@ import os
 import tempfile
 from typing import Any, Dict, List, Optional
 
-import dash_bootstrap_components as dbc
-import pandas as pd
+import dash_bootstrap_components as dbc  # type: ignore[import]
+import pandas as pd  # type: ignore[import]
 from dash import (
     Input,
     Output,
@@ -21,8 +21,16 @@ from dash import (
     html,
     no_update,
     register_page,
+)  # type: ignore[import]
+from dash.exceptions import PreventUpdate  # type: ignore[import]
+
+from components.ui_component import UIComponent
+from services.upload_data_service import clear_uploaded_data as _svc_clear_uploaded_data
+from services.upload_data_service import get_uploaded_data as _svc_get_uploaded_data
+from services.upload_data_service import (
+    get_uploaded_filenames as _svc_get_uploaded_filenames,
 )
-from dash.exceptions import PreventUpdate
+from config.dynamic_config import dynamic_config
 
 # Register this page with Dash when imported
 register_page(__name__, path="/upload", name="Upload")
@@ -37,19 +45,12 @@ try:
     from core.unicode import safe_decode_bytes, safe_encode_text
 except ImportError:
 
-    def safe_encode_text(text):
-        return str(text)
+    def safe_encode_text(value: Any) -> str:
+        return str(value)
 
-    def safe_decode_bytes(data):
+    def safe_decode_bytes(data: bytes) -> str:
         return data.decode("utf-8", errors="replace")
 
-
-from components.ui_component import UIComponent
-from services.upload_data_service import clear_uploaded_data as _svc_clear_uploaded_data
-from services.upload_data_service import get_uploaded_data as _svc_get_uploaded_data
-from services.upload_data_service import (
-    get_uploaded_filenames as _svc_get_uploaded_filenames,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,8 @@ class UploadPage(UIComponent):
                             [
                                 html.H2("📁 File Upload", className="mb-3"),
                                 html.P(
-                                    "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
+                                    "Drag and drop files or click to browse. "
+                                    "Supports CSV, Excel, and JSON files.",
                                     className="text-muted mb-4",
                                 ),
                             ]
@@ -89,7 +91,10 @@ class UploadPage(UIComponent):
                                     children=html.Div(
                                         [
                                             html.I(
-                                                className="fas fa-cloud-upload-alt fa-3x mb-3",
+                                                className=(
+                                                    "fas fa-cloud-upload-alt "
+                                                    "fa-3x mb-3"
+                                                ),
                                                 style={"color": "#6c757d"},
                                             ),
                                             html.H5("Drag & Drop Files Here"),
@@ -193,7 +198,9 @@ class UploadPage(UIComponent):
         )
 
     # ------------------------------------------------------------------
-    def register_callbacks(self, manager, controller=None) -> None:  # type: ignore[override]
+    def register_callbacks(
+        self, manager, controller=None
+    ) -> None:  # type: ignore[override]
         """Register upload callbacks - simplified and working."""
 
         if manager is None:
@@ -373,7 +380,7 @@ def _create_file_preview(results: List[Dict[str, Any]]) -> List[Any]:
         columns = [{"name": col, "id": col} for col in df.columns]
 
         try:
-            from dash import dash_table
+            from dash import dash_table  # type: ignore[import]
 
             table = dash_table.DataTable(
                 data=preview_data,
@@ -386,7 +393,7 @@ def _create_file_preview(results: List[Dict[str, Any]]) -> List[Any]:
                 },
                 page_size=5,
             )
-        except:
+        except Exception:
             # Fallback if dash_table not available
             table = html.P("Preview table not available")
 
@@ -400,7 +407,8 @@ def _create_file_preview(results: List[Dict[str, Any]]) -> List[Any]:
                                 dbc.Col(
                                     [
                                         html.P(
-                                            f"📊 {result['rows']:,} rows × {result['columns']} columns"
+                                            f"📊 {result['rows']:,} rows "
+                                            f"× {result['columns']} columns"
                                         ),
                                         html.P(f"💾 Size: {result['size_mb']} MB"),
                                     ],
@@ -409,9 +417,10 @@ def _create_file_preview(results: List[Dict[str, Any]]) -> List[Any]:
                                 dbc.Col(
                                     [
                                         html.P(
-                                            f"📅 Uploaded: {pd.Timestamp.now().strftime('%H:%M:%S')}"
+                                            "📅 Uploaded: "
+                                            f"{pd.Timestamp.now().strftime('%H:%M:%S')}"
                                         ),
-                                        html.P(f"✅ Status: Ready for analysis"),
+                                        html.P("✅ Status: Ready for analysis"),
                                     ],
                                     md=6,
                                 ),
@@ -436,7 +445,7 @@ def _create_success_status(file_count: int) -> Any:
 
     return dbc.Alert(
         [
-            html.H6(f"✅ Upload Successful!", className="mb-1"),
+            html.H6("✅ Upload Successful!", className="mb-1"),
             html.P(f"Successfully processed {file_count} file(s). Ready for analysis."),
         ],
         color="success",
@@ -544,7 +553,6 @@ __all__ = [
     "get_uploaded_data",
     "clear_uploaded_data",
 ]
-from config.dynamic_config import dynamic_config
 
 
 def __getattr__(name: str):


### PR DESCRIPTION
## Summary
- silence Pylance missing import warnings in `pages/file_upload.py`
- silence missing pandas import in `core/unicode.py`
- tweak fallback helper signatures and fix style issues

## Testing
- `flake8 pages/file_upload.py core/unicode.py`
- `mypy pages/file_upload.py core/unicode.py` *(fails: found 459 errors in 89 files)*
- `pytest -q` *(fails: 123 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68736f8f8d588320ad6afb7e801237e8