### PR TITLE
Add Dash component previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,19 @@ dropdown so you can revisit earlier uploads without re-uploading them.
 **Important:** keep the `temp/uploaded_data` directory intact until device
 mappings have been saved, otherwise the mapping step will fail.
 
+## Component Previews
+
+Standalone preview scripts live in the `storybook/` directory. They showcase
+common UI components without launching the entire dashboard. Run a script with
+
+```bash
+python storybook/navbar_app.py
+python storybook/upload_area_app.py
+```
+
+Each command starts a small Dash server on port `8050` so you can interact with
+the component in isolation.
+
 
 ## 🤝 Contributing
 

--- a/storybook/navbar_app.py
+++ b/storybook/navbar_app.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Standalone preview for the Navbar component."""
+
+import dash
+import dash_bootstrap_components as dbc
+from dash import html
+
+from components.ui.navbar import create_navbar_layout
+
+app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+
+app.layout = html.Div(
+    [
+        create_navbar_layout(),
+        html.Div("Navbar preview", className="p-4"),
+    ]
+)
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/storybook/upload_area_app.py
+++ b/storybook/upload_area_app.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Standalone preview for the UploadArea component."""
+
+import dash
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from components.upload import UploadArea
+
+app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+upload = UploadArea()
+
+app.layout = dbc.Container(
+    [
+        html.H2("UploadArea preview", className="my-3"),
+        upload.render(),
+    ],
+    fluid=True,
+)
+
+
+@app.callback(
+    dash.Output(upload.results_id, "children"),
+    dash.Input(upload.upload_id, "contents"),
+    dash.State(upload.upload_id, "filename"),
+    prevent_initial_call=True,
+)
+def _display_upload(contents, names):
+    if contents is None:
+        raise dash.exceptions.PreventUpdate
+    if isinstance(names, list):
+        names = ", ".join(names)
+    return html.Div([html.P(f"Uploaded: {names}")])
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)


### PR DESCRIPTION
## Summary
- add simple Navbar and UploadArea preview apps
- describe how to run component previews in README

## Testing
- `pre-commit run --files storybook/navbar_app.py storybook/upload_area_app.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_68776d299cf88320944ae8a7eaf80d3a