### PR TITLE
Fix page folder path and run method

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,7 +271,7 @@ def main():
         try:
             if ssl_context:
                 logger.info("🔒 Starting with HTTPS")
-                app.run_server(
+                app.run(
                     host=app_config.host,
                     port=str(app_config.port),
                     debug=app_config.debug,
@@ -279,7 +279,7 @@ def main():
                 )
             else:
                 logger.info("🌐 Starting with HTTP")
-                app.run_server(
+                app.run(
                     host=app_config.host,
                     port=str(app_config.port),
                     debug=app_config.debug,

--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -18,7 +18,9 @@ from pages import (
 def create_app(mode=None, **kwargs):
     """Create a working Dash app with logo, navigation, and routing - HTTPS ready."""
 
-    pages_path = Path(__file__).resolve().parent.parent / "pages"
+    # The pages module lives in the project root, not under ``core``.
+    # Resolve the project root and point Dash to the correct directory.
+    pages_path = Path(__file__).resolve().parent.parent.parent / "pages"
     app = dash.Dash(
         __name__,
         use_pages=True,


### PR DESCRIPTION
## Summary
- fix incorrect pages folder path in app factory
- use `app.run` instead of deprecated `app.run_server`

## Testing
- `python app.py > /tmp/app.log && tail -n 5 /tmp/app.log`


------
https://chatgpt.com/codex/tasks/task_e_68778a7687b88320b648c5aaa05cf3c3