### PR TITLE
Update DoorMappingService initialization

### DIFF
--- a/services/configuration_service.py
+++ b/services/configuration_service.py
@@ -27,7 +27,7 @@ class ConfigurationServiceProtocol(Protocol):
 
 
 class DynamicConfigurationService(ConfigurationServiceProtocol):
-    """Adapter exposing ``DynamicConfigManager`` via ``ConfigurationServiceProtocol``."""
+    """Expose :class:`DynamicConfigManager` via ``ConfigurationServiceProtocol``."""
 
     def __init__(self, manager: DynamicConfigManager = dynamic_config) -> None:
         self._cfg = manager

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -3,18 +3,19 @@ Door Mapping Service - Business logic for device attribute assignment
 Handles AI model data processing and manual override management
 """
 
-import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from services.configuration_service import ConfigurationServiceProtocol
-
 # ADD after existing imports
 from services.ai_device_generator import AIDeviceGenerator
+from services.configuration_service import (
+    ConfigurationServiceProtocol,
+    DynamicConfigurationService,
+)
 from services.consolidated_learning_service import get_learning_service
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,10 @@ class DoorMappingService:
     def _generate_ai_attributes(
         self, door_id: str, df: pd.DataFrame, client_profile: str
     ) -> DeviceAttributeData:
-        """Generate AI-based attribute assignments using enhanced modular AI generator"""
+        """Generate AI-based attribute assignments.
+
+        Uses an enhanced modular AI generator.
+        """
 
         # Use new modular AI generator
         ai_generator = AIDeviceGenerator()
@@ -128,7 +132,7 @@ class DoorMappingService:
             is_elevator=ai_attributes.is_elevator,
             is_stairwell=ai_attributes.is_stairwell,
             is_fire_escape=ai_attributes.is_fire_escape,
-            is_restricted=ai_attributes.is_restricted,  # CHANGE: Remove getattr, use direct access
+            is_restricted=ai_attributes.is_restricted,
             other=not any(
                 [
                     ai_attributes.is_entry,
@@ -428,7 +432,9 @@ class DoorMappingService:
             )
 
             logger.info(
-                f"Saved {len(device_mappings)} device mappings with ID: {fingerprint[:8]}"
+                "Saved %d device mappings with ID: %s",
+                len(device_mappings),
+                fingerprint[:8],
             )
             return fingerprint
 
@@ -438,6 +444,6 @@ class DoorMappingService:
 
 
 # Service instance
-door_mapping_service = DoorMappingService()
+door_mapping_service = DoorMappingService(DynamicConfigurationService())
 
 __all__ = ["DoorMappingService", "DeviceAttributeData", "door_mapping_service"]

--- a/tests/test_door_mapping_service.py
+++ b/tests/test_door_mapping_service.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+from services.configuration_service import DynamicConfigurationService
 from services.door_mapping_service import DoorMappingService
 
 
@@ -24,7 +25,7 @@ def test_standardized_output(monkeypatch):
         return dummy
 
     monkeypatch.setattr(AIDeviceGenerator, "generate_device_attributes", fake_generate)
-    service = DoorMappingService()
+    service = DoorMappingService(DynamicConfigurationService())
     df = pd.DataFrame({"door_id": ["d1"]})
     result = service.process_uploaded_data(df)
     device = result["devices"][0]


### PR DESCRIPTION
## Summary
- instantiate DoorMappingService with DynamicConfigurationService
- export DynamicConfigurationService from configuration_service
- adapt the door mapping service test to use the new signature

## Testing
- `flake8 services/door_mapping_service.py tests/test_door_mapping_service.py services/configuration_service.py`
- `bandit -q -lll services/door_mapping_service.py tests/test_door_mapping_service.py services/configuration_service.py`
- `pytest tests/test_door_mapping_service.py::test_standardized_output -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6877802d346c832083db7bdc25d0430d