### PR TITLE
Refactor database connection type

### DIFF
--- a/config/connection_pool.py
+++ b/config/connection_pool.py
@@ -4,8 +4,7 @@ import threading
 import time
 from typing import Callable, List, Tuple
 
-from .database_exceptions import ConnectionValidationFailed
-from .database_manager import DatabaseConnection
+from database.types import DatabaseConnection
 
 
 class DatabaseConnectionPool:

--- a/database/connection_pool.py
+++ b/database/connection_pool.py
@@ -5,7 +5,7 @@ import time
 from typing import Any, Callable, Dict, List, Tuple
 
 from config.database_exceptions import ConnectionValidationFailed
-from config.database_manager import DatabaseConnection
+from database.types import DatabaseConnection
 
 
 class CircuitBreaker:

--- a/database/types.py
+++ b/database/types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol
+
+
+class DatabaseConnection(Protocol):
+    """Protocol for database connections"""
+
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> Any:
+        """Execute a query and return results"""
+        ...
+
+    def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
+        """Execute a command (INSERT, UPDATE, DELETE)"""
+        ...
+
+    def health_check(self) -> bool:
+        """Verify database connectivity"""
+        ...
+
+
+__all__ = ["DatabaseConnection"]


### PR DESCRIPTION
## Summary
- centralize `DatabaseConnection` protocol in `database/types.py`
- update connection pool modules to use the new protocol
- reference the protocol from `DatabaseManager` and keep lazy pool import

## Testing
- `pre-commit run --files config/connection_pool.py database/connection_pool.py config/database_manager.py database/types.py` *(fails: mypy errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6875f46749748320b1824146a9f587f4