### PR TITLE
Allow extra args in navbar stub

### DIFF
--- a/tests/stubs/components/ui/navbar.py
+++ b/tests/stubs/components/ui/navbar.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 
-def create_navbar_layout():
+def create_navbar_layout(*_args, **_kwargs):
+    """Return a dummy navbar layout, ignoring any parameters."""
+
     return "navbar"
 
 


### PR DESCRIPTION
## Summary
- update navbar test stub to accept additional args

## Testing
- `pytest tests/di/test_app_factory_helpers.py::test_register_callbacks -q` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_6876e5272a408320960e02d9e7eedc14