### PR TITLE
Fix dash page setup

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -101,7 +101,6 @@ def create_navbar_layout(
                         children,
                         href=href,
                         className="nav-link px-3",
-                        **{"aria-label": name},
                     )
                 )
             )

--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -2,18 +2,12 @@
 """Fresh, minimal app factory that WORKS with real pages - HTTPS enabled."""
 
 import dash
-from dash import html, dcc, Input, Output
+from dash import html, dcc, page_container
 import dash_bootstrap_components as dbc
 # Import Path for building robust file paths
 from pathlib import Path
 from components.ui.navbar import create_navbar_layout
-from pages import (
-    file_upload,
-    deep_analytics,
-    graphs,
-    export,
-    settings,
-)
+
 
 
 def create_app(mode=None, **kwargs):
@@ -34,30 +28,10 @@ def create_app(mode=None, **kwargs):
         [
             dcc.Location(id="url", refresh=False),
             create_navbar_layout(),
-            html.Div(id="page-content", className="main-content p-4"),
+            html.Div(page_container, id="page-content", className="main-content p-4"),
             dcc.Store(id="global-store", data={}),
         ]
     )
-
-    # Simple routing callback that uses REAL pages
-    @app.callback(Output("page-content", "children"), Input("url", "pathname"))
-    def display_page(pathname):
-        """Return the layout for the requested URL path."""
-        pathname = pathname.rstrip("/") if pathname else "/"
-
-        if pathname in {"/", "/dashboard", "/analytics"}:
-            return deep_analytics.layout()
-        if pathname == "/graphs":
-            return graphs.layout()
-        if pathname == "/upload":
-            return file_upload.layout()
-        if pathname == "/export":
-            return export.layout()
-        if pathname == "/settings":
-            return settings.layout()
-
-        # Fallback to analytics page
-        return deep_analytics.layout()
 
     app.title = "🏯 Yōsai Intel Dashboard"
     return app

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -143,20 +143,13 @@ def load_page(**kwargs) -> AnalyticsPage:
 def register_page(app=None) -> None:
     """Register the analytics page with Dash."""
     try:
-        if app is not None:
-            app.register_page(
-                __name__,
-                path="/analytics",
-                name="Analytics",
-                aliases=["/", "/dashboard"],
-            )
-        else:
-            dash_register_page(
-                __name__,
-                path="/analytics",
-                name="Analytics",
-                aliases=["/", "/dashboard"],
-            )
+        dash_register_page(
+            __name__,
+            path="/analytics",
+            name="Analytics",
+            aliases=["/", "/dashboard"],
+            app=app,
+        )
     except Exception as e:
         import logging
 

--- a/pages/export.py
+++ b/pages/export.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Export page providing download instructions."""
 
+import logging
 import dash_bootstrap_components as dbc
 from dash import dcc, html, register_page as dash_register_page
 
@@ -10,10 +11,7 @@ from security.unicode_security_processor import sanitize_unicode_input
 def register_page(app=None) -> None:
     """Register the export page with Dash."""
     try:
-        if app is not None:
-            app.register_page(__name__, path="/export", name="Export")
-        else:
-            dash_register_page(__name__, path="/export", name="Export")
+        dash_register_page(__name__, path="/export", name="Export", app=app)
     except Exception as e:
         logger = logging.getLogger(__name__)
         logger.warning(f"Failed to register page {__name__}: {e}")

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -218,10 +218,7 @@ def load_page(**kwargs):
 
 def register_page(app=None):
     try:
-        if app is not None:
-            app.register_page(__name__, path="/upload", name="Upload")
-        else:
-            dash_register_page(__name__, path="/upload", name="Upload")
+        dash_register_page(__name__, path="/upload", name="Upload", app=app)
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")
 

--- a/pages/file_upload_simple.py
+++ b/pages/file_upload_simple.py
@@ -130,10 +130,7 @@ def handle_upload(contents: str | List[str], filenames: str | List[str]):
 def register_page(app=None):
     """Register this page with Dash."""
     try:
-        if app is not None:
-            app.register_page(__name__, path="/upload", name="Upload")
-        else:
-            dash_register_page(__name__, path="/upload", name="Upload")
+        dash_register_page(__name__, path="/upload", name="Upload", app=app)
     except Exception as e:  # pragma: no cover - best effort
         logger.warning("Failed to register page %s: %s", __name__, e)
 

--- a/pages/graphs.py
+++ b/pages/graphs.py
@@ -84,10 +84,7 @@ def load_page(**kwargs):
 
 def register_page(app=None):
     try:
-        if app is not None:
-            app.register_page(__name__, path="/graphs", name="Graphs")
-        else:
-            dash_register_page(__name__, path="/graphs", name="Graphs")
+        dash_register_page(__name__, path="/graphs", name="Graphs", app=app)
     except Exception as e:
         logger.warning(f"Failed to register page {__name__}: {e}")
 

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -102,10 +102,7 @@ def load_page(**kwargs) -> SettingsPage:
 def register_page(app=None) -> None:
     """Register the settings page with Dash."""
     try:
-        if app is not None:
-            app.register_page(__name__, path="/settings", name="Settings")
-        else:
-            dash_register_page(__name__, path="/settings", name="Settings")
+        dash_register_page(__name__, path="/settings", name="Settings", app=app)
     except Exception as e:
         import logging
 


### PR DESCRIPTION
## Summary
- fix navbar link attributes to avoid invalid `aria-label`
- use Dash's `dash.register_page` for all pages
- remove unused manual routing and switch to `page_container`
- add missing `logging` import

## Testing
- `pytest -q` *(fails: 128 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6877970c18f0832099ad9c73c3461cef