### PR TITLE
Refactor upload analytics helpers

### DIFF
--- a/services/upload_processing.py
+++ b/services/upload_processing.py
@@ -7,18 +7,61 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
     def __init__(self, *args, **kwargs) -> None:
         pass
 
-    def _process_uploaded_data_directly(self, data):
+    # ------------------------------------------------------------------
+    def _load_data(self):
+        """Return uploaded data using :meth:`load_uploaded_data`."""
+        return self.load_uploaded_data()
+
+    # ------------------------------------------------------------------
+    def _validate_data(self, data):
+        """Remove empty dataframes from ``data``."""
+        return {name: df for name, df in data.items() if not df.empty}
+
+    # ------------------------------------------------------------------
+    def _calculate_statistics(self, data):
+        """Calculate basic statistics for uploaded ``data``."""
+        total_events = sum(len(df) for df in data.values())
+        unique_users = {
+            row.get("Person ID")
+            for df in data.values()
+            for row in df.to_dict("records")
+            if "Person ID" in row
+        }
+        unique_doors = {
+            row.get("Device name")
+            for df in data.values()
+            for row in df.to_dict("records")
+            if "Device name" in row
+        }
         return {
-            "total_events": sum(len(df) for df in data.values()),
-            "active_users": len({row['Person ID'] for df in data.values() for row in df.to_dict('records')}),
-            "active_doors": len({row['Device name'] for df in data.values() for row in df.to_dict('records')}),
+            "total_events": total_events,
+            "active_users": len(unique_users),
+            "active_doors": len(unique_doors),
         }
 
+    # ------------------------------------------------------------------
+    def _format_results(self, stats):
+        """Return final result dictionary with ``status`` key."""
+        result = dict(stats)
+        result["status"] = "success"
+        return result
+
+    # ------------------------------------------------------------------
+    def _process_uploaded_data_directly(self, data):
+        """Backward compatible helper to process uploaded ``data``."""
+        validated = self._validate_data(data)
+        return self._calculate_statistics(validated)
+
+    # ------------------------------------------------------------------
     def analyze_uploaded_data(self):
-        data = self.load_uploaded_data()
-        metrics = self._process_uploaded_data_directly(data)
-        metrics["status"] = "success"
-        return metrics
+        """Main entry point coordinating upload analytics."""
+        try:
+            data = self._load_data()
+            validated = self._validate_data(data)
+            stats = self._calculate_statistics(validated)
+            return self._format_results(stats)
+        except Exception as exc:  # pragma: no cover - best effort
+            return {"status": "error", "message": str(exc)}
 
     def load_uploaded_data(self):  # pragma: no cover - simple stub
         return {}

--- a/tests/test_upload_processing_helpers.py
+++ b/tests/test_upload_processing_helpers.py
@@ -1,0 +1,51 @@
+import pandas as pd
+from tests.utils.builders import DataFrameBuilder
+from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from services.data_processing.processor import Processor
+from core.security_validator import SecurityValidator
+
+
+def _make_processor():
+    from flask import Flask
+    from core.cache import cache
+    cache.init_app(Flask(__name__))
+    vs = SecurityValidator()
+    processor = Processor(validator=vs)
+    return UploadAnalyticsProcessor(vs, processor)
+
+
+def test_load_data_helper(monkeypatch):
+    df = DataFrameBuilder().add_column("A", [1]).build()
+    ua = _make_processor()
+    monkeypatch.setattr(ua, "load_uploaded_data", lambda: {"f.csv": df})
+    assert ua._load_data() == {"f.csv": df}
+
+
+def test_validate_data_filters_empty():
+    df = DataFrameBuilder().add_column("A", [1]).build()
+    ua = _make_processor()
+    data = {"empty.csv": pd.DataFrame(), "f.csv": df}
+    cleaned = ua._validate_data(data)
+    assert list(cleaned.keys()) == ["f.csv"]
+
+
+def test_calculate_statistics():
+    df = (
+        DataFrameBuilder()
+        .add_column("Person ID", ["u1"])
+        .add_column("Device name", ["d1"])
+        .build()
+    )
+    ua = _make_processor()
+    stats = ua._calculate_statistics({"x.csv": df})
+    assert stats["total_events"] == 1
+    assert stats["active_users"] == 1
+    assert stats["active_doors"] == 1
+
+
+def test_format_results():
+    ua = _make_processor()
+    formatted = ua._format_results({"total_events": 1})
+    assert formatted["status"] == "success"
+    assert formatted["total_events"] == 1
+


### PR DESCRIPTION
## Summary
- extract helper methods for data loading, validation, statistics calculation, and result formatting in `UploadAnalyticsProcessor`
- keep `analyze_uploaded_data` focused on orchestration
- add unit tests covering new helper methods

## Testing
- `pytest tests/test_upload_processing_helpers.py tests/test_upload_processing_module.py tests/test_process_and_analyze.py -q` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_68779e69d92c8320940f466713823496