### PR TITLE
Implement DB repositories and tests

### DIFF
--- a/repositories/implementations.py
+++ b/repositories/implementations.py
@@ -1,64 +1,265 @@
 """Placeholder repository implementations"""
 
+from __future__ import annotations
+
+import asyncio
+import json
 from datetime import datetime
 from typing import List, Optional
 
 from models.entities import AccessEvent, Door, Person
+from models.enums import AccessResult, BadgeStatus, DoorType
+from database.types import DatabaseConnection
 
 from .interfaces import IAccessEventRepository, IDoorRepository, IPersonRepository
 
 
+def _row_to_person(row: dict) -> Person:
+    return Person(
+        person_id=row["person_id"],
+        name=row.get("name"),
+        employee_id=row.get("employee_id"),
+        department=row.get("department"),
+        clearance_level=int(row.get("clearance_level", 1)),
+        access_groups=tuple(row.get("access_groups", "").split(","))
+        if row.get("access_groups")
+        else tuple(),
+        is_visitor=bool(row.get("is_visitor")),
+        host_person_id=row.get("host_person_id"),
+        created_at=datetime.fromisoformat(row["created_at"])
+        if row.get("created_at")
+        else datetime.now(),
+        last_active=datetime.fromisoformat(row["last_active"])
+        if row.get("last_active")
+        else None,
+        risk_score=float(row.get("risk_score", 0.0)),
+    )
+
+
+def _row_to_event(row: dict) -> AccessEvent:
+    return AccessEvent(
+        event_id=row["event_id"],
+        timestamp=datetime.fromisoformat(row["timestamp"]),
+        person_id=row.get("person_id"),
+        door_id=row.get("door_id"),
+        badge_id=row.get("badge_id"),
+        access_result=AccessResult(row["access_result"]),
+        badge_status=BadgeStatus(row.get("badge_status", BadgeStatus.VALID.value)),
+        door_held_open_time=float(row.get("door_held_open_time", 0.0)),
+        entry_without_badge=bool(row.get("entry_without_badge")),
+        device_status=row.get("device_status", ""),
+        raw_data=json.loads(row.get("raw_data")) if row.get("raw_data") else {},
+    )
+
+
+def _row_to_door(row: dict) -> Door:
+    return Door(
+        door_id=row["door_id"],
+        door_name=row.get("door_name"),
+        facility_id=row.get("facility_id"),
+        area_id=row.get("area_id"),
+        floor=row.get("floor"),
+        door_type=DoorType(row.get("door_type", DoorType.STANDARD.value)),
+        required_clearance=int(row.get("required_clearance", 1)),
+        is_critical=bool(row.get("is_critical")),
+        location_coordinates=None,
+        device_id=row.get("device_id"),
+        is_active=bool(row.get("is_active", True)),
+        created_at=datetime.fromisoformat(row["created_at"])
+        if row.get("created_at")
+        else datetime.now(),
+    )
+
+
 class PersonRepository(IPersonRepository):
-    async def get_by_id(self, person_id: str) -> Optional[Person]:  # pragma: no cover
-        raise NotImplementedError
+    """Database backed ``Person`` repository."""
 
-    async def get_all(
-        self, limit: int = 100, offset: int = 0
-    ) -> List[Person]:  # pragma: no cover
-        raise NotImplementedError
+    def __init__(self, connection: "DatabaseConnection") -> None:
+        self.conn = connection
 
-    async def create(self, person: Person) -> Person:  # pragma: no cover
-        raise NotImplementedError
+    # --------------------------------------------------------------
+    async def get_by_id(self, person_id: str) -> Optional[Person]:
+        query = "SELECT * FROM people WHERE person_id = ?"
 
-    async def update(self, person: Person) -> Person:  # pragma: no cover
-        raise NotImplementedError
+        rows = await asyncio.to_thread(self.conn.execute_query, query, (person_id,))
+        if rows:
+            return _row_to_person(rows[0])
+        return None
 
