### PR TITLE
Add mypy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           set -xe
           flake8 . --max-line-length 88 -v
 
+      - name: Mypy
+        run: |
+          set -xe
+          mypy .
+
       - name: Bandit
         run: |
           set -xe

--- a/plugins/compliance_plugin/__init__.py
+++ b/plugins/compliance_plugin/__init__.py
@@ -517,7 +517,8 @@ class ComplianceServices:
 
 
 # plugins/compliance_plugin/plugin_manifest.yaml
-# Plugin manifest file
+# The following YAML manifest is included for reference only.
+PLUGIN_MANIFEST = """
 name: compliance_plugin
 version: 1.0.0
 description: GDPR/APPI compliance framework
@@ -544,23 +545,23 @@ config_schema:
       type: boolean
       default: true
       description: "Enable compliance plugin"
-    
+
     jurisdiction:
       type: string
       enum: [EU, JP, US, CA]
       default: EU
       description: "Primary jurisdiction for compliance"
-    
+
     consent_enabled:
       type: boolean
       default: true
       description: "Enable consent management"
-    
+
     audit_enabled:
       type: boolean
       default: true
       description: "Enable audit logging"
-    
+
     retention_enabled:
       type: boolean
       default: true
@@ -600,6 +601,7 @@ dashboard_widgets:
   - id: consent_status
     title: "Consent Management"
     type: chart
+"""
 
 
 # plugins/compliance_plugin/install.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,10 @@ black
 isort
 flake8
 mypy
+types-bleach
+types-hvac
+types-psutil
+types-requests
 bandit
 pytest
 pytest-cov


### PR DESCRIPTION
## Summary
- run mypy in CI
- store plugin manifest as a string so mypy can parse the module
- include common type stubs in dev requirements

## Testing
- `pytest -q` *(fails: Missing required test dependencies)*
- `mypy .` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68779e685db883209f6e80245488509e