### PR TITLE
Add service container doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ This project follows a fully modular design built around a dependency injection 
 - [Data Versioning](docs/data_versioning.md)
 - [Data Processing](docs/data_processing.md)
 - [Column Verification](docs/column_verification.md)
+- [Service Container](docs/service_container.md)
 - [Testing Architecture](docs/test_architecture.md)
 
 Core service protocols live in `services/interfaces.py`. Components obtain
 implementations from the `ServiceContainer` when an explicit instance is not
-provided, allowing tests to supply lightweight mocks.
+provided, allowing tests to supply lightweight mocks. See
+[docs/service_container.md](docs/service_container.md) for registration
+patterns and lifetime options.
 
 The dashboard is extensible through a lightweight plugin system. Plugins live in the `plugins/` directory and are loaded by a `PluginManager`. See [docs/plugins.md](docs/plugins.md) for discovery, configuration details and a simple **Hello World** example. The [plugin lifecycle diagram](docs/plugin_lifecycle.md) illustrates how plugins are discovered, dependencies resolved and health checks performed.
 

--- a/docs/service_container.md
+++ b/docs/service_container.md
@@ -1,0 +1,52 @@
+# Service Container
+
+The dashboard uses a lightweight dependency injection container to wire together services.
+`ServiceContainer` from `core.service_container` manages service lifetimes and resolves
+implementations by name or protocol. Components fall back to the container when an
+explicit instance is not supplied.
+
+## Registering Services
+
+Create a container and register implementations with the desired lifetime:
+
+```python
+from core.service_container import ServiceContainer
+from services.analytics_service import AnalyticsService
+from services.interfaces import AnalyticsServiceProtocol
+
+container = ServiceContainer()
+container.register_singleton(
+    "analytics",
+    AnalyticsService,
+    protocol=AnalyticsServiceProtocol,
+)
+container.register_transient("validator", UnifiedFileValidator)
+container.register_scoped("request_logger", RequestLogger)
+```
+
+`register_singleton` stores one instance for the entire application. Use
+`register_transient` for a new instance each time `get()` is called. Scoped
+registrations create a single instance per logical scope.
+
+## Service Lifetimes
+
+The `ServiceLifetime` enumeration defines how instances are cached:
+
+- **SINGLETON** – one shared instance for the lifetime of the container.
+- **TRANSIENT** – a new instance is created on every resolution.
+- **SCOPED** – a unique instance is created per scope.
+
+A factory callable can also be supplied to lazily construct an implementation
+only when it is first requested.
+
+## Example Usage
+
+Retrieve services by key anywhere in the application:
+
+```python
+analytics = container.get("analytics")
+validator = container.get("validator")
+```
+
+Attach the container to the app during startup so callbacks and plugins can
+resolve dependencies on demand.


### PR DESCRIPTION
## Summary
- document how to register and use the ServiceContainer
- link the new doc from README

## Testing
- `pre-commit run --files docs/service_container.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_6877ba43dda083208a6cd8297002e82f