### PR TITLE
Enable AI defaults post-upload

### DIFF
--- a/mapping/ui/callbacks/callback_manager.py
+++ b/mapping/ui/callbacks/callback_manager.py
@@ -8,8 +8,8 @@ from dash.dependencies import Input, Output, State
 
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
-from .device_callbacks import toggle_simple_device_modal
 from .file_callbacks import UploadCallbackManager
+from components.simple_device_mapping import register_callbacks as register_device_callbacks
 
 
 class MappingCallbackManager:
@@ -19,18 +19,7 @@ class MappingCallbackManager:
         self.service = service
 
     def register_all(self, manager: TrulyUnifiedCallbacks) -> None:
-        manager.register_callback(  # type: ignore[misc]
-            Output("simple-device-modal", "is_open"),
-            [
-                Input("open-device-mapping", "n_clicks"),
-                Input("device-modal-cancel", "n_clicks"),
-                Input("device-modal-save", "n_clicks"),
-            ],
-            [State("simple-device-modal", "is_open")],
-            callback_id="toggle_simple_device_modal",
-            component_name="device_components",
-        )(toggle_simple_device_modal)
-
+        register_device_callbacks(manager)
         UploadCallbackManager().register(manager)
 
     @classmethod

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -124,6 +124,11 @@ def test_finalize_upload_results_done(monkeypatch):
     monkeypatch.setattr(
         cb.task_queue, "clear_task", lambda tid: called.setdefault("tid", tid)
     )
+    monkeypatch.setattr(
+        "components.simple_device_mapping.generate_ai_device_defaults",
+        lambda df, profile="auto": called.setdefault("gen", True),
+    )
     out = cb.finalize_upload_results(1, "tid")
     assert out == (*result, True)
     assert called["tid"] == "tid"
+    assert called.get("gen") is True

--- a/tests/components/test_ui_callback_helpers.py
+++ b/tests/components/test_ui_callback_helpers.py
@@ -67,3 +67,4 @@ def test_register_callbacks_invoked():
     calls = [c.kwargs.get("callback_id") for c in manager.register_callback.mock_calls]
     assert "toggle_custom_field" in calls
     assert "apply_ai_device_suggestions" in calls
+    assert "populate_simple_device_modal" in calls

--- a/tests/test_upload_end_to_end.py
+++ b/tests/test_upload_end_to_end.py
@@ -174,8 +174,14 @@ def test_complete_upload_flow(tmp_path):
 
     assert progress == 100
 
+    called = {}
+    monkeypatch.setattr(
+        "components.simple_device_mapping.generate_ai_device_defaults",
+        lambda df, profile="auto": called.setdefault("gen", True),
+    )
     result = core.finalize_upload_results(1, tid)
     assert result[-1] is True
+    assert called.get("gen") is True
 
     saved = store.load_dataframe("sample.csv")
     pd.testing.assert_frame_equal(saved, df)

--- a/ui/callbacks/callback_manager.py
+++ b/ui/callbacks/callback_manager.py
@@ -9,13 +9,8 @@ from dash.dependencies import Input, Output, State
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 from ui.callbacks.column_callbacks import toggle_custom_field
-from ui.callbacks.device_callbacks import (
-    apply_ai_device_suggestions,
-    populate_simple_device_modal,
-    save_user_inputs,
-    toggle_simple_device_modal,
-)
 from ui.callbacks.file_callbacks import UploadCallbackManager
+from components.simple_device_mapping import register_callbacks as register_device_callbacks
 
 
 class CallbackManager:
@@ -25,16 +20,5 @@ class CallbackManager:
         self.service = service
 
     def register_all(self, manager: TrulyUnifiedCallbacks) -> None:
-        manager.register_callback(  # type: ignore[misc]
-            Output("simple-device-modal", "is_open"),
-            [
-                Input("open-device-mapping", "n_clicks"),
-                Input("device-modal-cancel", "n_clicks"),
-                Input("device-modal-save", "n_clicks"),
-            ],
-            [State("simple-device-modal", "is_open")],
-            callback_id="toggle_simple_device_modal",
-            component_name="device_components",
-        )(toggle_simple_device_modal)
-
+        register_device_callbacks(manager)
         UploadCallbackManager().register(manager)

--- a/upload_core.py
+++ b/upload_core.py
@@ -156,7 +156,19 @@ class UploadCore:
 
         if status.get("done") and result is not None:
             self.task_queue.clear_task(task_id)
-            if isinstance(result, Exception):
+            if not isinstance(result, Exception):
+                try:
+                    from components.simple_device_mapping import (
+                        generate_ai_device_defaults,
+                    )
+
+                    for fname in self.store.get_filenames():
+                        df = self.store.load_dataframe(fname)
+                        if df is not None and not df.empty:
+                            generate_ai_device_defaults(df, "auto")
+                except Exception as exc:  # pragma: no cover - best effort
+                    logger.error("Failed to generate AI defaults: %s", exc)
+            else:
                 result = (
                     [self.processing.build_failure_alert(str(result))],
                     [],


### PR DESCRIPTION
## Summary
- trigger AI mapping generation once uploads finish
- use simple device callbacks everywhere
- ensure tests patch AI default generation

## Testing
- `flake8` *(fails: command not found)*
- `pytest tests/callbacks/test_upload_callbacks_split.py -k test_finalize_upload_results_done -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6877b63c5b78832096de9ca18cdf0c0f