### PR TITLE
Improve navbar accessibility

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -63,12 +63,30 @@ def create_navbar_layout(
     nav_links = links or default_links
 
     default_icons: Dict[str, Any] = {
-        "Dashboard": html.I(className="fas fa-home me-2", **{"aria-hidden": "true"}),
-        "Analytics": html.I(className="fas fa-chart-bar me-2", **{"aria-hidden": "true"}),
-        "Graphs": html.I(className="fas fa-chart-line me-2", **{"aria-hidden": "true"}),
-        "File Upload": html.I(className="fas fa-upload me-2", **{"aria-hidden": "true"}),
-        "Export": html.I(className="fas fa-download me-2", **{"aria-hidden": "true"}),
-        "Settings": html.I(className="fas fa-cog me-2", **{"aria-hidden": "true"}),
+        "Dashboard": html.I(
+            className="fas fa-home me-2",
+            **{"aria-hidden": "true", "aria-label": "Dashboard"},
+        ),
+        "Analytics": html.I(
+            className="fas fa-chart-bar me-2",
+            **{"aria-hidden": "true", "aria-label": "Analytics"},
+        ),
+        "Graphs": html.I(
+            className="fas fa-chart-line me-2",
+            **{"aria-hidden": "true", "aria-label": "Graphs"},
+        ),
+        "File Upload": html.I(
+            className="fas fa-upload me-2",
+            **{"aria-hidden": "true", "aria-label": "File Upload"},
+        ),
+        "Export": html.I(
+            className="fas fa-download me-2",
+            **{"aria-hidden": "true", "aria-label": "Export"},
+        ),
+        "Settings": html.I(
+            className="fas fa-cog me-2",
+            **{"aria-hidden": "true", "aria-label": "Settings"},
+        ),
     }
     icon_map = {**default_icons, **(icons or {})}
 
@@ -79,7 +97,12 @@ def create_navbar_layout(
             children = [icon, name] if icon is not None else [name]
             nav_items.append(
                 dbc.NavItem(
-                    dcc.Link(children, href=href, className="nav-link px-3")
+                    dcc.Link(
+                        children,
+                        href=href,
+                        className="nav-link px-3",
+                        **{"aria-label": name},
+                    )
                 )
             )
 

--- a/tests/components/test_navbar_config.py
+++ b/tests/components/test_navbar_config.py
@@ -25,6 +25,14 @@ def test_create_navbar_layout_accepts_custom_links_icons():
     link = nav.children[0].children
     assert link.href == "/foo"
     assert getattr(link.children[0][0], "id", None) == "foo-icon"
+    assert getattr(link, "aria-label", None) == "Foo"
+
+
+def test_default_nav_links_have_labels():
+    layout = create_navbar_layout()
+    nav = layout.children.children[1]
+    first_link = nav.children[0].children
+    assert getattr(first_link, "aria-label", None) == "Dashboard"
 
 
 def test_register_navbar_callbacks_connects_toggle():


### PR DESCRIPTION
## Summary
- enhance default navbar icons with explicit aria labels
- expose aria-label attributes on navbar links for accessibility
- test that aria labels are present on navbar links

## Testing
- `pytest tests/components/test_navbar_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68776d16bba883208dae75016cbc7a90