### PR TITLE
Refactor inline styles into CSS classes

### DIFF
--- a/assets/css/03-components/_upload.css
+++ b/assets/css/03-components/_upload.css
@@ -28,6 +28,19 @@
   will-change: auto;
 }
 
+/* Simple variant with neutral border */
+.upload-simple {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--surface-tertiary);
+  border-radius: var(--radius-md);
+  text-align: center;
+  cursor: pointer;
+  padding: var(--space-5);
+}
+
 /* Upload content stability */
 #drag-drop-upload > *,
 .drag-drop-upload > * {

--- a/assets/css/07-utilities/_colors.css
+++ b/assets/css/07-utilities/_colors.css
@@ -29,3 +29,5 @@
 .bg-surface-primary { background-color: var(--surface-primary); }
 .bg-surface-secondary { background-color: var(--surface-secondary); }
 .bg-surface-tertiary { background-color: var(--surface-tertiary); }
+.bg-gray-900 { background-color: var(--color-gray-900); }
+.bg-black { background-color: var(--black); }

--- a/assets/css/07-utilities/_spacing.css
+++ b/assets/css/07-utilities/_spacing.css
@@ -43,3 +43,8 @@
 .pt-2 { padding-top: var(--space-2); }
 .pt-3 { padding-top: var(--space-3); }
 .pt-4 { padding-top: var(--space-4); }
+
+/* Extended Spacing Utilities */
+.m-2-5 { margin: var(--space-2-5); }
+.mt-2-5 { margin-top: var(--space-2-5); }
+.mr-2-5 { margin-right: var(--space-2-5); }

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 import dash_bootstrap_components as dbc
 
 if not hasattr(dbc, "Alert"):
+
     class _DummyComponent:
         def __init__(self, *a, **k):
             pass
@@ -18,8 +19,10 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash import dcc, html
+
 from core.container import container
 from core.protocols import ConfigurationProtocol
+
 # from components.analytics.real_time_dashboard import RealTimeAnalytics
 
 try:  # Prefer configuration from the DI container when available
@@ -36,7 +39,9 @@ if not _cfg:
 from config.constants import MAX_DISPLAY_ROWS as DEFAULT_MAX_DISPLAY_ROWS
 
 if _cfg is not None and hasattr(_cfg, "analytics"):
-    MAX_DISPLAY_ROWS = getattr(_cfg.analytics, "max_display_rows", DEFAULT_MAX_DISPLAY_ROWS)
+    MAX_DISPLAY_ROWS = getattr(
+        _cfg.analytics, "max_display_rows", DEFAULT_MAX_DISPLAY_ROWS
+    )
     _MAX_UPLOAD_BYTES = getattr(_cfg.security, "max_upload_mb", 50) * 1024 * 1024
 else:  # pragma: no cover - fallback for optional config
     MAX_DISPLAY_ROWS = DEFAULT_MAX_DISPLAY_ROWS
@@ -366,13 +371,7 @@ def create_file_uploader() -> html.Div:
                             ],
                             className="text-center p-4",
                         ),
-                        style={
-                            "border": "2px dashed #ddd",
-                            "borderRadius": "8px",
-                            "textAlign": "center",
-                            "cursor": "pointer",
-                            "padding": "20px",
-                        },
+                        className="upload-simple",
                         multiple=True,
                     ),
                     html.Div(id="upload-output", className="mt-3"),
@@ -501,7 +500,7 @@ class ComponentRegistry:
             "success_alert": create_success_alert,
             "info_alert": create_info_alert,
             "sample_analytics": generate_sample_analytics,
-#             "realtime_analytics": RealTimeAnalytics,
+            #             "realtime_analytics": RealTimeAnalytics,
         }
 
     def get_component(self, name: str):
@@ -541,5 +540,5 @@ __all__ = [
     "ComponentRegistry",
     "get_component",
     "register_component",
-#     "RealTimeAnalytics",
+    #     "RealTimeAnalytics",
 ]

--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -68,7 +68,10 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-home me-2", **{"aria-hidden": "true"}),
+                                        html.I(
+                                            className="fas fa-home me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
                                         "Dashboard",
                                     ],
                                     href="/dashboard",
@@ -78,7 +81,10 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-chart-bar me-2", **{"aria-hidden": "true"}),
+                                        html.I(
+                                            className="fas fa-chart-bar me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
                                         "Analytics",
                                     ],
                                     href="/analytics",
