### PR TITLE
Refactor pages layouts

### DIFF
--- a/pages/deep_analytics_complex/layout.py
+++ b/pages/deep_analytics_complex/layout.py
@@ -85,13 +85,22 @@ def layout() -> dbc.Container:
     hidden_trigger = html.Div(id="hidden-trigger", className="hidden")
 
     return dbc.Container(
-        [intro_card, status_alert, config_section, results_area, hidden_trigger],
+        [
+            dbc.Row(dbc.Col(intro_card)),
+            dbc.Row(dbc.Col(status_alert)),
+            dbc.Row(dbc.Col(config_section)),
+            dbc.Row(dbc.Col(results_area)),
+            dbc.Row(dbc.Col(hidden_trigger)),
+        ],
         fluid=True,
     )
 
+
 def __getattr__(name: str):
     if name.startswith(("create_", "get_")):
+
         def _stub(*args, **kwargs):
             return None
+
         return _stub
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pages/export.py
+++ b/pages/export.py
@@ -11,13 +11,16 @@ def register_page() -> None:
     """Register the export page with Dash using current app context."""
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
             dash.register_page(__name__, path="/export", name="Export")
         else:
             from dash import register_page as dash_register_page
+
             dash_register_page(__name__, path="/export", name="Export")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")
 
@@ -26,6 +29,7 @@ def register_page_with_app(app) -> None:
     """Register the page with a specific Dash app instance."""
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
         dash.register_page(__name__, path="/export", name="Export")
@@ -35,6 +39,7 @@ def register_page_with_app(app) -> None:
             delattr(dash, "_current_app")
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
@@ -90,7 +95,10 @@ csv_content = export_service.to_csv_string(data)
 
 def layout() -> dbc.Container:
     """Export page layout with usage instructions."""
-    return dbc.Container([_instructions()], fluid=True)
+    return dbc.Container(
+        dbc.Row(dbc.Col(_instructions())),
+        fluid=True,
+    )
 
 
 __all__ = ["layout", "register_page"]

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -41,19 +41,24 @@ class UploadPage(UIComponent):
 
     def layout(self) -> dbc.Container:
         """Full upload layout with pre-mount stability."""
-        
+
         # Pre-initialize all components to prevent flash
         upload_area = dcc.Upload(
             id="drag-drop-upload",
-            children=html.Div([
-                html.I(
-                    className="fas fa-cloud-upload-alt fa-3x mb-3",
-                    **{"aria-hidden": "true"},
-                ),
-                html.H5("Drag & Drop Files Here"),
-                html.P("or click to select files", className="text-muted"),
-                html.P("Supports CSV, Excel, and JSON files", className="small text-muted"),
-            ]),
+            children=html.Div(
+                [
+                    html.I(
+                        className="fas fa-cloud-upload-alt fa-3x mb-3",
+                        **{"aria-hidden": "true"},
+                    ),
+                    html.H5("Drag & Drop Files Here"),
+                    html.P("or click to select files", className="text-muted"),
+                    html.P(
+                        "Supports CSV, Excel, and JSON files",
+                        className="small text-muted",
+                    ),
+                ]
+            ),
             style={
                 "width": "100%",
                 "height": "200px",
@@ -62,93 +67,142 @@ class UploadPage(UIComponent):
                 "borderStyle": "dashed",
                 "borderRadius": "5px",
                 "textAlign": "center",
-                "margin": "10px",
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
                 "justifyContent": "center",
                 "alignItems": "center",
                 "opacity": "1",
-                "visibility": "visible"
+                "visibility": "visible",
             },
+            className="m-2",
             multiple=True,
         )
 
