### PR TITLE
Fix trailing slash routing in display_page

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -30,6 +30,7 @@ def create_app(mode=None, **kwargs):
     # Simple routing callback that uses REAL pages
     @app.callback(Output("page-content", "children"), Input("url", "pathname"))
     def display_page(pathname):
+        pathname = pathname.rstrip("/") if pathname else "/"
         if pathname == "/dashboard":
             return html.Div(
                 [


### PR DESCRIPTION
## Summary
- normalize url paths by stripping trailing slashes before routing

## Testing
- `pytest -q` *(fails: 118 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6875b2c18a108320ac2454ea23c50326