@@ -88,7 +94,10 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-chart-line me-2", **{"aria-hidden": "true"}),
+                                        html.I(
+                                            className="fas fa-chart-line me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
                                         "Graphs",
                                     ],
                                     href="/graphs",
@@ -97,7 +106,13 @@ def create_navbar_layout() -> Any:
                             ),
                             dbc.NavItem(
                                 dcc.Link(
-                                    [html.I(className="fas fa-upload me-2", **{"aria-hidden": "true"}), "File Upload"],
+                                    [
+                                        html.I(
+                                            className="fas fa-upload me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
+                                        "File Upload",
+                                    ],
                                     href="/upload",
                                     className="nav-link px-3",
                                 )
@@ -105,7 +120,10 @@ def create_navbar_layout() -> Any:
                             dbc.NavItem(
                                 dcc.Link(
                                     [
-                                        html.I(className="fas fa-download me-2", **{"aria-hidden": "true"}),
+                                        html.I(
+                                            className="fas fa-download me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
                                         "Export",
                                     ],
                                     href="/export",
@@ -114,11 +132,18 @@ def create_navbar_layout() -> Any:
                             ),
                             dbc.NavItem(
                                 dcc.Link(
-                                    [html.I(className="fas fa-cog me-2", **{"aria-hidden": "true"}), "Settings"],
+                                    [
+                                        html.I(
+                                            className="fas fa-cog me-2",
+                                            **{"aria-hidden": "true"},
+                                        ),
+                                        "Settings",
+                                    ],
                                     href="/settings",
                                     className="nav-link px-3",
                                 )
-                            ),                        ],
+                            ),
+                        ],
                         navbar=True,
                         className="ms-auto",
                     ),
@@ -129,8 +154,7 @@ def create_navbar_layout() -> Any:
             color="dark",
             dark=True,
             expand="lg",
-            className="navbar navbar-expand-lg navbar-stable",
-            style={"backgroundColor": "var(--gray-900)"},
+            className="navbar navbar-expand-lg navbar-stable bg-gray-900",
         )
 
     except Exception as e:

--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -33,7 +33,8 @@ def create_navbar_layout() -> Any:
                         html.Img(
                             src="/assets/yosai_logo_name_white.png",
                             height="40px",
-                            style={"margin-right": "10px", "filter": "brightness(1)"},
+                            className="mr-2-5",
+                            style={"filter": "brightness(1)"},
                             alt="Yōsai logo",
                         ),
                         href="/",
@@ -48,7 +49,10 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-chart-bar me-2", **{"aria-hidden": "true"}),
+                                            html.I(
+                                                className="fas fa-chart-bar me-2",
+                                                **{"aria-hidden": "true"},
+                                            ),
                                             "Analytics",
                                         ],
                                         href="/analytics",
@@ -60,7 +64,10 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-chart-line me-2", **{"aria-hidden": "true"}),
+                                            html.I(
+                                                className="fas fa-chart-line me-2",
+                                                **{"aria-hidden": "true"},
+                                            ),
                                             "Graphs",
                                         ],
                                         href="/graphs",
@@ -72,7 +79,10 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-upload me-2", **{"aria-hidden": "true"}),
+                                            html.I(
+                                                className="fas fa-upload me-2",
+                                                **{"aria-hidden": "true"},
+                                            ),
                                             "Upload",
                                         ],
                                         href="/upload",
@@ -84,7 +94,10 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-download me-2", **{"aria-hidden": "true"}),
+                                            html.I(
+                                                className="fas fa-download me-2",
+                                                **{"aria-hidden": "true"},
+                                            ),
                                             "Export",
                                         ],
                                         href="/export",
@@ -96,7 +109,10 @@ def create_navbar_layout() -> Any:
                                 dbc.NavItem(
                                     dbc.NavLink(
                                         [
-                                            html.I(className="fas fa-cog me-2", **{"aria-hidden": "true"}),
+                                            html.I(
+                                                className="fas fa-cog me-2",
+                                                **{"aria-hidden": "true"},
+                                            ),
                                             "Settings",
                                         ],
                                         href="/settings",
@@ -120,8 +136,7 @@ def create_navbar_layout() -> Any:
             color="dark",
             dark=True,
             expand="lg",
-            className="navbar navbar-expand-lg fixed-top shadow-sm",
-            style={"background-color": "#000000"},
+            className="navbar navbar-expand-lg fixed-top shadow-sm bg-black",
         )
 
     except Exception as e:

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -9,12 +9,14 @@ import logging
 from typing import Any
 
 import dash_bootstrap_components as dbc
-from dash import html, register_page as dash_register_page
+from dash import html
+from dash import register_page as dash_register_page
 
-from components.ui_component import UIComponent
 from components.analytics.real_time_dashboard import RealTimeAnalytics
+from components.ui_component import UIComponent
 
 logger = logging.getLogger(__name__)
+
 
 class AnalyticsPage(UIComponent):
     """Simple analytics page component."""
@@ -44,12 +46,13 @@ class AnalyticsPage(UIComponent):
                                                 ),
                                                 html.Hr(),
                                                 html.I(
-                                                    className="fas fa-chart-line fa-3x mb-3",
-                                                    style={"color": "#007bff"},
+                                                    className="fas fa-chart-line fa-3x mb-3 text-accent",
                                                     **{"aria-hidden": "true"},
                                                 ),
                                                 html.H6("✅ Navigation Flash: FIXED"),
