### PR TITLE
Fix missing AI suggestions module

### DIFF
--- a/services/ai_suggestions.py
+++ b/services/ai_suggestions.py
@@ -1,0 +1,18 @@
+import logging
+from typing import Any, Dict, Sequence
+
+from services.data_enhancer import get_ai_column_suggestions
+
+logger = logging.getLogger(__name__)
+
+
+def generate_column_suggestions(columns: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Return AI-based column suggestions for the given column names."""
+    try:
+        return get_ai_column_suggestions(columns)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.exception("Fallback column suggestion logic failed: %s", exc)
+        return {c: {"field": "", "confidence": 0.0} for c in columns}
+
+
+__all__ = ["generate_column_suggestions"]


### PR DESCRIPTION
## Summary
- implement `services/ai_suggestions.py` to expose `generate_column_suggestions`
  using the existing helper in `data_enhancer`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: sklearn, flask, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68777a8a4790832099dfdb32c47b84e3