-        return dbc.Container([
-            # Header - Pre-rendered stable
-            dbc.Row([
-                dbc.Col([
-                    html.H2("📁 File Upload", className="mb-3"),
-                    html.P(
-                        "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
-                        className="text-muted mb-4",
-                    ),
-                ])
-            ]),
-            
-            # Upload area - Pre-rendered
-            dbc.Row([
-                dbc.Col([
-                    html.Label("Upload data files", htmlFor="drag-drop-upload", className="visually-hidden"),
-                    upload_area,
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Progress area - Pre-rendered but hidden
-            dbc.Row([
-                dbc.Col([
-                    dbc.Progress(
-                        id="upload-progress",
-                        value=0,
-                        striped=True,
-                        animated=False,
-                        style={"display": "none"},
-                    ),
-                    html.Div(id="upload-status", style={"marginTop": "10px"}),
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Preview area - Pre-rendered empty
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="preview-area",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "50px"}
-                    )
-                ], lg=10, md=12, sm=12, className="mx-auto")
-            ]),
-            
-            # Navigation area - Pre-rendered empty  
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="upload-navigation",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "30px"}
-                    )
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ], className="mt-4"),
-            
-            # Data stores - Pre-initialized
-            dcc.Store(id="uploaded-files-store", data={}),
-            dcc.Store(id="upload-session-store", data={}),
-            
-        ], fluid=True, className="py-4", style={"opacity": "1", "visibility": "visible"})
+        return dbc.Container(
+            [
+                # Header - Pre-rendered stable
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H2("📁 File Upload", className="mb-3"),
+                                html.P(
+                                    "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
+                                    className="text-muted mb-4",
+                                ),
+                            ]
+                        )
+                    ]
+                ),
+                # Upload area - Pre-rendered
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Label(
+                                    "Upload data files",
+                                    htmlFor="drag-drop-upload",
+                                    className="visually-hidden",
+                                ),
+                                upload_area,
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Progress area - Pre-rendered but hidden
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                dbc.Progress(
+                                    id="upload-progress",
+                                    value=0,
+                                    striped=True,
+                                    animated=False,
+                                    style={"display": "none"},
+                                ),
+                                html.Div(id="upload-status", className="mt-2"),
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Preview area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="preview-area",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "50px",
+                                    },
+                                )
+                            ],
+                            lg=10,
+                            md=12,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Navigation area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="upload-navigation",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "30px",
+                                    },
+                                )
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ],
+                    className="mt-4",
+                ),
+                # Data stores - Pre-initialized
+                dcc.Store(id="uploaded-files-store", data={}),
+                dcc.Store(id="upload-session-store", data={}),
+            ],
+            fluid=True,
+            className="py-4",
+            style={"opacity": "1", "visibility": "visible"},
+        )
 
     def register_callbacks(self, manager, controller=None):
         """Register upload callbacks with timing fixes."""
         try:
+
             @manager.unified_callback(
                 [
                     Output("upload-status", "children"),
                     Output("upload-progress", "value"),
                     Output("upload-progress", "style"),
                     Output("uploaded-files-store", "data"),
-                    Output("preview-area", "children")
+                    Output("preview-area", "children"),
                 ],
                 Input("drag-drop-upload", "contents"),
                 [
                     State("drag-drop-upload", "filename"),
-                    State("uploaded-files-store", "data")
+                    State("uploaded-files-store", "data"),
                 ],
                 callback_id="file_upload_process",
                 component_name="file_upload",
@@ -157,21 +211,23 @@ class UploadPage(UIComponent):
             def process_upload(contents, filenames, existing_files):
                 if not contents:
                     return no_update, no_update, no_update, no_update, no_update
-                
+
                 try:
                     # Simple success response
                     status = dbc.Alert("Files uploaded successfully!", color="success")
                     progress_style = {"display": "block"}
                     updated_files = existing_files or {}
-                    
+
                     # Simple preview
-                    preview = html.Div([
-                        html.H6("Uploaded Files:"),
-                        html.Ul([html.Li(f) for f in (filenames or [])])
-                    ])
-                    
+                    preview = html.Div(
+                        [
+                            html.H6("Uploaded Files:"),
+                            html.Ul([html.Li(f) for f in (filenames or [])]),
+                        ]
+                    )
+
                     return status, 100, progress_style, updated_files, preview
-                    
+
                 except Exception as e:
                     error_status = dbc.Alert(f"Upload failed: {str(e)}", color="danger")
                     return error_status, 0, {"display": "none"}, no_update, no_update
@@ -184,23 +240,29 @@ class UploadPage(UIComponent):
 
 _upload_component = UploadPage()
 
+
 def load_page(**kwargs):
     return UploadPage(**kwargs)
+
 
 def register_page():
     try:
         import dash
+
         if hasattr(dash, "_current_app") and dash._current_app is not None:
             dash.register_page(__name__, path="/upload", name="Upload")
         else:
             from dash import register_page as dash_register_page
+
             dash_register_page(__name__, path="/upload", name="Upload")
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")
 
+
 def register_page_with_app(app):
     try:
         import dash
+
         old_app = getattr(dash, "_current_app", None)
         dash._current_app = app
         dash.register_page(__name__, path="/upload", name="Upload")
@@ -211,10 +273,13 @@ def register_page_with_app(app):
     except Exception as e:
         logger.warning(f"Failed to register page {__name__} with app: {e}")
 
+
 def layout():
     return _upload_component.layout()
 
+
 def register_callbacks(manager):
     _upload_component.register_callbacks(manager)
+
 
 __all__ = ["UploadPage", "load_page", "layout", "register_page"]

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -43,13 +43,13 @@ def layout() -> dbc.Container:
             "borderStyle": "dashed",
             "borderRadius": "5px",
             "textAlign": "center",
-            "margin": "10px",
             "cursor": "pointer",
             "display": "flex",
             "flexDirection": "column",
             "justifyContent": "center",
             "alignItems": "center",
         },
+        className="m-2",
         multiple=True,
     )
 


### PR DESCRIPTION
## Summary
- standardize Export layout into container/row/col structure
- enforce container/row/col pattern for complex analytics layout
- use spacing utility classes for upload pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6876951911448320a33905ea936293c6