### PR TITLE
Update service factory imports

### DIFF
--- a/mapping/factories/service_factory.py
+++ b/mapping/factories/service_factory.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mapping.storage.base import JsonStorage, MemoryStorage
 from mapping.processors.ai_processor import AIColumnMapperAdapter
 from mapping.processors.column_processor import ColumnProcessor
 from mapping.processors.device_processor import DeviceProcessor
-from services.learning.coordinator import LearningCoordinator
 from mapping.service import MappingService
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from services.learning.coordinator import LearningCoordinator
 
 
 def create_learning_service(
     path: str | None = None, in_memory: bool = False
-) -> LearningCoordinator:
+) -> "LearningCoordinator":
+    from services.learning.coordinator import LearningCoordinator
+
     storage = (
         MemoryStorage()
         if in_memory


### PR DESCRIPTION
## Summary
- lazy load `LearningCoordinator` inside `create_learning_service`
- only import `LearningCoordinator` for typing under `TYPE_CHECKING`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: Interrupted with 118 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875d602d85c832080cdff41bfbb2dc8