### PR TITLE
Fix Pylance stub path and redis asyncio stub

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,6 @@
   "python.linting.flake8Enabled": true,
   "editor.rulers": [88],
   "editor.formatOnSave": true
+  ,"python.analysis.extraPaths": ["./tests/stubs"]
+  ,"python.analysis.stubPath": "./tests/stubs"
 }

--- a/tests/stubs/redis/asyncio/__init__.py
+++ b/tests/stubs/redis/asyncio/__init__.py
@@ -1,0 +1,3 @@
+class Redis:
+    async def get(self, key):
+        return None


### PR DESCRIPTION
## Summary
- configure Pylance to look at the test stubs
- add a simple stub for `redis.asyncio` so imports succeed when redis isn't installed

## Testing
- `PYTHONPATH=tests/stubs pytest -q` *(fails: 96 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68758321e14883208000edf5bba51ff3