### PR TITLE
Fix Pylance missing imports

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,5 @@ pytest==7.4.0
 pytest-cov>=2.12.0
 PyYAML>=6.0
 psutil>=5.9.0
+selenium>=4.20.0
+requests>=2.32.0


### PR DESCRIPTION
## Summary
- ensure Selenium based tests have necessary dependencies

## Testing
- `pytest -q` *(fails: No module named 'hvac')*

------
https://chatgpt.com/codex/tasks/task_e_687583546bec8320b29a321360c80e97