### PR TITLE
Refactor security event module

### DIFF
--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -21,10 +21,7 @@ from config.constants import FileProcessingLimits
 from core.exceptions import ValidationError
 from security.attack_detection import AttackDetection
 from security.unicode_security_processor import sanitize_unicode_input
-from security_callback_controller import (
-    SecurityEvent,
-    emit_security_event,
-)
+from security.events import SecurityEvent, emit_security_event
 
 from .security_patterns import (
     PATH_TRAVERSAL_PATTERNS as RAW_PATH_PATTERNS,

--- a/security/events.py
+++ b/security/events.py
@@ -1,0 +1,18 @@
+"""Security event utilities."""
+
+from typing import Any
+
+from core.callback_events import CallbackEvent
+
+SecurityEvent = CallbackEvent
+
+# Instance of ``TrulyUnifiedCallbacks`` assigned at runtime.
+security_unified_callbacks: Any
+
+
+def emit_security_event(event: SecurityEvent, data: dict | None = None) -> None:
+    """Trigger *event* through ``security_unified_callbacks``."""
+    security_unified_callbacks.trigger(event, data)
+
+
+__all__ = ["SecurityEvent", "emit_security_event", "security_unified_callbacks"]

--- a/security_callback_controller.py
+++ b/security_callback_controller.py
@@ -1,15 +1,13 @@
 """Compatibility wrapper exposing security-specific callback names."""
 
-from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-
-SecurityEvent = CallbackEvent
+from security.events import (
+    SecurityEvent,
+    emit_security_event,
+    security_unified_callbacks,
+)
 SecurityCallbackController = CallbackManager
 security_callback_controller = CallbackManager()
-
-def emit_security_event(event: SecurityEvent, data: dict | None = None) -> None:
-    security_unified_callbacks.trigger(event, data)
 
 __all__ = [
     "SecurityEvent",


### PR DESCRIPTION
## Summary
- add `security/events.py` with event helper
- update validator to pull events from new module
- avoid import cycle in `security_callback_controller`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash._callback_context')*

------
https://chatgpt.com/codex/tasks/task_e_6875f463b47083208808dcb5bc14edb6