### PR TITLE
Add aria-hidden for navbar icons

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -68,7 +68,7 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-chart-bar me-2"),
+                                        html.I(className="fas fa-chart-bar me-2", aria_hidden="true"),
                                         "Analytics",
                                     ],
                                     href="/analytics",
@@ -79,7 +79,7 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-chart-line me-2"),
+                                        html.I(className="fas fa-chart-line me-2", aria_hidden="true"),
                                         "Graphs",
                                     ],
                                     href="/graphs",
@@ -89,7 +89,7 @@ def create_navbar_layout() -> Any:
                             ),
                             dbc.NavItem(
                                 dcc.Link(
-                                    [html.I(className="fas fa-upload me-2"), "Upload"],
+                                    [html.I(className="fas fa-upload me-2", aria_hidden="true"), "Upload"],
                                     href="/upload",
                                     className="nav-link px-3",
                                     aria_label="Upload page",
@@ -98,7 +98,7 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-download me-2"),
+                                        html.I(className="fas fa-download me-2", aria_hidden="true"),
                                         "Export",
                                     ],
                                     href="/export",
@@ -108,7 +108,7 @@ def create_navbar_layout() -> Any:
                             ),
                             dbc.NavItem(
                                 dcc.Link(
-                                    [html.I(className="fas fa-cog me-2"), "Settings"],
+                                    [html.I(className="fas fa-cog me-2", aria_hidden="true"), "Settings"],
                                     href="/settings",
                                     className="nav-link px-3",
                                     aria_label="Settings page",

--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -48,7 +48,7 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-chart-bar me-2"),
+                                            html.I(className="fas fa-chart-bar me-2", aria_hidden="true"),
                                             "Analytics",
                                         ],
                                         href="/analytics",
@@ -61,7 +61,7 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-chart-line me-2"),
+                                            html.I(className="fas fa-chart-line me-2", aria_hidden="true"),
                                             "Graphs",
                                         ],
                                         href="/graphs",
@@ -74,7 +74,7 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-upload me-2"),
+                                            html.I(className="fas fa-upload me-2", aria_hidden="true"),
                                             "Upload",
                                         ],
                                         href="/upload",
@@ -87,7 +87,7 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-download me-2"),
+                                            html.I(className="fas fa-download me-2", aria_hidden="true"),
                                             "Export",
                                         ],
                                         href="/export",
@@ -100,7 +100,7 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-cog me-2"),
+                                            html.I(className="fas fa-cog me-2", aria_hidden="true"),
                                             "Settings",
                                         ],
                                         href="/settings",


### PR DESCRIPTION
## Summary
- mark decorative `<html.I>` icons as hidden from screen readers in the navigation bars
- keep existing `aria_label` attributes on all `dbc.NavLink`

## Testing
- `pytest tests/components/test_nav_icon.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687374e0ac048320b8541e04b2ae735a