### PR TITLE
Remove aria-label from navbar links

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -102,7 +102,6 @@ def create_navbar_layout(
                         children,
                         href=href,
                         className="nav-link px-3",
-                        **{"aria-label": name},
                     )
                 )
             )

--- a/tests/components/test_navbar_config.py
+++ b/tests/components/test_navbar_config.py
@@ -25,15 +25,13 @@ def test_create_navbar_layout_accepts_custom_links_icons():
     link = nav.children[0].children
     assert link.href == "/foo"
     assert getattr(link.children[0][0], "id", None) == "foo-icon"
-    assert getattr(link, "aria-label", None) == "Foo"
 
 
 def test_default_nav_links_have_labels():
     layout = create_navbar_layout()
     nav = layout.children.children[1]
     first_link = nav.children[0].children
-    assert getattr(first_link, "aria-label", None) == "Dashboard"
-
+    assert first_link.children[0][1] == "Dashboard"
 
 def test_register_navbar_callbacks_connects_toggle():
     mgr = StubManager()


### PR DESCRIPTION
## Summary
- drop aria-label attribute from dcc.Link in navbar
- adjust navbar tests to match new structure

## Testing
- `pytest -q tests/components/test_navbar_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68779e2ef17483208cb15e50804ba7cb