### PR TITLE
Fix Dash pages folder

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -17,7 +17,13 @@ from pages import (
 def create_app(mode=None, **kwargs):
     """Create a working Dash app with logo, navigation, and routing - HTTPS ready."""
 
-    app = dash.Dash(__name__, use_pages=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    pages_path = Path(__file__).resolve().parent.parent / "pages"
+    app = dash.Dash(
+        __name__,
+        use_pages=True,
+        pages_folder=str(pages_path),
+        external_stylesheets=[dbc.themes.BOOTSTRAP],
+    )
 
     # Simple working layout
     app.layout = html.Div(


### PR DESCRIPTION
## Summary
- fix Dash `pages_folder` path so app finds the pages directory

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 127 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6877820c460083209cb5aedfad17d70f