### PR TITLE
Fix imports in utility code

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -293,7 +293,6 @@ def diagnose_upload_config():
     """Diagnostic function to check upload configuration"""
     import os
 
-    from config.dynamic_config import dynamic_config
 
     print("=== Upload Configuration Diagnosis ===")
     print(f"Environment MAX_UPLOAD_MB: {os.getenv('MAX_UPLOAD_MB', 'Not Set')}")

--- a/utils/sample_data_generator.py
+++ b/utils/sample_data_generator.py
@@ -162,9 +162,7 @@ Run this after setting up the project structure
 def test_file_upload():
     """Test file upload functionality"""
 
-    # Generate test data
-    from utils.sample_data_generator import generate_sample_access_data
-
+    # Generate test data using function defined above
     df = generate_sample_access_data(100)
     logger.info(f"Generated test data: {len(df)} records")
     logger.info(f"Columns: {list(df.columns)}")


### PR DESCRIPTION
## Summary
- remove self-import from diagnose_upload_config
- reference generate_sample_access_data directly within sample_data_generator

## Testing
- `pytest -q` *(fails: 118 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6875f46b0c0083208f08564506dfbd1e