### PR TITLE
Fix safe_callback import and refine fallback PluginManager

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -8,15 +8,15 @@ try:
     from .auto_config import PluginAutoConfiguration
     from .manager import ThreadSafePluginManager as PluginManager
     from .performance_manager import EnhancedThreadSafePluginManager
-    from .decorators import safe_callback
-
     PLUGINS_AVAILABLE = True
 except ImportError as e:
     logger.warning(f"Plugin system not available: {e}")
     PLUGINS_AVAILABLE = False
 
     class PluginManager:
-        def __init__(self, *args, **kwargs):
+        """Minimal stub used when plugin dependencies are missing."""
+
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
             pass
 
         def discover_plugins(self):
@@ -26,7 +26,9 @@ except ImportError as e:
             return False
 
     class PluginAutoConfiguration:
-        def __init__(self, *args, **kwargs):
+        """No-op auto configuration when plugins are disabled."""
+
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
             pass
 
         def scan_and_configure(self, *args):


### PR DESCRIPTION
## Summary
- remove duplicate `safe_callback` import in `core.plugins`
- document and stub out fallback `PluginManager` for missing plugin deps

## Testing
- `pytest tests/test_auto_configuration.py::test_setup_exposes_container_and_safe_callback -q` *(fails: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_6877c3ae91b883208ff93d0326d8cc16