### PR TITLE
Add layout factory for cards

### DIFF
--- a/components/layout_factory.py
+++ b/components/layout_factory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import dash_bootstrap_components as dbc
+from dash import html
+
+
+def card(title: str, body, color: str = "primary", icon: str | None = None, **kwargs):
+    """Return a simple Bootstrap card.
+
+    Parameters
+    ----------
+    title: str
+        Card title text.
+    body: Any
+        Card body content. Can be a Dash component, list of components or
+        plain text.
+    color: str
+        Bootstrap color scheme.
+    icon: str | None
+        Optional CSS class for an icon displayed before the title.
+    kwargs: Any
+        Additional arguments passed to :class:`dbc.Card`.
+    """
+    # Normalize body into list of components
+    if isinstance(body, (str, bytes)):
+        body_children = [html.P(body, className="card-text")]
+    elif isinstance(body, (list, tuple)):
+        body_children = list(body)
+    else:
+        body_children = [body]
+
+    title_children = []
+    if icon:
+        title_children.append(
+            html.I(className=f"{icon} me-2", **{"aria-hidden": "true"})
+        )
+    title_children.append(title)
+
+    body_children.insert(0, html.H5(title_children, className="card-title"))
+
+    kwargs.setdefault("className", "mb-4")
+
+    return dbc.Card(dbc.CardBody(body_children), color=color, **kwargs)

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -13,8 +13,10 @@ from dash import html, register_page as dash_register_page
 
 from components.ui_component import UIComponent
 from components.analytics.real_time_dashboard import RealTimeAnalytics
+from components.layout_factory import card
 
 logger = logging.getLogger(__name__)
+
 
 class AnalyticsPage(UIComponent):
     """Simple analytics page component."""
@@ -30,51 +32,47 @@ class AnalyticsPage(UIComponent):
                     [
                         dbc.Col(
                             [
-                                dbc.Card(
+                                card(
+                                    "📊 Analytics Dashboard",
                                     [
-                                        dbc.CardBody(
+                                        html.P(
+                                            "Advanced analytics restored without navigation flash.",
+                                            className="card-text",
+                                        ),
+                                        html.Hr(),
+                                        html.I(
+                                            className="fas fa-chart-line fa-3x mb-3",
+                                            style={"color": "#007bff"},
+                                            **{"aria-hidden": "true"},
+                                        ),
+                                        html.H6("✅ Navigation Flash: FIXED"),
+                                        html.H6("🔧 Advanced Analytics: Coming Next"),
+                                        html.P(
+                                            "Page loads stable like Settings/Export",
+                                            className="text-muted",
+                                        ),
+                                        html.Hr(),
+                                        html.H6("📋 Planned Features:"),
+                                        html.Ul(
                                             [
-                                                html.H5(
-                                                    "📊 Analytics Dashboard",
-                                                    className="card-title",
+                                                html.Li("Data source selection"),
+                                                html.Li(
+                                                    "Interactive charts and graphs"
                                                 ),
-                                                html.P(
-                                                    "Advanced analytics restored without navigation flash.",
-                                                    className="card-text",
-                                                ),
-                                                html.Hr(),
-                                                html.I(
-                                                    className="fas fa-chart-line fa-3x mb-3",
-                                                    style={"color": "#007bff"},
-                                                    **{"aria-hidden": "true"},
-                                                ),
-                                                html.H6("✅ Navigation Flash: FIXED"),
-                                                html.H6("🔧 Advanced Analytics: Coming Next"),
-                                                html.P(
-                                                    "Page loads stable like Settings/Export",
-                                                    className="text-muted",
-                                                ),
-                                                html.Hr(),
-                                                html.H6("📋 Planned Features:"),
-                                                html.Ul(
-                                                    [
-                                                        html.Li("Data source selection"),
-                                                        html.Li("Interactive charts and graphs"),
-                                                        html.Li("Device pattern analysis"),
-                                                        html.Li("Anomaly detection"),
-                                                        html.Li("Behavior analysis"),
-                                                    ]
-                                                ),
+                                                html.Li("Device pattern analysis"),
+                                                html.Li("Anomaly detection"),
+                                                html.Li("Behavior analysis"),
                                             ]
-                                        )
+                                        ),
                                     ],
-                                    className="mb-4",
+                                    color="light",
                                 )
-                            ]
-                        , md=8)
+                            ],
+                            md=8,
+                        )
                     ]
                 ),
-                dbc.Row([dbc.Col(self._realtime.layout())])
+                dbc.Row([dbc.Col(self._realtime.layout())]),
             ],
             fluid=True,
         )
@@ -97,13 +95,26 @@ def register_page() -> None:
     """Register the analytics page with Dash using current app context."""
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+            dash.register_page(
+                __name__,
+                path="/analytics",
+                name="Analytics",
+                aliases=["/", "/dashboard"],
+            )
         else:
             from dash import register_page as dash_register_page
-            dash_register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+
+            dash_register_page(
+                __name__,
+                path="/analytics",
+                name="Analytics",
+                aliases=["/", "/dashboard"],
+            )
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")
 