-                                                html.H6("🔧 Advanced Analytics: Coming Next"),
+                                                html.H6(
+                                                    "🔧 Advanced Analytics: Coming Next"
+                                                ),
                                                 html.P(
                                                     "Page loads stable like Settings/Export",
                                                     className="text-muted",
@@ -58,9 +61,15 @@ class AnalyticsPage(UIComponent):
                                                 html.H6("📋 Planned Features:"),
                                                 html.Ul(
                                                     [
-                                                        html.Li("Data source selection"),
-                                                        html.Li("Interactive charts and graphs"),
-                                                        html.Li("Device pattern analysis"),
+                                                        html.Li(
+                                                            "Data source selection"
+                                                        ),
+                                                        html.Li(
+                                                            "Interactive charts and graphs"
+                                                        ),
+                                                        html.Li(
+                                                            "Device pattern analysis"
+                                                        ),
                                                         html.Li("Anomaly detection"),
                                                         html.Li("Behavior analysis"),
                                                     ]
@@ -70,11 +79,12 @@ class AnalyticsPage(UIComponent):
                                     ],
                                     className="mb-4",
                                 )
-                            ]
-                        , md=8)
+                            ],
+                            md=8,
+                        )
                     ]
                 ),
-                dbc.Row([dbc.Col(self._realtime.layout())])
+                dbc.Row([dbc.Col(self._realtime.layout())]),
             ],
             fluid=True,
         )
@@ -97,13 +107,26 @@ def register_page() -> None:
     """Register the analytics page with Dash using current app context."""
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+            dash.register_page(
+                __name__,
+                path="/analytics",
+                name="Analytics",
+                aliases=["/", "/dashboard"],
+            )
         else:
             from dash import register_page as dash_register_page
-            dash_register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+
+            dash_register_page(
+                __name__,
+                path="/analytics",
+                name="Analytics",
+                aliases=["/", "/dashboard"],
+            )
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")
 
@@ -112,15 +135,19 @@ def register_page_with_app(app) -> None:
     """Register the page with a specific Dash app instance."""
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
-        dash.register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+        dash.register_page(
+            __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
+        )
         if old_app is not None:
             dash._current_app = old_app
         else:
             delattr(dash, "_current_app")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
@@ -136,10 +163,12 @@ def register_callbacks(manager: Any) -> None:
 
     _analytics_component.register_callbacks(manager)
 
+
 # For backward compatibility with app_factory
 def deep_analytics_layout():
     """Compatibility function for app_factory."""
     return layout()
+
 
 __all__ = [
     "AnalyticsPage",
@@ -150,10 +179,12 @@ __all__ = [
     "deep_analytics_layout",
 ]
 
+
 def __getattr__(name: str):
     if name.startswith(("create_", "get_")):
+
         def _stub(*args, **kwargs):
             return None
+
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
-

--- a/pages/deep_analytics_complex/layout.py
+++ b/pages/deep_analytics_complex/layout.py
@@ -25,8 +25,7 @@ def layout() -> dbc.Container:
                 ),
                 html.Hr(),
                 html.I(
-                    className="fas fa-chart-line fa-3x mb-3",
-                    style={"color": "#007bff"},
+                    className="fas fa-chart-line fa-3x mb-3 text-accent",
                     **{"aria-hidden": "true"},
                 ),
                 html.H6("✅ Navigation Flash: FIXED"),
@@ -89,9 +88,12 @@ def layout() -> dbc.Container:
         fluid=True,
     )
 
+
 def __getattr__(name: str):
     if name.startswith(("create_", "get_")):
+
         def _stub(*args, **kwargs):
             return None
