### PR TITLE
Handle missing AI suggestions module gracefully

### DIFF
--- a/services/analytics_processing.py
+++ b/services/analytics_processing.py
@@ -8,7 +8,14 @@ from dash import html
 from core.unicode import safe_format_number
 from core.unicode_utils import sanitize_for_utf8
 from services import get_analytics_service
-from services.ai_suggestions import generate_column_suggestions
+try:
+    from services.ai_suggestions import generate_column_suggestions
+    AI_SUGGESTIONS_AVAILABLE = True
+except Exception:  # pragma: no cover - optional AI suggestions
+    AI_SUGGESTIONS_AVAILABLE = False
+
+    def generate_column_suggestions(*args: Any, **kwargs: Any) -> Dict[str, Dict[str, Any]]:
+        return {}
 from services.upload_data_service import get_uploaded_data
 from services.interfaces import get_upload_data_service
 from utils.preview_utils import serialize_dataframe_preview


### PR DESCRIPTION
## Summary
- prevent crash when `services.ai_suggestions` module is absent

## Testing
- `python -m py_compile services/analytics_processing.py`
- `python mde.py` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68772282e5688320aefb1d9ad2cc0cdc