### PR TITLE
Update Enhanced Data navigation to open device analysis

### DIFF
--- a/components/ui/navbar.py
+++ b/components/ui/navbar.py
@@ -56,6 +56,7 @@ def create_navbar_layout(
         "Dashboard": "/dashboard",
         "Analytics": "/analytics",
         "Graphs": "/graphs",
+        "Device Analysis": "/device-analysis",
         "File Upload": "/upload",
         "Export": "/export",
         "Settings": "/settings",
@@ -74,6 +75,10 @@ def create_navbar_layout(
         "Graphs": html.I(
             className="fas fa-chart-line me-2",
             **{"aria-hidden": "true", "aria-label": "Graphs"},
+        ),
+        "Device Analysis": html.I(
+            className="fas fa-microchip me-2",
+            **{"aria-hidden": "true", "aria-label": "Device Analysis"},
         ),
         "File Upload": html.I(
             className="fas fa-upload me-2",
@@ -161,6 +166,13 @@ def create_fallback_navbar():
                             dbc.NavLink(
                                 "Graphs",
                                 href="/graphs",
+                                external_link=False,
+                            )
+                        ),
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                "Device Analysis",
+                                href="/device-analysis",
                                 external_link=False,
                             )
                         ),

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -19,8 +19,9 @@ PAGE_MODULES: Dict[str, str] = {
     "deep_analytics": "pages.deep_analytics",
     "file_upload": "pages.file_upload",
     "graphs": "pages.graphs",
-    "export": "pages.export", 
+    "export": "pages.export",
     "settings": "pages.settings",
+    "device_analysis": "pages.device_analysis",
 }
 
 # Cache of loaded page modules
@@ -119,12 +120,13 @@ def register_router_callback(manager):
         try:
             path_mapping = {
                 "/": "deep_analytics",
-                "/analytics": "deep_analytics", 
+                "/analytics": "deep_analytics",
                 "/dashboard": "deep_analytics",
                 "/upload": "file_upload",
                 "/export": "export",
                 "/settings": "settings",
                 "/graphs": "graphs",
+                "/device-analysis": "device_analysis",
             }
             
             page_name = path_mapping.get(pathname, "deep_analytics")

--- a/pages/device_analysis.py
+++ b/pages/device_analysis.py
@@ -1,0 +1,37 @@
+import logging
+import dash_bootstrap_components as dbc
+from dash import html, register_page as dash_register_page
+
+from ui.components.device_components import create_device_mapping_section
+
+logger = logging.getLogger(__name__)
+
+
+def layout() -> dbc.Container:
+    return dbc.Container(
+        dbc.Row(
+            dbc.Col(
+                [
+                    html.H2("Device Analysis", className="mb-3"),
+                    html.P("Configure or review device mapping for uploaded data", className="text-muted"),
+                    create_device_mapping_section(),
+                ]
+            )
+        ),
+        fluid=True,
+    )
+
+
+def register_page(app=None) -> None:
+    try:
+        dash_register_page(__name__, path="/device-analysis", name="Device Analysis", app=app)
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning(f"Failed to register page {__name__}: {e}")
+
+
+def register_callbacks(manager):
+    # No custom callbacks beyond those included in components
+    pass
+
+
+__all__ = ["layout", "register_page", "register_callbacks"]

--- a/services/upload/core/processor.py
+++ b/services/upload/core/processor.py
@@ -271,8 +271,8 @@ class UploadProcessingService(UploadProcessingServiceProtocol):
         if result["file_info_dict"]:
             result["upload_nav"] = html.Div([
                 html.Hr(),
-                html.H5("Ready to analyze?"),
-                dbc.Button("�� Go to Analytics", href="/analytics", color="success", size="lg")
+                html.H5("Ready for device analysis?"),
+                dbc.Button("🚀 Start Device Analysis", href="/device-analysis", color="success", size="lg")
             ])
 
         # Add processing statistics


### PR DESCRIPTION
## Summary
- add a new `Device Analysis` page with device mapping section
- register the new page and route `/device-analysis`
- link to the page from upload processing navigation
- expose `Device Analysis` in navbar with icon

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6877b63f6df4832087701d5756d5ea5c