### PR TITLE
Fix relative imports in MVP scripts

### DIFF
--- a/mvp/investor_demo_interface.py
+++ b/mvp/investor_demo_interface.py
@@ -6,9 +6,9 @@ from tempfile import NamedTemporaryFile
 
 from flask import Flask, render_template_string, request, send_file
 
-from .data_verification_component import DataVerificationComponent
-from .mvp_cli_engine import load_dataframe, generate_analytics
-from .unicode_fix_module import safe_file_write
+from mvp.data_verification_component import DataVerificationComponent
+from mvp.mvp_cli_engine import generate_analytics, load_dataframe
+from mvp.unicode_fix_module import safe_file_write
 
 app = Flask(__name__)
 
@@ -65,7 +65,9 @@ def investor_demo():
                     stages[5]["complete"] = True
                     out_path = Path("mvp_output/investor_result.json")
                     safe_file_write(out_path, json.dumps(analytics, indent=2))
-                    verifier.save_verification(mapping, Path("mvp_output/investor_verification.json"))
+                    verifier.save_verification(
+                        mapping, Path("mvp_output/investor_verification.json")
+                    )
                     stages[6]["complete"] = True
                     download_url = "/download"
                 except Exception as exc:

--- a/mvp/mvp_cli_engine.py
+++ b/mvp/mvp_cli_engine.py
@@ -7,8 +7,13 @@ from typing import Any
 
 import pandas as pd
 
-from .unicode_fix_module import clean_text, safe_file_read, safe_file_write, sanitize_dataframe
-from .data_verification_component import DataVerificationComponent
+from mvp.data_verification_component import DataVerificationComponent
+from mvp.unicode_fix_module import (
+    clean_text,
+    safe_file_read,
+    safe_file_write,
+    sanitize_dataframe,
+)
 
 try:
     from core.security_validator import SecurityValidator
@@ -64,7 +69,9 @@ def generate_analytics(df: pd.DataFrame) -> dict:
         return {"rows": len(df)}
 
 
-def process_file(filepath: Path, output: Path, validate_only: bool, debug: bool) -> None:
+def process_file(
+    filepath: Path, output: Path, validate_only: bool, debug: bool
+) -> None:
     if debug:
         print(f"Processing {filepath} -> {output}")
     df = load_dataframe(filepath, debug=debug)
@@ -90,7 +97,9 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="MVP CLI Engine")
     parser.add_argument("file", help="Path to input file")
     parser.add_argument("--output", default="mvp_output", help="Output directory")
-    parser.add_argument("--validate-only", action="store_true", help="Only run validation steps")
+    parser.add_argument(
+        "--validate-only", action="store_true", help="Only run validation steps"
+    )
     parser.add_argument("--debug", action="store_true", help="Verbose output")
     args = parser.parse_args(argv)
 

--- a/mvp/mvp_web_interface.py
+++ b/mvp/mvp_web_interface.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-import json
 
 from flask import Flask, render_template_string, request, send_file
 
-from .data_verification_component import DataVerificationComponent
-from .mvp_cli_engine import load_dataframe, generate_analytics
-from .unicode_fix_module import safe_file_write
+from mvp.data_verification_component import DataVerificationComponent
+from mvp.mvp_cli_engine import generate_analytics, load_dataframe
+from mvp.unicode_fix_module import safe_file_write
 
 app = Flask(__name__)
 
@@ -43,12 +43,16 @@ def upload_file():
                     analytics = generate_analytics(df)
                     out_path = Path("mvp_output/web_result.json")
                     safe_file_write(out_path, json.dumps(analytics, indent=2))
-                    verifier.save_verification(mapping, Path("mvp_output/web_verification.json"))
+                    verifier.save_verification(
+                        mapping, Path("mvp_output/web_verification.json")
+                    )
                     download_url = "/download"
                     message = "Processing complete"
                 except Exception as exc:
                     message = f"Error: {exc}"
-    return render_template_string(UPLOAD_FORM, message=message, download_url=download_url)
+    return render_template_string(
+        UPLOAD_FORM, message=message, download_url=download_url
+    )
 
 
 @app.route("/download")


### PR DESCRIPTION
## Summary
- switch relative imports to absolute in MVP interfaces
- apply formatting changes via pre-commit

## Testing
- `pre-commit run --files mvp/investor_demo_interface.py mvp/mvp_web_interface.py mvp/mvp_cli_engine.py` *(fails: line length, mypy, bandit)*
- `pytest` *(fails: missing test dependency psutil)*

------
https://chatgpt.com/codex/tasks/task_e_6875774a5e6483208cf2fc0565dbf475