### PR TITLE
Improve upload area accessibility

### DIFF
--- a/assets/css/05-pages/upload.css
+++ b/assets/css/05-pages/upload.css
@@ -14,3 +14,9 @@
     justify-content: center;
     align-items: center;
 }
+
+/* Make keyboard focus clearly visible */
+.upload-area:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}

--- a/components/upload/ui/upload_area.py
+++ b/components/upload/ui/upload_area.py
@@ -1,4 +1,5 @@
 """Pure Dash UI component for drag-and-drop uploads."""
+
 from __future__ import annotations
 
 from typing import Callable
@@ -9,7 +10,11 @@ from dash import dcc, html
 class UploadArea:
     """Drag and drop upload area without business logic."""
 
-    def __init__(self, upload_handler: Callable | None = None, upload_id: str = "drag-drop-upload") -> None:
+    def __init__(
+        self,
+        upload_handler: Callable | None = None,
+        upload_id: str = "drag-drop-upload",
+    ) -> None:
         self.upload_handler = upload_handler
         self.upload_id = upload_id
         self.status_id = f"{upload_id}-status"
@@ -20,6 +25,7 @@ class UploadArea:
             [
                 dcc.Upload(
                     id=self.upload_id,
+                    tabIndex=0,
                     children=self._render_upload_area(),
                     multiple=True,
                 ),
@@ -31,7 +37,9 @@ class UploadArea:
     def _render_upload_area(self) -> html.Div:
         return html.Div(
             [
-                html.I(className="fas fa-cloud-upload-alt fa-3x", **{"aria-hidden": "true"}),
+                html.I(
+                    className="fas fa-cloud-upload-alt fa-3x", **{"aria-hidden": "true"}
+                ),
                 html.H4("Drop files here or click to browse"),
             ]
         )

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -44,75 +44,118 @@ class UploadPage(UIComponent):
         upload_area = dcc.Upload(
             id="drag-drop-upload",
             className="drag-drop-upload upload-area",
-            children=html.Div([
-                html.I(
-                    className="fas fa-cloud-upload-alt fa-3x mb-3",
-                    **{"aria-hidden": "true"},
-                ),
-                html.H5("Drag & Drop Files Here"),
-                html.P("or click to select files", className="text-muted"),
-                html.P("Supports CSV, Excel, and JSON files", className="small text-muted"),
-            ]),
+            tabIndex=0,
+            children=html.Div(
+                [
+                    html.I(
+                        className="fas fa-cloud-upload-alt fa-3x mb-3",
+                        **{"aria-hidden": "true"},
+                    ),
+                    html.H5("Drag & Drop Files Here"),
+                    html.P("or click to select files", className="text-muted"),
+                    html.P(
+                        "Supports CSV, Excel, and JSON files",
+                        className="small text-muted",
+                    ),
+                ]
+            ),
             multiple=True,
         )
 
-        return dbc.Container([
-            # Header - Pre-rendered stable
-            dbc.Row([
-                dbc.Col([
-                    html.H2("📁 File Upload", className="mb-3"),
-                    html.P(
-                        "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
-                        className="text-muted mb-4",
-                    ),
-                ])
-            ]),
-            
-            # Upload area - Pre-rendered
-            dbc.Row([
-                dbc.Col(upload_area, lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Progress area - Pre-rendered but hidden
-            dbc.Row([
-                dbc.Col([
-                    dbc.Progress(
-                        id="upload-progress",
-                        value=0,
-                        striped=True,
-                        animated=False,
-                        style={"display": "none"},
-                    ),
-                    html.Div(id="upload-status", style={"marginTop": "10px"}),
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ]),
-            
-            # Preview area - Pre-rendered empty
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="preview-area",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "50px"}
-                    )
-                ], lg=10, md=12, sm=12, className="mx-auto")
-            ]),
-            
-            # Navigation area - Pre-rendered empty  
-            dbc.Row([
-                dbc.Col([
-                    html.Div(
-                        id="upload-navigation",
-                        style={"opacity": "1", "visibility": "visible", "minHeight": "30px"}
-                    )
-                ], lg=8, md=10, sm=12, className="mx-auto")
-            ], className="mt-4"),
-            
-            # Data stores - Pre-initialized
-            dcc.Store(id="uploaded-files-store", data={}),
-            dcc.Store(id="upload-session-store", data={}),
-            
-        ], fluid=True, className="py-4", style={"opacity": "1", "visibility": "visible"})
-
+        return dbc.Container(
+            [
+                # Header - Pre-rendered stable
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.H2("📁 File Upload", className="mb-3"),
+                                html.P(
+                                    "Drag and drop files or click to browse. Supports CSV, Excel, and JSON files.",
+                                    className="text-muted mb-4",
+                                ),
+                            ]
+                        )
+                    ]
+                ),
+                # Upload area - Pre-rendered
+                dbc.Row(
+                    [dbc.Col(upload_area, lg=8, md=10, sm=12, className="mx-auto")]
+                ),
+                # Progress area - Pre-rendered but hidden
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                dbc.Progress(
+                                    id="upload-progress",
+                                    value=0,
+                                    striped=True,
+                                    animated=False,
+                                    style={"display": "none"},
+                                ),
+                                html.Div(
+                                    id="upload-status", style={"marginTop": "10px"}
+                                ),
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Preview area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="preview-area",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "50px",
+                                    },
+                                )
+                            ],
+                            lg=10,
+                            md=12,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ]
+                ),
+                # Navigation area - Pre-rendered empty
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    id="upload-navigation",
+                                    style={
+                                        "opacity": "1",
+                                        "visibility": "visible",
+                                        "minHeight": "30px",
+                                    },
+                                )
+                            ],
+                            lg=8,
+                            md=10,
+                            sm=12,
+                            className="mx-auto",
+                        )
+                    ],
+                    className="mt-4",
+                ),
+                # Data stores - Pre-initialized
+                dcc.Store(id="uploaded-files-store", data={}),
+                dcc.Store(id="upload-session-store", data={}),
+            ],
+            fluid=True,
+            className="py-4",
+            style={"opacity": "1", "visibility": "visible"},
+        )
 
     def register_callbacks(self, manager, controller=None):
         """Register upload callbacks with timing fixes."""

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -22,6 +22,7 @@ def layout() -> dbc.Container:
     upload_area = dcc.Upload(
         id="drag-drop-upload",
         className="drag-drop-upload upload-area",
+        tabIndex=0,
         children=html.Div(
             [
                 html.I(
@@ -36,7 +37,6 @@ def layout() -> dbc.Container:
                 ),
             ]
         ),
-
         multiple=True,
     )
 


### PR DESCRIPTION
## Summary
- style focus indicator for `.upload-area`
- allow keyboard focus on upload components via `tabIndex=0`

## Testing
- `pre-commit run --files assets/css/05-pages/upload.css pages/file_upload.py pages/file_upload_simple.py components/upload/ui/upload_area.py` *(fails: flake8, mypy, bandit)*
- `sh scripts/build_css.sh` *(fails: `postcss` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776d24d1848320b0db3d300541fdf0