@@ -112,15 +123,19 @@ def register_page_with_app(app) -> None:
     """Register the page with a specific Dash app instance."""
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
-        dash.register_page(__name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"])
+        dash.register_page(
+            __name__, path="/analytics", name="Analytics", aliases=["/", "/dashboard"]
+        )
         if old_app is not None:
             dash._current_app = old_app
         else:
             delattr(dash, "_current_app")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
@@ -136,10 +151,12 @@ def register_callbacks(manager: Any) -> None:
 
     _analytics_component.register_callbacks(manager)
 
+
 # For backward compatibility with app_factory
 def deep_analytics_layout():
     """Compatibility function for app_factory."""
     return layout()
+
 
 __all__ = [
     "AnalyticsPage",
@@ -150,10 +167,12 @@ __all__ = [
     "deep_analytics_layout",
 ]
 
+
 def __getattr__(name: str):
     if name.startswith(("create_", "get_")):
+
         def _stub(*args, **kwargs):
             return None
+
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
-

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -12,6 +12,8 @@ from config.dynamic_config import dynamic_config
 from security.unicode_security_processor import sanitize_unicode_input
 
 from components.ui_component import UIComponent
+from components.layout_factory import card
+
 
 class SettingsPage(UIComponent):
     """Settings page component."""
@@ -21,7 +23,6 @@ class SettingsPage(UIComponent):
             [
                 dbc.Col(self._settings_section("User Preferences"), md=6),
                 dbc.Col(self._system_config_section(), md=6),
-
             ]
         )
 
@@ -31,13 +32,10 @@ class SettingsPage(UIComponent):
     @staticmethod
     def _settings_section(title: str) -> dbc.Card:
         title = sanitize_unicode_input(title)
-        return dbc.Card(
-            dbc.CardBody(
-                [
-                    html.H5(title, className="card-title"),
-                    html.P("Configuration options coming soon.", className="card-text"),
-                ]
-            ),
+        return card(
+            title,
+            html.P("Configuration options coming soon.", className="card-text"),
+            color="light",
             className="mb-4 settings-section",
         )
 
@@ -48,47 +46,46 @@ class SettingsPage(UIComponent):
         timeout_options = [5, 10, 20, 30, 60]
         batch_options = [1000, 2000, 5000, 10000, 25000]
 
-        return dbc.Card(
-            dbc.CardBody(
-                [
-                    html.H5("System Configuration", className="card-title"),
-                    dbc.Label(
-                        "Rate Limit (per minute)",
-                        html_for="setting-rate-limit",
-                        className="fw-bold",
-                    ),
-                    dcc.Dropdown(
-                        id="setting-rate-limit",
-                        options=[{"label": str(o), "value": o} for o in rate_options],
-                        value=dynamic_config.security.rate_limit_requests,
-                        clearable=False,
-                        className="mb-3",
-                    ),
-                    dbc.Label(
-                        "DB Connection Timeout",
-                        html_for="setting-db-timeout",
-                        className="fw-bold",
-                    ),
-                    dcc.Dropdown(
-                        id="setting-db-timeout",
-                        options=[{"label": str(o), "value": o} for o in timeout_options],
-                        value=dynamic_config.database.connection_timeout_seconds,
-                        clearable=False,
-                        className="mb-3",
-                    ),
-                    dbc.Label(
-                        "Analytics Batch Size",
-                        html_for="setting-batch-size",
-                        className="fw-bold",
-                    ),
-                    dcc.Dropdown(
-                        id="setting-batch-size",
-                        options=[{"label": str(o), "value": o} for o in batch_options],
-                        value=dynamic_config.analytics.batch_size,
-                        clearable=False,
-                    ),
-                ]
-            ),
+        return card(
+            "System Configuration",
+            [
+                dbc.Label(
+                    "Rate Limit (per minute)",
+                    html_for="setting-rate-limit",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-rate-limit",
+                    options=[{"label": str(o), "value": o} for o in rate_options],
+                    value=dynamic_config.security.rate_limit_requests,
+                    clearable=False,
+                    className="mb-3",
+                ),
+                dbc.Label(
+                    "DB Connection Timeout",
+                    html_for="setting-db-timeout",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-db-timeout",
+                    options=[{"label": str(o), "value": o} for o in timeout_options],
+                    value=dynamic_config.database.connection_timeout_seconds,
+                    clearable=False,
+                    className="mb-3",
+                ),
+                dbc.Label(
+                    "Analytics Batch Size",
+                    html_for="setting-batch-size",
+                    className="fw-bold",
+                ),
+                dcc.Dropdown(
+                    id="setting-batch-size",
+                    options=[{"label": str(o), "value": o} for o in batch_options],
+                    value=dynamic_config.analytics.batch_size,
+                    clearable=False,
+                ),
+            ],
+            color="light",
             className="mb-4 settings-section",
         )
 
@@ -106,13 +103,16 @@ def register_page() -> None:
     """Register the settings page with Dash using current app context."""
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
             dash.register_page(__name__, path="/settings", name="Settings")
         else:
             from dash import register_page as dash_register_page
+
             dash_register_page(__name__, path="/settings", name="Settings")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")
 
@@ -121,6 +121,7 @@ def register_page_with_app(app) -> None:
     """Register the page with a specific Dash app instance."""
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
         dash.register_page(__name__, path="/settings", name="Settings")
@@ -130,6 +131,7 @@ def register_page_with_app(app) -> None:
             delattr(dash, "_current_app")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
@@ -137,16 +139,17 @@ def register_page_with_app(app) -> None:
 def layout() -> dbc.Container:
     """Compatibility wrapper returning the default component layout."""
 
-
     return _settings_component.layout()
 
 
 __all__ = ["SettingsPage", "load_page", "layout", "register_page"]
 
+
 def __getattr__(name: str):
     if name.startswith(("create_", "get_")):
+
         def _stub(*args, **kwargs):
             return None
+
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")
-


### PR DESCRIPTION
## Summary
- provide `layout_factory.card` for consistent Bootstrap card creation
- refactor `deep_analytics` and `settings` pages to use the factory

## Testing
- `black --check components/layout_factory.py pages/deep_analytics.py pages/settings.py`
- `pytest -q` *(fails: 126 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687695099e308320b0eaec5f9e538bae