-    async def delete(self, person_id: str) -> bool:  # pragma: no cover
-        raise NotImplementedError
+    # --------------------------------------------------------------
+    async def get_all(self, limit: int = 100, offset: int = 0) -> List[Person]:
+        query = "SELECT * FROM people ORDER BY person_id LIMIT ? OFFSET ?"
+        rows = await asyncio.to_thread(
+            self.conn.execute_query, query, (limit, offset)
+        )
+        return [_row_to_person(r) for r in rows]
+
+    # --------------------------------------------------------------
+    async def create(self, person: Person) -> Person:
+        query = (
+            "INSERT INTO people (person_id, name, employee_id, department, "
+            "clearance_level, access_groups, is_visitor, host_person_id, "
+            "created_at, last_active, risk_score) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        params = (
+            person.person_id,
+            person.name,
+            person.employee_id,
+            person.department,
+            person.clearance_level,
+            ",".join(person.access_groups),
+            int(person.is_visitor),
+            person.host_person_id,
+            person.created_at.isoformat(),
+            person.last_active.isoformat() if person.last_active else None,
+            person.risk_score,
+        )
+        await asyncio.to_thread(self.conn.execute_command, query, params)
+        return person
+
+    # --------------------------------------------------------------
+    async def update(self, person: Person) -> Person:
+        query = (
+            "UPDATE people SET name=?, employee_id=?, department=?, "
+            "clearance_level=?, access_groups=?, is_visitor=?, host_person_id=?, "
+            "last_active=?, risk_score=? WHERE person_id=?"
+        )
+        params = (
+            person.name,
+            person.employee_id,
+            person.department,
+            person.clearance_level,
+            ",".join(person.access_groups),
+            int(person.is_visitor),
+            person.host_person_id,
+            person.last_active.isoformat() if person.last_active else None,
+            person.risk_score,
+            person.person_id,
+        )
+        await asyncio.to_thread(self.conn.execute_command, query, params)
+        return person
+
+    # --------------------------------------------------------------
+    async def delete(self, person_id: str) -> bool:
+        query = "DELETE FROM people WHERE person_id=?"
+        await asyncio.to_thread(self.conn.execute_command, query, (person_id,))
+        return True
 
 
 class AccessEventRepository(IAccessEventRepository):
+    """Repository for ``AccessEvent`` records."""
+
+    def __init__(self, connection: "DatabaseConnection") -> None:
+        self.conn = connection
+
+    # --------------------------------------------------------------
     async def get_events_by_person(
         self,
         person_id: str,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-    ) -> List[AccessEvent]:  # pragma: no cover
-        raise NotImplementedError
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[AccessEvent]:
+        query = "SELECT * FROM access_events WHERE person_id=?"
+        params: list = [person_id]
+        if start_date:
+            query += " AND timestamp >= ?"
+            params.append(start_date.isoformat())
+        if end_date:
+            query += " AND timestamp <= ?"
+            params.append(end_date.isoformat())
+        query += " ORDER BY timestamp DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
 
+        rows = await asyncio.to_thread(
+            self.conn.execute_query, query, tuple(params)
+        )
+        return [_row_to_event(r) for r in rows]
+
+    # --------------------------------------------------------------
     async def get_events_by_door(
         self,
         door_id: str,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-    ) -> List[AccessEvent]:  # pragma: no cover
-        raise NotImplementedError
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[AccessEvent]:
+        query = "SELECT * FROM access_events WHERE door_id=?"
+        params: list = [door_id]
+        if start_date:
+            query += " AND timestamp >= ?"
+            params.append(start_date.isoformat())
+        if end_date:
+            query += " AND timestamp <= ?"
+            params.append(end_date.isoformat())
+        query += " ORDER BY timestamp DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        rows = await asyncio.to_thread(
+            self.conn.execute_query, query, tuple(params)
+        )
+        return [_row_to_event(r) for r in rows]
 
-    async def create_event(self, event: AccessEvent) -> AccessEvent:  # pragma: no cover
-        raise NotImplementedError
+    # --------------------------------------------------------------
+    async def create_event(self, event: AccessEvent) -> AccessEvent:
+        query = (
+            "INSERT INTO access_events (event_id, timestamp, person_id, door_id, "
+            "badge_id, access_result, badge_status, door_held_open_time, "
+            "entry_without_badge, device_status, raw_data, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        params = (
+            event.event_id,
+            event.timestamp.isoformat(),
+            event.person_id,
+            event.door_id,
+            event.badge_id,
+            event.access_result.value,
+            event.badge_status.value,
+            event.door_held_open_time,
+            int(event.entry_without_badge),
+            event.device_status,
+            json.dumps(event.raw_data),
+            datetime.now().isoformat(),
+        )
+        await asyncio.to_thread(self.conn.execute_command, query, params)
+        return event
 
