### PR TITLE
Fix dash imports to reduce Pylance errors

### DIFF
--- a/mde.py
+++ b/mde.py
@@ -12,7 +12,8 @@ PROJECT_ROOT = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 import dash
-from dash import dcc, html, Input, Output, State, dash_table
+from dash import dcc, html, dash_table
+from dash.dependencies import Input, Output, State
 import pandas as pd
 import dash_bootstrap_components as dbc
 from components.column_verification import (


### PR DESCRIPTION
## Summary
- fix imports in `mde.py` for compatibility with Pylance

## Testing
- `pytest -q` *(fails: 127 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68777a95295883208d45a77f195e5d02