### PR TITLE
Add Enhanced Unicode Processor

### DIFF
--- a/core/unicode_enhanced.py
+++ b/core/unicode_enhanced.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Enhanced Unicode processing utilities with surrogate handling."""
+
+from dataclasses import dataclass
+from enum import Enum
+import logging
+import re
+import unicodedata
+from typing import Optional
+
+from .unicode import contains_surrogates
+
+logger = logging.getLogger(__name__)
+
+
+class SurrogateHandlingStrategy(Enum):
+    """Strategies for handling surrogate characters."""
+
+    REPLACE = "replace"
+    REJECT = "reject"
+    STRIP = "strip"
+
+
+@dataclass
+class SurrogateHandlingConfig:
+    """Configuration for :class:`EnhancedUnicodeProcessor`."""
+
+    strategy: SurrogateHandlingStrategy = SurrogateHandlingStrategy.REPLACE
+    replacement_char: str = "\ufffd"
+    normalize_form: str = "NFC"
+    log_errors: bool = True
+
+
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+
+
+class EnhancedUnicodeProcessor:
+    """Process text with configurable surrogate handling."""
+
+    def __init__(self, config: Optional[SurrogateHandlingConfig] = None) -> None:
+        self.config = config or SurrogateHandlingConfig()
+
+    def process_text(self, text: str) -> str:
+        if not text:
+            return ""
+
+        if contains_surrogates(text):
+            if self.config.strategy is SurrogateHandlingStrategy.REJECT:
+                raise UnicodeError("Surrogate characters not allowed")
+            elif self.config.strategy is SurrogateHandlingStrategy.STRIP:
+                text = _SURROGATE_RE.sub("", text)
+            else:  # REPLACE
+                text = _SURROGATE_RE.sub(self.config.replacement_char, text)
+
+        try:
+            text = unicodedata.normalize(self.config.normalize_form, text)
+        except Exception as exc:  # pragma: no cover - defensive
+            if self.config.log_errors:
+                logger.warning("Unicode normalization failed: %s", exc)
+
+        return text
+
+
+__all__ = [
+    "EnhancedUnicodeProcessor",
+    "SurrogateHandlingConfig",
+    "SurrogateHandlingStrategy",
+]

--- a/tests/test_unicode_enhanced.py
+++ b/tests/test_unicode_enhanced.py
@@ -1,0 +1,40 @@
+import pytest
+
+from core.unicode_enhanced import (
+    EnhancedUnicodeProcessor,
+    SurrogateHandlingConfig,
+    SurrogateHandlingStrategy,
+)
+
+
+def test_no_surrogates_returns_same_text():
+    processor = EnhancedUnicodeProcessor()
+    text = "Hello World"
+    assert processor.process_text(text) == text
+
+
+def test_replace_surrogates():
+    cfg = SurrogateHandlingConfig(strategy=SurrogateHandlingStrategy.REPLACE)
+    processor = EnhancedUnicodeProcessor(cfg)
+    text = "A\ud800B"
+    assert processor.process_text(text) == "A�B"
+
+
+def test_strip_surrogates():
+    cfg = SurrogateHandlingConfig(strategy=SurrogateHandlingStrategy.STRIP)
+    processor = EnhancedUnicodeProcessor(cfg)
+    text = "A\ud800B"
+    assert processor.process_text(text) == "AB"
+
+
+def test_reject_surrogates():
+    cfg = SurrogateHandlingConfig(strategy=SurrogateHandlingStrategy.REJECT)
+    processor = EnhancedUnicodeProcessor(cfg)
+    with pytest.raises(UnicodeError):
+        processor.process_text("A\ud800B")
+
+
+def test_normalization_applied():
+    processor = EnhancedUnicodeProcessor()
+    text = "cafe\u0301"
+    assert processor.process_text(text) == "café"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -19,6 +19,11 @@ from core.unicode import (
     utf8_safe_encode,
     utf8_safe_decode,
 )
+from core.unicode_enhanced import (
+    EnhancedUnicodeProcessor,
+    SurrogateHandlingConfig,
+    SurrogateHandlingStrategy,
+)
 
 from .assets_debug import (
     check_navbar_assets,
@@ -43,6 +48,9 @@ __all__ = [
     "UnicodeTextProcessor",
     "UnicodeSQLProcessor",
     "UnicodeSecurityProcessor",
+    "EnhancedUnicodeProcessor",
+    "SurrogateHandlingConfig",
+    "SurrogateHandlingStrategy",
     "clean_unicode_text",
     "sanitize_unicode_input",
     "safe_decode_bytes",


### PR DESCRIPTION
## Summary
- add `EnhancedUnicodeProcessor` with configurable surrogate strategies
- expose new processor via `utils`
- test replacement, stripping, rejection and normalization

## Testing
- `pytest tests/test_unicode_enhanced.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c86570b48320be3d4e89819400b3