### PR TITLE
Fix navbar logo spacing class

### DIFF
--- a/components/ui/navbar_enhanced.py
+++ b/components/ui/navbar_enhanced.py
@@ -33,7 +33,7 @@ def create_navbar_layout() -> Any:
                         html.Img(
                             src="/assets/yosai_logo_name_white.png",
                             height="40px",
-                            className="mr-2-5",
+                            className="me-2",
                             style={"filter": "brightness(1)"},
                             alt="Yōsai logo",
                         ),


### PR DESCRIPTION
## Summary
- fix margin class on navbar logo

## Testing
- `pytest` *(fails: Missing required test dependencies)*
- `black --check .` *(fails: would reformat files)*
- `flake8 .` *(fails: command not found)*
- `isort --check .` *(fails: imports not correctly sorted)*
- `mypy --strict components/ui/navbar_enhanced.py` *(fails: many errors)*
- `bandit -r .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68770517ce7c8320b185ca1fc6963c66