-    async def get_recent_events(
-        self, limit: int = 100
-    ) -> List[AccessEvent]:  # pragma: no cover
-        raise NotImplementedError
+    # --------------------------------------------------------------
+    async def get_recent_events(self, limit: int = 100) -> List[AccessEvent]:
+        query = "SELECT * FROM access_events ORDER BY timestamp DESC LIMIT ?"
+        rows = await asyncio.to_thread(self.conn.execute_query, query, (limit,))
+        return [_row_to_event(r) for r in rows]
 
 
 class DoorRepository(IDoorRepository):
-    async def get_by_id(self, door_id: str) -> Optional[Door]:  # pragma: no cover
-        raise NotImplementedError
+    """Repository for ``Door`` entities."""
 
-    async def get_by_facility(self, facility_id: str) -> List[Door]:  # pragma: no cover
-        raise NotImplementedError
+    def __init__(self, connection: "DatabaseConnection") -> None:
+        self.conn = connection
 
-    async def get_critical_doors(self) -> List[Door]:  # pragma: no cover
-        raise NotImplementedError
+    # --------------------------------------------------------------
+    async def get_by_id(self, door_id: str) -> Optional[Door]:
+        query = "SELECT * FROM doors WHERE door_id=?"
+        rows = await asyncio.to_thread(self.conn.execute_query, query, (door_id,))
+        if rows:
+            return _row_to_door(rows[0])
+        return None
+
+    # --------------------------------------------------------------
+    async def get_by_facility(self, facility_id: str, *, limit: int = 100, offset: int = 0) -> List[Door]:
+        query = "SELECT * FROM doors WHERE facility_id=? ORDER BY door_id LIMIT ? OFFSET ?"
+        rows = await asyncio.to_thread(
+            self.conn.execute_query, query, (facility_id, limit, offset)
+        )
+        return [_row_to_door(r) for r in rows]
+
+    # --------------------------------------------------------------
+    async def get_critical_doors(self) -> List[Door]:
+        query = "SELECT * FROM doors WHERE is_critical=1"
+        rows = await asyncio.to_thread(self.conn.execute_query, query)
+        return [_row_to_door(r) for r in rows]

