### PR TITLE
Fix circular import in analytics controllers

### DIFF
--- a/analytics/controllers/deep_analytics_logic.py
+++ b/analytics/controllers/deep_analytics_logic.py
@@ -7,7 +7,7 @@ from typing import Any
 import dash_bootstrap_components as dbc
 from dash import html
 
-from pages.deep_analytics_complex.analysis import (
+from pages.deep_analytics_complex import (
     create_analysis_results_display,
     create_analysis_results_display_safe,
     get_initial_message_safe,

--- a/components/analytics/real_time_dashboard.py
+++ b/components/analytics/real_time_dashboard.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
 from dash_extensions import WebSocket
 
-from analytics.controllers import RealTimeWebSocketController
+from analytics.controllers.realtime_ws import RealTimeWebSocketController
 
 
 class RealTimeAnalytics:

--- a/components/column_verification.py
+++ b/components/column_verification.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 import logging
 
-from analytics.controllers import UnifiedAnalyticsController
+from analytics.controllers.unified_controller import UnifiedAnalyticsController
 
 
 class ColumnVerifierProtocol(Protocol):

--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dash import dcc, html
 from dash.dependencies import ALL, MATCH, Input, Output, State
 
-from analytics.controllers import UnifiedAnalyticsController
+from analytics.controllers.unified_controller import UnifiedAnalyticsController
 from components.simple_device_mapping import special_areas_options
 from services.ai_mapping_store import ai_mapping_store
 

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 import logging
 
-from analytics.controllers import UnifiedAnalyticsController
+from analytics.controllers.unified_controller import UnifiedAnalyticsController
 
 logger = logging.getLogger(__name__)
 from typing import Any, Dict, List

--- a/pages/deep_analytics_complex/callbacks.py
+++ b/pages/deep_analytics_complex/callbacks.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
 
 import logging
 
-from analytics.controllers import (
-    UnifiedAnalyticsController,
+from analytics.controllers.unified_controller import UnifiedAnalyticsController
+from analytics.controllers.deep_analytics_logic import (
     dispatch_analysis,
     get_data_sources,
     get_initial_message_safe,
@@ -19,8 +19,8 @@ from analytics.controllers import (
     run_service_analysis,
     run_suggests_analysis,
     run_unique_patterns_analysis,
+    update_status_alert as _controller_update_status_alert,
 )
-from analytics.controllers import update_status_alert as _controller_update_status_alert
 from core.callback_registry import _callback_registry
 from core.dash_profile import profile_callback
 from core.state import CentralizedStateManager

--- a/tests/test_unified_analytics_controller.py
+++ b/tests/test_unified_analytics_controller.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from analytics.controllers import UnifiedAnalyticsController
+from analytics.controllers.unified_controller import UnifiedAnalyticsController
 
 
 def test_async_security_and_error_logging(caplog):


### PR DESCRIPTION
## Summary
- avoid importing analytics controller package to prevent circular refs
- update callbacks to import controller utilities directly
- use deep analytics package import for UI helper functions

## Testing
- `pip install -r requirements-test.txt`
- `pip install flask`
- `pytest tests/test_unified_analytics_controller.py::test_async_security_and_error_logging -vv` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_687709ff758c83209a4746c1ff1e2a8d