### PR TITLE
Add wrapper for create_mapping_service

### DIFF
--- a/mapping/__init__.py
+++ b/mapping/__init__.py
@@ -7,7 +7,15 @@ from .core.interfaces import (
 )
 from .core.models import ProcessingResult, MappingData
 from .service import MappingService
-from .factories.service_factory import create_mapping_service
+
+
+def create_mapping_service(*args, **kwargs):
+    """Lazily import and delegate to the mapping service factory."""
+    from .factories.service_factory import (
+        create_mapping_service as _factory,
+    )
+
+    return _factory(*args, **kwargs)
 
 __all__ = [
     "StorageInterface",


### PR DESCRIPTION
## Summary
- avoid importing the service factory eagerly
- expose `create_mapping_service` via lazy wrapper

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask', 'sqlparse', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6875e05ce0c88320a9df6e9b89f624a4