### PR TITLE
Refactor page registration to avoid dash._current_app

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -17,7 +17,7 @@ from pages import (
 def create_app(mode=None, **kwargs):
     """Create a working Dash app with logo, navigation, and routing - HTTPS ready."""
 
-    app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    app = dash.Dash(__name__, use_pages=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
 
     # Simple working layout
     app.layout = html.Div(

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any
 
 import dash_bootstrap_components as dbc
-from dash import html
+from dash import html, register_page as dash_register_page
 
 from components.analytics.real_time_dashboard import RealTimeAnalytics
 from components.layout_factory import card
@@ -140,21 +140,17 @@ def load_page(**kwargs) -> AnalyticsPage:
     return AnalyticsPage(**kwargs)
 
 
-def register_page() -> None:
-    """Register the analytics page with Dash using current app context."""
+def register_page(app=None) -> None:
+    """Register the analytics page with Dash."""
     try:
-        import dash
-
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(
+        if app is not None:
+            app.register_page(
                 __name__,
                 path="/analytics",
                 name="Analytics",
                 aliases=["/", "/dashboard"],
             )
         else:
-            from dash import register_page as dash_register_page
-
             dash_register_page(
                 __name__,
                 path="/analytics",

--- a/pages/export.py
+++ b/pages/export.py
@@ -7,41 +7,16 @@ from dash import dcc, html, register_page as dash_register_page
 from security.unicode_security_processor import sanitize_unicode_input
 
 
-def register_page() -> None:
-    """Register the export page with Dash using current app context."""
+def register_page(app=None) -> None:
+    """Register the export page with Dash."""
     try:
-        import dash
-
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/export", name="Export")
+        if app is not None:
+            app.register_page(__name__, path="/export", name="Export")
         else:
-            from dash import register_page as dash_register_page
-
             dash_register_page(__name__, path="/export", name="Export")
     except Exception as e:
-        import logging
-
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")
-
-
-def register_page_with_app(app) -> None:
-    """Register the page with a specific Dash app instance."""
-    try:
-        import dash
-
-        old_app = getattr(dash, "_current_app", None)
-        dash._current_app = app
-        dash.register_page(__name__, path="/export", name="Export")
-        if old_app is not None:
-            dash._current_app = old_app
-        else:
-            delattr(dash, "_current_app")
-    except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.warning(f"Failed to register page {__name__} with app: {e}")
 
 def _instructions() -> dbc.Card:
     """Return a card describing how to export learned data."""

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -173,33 +173,14 @@ def load_page(**kwargs):
     return UploadPage(**kwargs)
 
 
-def register_page():
+def register_page(app=None):
     try:
-        import dash
-
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/upload", name="Upload")
+        if app is not None:
+            app.register_page(__name__, path="/upload", name="Upload")
         else:
-            from dash import register_page as dash_register_page
-
             dash_register_page(__name__, path="/upload", name="Upload")
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")
-
-
-def register_page_with_app(app):
-    try:
-        import dash
-
-        old_app = getattr(dash, "_current_app", None)
-        dash._current_app = app
-        dash.register_page(__name__, path="/upload", name="Upload")
-        if old_app is not None:
-            dash._current_app = old_app
-        else:
-            delattr(dash, "_current_app")
-    except Exception as e:
-        logger.warning(f"Failed to register page {__name__} with app: {e}")
 
 
 def layout():

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -9,7 +9,7 @@ from typing import List
 
 import dash_bootstrap_components as dbc
 import pandas as pd
-from dash import Input, Output, State, callback, dcc, html
+from dash import Input, Output, State, callback, dcc, html, register_page as dash_register_page
 from dash.exceptions import PreventUpdate
 
 from utils.upload_store import uploaded_data_store
@@ -127,16 +127,12 @@ def handle_upload(contents: str | List[str], filenames: str | List[str]):
     return alerts, previews
 
 
-def register_page():
-    """Register this page with Dash Pages if available."""
+def register_page(app=None):
+    """Register this page with Dash."""
     try:
-        import dash
-
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/upload", name="Upload")
+        if app is not None:
+            app.register_page(__name__, path="/upload", name="Upload")
         else:
-            from dash import register_page as dash_register_page
-
             dash_register_page(__name__, path="/upload", name="Upload")
     except Exception as e:  # pragma: no cover - best effort
         logger.warning("Failed to register page %s: %s", __name__, e)

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -3,7 +3,7 @@
 
 import logging
 import dash_bootstrap_components as dbc
-from dash import dcc, html
+from dash import dcc, html, register_page as dash_register_page
 
 logger = logging.getLogger(__name__)
 
@@ -82,13 +82,11 @@ _graphs_component = GraphsPage()
 def load_page(**kwargs):
     return GraphsPage(**kwargs)
 
-def register_page():
+def register_page(app=None):
     try:
-        import dash
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/graphs", name="Graphs")
+        if app is not None:
+            app.register_page(__name__, path="/graphs", name="Graphs")
         else:
-            from dash import register_page as dash_register_page
             dash_register_page(__name__, path="/graphs", name="Graphs")
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -99,16 +99,12 @@ def load_page(**kwargs) -> SettingsPage:
     return SettingsPage(**kwargs)
 
 
-def register_page() -> None:
-    """Register the settings page with Dash using current app context."""
+def register_page(app=None) -> None:
+    """Register the settings page with Dash."""
     try:
-        import dash
-
-        if hasattr(dash, "_current_app") and dash._current_app is not None:
-            dash.register_page(__name__, path="/settings", name="Settings")
+        if app is not None:
+            app.register_page(__name__, path="/settings", name="Settings")
         else:
-            from dash import register_page as dash_register_page
-
             dash_register_page(__name__, path="/settings", name="Settings")
     except Exception as e:
         import logging


### PR DESCRIPTION
## Summary
- simplify Dash page registration
- remove direct access to `dash._current_app`
- enable page registry by creating apps with `use_pages=True`

## Testing
- `pytest tests/pages/test_page_loading.py -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68776d1abd948320bb045236f7af75f4