### PR TITLE
Add investor demo and component tests

### DIFF
--- a/tests/components/test_components_main.py
+++ b/tests/components/test_components_main.py
@@ -1,0 +1,33 @@
+import pytest
+from dash import html
+import components as comp
+
+pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
+
+
+def test_create_loading_spinner(monkeypatch):
+    # ensure Spinner component exists in stub
+    monkeypatch.setattr(comp.dbc, "Spinner", lambda *a, **k: html.Div(), raising=False)
+    monkeypatch.setattr(comp.html, "P", html.Div, raising=False)
+    spinner = comp.create_loading_spinner("Wait")
+    assert isinstance(spinner, html.Div)
+    assert spinner.children
+
+
+def test_component_registry_basic():
+    reg = comp.ComponentRegistry()
+    reg.register_component("dummy", lambda: "ok")
+    assert reg.get_component("dummy")() == "ok"
+
+
+def test_create_summary_cards(monkeypatch):
+    monkeypatch.setattr(comp.html, "H4", html.H5, raising=False)
+    monkeypatch.setattr(comp.html, "P", html.Span, raising=False)
+    data = {
+        "total_events": 5,
+        "active_users": 2,
+        "active_doors": 1,
+        "date_range": {"start": "2024-01-01", "end": "2024-01-31"},
+    }
+    cards = comp.create_summary_cards(data)
+    assert cards.children

--- a/tests/integration/test_plugin_health_endpoint.py
+++ b/tests/integration/test_plugin_health_endpoint.py
@@ -1,0 +1,81 @@
+import sys
+import types
+import importlib.util
+import enum
+from flask.json.provider import DefaultJSONProvider
+
+# Minimal services stubs
+spec = importlib.util.spec_from_file_location("services.data_processing.core.protocols", "tests/stubs/protocols_stub.py")
+protocols_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(protocols_mod)
+
+services_mod = types.ModuleType("services")
+registry_mod = types.ModuleType("services.registry")
+registry_mod.get_service = lambda name: None
+services_mod.registry = registry_mod
+
+core_mod = types.ModuleType("services.data_processing.core")
+core_mod.protocols = protocols_mod
+
+data_proc_mod = types.ModuleType("services.data_processing")
+data_proc_mod.core = core_mod
+services_mod.data_processing = data_proc_mod
+
+sys.modules["services"] = services_mod
+sys.modules["services.registry"] = registry_mod
+sys.modules["services.data_processing"] = data_proc_mod
+sys.modules["services.data_processing.core"] = core_mod
+sys.modules["services.data_processing.core.protocols"] = protocols_mod
+
+import pytest
+from flask import Flask
+from core.service_container import ServiceContainer
+from core.plugins.manager import PluginManager
+from config import create_config_manager
+from services.data_processing.core.protocols import PluginMetadata
+
+class EnumJSONProvider(DefaultJSONProvider):
+    def default(self, o):
+        if isinstance(o, enum.Enum):
+            return o.name
+        return super().default(o)
+
+class DummyPlugin:
+    metadata = PluginMetadata(name="dummy", version="0.1", description="d", author="t")
+
+    def load(self, container, config):
+        return True
+
+    def configure(self, config):
+        return True
+
+    def start(self):
+        return True
+
+    def stop(self):
+        return True
+
+    def health_check(self):
+        return {"healthy": True}
+
+    def register_callbacks(self, manager, container):
+        return True
+
+
+@pytest.mark.integration
+def test_health_endpoint_returns_status():
+    app = Flask(__name__)
+    app.json_provider_class = EnumJSONProvider
+    app.json = app.json_provider_class(app)
+    cfg = create_config_manager()
+    manager = PluginManager(ServiceContainer(), cfg, health_check_interval=1)
+    manager.load_plugin(DummyPlugin())
+    manager.register_health_endpoint(app)
+
+    client = app.test_client()
+    resp = client.get("/health/plugins")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "dummy" in data
+    assert data["dummy"]["health"]["healthy"] is True
+    manager.stop_health_monitor()

