### PR TITLE
Add pip-audit gating and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,16 @@ jobs:
           safety check -r requirements.txt -r requirements-dev.txt --full-report
 
       - name: Pip Audit
+        if: github.event_name == 'pull_request'
         run: |
           set -xe
-          pip-audit --format=json --output=audit-report.json
+          pip-audit --format=json --output=audit-report.json || true
+
+      - name: Fail on Critical Vulns
+        if: github.event_name == 'pull_request'
+        run: |
+          set -xe
+          python scripts/check_pip_audit.py audit-report.json
 
       - name: PyTest
         run: |

--- a/README.md
+++ b/README.md
@@ -299,8 +299,9 @@ function inside a test simply pass `async_runner` and call it with your
 coroutine.
 
 The CI workflow also stores the `audit-report.json` file produced by `pip-audit`
-as the **pip-audit-report** artifact. Download it from the **Actions** tab to
-review dependency vulnerability results.
+as the **pip-audit-report** artifact. It runs on pull requests and fails when
+critical vulnerabilities are detected. Download the artifact from the
+**Actions** tab to review dependency vulnerability results.
 
 ## <span aria-hidden="true">📋</span> Features
 
@@ -321,6 +322,7 @@ review dependency vulnerability results.
   This single interface replaces previous callback controllers.
 - **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance
   using `psutil`.
+- **Dependabot Updates**: Python dependencies automatically kept up-to-date.
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run

--- a/scripts/check_pip_audit.py
+++ b/scripts/check_pip_audit.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fail if pip-audit reports any critical vulnerabilities."""
+import json
+import sys
+from pathlib import Path
+
+
+def main(path: str = "audit-report.json") -> int:
+    try:
+        data = Path(path).read_text()
+    except FileNotFoundError:
+        print(f"Report file {path} not found", file=sys.stderr)
+        return 1
+
+    try:
+        results = json.loads(data)
+    except json.JSONDecodeError as exc:
+        print("Failed to parse pip-audit JSON", file=sys.stderr)
+        print(data)
+        return 1
+
+    critical = []
+    for entry in results:
+        for vuln in entry.get("vulns", []):
+            if vuln.get("severity", "").lower() == "critical":
+                ident = vuln.get("id")
+                pkg = entry.get("name")
+                version = entry.get("version")
+                critical.append(f"{pkg} {version}: {ident}")
+
+    if critical:
+        print("Critical vulnerabilities detected:")
+        for item in critical:
+            print(f"- {item}")
+        return 1
+
+    print("No critical vulnerabilities found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
## Summary
- gate critical vulnerabilities with a new script
- run pip-audit on pull requests only and fail on critical issues
- document pip-audit gating and Dependabot updates

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml scripts/check_pip_audit.py`
- `pytest -k version -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba4586e88320acc2a6e15efa44d3