+
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -26,9 +26,7 @@ from dash.exceptions import PreventUpdate
 
 from components.ui_component import UIComponent
 from config.dynamic_config import dynamic_config
-from services.upload_data_service import (
-    clear_uploaded_data as _svc_clear_uploaded_data,
-)
+from services.upload_data_service import clear_uploaded_data as _svc_clear_uploaded_data
 
 logger = logging.getLogger(__name__)
 
@@ -41,19 +39,25 @@ class UploadPage(UIComponent):
 
     def layout(self) -> dbc.Container:
         """Full upload layout with pre-mount stability."""
-        
+
         # Pre-initialize all components to prevent flash
         upload_area = dcc.Upload(
             id="drag-drop-upload",
-            children=html.Div([
-                html.I(
-                    className="fas fa-cloud-upload-alt fa-3x mb-3",
-                    **{"aria-hidden": "true"},
-                ),
-                html.H5("Drag & Drop Files Here"),
-                html.P("or click to select files", className="text-muted"),
-                html.P("Supports CSV, Excel, and JSON files", className="small text-muted"),
-            ]),
+            children=html.Div(
+                [
+                    html.I(
+                        className="fas fa-cloud-upload-alt fa-3x mb-3",
+                        **{"aria-hidden": "true"},
+                    ),
+                    html.H5("Drag & Drop Files Here"),
+                    html.P("or click to select files", className="text-muted"),
+                    html.P(
+                        "Supports CSV, Excel, and JSON files",
+                        className="small text-muted",
+                    ),
+                ]
+            ),
+            className="upload-simple m-2-5",
             style={
                 "width": "100%",
                 "height": "200px",
@@ -62,93 +66,141 @@ class UploadPage(UIComponent):
                 "borderStyle": "dashed",
                 "borderRadius": "5px",
                 "textAlign": "center",
-                "margin": "10px",
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
                 "justifyContent": "center",
                 "alignItems": "center",
                 "opacity": "1",
-                "visibility": "visible"
+                "visibility": "visible",
             },
             multiple=True,
         )
 
-        return dbc.Container([
-            # Header - Pre-rendered stable
-            dbc.Row([
-                dbc.Col([
-                    html.H2("📁 File Upload", className="mb-3"),
-                    html.P(
-                        "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
-                        className="text-muted mb-4",
-                    ),
-                ])
-            ]),
-            
-            # Upload area - Pre-rendered
-            dbc.Row([
-                dbc.Col([
-                    html.Label("Upload data files", htmlFor="drag-drop-upload", className="visually-hidden"),
-                    upload_area,
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Progress area - Pre-rendered but hidden
-            dbc.Row([
-                dbc.Col([
-                    dbc.Progress(
-                        id="upload-progress",
-                        value=0,
-                        striped=True,
-                        animated=False,
-                        style={"display": "none"},
-                    ),
-                    html.Div(id="upload-status", style={"marginTop": "10px"}),
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Preview area - Pre-rendered empty
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="preview-area",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "50px"}
-                    )
-                ], lg=10, md=12, sm=12, className="mx-auto")
-            ]),
-            
-            # Navigation area - Pre-rendered empty  
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="upload-navigation",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "30px"}
-                    )
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ], className="mt-4"),
-            
-            # Data stores - Pre-initialized
-            dcc.Store(id="uploaded-files-store", data={}),
-            dcc.Store(id="upload-session-store", data={}),
-            
-        ], fluid=True, className="py-4", style={"opacity": "1", "visibility": "visible"})
+        return dbc.Container(
+            [
+                # Header - Pre-rendered stable
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H2("📁 File Upload", className="mb-3"),
+                                html.P(
+                                    "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
+                                    className="text-muted mb-4",
+                                ),
+                            ]
+                        )
+                    ]
+                ),
+                # Upload area - Pre-rendered
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Label(
+                                    "Upload data files",
+                                    htmlFor="drag-drop-upload",
+                                    className="visually-hidden",
+                                ),
+                                upload_area,
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Progress area - Pre-rendered but hidden
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                dbc.Progress(
+                                    id="upload-progress",
+                                    value=0,
+                                    striped=True,
+                                    animated=False,
+                                    style={"display": "none"},
+                                ),
+                                html.Div(id="upload-status", className="mt-2-5"),
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Preview area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="preview-area",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "50px",
+                                    },
+                                )
+                            ],
+                            lg=10,
+                            md=12,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Navigation area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="upload-navigation",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "30px",
+                                    },
+                                )
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ],
+                    className="mt-4",
+                ),
+                # Data stores - Pre-initialized
+                dcc.Store(id="uploaded-files-store", data={}),
+                dcc.Store(id="upload-session-store", data={}),
+            ],
+            fluid=True,
+            className="py-4",
+            style={"opacity": "1", "visibility": "visible"},
+        )
 
     def register_callbacks(self, manager, controller=None):
         """Register upload callbacks with timing fixes."""
         try:
+
             @manager.unified_callback(
                 [
                     Output("upload-status", "children"),
                     Output("upload-progress", "value"),
                     Output("upload-progress", "style"),
                     Output("uploaded-files-store", "data"),
-                    Output("preview-area", "children")
+                    Output("preview-area", "children"),
                 ],
                 Input("drag-drop-upload", "contents"),
                 [
                     State("drag-drop-upload", "filename"),
-                    State("uploaded-files-store", "data")
+                    State("uploaded-files-store", "data"),
                 ],
                 callback_id="file_upload_process",
                 component_name="file_upload",
@@ -157,21 +209,23 @@ class UploadPage(UIComponent):
             def process_upload(contents, filenames, existing_files):
                 if not contents:
                     return no_update, no_update, no_update, no_update, no_update
-                
+
                 try:
                     # Simple success response
                     status = dbc.Alert("Files uploaded successfully!", color="success")
                     progress_style = {"display": "block"}
                     updated_files = existing_files or {}
-                    
+
                     # Simple preview
-                    preview = html.Div([
-                        html.H6("Uploaded Files:"),
-                        html.Ul([html.Li(f) for f in (filenames or [])])
-                    ])
-                    
+                    preview = html.Div(
+                        [
+                            html.H6("Uploaded Files:"),
+                            html.Ul([html.Li(f) for f in (filenames or [])]),
+                        ]
+                    )
+
                     return status, 100, progress_style, updated_files, preview
-                    
+
                 except Exception as e:
                     error_status = dbc.Alert(f"Upload failed: {str(e)}", color="danger")
                     return error_status, 0, {"display": "none"}, no_update, no_update
@@ -184,23 +238,29 @@ class UploadPage(UIComponent):
 
 _upload_component = UploadPage()
 
+
 def load_page(**kwargs):
     return UploadPage(**kwargs)
+
 
 def register_page():
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
             dash.register_page(__name__, path="/upload", name="Upload")
         else:
             from dash import register_page as dash_register_page
+
             dash_register_page(__name__, path="/upload", name="Upload")
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")
 
+
 def register_page_with_app(app):
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
         dash.register_page(__name__, path="/upload", name="Upload")
@@ -211,10 +271,13 @@ def register_page_with_app(app):
     except Exception as e:
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
+
 def layout():
     return _upload_component.layout()
 
+
 def register_callbacks(manager):
     _upload_component.register_callbacks(manager)
+
 
 __all__ = ["UploadPage", "load_page", "layout", "register_page"]

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import base64
-from io import BytesIO
 import logging
+from io import BytesIO
 from typing import List
 
 import dash_bootstrap_components as dbc
 import pandas as pd
-from dash import dcc, html, callback, Output, Input, State
+from dash import Input, Output, State, callback, dcc, html
 from dash.exceptions import PreventUpdate
 
 from utils.upload_store import uploaded_data_store
@@ -35,6 +35,7 @@ def layout() -> dbc.Container:
                 ),
             ]
         ),
+        className="upload-simple m-2-5",
         style={
             "width": "100%",
             "height": "200px",
@@ -43,7 +44,6 @@ def layout() -> dbc.Container:
             "borderStyle": "dashed",
             "borderRadius": "5px",
             "textAlign": "center",
-            "margin": "10px",
             "cursor": "pointer",
             "display": "flex",
             "flexDirection": "column",


### PR DESCRIPTION
## Summary
- extract inline margins and colors into CSS classes
- create spacing utilities for 10px margins
- add color helpers for gray and black backgrounds
- implement neutral upload dropzone style
- update navigation bars and pages to use the new classes

## Testing
- `pre-commit run --files assets/css/03-components/_upload.css assets/css/07-utilities/_colors.css assets/css/07-utilities/_spacing.css components/__init__.py components/ui/navbar.py components/ui/navbar_enhanced.py pages/deep_analytics.py pages/deep_analytics_complex/layout.py pages/file_upload.py pages/file_upload_simple.py`

------
https://chatgpt.com/codex/tasks/task_e_687695084d948320be570dd767b4070f