### PR TITLE
Add helper to display unused root scripts

### DIFF
--- a/cat_unused_root_files.sh
+++ b/cat_unused_root_files.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Concatenate unused helper scripts in the repository root
+
+files=(
+    add_navbar_callbacks.py
+    add_navbar_callbacks_minimal.py
+    add_navbar_to_minimal.py
+    add_original_navbar.py
+    add_register_callback_method.py
+    add_routing.py
+    app_factory_simple_fix.py
+    check_fix.py
+    check_fixes.py
+    column_mapper.py
+    enable_router_fix.py
+    example_ai_adapter.py
+    force_initial_callback.py
+    minimal_dash_pages_test.py
+    minimal_test.py
+    minimal_test_app.py
+    nuclear_fix_dependencies.py
+    persistence_diagnostics.py
+    project_dash_diagnosis.py
+    restore_original_navbar.py
+    run_focused_audit.py
+    ui_callback_controller.py
+    ui_tracker.py
+    upload_callback_standalone.py
+    upload_handler.py
+    validate_core_import.py
+    validate_future_imports.py
+    validate_imports.py
+    working_app_test.py
+)
+
+for f in "${files[@]}"; do
+    echo "========== $f =========="
+    if [[ -f "$f" ]]; then
+        cat "$f"
+    else
+        echo "File not found: $f" >&2
+    fi
+    echo
+done


### PR DESCRIPTION
## Summary
- add `cat_unused_root_files.sh` to print unused Python files for reference

## Testing
- `black . --check` *(fails: would reformat 320 files)*
- `flake8` *(fails: multiple style violations)*
- `mypy .` *(fails: found 2437 errors in 523 files)*
- `pytest -q` *(fails: missing required test dependencies: yaml, psutil)*

------
https://chatgpt.com/codex/tasks/task_e_687583e808188320862a5577a31680e9