### PR TITLE
Fix Dash type hints

### DIFF
--- a/core/app_factory/plugins.py
+++ b/core/app_factory/plugins.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from dash import Dash
 
 from core.service_container import ServiceContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 
 
 def _initialize_plugins(
-    app: "Dash",
+    app: Dash,
     config_manager: Any,
     *,
     container: Optional[Any] = None,

--- a/core/app_factory/security.py
+++ b/core/app_factory/security.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from dash import Dash
 
 from dash_csrf_plugin import CSRFMode, setup_enhanced_csrf_protection
 
 logger = logging.getLogger(__name__)
 
 
-def initialize_csrf(app: "Dash", config_manager: Any) -> None:
+def initialize_csrf(app: Dash, config_manager: Any) -> None:
     """Initialize CSRF protection if enabled."""
     if (
         config_manager.get_security_config().csrf_enabled


### PR DESCRIPTION
## Summary
- fix flake8 F821 by adding TYPE_CHECKING imports for Dash

## Testing
- `flake8 core/app_factory/plugins.py core/app_factory/security.py`
- `pytest -k "plugins or security" -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6877c3aaa5488320bd8626c195ee33cb