### PR TITLE
Update dev mode test for new warning behavior

### DIFF
--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
+
 from config import dev_mode
 
 
-def test_dev_mode_requires_secrets(monkeypatch):
+def test_dev_mode_requires_secrets(monkeypatch, caplog):
     monkeypatch.setenv("YOSAI_ENV", "development")
     for var in [
         "AUTH0_CLIENT_ID",
@@ -14,5 +16,10 @@ def test_dev_mode_requires_secrets(monkeypatch):
         "DB_PASSWORD",
     ]:
         monkeypatch.delenv(var, raising=False)
-    with pytest.raises(RuntimeError):
+
+    with caplog.at_level("WARNING"):
         dev_mode.setup_dev_mode()
+
+    assert any(
+        "Missing environment variables" in r.getMessage() for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- update `test_dev_mode_requires_secrets` to match new non-raising behaviour
- assert warning log is emitted when secrets are missing

## Testing
- `pytest tests/test_dev_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6877648018e08320bb7b5883d7d2f04b