### PR TITLE
Fix imports in simple app factory

### DIFF
--- a/app_factory_simple_fix.py
+++ b/app_factory_simple_fix.py
@@ -1,7 +1,55 @@
-def _create_simple_app(assets_folder: str) -> "Dash":
+"""Simplified application factory used in tests and examples."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+import dash
+from dash import Dash, dcc, html
+import dash_bootstrap_components as dbc
+from flask import Flask
+from flask_caching import Cache
+
+from core.theme_manager import apply_theme_settings
+from utils.assets_utils import fix_flask_mime_types, ensure_icon_cache_headers
+from core.app_factory.health import register_health_endpoints
+
+
+ASSETS_DIR = Path(__file__).resolve().parent / "assets"
+BUNDLE = "/assets/dist/main.min.css"
+
+logger = logging.getLogger(__name__)
+
+
+class DummyConfigManager:
+    """Minimal stand-in configuration manager."""
+
+    def get_plugin_config(self, name: str) -> dict[str, Any]:
+        return {}
+
+
+def _register_callbacks(app: Dash, config_manager: Any, container: Any | None = None) -> None:
+    """Placeholder callback registration used in simplified mode."""
+    logger.info("Registering callbacks (simplified)")
+
+
+def _configure_swagger(server: Any) -> None:
+    """Minimal Swagger configuration for development."""
+    try:
+        from flasgger import Swagger
+
+        server.config.setdefault("SWAGGER", {"uiversion": 3})
+        Swagger(server, template={"openapi": "3.0.2", "info": {"title": "Yōsai Intel Dashboard API", "version": "1.0.0"}})
+        logger.info("✅ Swagger configured successfully")
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning(f"Swagger configuration failed: {e}")
+
+
+def _create_simple_app(assets_folder: str) -> Dash:
     """Create simple Dash application for development"""
     try:
-        from dash import dcc, html
 
         external_stylesheets = [dbc.themes.BOOTSTRAP]
         built_css = ASSETS_DIR / "dist" / "main.min.css"


### PR DESCRIPTION
## Summary
- add proper imports to `app_factory_simple_fix.py`
- provide small stubs for configuration and callbacks
- configure minimal Swagger helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography' and others)*

------
https://chatgpt.com/codex/tasks/task_e_687579ba59a88320a2ec5cd906a77eef