### PR TITLE
Add navbar customization tests

### DIFF
--- a/tests/components/test_navbar_config.py
+++ b/tests/components/test_navbar_config.py
@@ -1,0 +1,33 @@
+import pytest
+from dash import html
+
+from components.ui.navbar import create_navbar_layout, register_navbar_callbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
+
+
+class StubManager:
+    def __init__(self):
+        self.registered = []
+
+    def handle_register(self, *args, **kwargs):
+        def decorator(func):
+            self.registered.append(kwargs.get("callback_id"))
+            return func
+        return decorator
+
+
+def test_create_navbar_layout_accepts_custom_links_icons():
+    links = {"Foo": "/foo"}
+    icons = {"Foo": html.Span(id="foo-icon")}
+    layout = create_navbar_layout(links=links, icons=icons)
+    nav = layout.children.children[1]
+    link = nav.children[0].children
+    assert link.href == "/foo"
+    assert getattr(link.children[0][0], "id", None) == "foo-icon"
+
+
+def test_register_navbar_callbacks_connects_toggle():
+    mgr = StubManager()
+    register_navbar_callbacks(mgr)
+    assert "navbar_toggle" in mgr.registered

--- a/tests/stubs/dash/dcc.py
+++ b/tests/stubs/dash/dcc.py
@@ -17,3 +17,9 @@ class Store:
         self.children = list(args)
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+class Link:
+    def __init__(self, *args, **kwargs):
+        self.children = list(args)
+        for k, v in kwargs.items():
+            setattr(self, k, v)

--- a/tests/stubs/dash/html.py
+++ b/tests/stubs/dash/html.py
@@ -43,6 +43,9 @@ class Small(_Base):
 class Strong(_Base):
     pass
 
+class Span(_Base):
+    pass
+
 
 class Img(_Base):
     pass

--- a/tests/stubs/dash_bootstrap_components.py
+++ b/tests/stubs/dash_bootstrap_components.py
@@ -15,6 +15,9 @@ class Card(_Base):
 class Navbar(_Base):
     pass
 
+class NavbarBrand(_Base):
+    pass
+
 class Container(_Base):
     pass
 
@@ -64,6 +67,15 @@ class Badge(_Base):
     pass
 
 class Checklist(_Base):
+    pass
+
+class Nav(_Base):
+    pass
+
+class NavItem(_Base):
+    pass
+
+class NavLink(_Base):
     pass
 
 NavbarToggler = Collapse = DropdownMenu = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- update navbar to accept custom link/icon dictionaries
- register navbar toggle callback if Dash is available
- extend component stubs with Nav and Link classes
- add tests for navbar customization

## Testing
- `pytest tests/components/test_navbar_config.py -q`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876e5254b308320a4ab67a801f82945