### PR TITLE
Fix dash imports for pylance

### DIFF
--- a/app_factory_simple_fix.py
+++ b/app_factory_simple_fix.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any, cast
 
 import dash
-from dash import Dash, dcc, html
+html = dash.html
+dcc = dash.dcc
 import dash_bootstrap_components as dbc
 from flask import Flask
 from flask_caching import Cache
@@ -30,7 +31,7 @@ class DummyConfigManager:
         return {}
 
 
-def _register_callbacks(app: Dash, config_manager: Any, container: Any | None = None) -> None:
+def _register_callbacks(app: dash.Dash, config_manager: Any, container: Any | None = None) -> None:
     """Placeholder callback registration used in simplified mode."""
     logger.info("Registering callbacks (simplified)")
 
@@ -47,7 +48,7 @@ def _configure_swagger(server: Any) -> None:
         logger.warning(f"Swagger configuration failed: {e}")
 
 
-def _create_simple_app(assets_folder: str) -> Dash:
+def _create_simple_app(assets_folder: str) -> dash.Dash:
     """Create simple Dash application for development"""
     try:
 


### PR DESCRIPTION
## Summary
- remove `from dash import Dash` usage to avoid pylance warnings
- use `dash.Dash` and assign `html` and `dcc` via `dash` module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*

------
https://chatgpt.com/codex/tasks/task_e_687583323f4c8320b02156bd80e324c1