### PR TITLE
Add simplified file upload page

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -5,100 +5,79 @@ import dash
 from dash import html, dcc, Input, Output
 import dash_bootstrap_components as dbc
 from components.ui.navbar import create_navbar_layout
+from pages import file_upload_simple
+
 
 def create_app(mode=None, **kwargs):
     """Create a working Dash app with logo, navigation, and routing - HTTPS ready."""
-    
+
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
-    
+
     # Simple working layout
-    app.layout = html.Div([
-        dcc.Location(id="url", refresh=False),
-        create_navbar_layout(),
-        html.Div(id="page-content", className="main-content p-4"),
-        dcc.Store(id="global-store", data={}),
-    ])
-    
+    app.layout = html.Div(
+        [
+            dcc.Location(id="url", refresh=False),
+            create_navbar_layout(),
+            html.Div(id="page-content", className="main-content p-4"),
+            dcc.Store(id="global-store", data={}),
+        ]
+    )
+
+    # Register callbacks for individual pages
+    file_upload_simple.register_page()
+    file_upload_simple.register_callbacks(app)
+
     # Simple routing callback that uses REAL pages
     @app.callback(Output("page-content", "children"), Input("url", "pathname"))
     def display_page(pathname):
         if pathname == "/dashboard":
-            return html.Div([
-                html.H1("🏠 Dashboard", className="mb-4"),
-                html.P("Welcome to your Yōsai Intel Dashboard!")
-            ])
+            return html.Div(
+                [
+                    html.H1("🏠 Dashboard", className="mb-4"),
+                    html.P("Welcome to your Yōsai Intel Dashboard!"),
+                ]
+            )
         elif pathname == "/analytics":
-            return html.Div([
-                html.H1("📊 Analytics", className="mb-4"),
-                html.P("Analytics page - working!")
-            ])
+            return html.Div(
+                [
+                    html.H1("📊 Analytics", className="mb-4"),
+                    html.P("Analytics page - working!"),
+                ]
+            )
         elif pathname == "/graphs":
-            return html.Div([
-                html.H1("📈 Graphs", className="mb-4"),
-                html.P("Graphs page - working!")
-            ])
+            return html.Div(
+                [
+                    html.H1("📈 Graphs", className="mb-4"),
+                    html.P("Graphs page - working!"),
+                ]
+            )
         elif pathname == "/upload":
-            # Simple upload layout without callback conflicts
-            return dbc.Container([
-                # Header
-                dbc.Row([
-                    dbc.Col([
-                        html.H2("📁 File Upload", className="mb-3"),
-                        html.P(
-                            "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
-                            className="text-muted mb-4",
-                        ),
-                    ])
-                ]),
-                # Upload area  
-                dbc.Row([
-                    dbc.Col([
-                        html.Div([
-                            html.I(className="fas fa-cloud-upload-alt fa-3x mb-3", style={"color": "#007bff"}),
-                            html.H5("Drag & Drop Files Here", className="mb-2"),
-                            html.P("or click to select files", className="text-muted"),
-                            html.P("Supported: CSV, Excel (.xlsx, .xls), JSON", className="small text-secondary"),
-                        ], style={
-                            "width": "100%",
-                            "height": "200px",
-                            "borderWidth": "2px",
-                            "borderStyle": "dashed",
-                            "borderRadius": "8px",
-                            "borderColor": "#007bff",
-                            "textAlign": "center",
-                            "background": "#f8f9fa",
-                            "cursor": "pointer",
-                            "display": "flex",
-                            "flexDirection": "column",
-                            "justifyContent": "center",
-                            "alignItems": "center",
-                        }),
-                    ], width=8, className="mx-auto")
-                ]),
-                # Status area
-                dbc.Row([
-                    dbc.Col([
-                        html.Div(id="upload-status", className="mt-3"),
-                        html.Div("Upload functionality will be enhanced in next update.", 
-                               className="text-info mt-2")
-                    ], width=8, className="mx-auto")
-                ])
-            ], fluid=True, className="py-4")
+            # Delegate to simplified upload page
+            return file_upload_simple.layout()
         elif pathname == "/export":
-            return html.Div([
-                html.H1("📥 Export", className="mb-4"),
-                html.P("Export page - working!")
-            ])
+            return html.Div(
+                [
+                    html.H1("📥 Export", className="mb-4"),
+                    html.P("Export page - working!"),
+                ]
+            )
         elif pathname == "/settings":
-            return html.Div([
-                html.H1("⚙️ Settings", className="mb-4"),
-                html.P("Settings page - working!")
-            ])
+            return html.Div(
+                [
+                    html.H1("⚙️ Settings", className="mb-4"),
+                    html.P("Settings page - working!"),
+                ]
+            )
         else:
-            return html.Div([
-                html.H1("🏯 Yōsai Intel Dashboard", className="text-center mb-4"),
-                html.P("Select a page from the navigation menu above.", className="text-center")
-            ])
-    
+            return html.Div(
+                [
+                    html.H1("🏯 Yōsai Intel Dashboard", className="text-center mb-4"),
+                    html.P(
+                        "Select a page from the navigation menu above.",
+                        className="text-center",
+                    ),
+                ]
+            )
+
     app.title = "🏯 Yōsai Intel Dashboard"
     return app

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Simplified file upload page compatible with basic routing."""
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+import logging
+from typing import List
+
+import dash_bootstrap_components as dbc
+import pandas as pd
+from dash import dcc, html, callback, Output, Input, State
+from dash.exceptions import PreventUpdate
+
+from utils.upload_store import uploaded_data_store
+
+logger = logging.getLogger(__name__)
+
+
+def layout() -> dbc.Container:
+    """Return the upload page layout."""
+    upload_area = dcc.Upload(
+        id="drag-drop-upload",
+        children=html.Div(
+            [
+                html.I(
+                    className="fas fa-cloud-upload-alt fa-3x mb-3",
+                    **{"aria-hidden": "true"},
+                ),
+                html.H5("Drag & Drop Files Here"),
+                html.P("or click to select files", className="text-muted"),
+                html.P(
+                    "Supports CSV, Excel, and JSON files",
+                    className="small text-muted",
+                ),
+            ]
+        ),
+        style={
+            "width": "100%",
+            "height": "200px",
+            "lineHeight": "60px",
+            "borderWidth": "2px",
+            "borderStyle": "dashed",
+            "borderRadius": "5px",
+            "textAlign": "center",
+            "margin": "10px",
+            "cursor": "pointer",
+            "display": "flex",
+            "flexDirection": "column",
+            "justifyContent": "center",
+            "alignItems": "center",
+        },
+        multiple=True,
+    )
+
+    return dbc.Container(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(
+                        [
+                            html.H2("\ud83d\udcc1 File Upload", className="mb-3"),
+                            html.P(
+                                "Drag and drop files or click to browse. Supports CSV, "
+                                "Excel, and JSON files.",
+                                className="text-muted mb-4",
+                            ),
+                        ]
+                    )
+                ]
+            ),
+            dbc.Row([dbc.Col(upload_area, lg=8, md=10, sm=12, className="mx-auto")]),
+            dbc.Row(
+                [
+                    dbc.Col(
+                        [
+                            html.Div(id="upload-status"),
+                            html.Div(id="preview-area"),
+                        ],
+                        lg=10,
+                        md=12,
+                        sm=12,
+                        className="mx-auto",
+                    )
+                ]
+            ),
+        ],
+        fluid=True,
+        className="py-4",
+    )
+
+
+@callback(
+    Output("upload-status", "children"),
+    Output("preview-area", "children"),
+    Input("drag-drop-upload", "contents"),
+    State("drag-drop-upload", "filename"),
+    prevent_initial_call=True,
+)
+def handle_upload(contents: str | List[str], filenames: str | List[str]):
+    """Handle uploaded files and store them using :mod:`upload_store`."""
+    if not contents:
+        raise PreventUpdate
+
+    if not isinstance(contents, list):
+        contents = [contents]
+        filenames = [filenames]  # type: ignore[list-item]
+
+    alerts = []
+    previews = []
+
+    for content, name in zip(contents, filenames):
+        try:
+            header, data = content.split(",", 1)
+            decoded = base64.b64decode(data)
+            buf = BytesIO(decoded)
+
+            if name.lower().endswith(".csv"):
+                df = pd.read_csv(buf)
+            elif name.lower().endswith((".xlsx", ".xls")):
+                df = pd.read_excel(buf)
+            elif name.lower().endswith(".json"):
+                df = pd.read_json(buf)
+            else:
+                alerts.append(
+                    dbc.Alert(f"Unsupported file type for {name}", color="warning")
+                )
+                continue
+
+            uploaded_data_store.add_file(name, df)
+            table = dbc.Table.from_dataframe(df.head(5), striped=True, bordered=True)
+            previews.append(html.Div([html.H6(name), table], className="mb-4"))
+            alerts.append(
+                dbc.Alert(f"Uploaded {name}", color="success", dismissable=True)
+            )
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Upload failed for %s: %s", name, exc)
+            alerts.append(dbc.Alert(f"Failed to process {name}", color="danger"))
+
+    return alerts, previews
+
+
+def register_page():
+    """Register this page with Dash Pages if available."""
+    try:
+        import dash
+
+        if hasattr(dash, "_current_app") and dash._current_app is not None:
+            dash.register_page(__name__, path="/upload", name="Upload")
+        else:
+            from dash import register_page as dash_register_page
+
+            dash_register_page(__name__, path="/upload", name="Upload")
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning("Failed to register page %s: %s", __name__, e)
+
+
+def register_callbacks(app):
+    """Compatibility wrapper for app callback registration."""
+    # callbacks are declared with the `@callback` decorator, so nothing to do.
+    return app
+
+
+__all__ = ["layout", "register_page", "register_callbacks"]


### PR DESCRIPTION
## Summary
- add `pages/file_upload_simple.py` for CSV/Excel/JSON uploads
- integrate new page in `core/app_factory`
- register upload callbacks during app creation

## Testing
- `flake8 pages/file_upload_simple.py core/app_factory/__init__.py`
- `black pages/file_upload_simple.py core/app_factory/__init__.py`
- `mypy pages/file_upload_simple.py core/app_factory/__init__.py` *(fails: many missing dependencies)*
- `pytest -q` *(fails: numerous import errors)*

------
https://chatgpt.com/codex/tasks/task_e_687508947fc08320998ecb3fb6a7bb03