### PR TITLE
Add column mapping learning integration

### DIFF
--- a/tests/test_consolidated_learning_service.py
+++ b/tests/test_consolidated_learning_service.py
@@ -127,3 +127,11 @@ class TestConsolidatedLearningService:
         service = ConsolidatedLearningService(str(self.storage_path))
         assert service.learned_data == json_content
         assert pkl_path.exists()
+
+    def test_save_column_mappings(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        cols = {"a": "door_id", "b": "timestamp"}
+        fingerprint = self.service.save_complete_mapping(df, "cols.csv", {}, cols)
+        reloaded = ConsolidatedLearningService(str(self.storage_path))
+        assert fingerprint in reloaded.learned_data
+        assert reloaded.learned_data[fingerprint]["column_mappings"] == cols


### PR DESCRIPTION
## Summary
- integrate learning service into column verification workflow
- forward DataFrame to `save_verified_mappings`
- support saving column mappings through consolidated learning service
- cover column mapping save in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6877b63c332c8320a076fac1ad780c15