### PR TITLE
Refactor upload data protocol

### DIFF
--- a/services/interfaces.py
+++ b/services/interfaces.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List, Protocol, runtime_checkable
 
 import pandas as pd
 
+from core.service_container import ServiceContainer
+
 
 @runtime_checkable
 class UploadValidatorProtocol(Protocol):
@@ -59,38 +61,12 @@ class DeviceLearningServiceProtocol(Protocol):
     ) -> bool: ...
 
 
-@runtime_checkable
-class UploadDataServiceProtocol(Protocol):
-    """Interface for accessing uploaded data."""
-
-    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
-        """Return all uploaded dataframes."""
-        ...
-
-    def get_uploaded_filenames(self) -> List[str]:
-        """Return names of uploaded files."""
-        ...
-
-    def clear_uploaded_data(self) -> None:
-        """Remove all uploaded data."""
-        ...
-
-    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
-        """Return info dictionary for uploaded files."""
-        ...
-
-    def load_dataframe(self, filename: str) -> pd.DataFrame:
-        """Load a specific uploaded dataframe."""
-        ...
-
-
 # ---------------------------------------------------------------------------
 # Helper accessors
 # ---------------------------------------------------------------------------
 # Use the same ServiceContainer implementation as ``core.app_factory``
 # to avoid type mismatches when helpers are accessed through the
 # application-wide dependency injection container.
-from core.service_container import ServiceContainer
 
 
 def _get_container(
@@ -156,6 +132,8 @@ def get_upload_data_service(
     container: ServiceContainer | None = None,
 ) -> UploadDataServiceProtocol:
     """Return the registered :class:`UploadDataService` instance."""
+    from services.protocols.upload_data import UploadDataServiceProtocol
+
     c = _get_container(container)
     if c and c.has("upload_data_service"):
         return c.get("upload_data_service")
@@ -170,7 +148,6 @@ __all__ = [
     "ExportServiceProtocol",
     "DoorMappingServiceProtocol",
     "DeviceLearningServiceProtocol",
-    "UploadDataServiceProtocol",
     "get_upload_validator",
     "get_export_service",
     "get_door_mapping_service",

--- a/services/protocols/upload_data.py
+++ b/services/protocols/upload_data.py
@@ -1,0 +1,35 @@
+"""Upload data service protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol, runtime_checkable
+
+import pandas as pd
+
+
+@runtime_checkable
+class UploadDataServiceProtocol(Protocol):
+    """Interface for accessing uploaded data."""
+
+    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        """Return all uploaded dataframes."""
+        ...
+
+    def get_uploaded_filenames(self) -> List[str]:
+        """Return names of uploaded files."""
+        ...
+
+    def clear_uploaded_data(self) -> None:
+        """Remove all uploaded data."""
+        ...
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]:
+        """Return info dictionary for uploaded files."""
+        ...
+
+    def load_dataframe(self, filename: str) -> pd.DataFrame:
+        """Load a specific uploaded dataframe."""
+        ...
+
+
+__all__ = ["UploadDataServiceProtocol"]

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -3,13 +3,10 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from services.interfaces import (
-    UploadDataServiceProtocol,
-    get_upload_data_service,
-)
 from core.service_container import ServiceContainer
-from utils.upload_store import uploaded_data_store, UploadedDataStore
-
+from services.interfaces import get_upload_data_service
+from services.protocols.upload_data import UploadDataServiceProtocol
+from utils.upload_store import UploadedDataStore, uploaded_data_store
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +32,7 @@ class UploadDataService(UploadDataServiceProtocol):
 
     def load_dataframe(self, filename: str) -> pd.DataFrame:
         return self.store.load_dataframe(filename)
+
 
 def _resolve_service(
     service: UploadDataServiceProtocol | None,


### PR DESCRIPTION
## Summary
- extract `UploadDataServiceProtocol` into `services/protocols/upload_data.py`
- import the new protocol in `UploadDataService`
- adjust helper in `services.interfaces`

## Testing
- `flake8 services/interfaces.py services/upload_data_service.py services/protocols/upload_data.py`
- `bandit -q -lll services/interfaces.py services/upload_data_service.py services/protocols/upload_data.py`
- `pytest tests/test_upload_data_service_interface.py -q` *(fails: ModuleNotFoundError: No module named 'hvac')*

------
https://chatgpt.com/codex/tasks/task_e_6875f4659a5c8320ad05976768e2bcbf