### PR TITLE
Lazy import initial message helper

### DIFF
--- a/analytics/controllers/analysis_helpers.py
+++ b/analytics/controllers/analysis_helpers.py
@@ -11,7 +11,6 @@ from services.analytics_processing import (
     create_analysis_results_display,
     create_analysis_results_display_safe,
 )
-from pages.deep_analytics_complex.layout import get_initial_message_safe
 from services.data_processing.analytics_engine import (
     AI_SUGGESTIONS_AVAILABLE,
     analyze_data_with_service,
@@ -460,6 +459,13 @@ def update_status_alert(_trigger: Any) -> str:
 def get_data_sources() -> list:
     """Return available data sources for the dropdown."""
     return get_data_source_options_safe()
+
+
+def get_initial_message_safe():
+    """Load and return the initial message for the analytics page."""
+    from pages.deep_analytics_complex.layout import get_initial_message_safe as _get_initial_message
+
+    return _get_initial_message()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- refactor `analysis_helpers` to avoid importing `get_initial_message_safe` at module load
- add helper that imports from layout only when needed

## Testing
- `pytest tests/pages/test_page_loading.py::test_missing_page_logs_error -q`
- `pytest -q` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_68776fae6ae88320ab3fccc8c3303485