### PR TITLE
Fix missing Path import comment

### DIFF
--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -4,6 +4,7 @@
 import dash
 from dash import html, dcc, Input, Output
 import dash_bootstrap_components as dbc
+# Import Path for building robust file paths
 from pathlib import Path
 from components.ui.navbar import create_navbar_layout
 from pages import (


### PR DESCRIPTION
## Summary
- clarify why `Path` import is required in `core/app_factory`

## Testing
- `pytest -q` *(fails: 129 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68778b2cf59c8320bf19b5682143a546