--- a/tests/stubs/protocols_stub.py
+++ b/tests/stubs/protocols_stub.py
@@ -1,0 +1,40 @@
+from enum import Enum
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, List, Protocol, runtime_checkable
+
+class PluginStatus(Enum):
+    DISCOVERED = "discovered"
+    LOADED = "loaded"
+    CONFIGURED = "configured"
+    STARTED = "started"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+class PluginPriority(Enum):
+    CRITICAL = 0
+    HIGH = 10
+    NORMAL = 50
+    LOW = 100
+
+@dataclass
+class PluginMetadata:
+    name: str
+    version: str
+    description: str
+    author: str
+    priority: PluginPriority = PluginPriority.NORMAL
+    dependencies: Optional[List[str]] = None
+
+@runtime_checkable
+class PluginProtocol(Protocol):
+    @property
+    def metadata(self) -> PluginMetadata: ...
+    def load(self, container: Any, config: Dict[str, Any]) -> bool: ...
+    def configure(self, config: Dict[str, Any]) -> bool: ...
+    def start(self) -> bool: ...
+    def stop(self) -> bool: ...
+    def health_check(self) -> Dict[str, Any]: ...
+
+@runtime_checkable
+class CallbackPluginProtocol(PluginProtocol, Protocol):
+    def register_callbacks(self, manager: Any, container: Any) -> bool: ...

--- a/tests/test_investor_demo_interface.py
+++ b/tests/test_investor_demo_interface.py
@@ -1,0 +1,58 @@
+import io
+import sys
+import types
+import pandas as pd
+import pytest
+
+# Provide minimal stubs for external modules used by investor_demo_interface
+sys.modules.setdefault('mvp_cli_engine', types.SimpleNamespace(
+    load_dataframe=lambda p: pd.DataFrame(),
+    generate_analytics=lambda df: {}
+))
+sys.modules.setdefault('simple_mapping_interface', types.SimpleNamespace(
+    enhance_data_with_mappings=lambda df, c, d: (df, {})
+))
+sys.modules.setdefault('unicode_fix_module', types.SimpleNamespace(
+    safe_file_write=lambda p, d: None
+))
+
+import investor_demo_interface as demo
+
+
+def setup_function():
+    demo.current_df = None
+    demo.column_mapping = {}
+    demo.device_mapping = []
+
+
+@pytest.fixture
+def client():
+    demo.app.config['TESTING'] = True
+    with demo.app.test_client() as c:
+        yield c
+
+
+def test_build_stages():
+    stages = demo.build_stages(2)
+    assert stages[0]['complete'] is True
+    assert stages[1]['complete'] is False
+    assert stages[2]['complete'] is False
+
+
+def test_upload_sets_dataframe(monkeypatch, client):
+    df = pd.DataFrame({'A': [1]})
+    monkeypatch.setattr(demo, 'load_dataframe', lambda path: df)
+    data = {'file': (io.BytesIO(b'A\n1\n'), 'test.csv')}
+    resp = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 302
+    assert demo.current_df is df
+
+
+def test_results_generates_file(monkeypatch, client):
+    demo.current_df = pd.DataFrame({'A': [1]})
+    monkeypatch.setattr(demo, 'enhance_data_with_mappings', lambda df, c, d: (df, {}))
+    monkeypatch.setattr(demo, 'generate_analytics', lambda df: {'rows': len(df)})
+    monkeypatch.setattr(demo, 'safe_file_write', lambda p, d: None)
+    resp = client.get('/results')
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- add investor_demo_interface tests
- add component module tests
- cover plugin health endpoint via integration test

## Testing
- `pytest tests/test_investor_demo_interface.py tests/components/test_components_main.py tests/integration/test_plugin_health_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ba4286f08320b65cabe0b0df16ce