--- a/tests/repositories/test_repositories.py
+++ b/tests/repositories/test_repositories.py
@@ -1,0 +1,201 @@
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from models.entities import Person, Door, AccessEvent
+from models.enums import AccessResult, BadgeStatus, DoorType
+from repositories.implementations import PersonRepository, DoorRepository, AccessEventRepository
+
+
+class _SQLiteConn:
+    def __init__(self):
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+
+    def execute_query(self, query: str, params: tuple | None = None):
+        cur = self.conn.cursor()
+        cur.execute(query, params or ())
+        rows = cur.fetchall()
+        return [dict(r) for r in rows]
+
+    def execute_command(self, command: str, params: tuple | None = None):
+        cur = self.conn.cursor()
+        cur.execute(command, params or ())
+        self.conn.commit()
+        return cur.rowcount
+
+    def health_check(self) -> bool:
+        try:
+            self.conn.execute('SELECT 1')
+            return True
+        except Exception:
+            return False
+
+
+@pytest.fixture()
+def db():
+    c = _SQLiteConn()
+    # create tables
+    c.execute_command(
+        """CREATE TABLE people (
+               person_id TEXT PRIMARY KEY,
+               name TEXT,
+               employee_id TEXT,
+               department TEXT,
+               clearance_level INTEGER,
+               access_groups TEXT,
+               is_visitor INTEGER,
+               host_person_id TEXT,
+               created_at TEXT,
+               last_active TEXT,
+               risk_score REAL
+           )"""
+    )
+    c.execute_command(
+        """CREATE TABLE doors (
+               door_id TEXT PRIMARY KEY,
+               door_name TEXT,
+               facility_id TEXT,
+               area_id TEXT,
+               floor TEXT,
+               door_type TEXT,
+               required_clearance INTEGER,
+               is_critical INTEGER,
+               location_coordinates TEXT,
+               device_id TEXT,
+               is_active INTEGER,
+               created_at TEXT
+           )"""
+    )
+    c.execute_command(
+        """CREATE TABLE access_events (
+               event_id TEXT PRIMARY KEY,
+               timestamp TEXT,
+               person_id TEXT,
+               door_id TEXT,
+               badge_id TEXT,
+               access_result TEXT,
+               badge_status TEXT,
+               door_held_open_time REAL,
+               entry_without_badge INTEGER,
+               device_status TEXT,
+               raw_data TEXT,
+               created_at TEXT
+           )"""
+    )
+    yield c
+    c.conn.close()
+
+
+def test_person_repository_crud(async_runner, db):
+    repo = PersonRepository(db)
+    p1 = Person(person_id='P1', name='Alpha')
+    async_runner(repo.create(p1))
+    fetched = async_runner(repo.get_by_id('P1'))
+    assert fetched == p1
+
+    p2 = Person(person_id='P2', name='Beta')
+    async_runner(repo.create(p2))
+
+    all_people = async_runner(repo.get_all(limit=1, offset=1))
+    assert len(all_people) == 1
+    assert all_people[0] == p2
+
+    updated = Person(
+        person_id='P1',
+        name='Gamma',
+        clearance_level=1,
+        created_at=fetched.created_at,
+    )
+    async_runner(repo.update(updated))
+    fetched2 = async_runner(repo.get_by_id('P1'))
+    assert fetched2.name == 'Gamma'
+
+    async_runner(repo.delete('P1'))
+    assert async_runner(repo.get_by_id('P1')) is None
+
+
+def _insert_door(db, door: Door):
+    db.execute_command(
+        "INSERT INTO doors (door_id, door_name, facility_id, area_id, door_type, required_clearance, is_critical, is_active, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            door.door_id,
+            door.door_name,
+            door.facility_id,
+            door.area_id,
+            door.door_type.value,
+            door.required_clearance,
+            int(door.is_critical),
+            int(door.is_active),
+            door.created_at.isoformat(),
+        ),
+    )
+
+
+def test_door_repository(async_runner, db):
+    repo = DoorRepository(db)
+    d1 = Door(door_id='D1', door_name='Front', facility_id='F1', area_id='A1')
+    d2 = Door(door_id='D2', door_name='Side', facility_id='F1', area_id='A1', is_critical=True)
+    _insert_door(db, d1)
+    _insert_door(db, d2)
+
+    door = async_runner(repo.get_by_id('D1'))
+    assert door.door_name == 'Front'
+
+    doors = async_runner(repo.get_by_facility('F1'))
+    assert len(doors) == 2
+
+    critical = async_runner(repo.get_critical_doors())
+    assert any(d.door_id == 'D2' for d in critical)
+
+
+def test_access_event_repository(async_runner, db):
+    person_repo = PersonRepository(db)
+    door_repo = DoorRepository(db)
+    event_repo = AccessEventRepository(db)
+
+    p = Person(person_id='P1', name='Tester')
+    async_runner(person_repo.create(p))
+    d = Door(door_id='D1', door_name='Main', facility_id='F1', area_id='A1')
+    _insert_door(db, d)
+
+    now = datetime.now()
+    e1 = AccessEvent(
+        event_id='E1',
+        timestamp=now - timedelta(minutes=1),
+        person_id='P1',
+        door_id='D1',
+        badge_id=None,
+        access_result=AccessResult.GRANTED,
+        badge_status=BadgeStatus.VALID,
+        door_held_open_time=0.0,
+        entry_without_badge=False,
+        device_status='normal',
+        raw_data={},
+    )
+    e2 = AccessEvent(
+        event_id='E2',
+        timestamp=now,
+        person_id='P1',
+        door_id='D1',
+        badge_id=None,
+        access_result=AccessResult.DENIED,
+        badge_status=BadgeStatus.VALID,
+        door_held_open_time=0.0,
+        entry_without_badge=False,
+        device_status='normal',
+        raw_data={},
+    )
+    async_runner(event_repo.create_event(e1))
+    async_runner(event_repo.create_event(e2))
+
+    by_person = async_runner(event_repo.get_events_by_person('P1', limit=1))
+    assert len(by_person) == 1
+
+    by_door = async_runner(event_repo.get_events_by_door('D1'))
+    assert len(by_door) == 2
+
+    recent = async_runner(event_repo.get_recent_events(limit=1))
+    assert recent[0].event_id == 'E2'


### PR DESCRIPTION
## Summary
- flesh out async repository implementations
- add helpers to convert DB rows to dataclasses
- provide SQLite-backed repository tests

## Testing
- `pytest tests/repositories -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687789673f74832086b217a2c0007513