### PR TITLE
Move dynamic_config import

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 
 import dash_bootstrap_components as dbc  # type: ignore[import]
 import pandas as pd  # type: ignore[import]
-from dash import (
+from dash import (  # type: ignore[import]
     Input,
     Output,
     State,
@@ -21,18 +21,16 @@ from dash import (
     html,
     no_update,
     register_page,
-)  # type: ignore[import]
+)
 from dash.exceptions import PreventUpdate  # type: ignore[import]
 
 from components.ui_component import UIComponent
+from config.dynamic_config import dynamic_config
 from services.upload_data_service import clear_uploaded_data as _svc_clear_uploaded_data
 from services.upload_data_service import get_uploaded_data as _svc_get_uploaded_data
 from services.upload_data_service import (
     get_uploaded_filenames as _svc_get_uploaded_filenames,
-
 )
-from config.dynamic_config import dynamic_config
-
 
 # Core imports that should always work
 try:


### PR DESCRIPTION
## Summary
- reorder imports in `pages/file_upload.py` so `dynamic_config` is in the main import block

## Testing
- `pytest tests/test_settings_page.py::test_apply_system_config_updates_dynamic_config -q` *(fails: AttributeError: module pages.settings has no attribute apply_system_config)*
- `black pages/file_upload.py --check`
- `flake8 pages/file_upload.py` *(fails: F811, F821)*

------
https://chatgpt.com/codex/tasks/task_e_687374db527c83208aced415ccbdc4f5