### PR TITLE
Fix missing Path import

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -4,6 +4,7 @@
 import dash
 from dash import html, dcc, Input, Output
 import dash_bootstrap_components as dbc
+from pathlib import Path
 from components.ui.navbar import create_navbar_layout
 from pages import (
     file_upload,
@@ -35,8 +36,6 @@ def create_app(mode=None, **kwargs):
         ]
     )
 
-
-
     # Simple routing callback that uses REAL pages
     @app.callback(Output("page-content", "children"), Input("url", "pathname"))
     def display_page(pathname):
@@ -56,5 +55,6 @@ def create_app(mode=None, **kwargs):
 
         # Fallback to analytics page
         return deep_analytics.layout()
+
     app.title = "🏯 Yōsai Intel Dashboard"
     return app


### PR DESCRIPTION
## Summary
- fix missing import for `Path` in `create_app`

## Testing
- `flake8 core/app_factory/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_687786dd3e4083208c09616c04f2f6fb