### PR TITLE
Fix page-content offset under navbar

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -24,12 +24,14 @@ def create_app(mode=None, **kwargs):
         [
             dcc.Location(id="url", refresh=False),
             create_navbar_layout(),
-            html.Div(id="page-content", className="main-content p-4"),
+            html.Div(
+                id="page-content",
+                className="main-content p-4",
+                style={"paddingTop": "70px"},  # offset fixed-top navbar
+            ),
             dcc.Store(id="global-store", data={}),
         ]
     )
-
-
 
     # Simple routing callback that uses REAL pages
     @app.callback(Output("page-content", "children"), Input("url", "pathname"))
@@ -50,5 +52,6 @@ def create_app(mode=None, **kwargs):
 
         # Fallback to analytics page
         return deep_analytics.layout()
+
     app.title = "🏯 Yōsai Intel Dashboard"
     return app


### PR DESCRIPTION
## Summary
- add extra top padding to `page-content` so it's visible below the fixed navbar

## Testing
- `black core/app_factory/__init__.py --line-length 88`
- `pytest -k nothing --maxfail=1` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68770516d634832090af061495ec4657