### PR TITLE
Add no-access anomaly detection

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -21,6 +21,7 @@ from .pattern_detection import (
     detect_pattern_threats,
     detect_rapid_attempts,
 )
+from .no_access_detection import detect_no_access_anomalies
 from .statistical_detection import (
     detect_failure_rate_anomalies,
     detect_frequency_anomalies,
@@ -44,6 +45,7 @@ __all__ = [
     "detect_pattern_threats",
     "detect_rapid_attempts",
     "detect_after_hours_anomalies",
+    "detect_no_access_anomalies",
     "ThreatIndicator",
 ]
 

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -60,6 +60,7 @@ from ..security_score_calculator import SecurityScoreCalculator
 from .data_prep import prepare_security_data
 from .pattern_detection import detect_pattern_threats
 from .statistical_detection import detect_statistical_threats
+from .no_access_detection import detect_no_access_anomalies
 from .types import ThreatIndicator
 
 # Ignore warnings from scikit-learn about missing feature names and automatic
@@ -177,6 +178,7 @@ class SecurityPatternsAnalyzer:
 
         threat_indicators.extend(self._detect_statistical_threats(df))
         threat_indicators.extend(self._detect_pattern_threats(df))
+        threat_indicators.extend(self._detect_no_access_anomalies(df))
 
         return threat_indicators
 
@@ -313,6 +315,10 @@ class SecurityPatternsAnalyzer:
             self.logger.warning("Baseline frequency check failed: %s", exc)
 
         return threats
+
+    def _detect_no_access_anomalies(self, df: pd.DataFrame) -> List[ThreatIndicator]:
+        """Detect repeated access denied events using baseline failure rates."""
+        return detect_no_access_anomalies(df, self.baseline_db, self.logger)
 
     def _detect_pattern_threats(self, df: pd.DataFrame) -> List[ThreatIndicator]:
         """Detect pattern-based security threats"""

--- a/analytics/security_patterns/no_access_detection.py
+++ b/analytics/security_patterns/no_access_detection.py
@@ -1,0 +1,74 @@
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+import pandas as pd
+
+from database.baseline_metrics import BaselineMetricsDB
+from .types import ThreatIndicator
+from .pattern_detection import _attack_info
+
+__all__ = ["detect_no_access_anomalies"]
+
+
+def _max_consecutive_failures(series: pd.Series) -> int:
+    """Return the longest run of True values in a boolean Series."""
+    max_streak = 0
+    streak = 0
+    for val in series:
+        if bool(val):
+            streak += 1
+            if streak > max_streak:
+                max_streak = streak
+        else:
+            streak = 0
+    return max_streak
+
+
+def detect_no_access_anomalies(
+    df: pd.DataFrame,
+    baseline_db: BaselineMetricsDB,
+    logger: Optional[logging.Logger] = None,
+) -> List[ThreatIndicator]:
+    """Flag repeated access denied events per user using baseline failure rates."""
+    logger = logger or logging.getLogger(__name__)
+    threats: List[ThreatIndicator] = []
+    try:
+        for user_id, group in df.groupby("person_id"):
+            sorted_group = group.sort_values("timestamp")
+            failures = sorted_group["access_granted"] == 0
+            max_streak = _max_consecutive_failures(failures)
+            if max_streak < 3:
+                continue
+            current_rate = float(1 - group["access_granted"].mean())
+            baseline = baseline_db.get_baseline("user", str(user_id)).get(
+                "failure_rate"
+            )
+            if baseline is None:
+                continue
+            if current_rate > baseline * 1.5 and current_rate - baseline > 0.1:
+                severity = "high" if max_streak >= 5 else "medium"
+                confidence = min(0.99, current_rate - baseline + max_streak / 10)
+                threats.append(
+                    ThreatIndicator(
+                        threat_type="repeated_access_denied",
+                        severity=severity,
+                        confidence=confidence,
+                        description=(
+                            f"User {user_id} had {max_streak} consecutive denied attempts; "
+                            f"failure rate {current_rate:.2%} vs baseline {baseline:.2%}"
+                        ),
+                        evidence={
+                            "user_id": str(user_id),
+                            "consecutive_failures": max_streak,
+                            "current_failure_rate": current_rate,
+                            "baseline_failure_rate": baseline,
+                        },
+                        timestamp=datetime.utcnow(),
+                        affected_entities=[str(user_id)],
+                        attack=_attack_info("repeated_access_denied"),
+                    )
+                )
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("No-access anomaly detection failed: %s", exc)
+    return threats

--- a/analytics/security_patterns/tests/test_security_modules.py
+++ b/analytics/security_patterns/tests/test_security_modules.py
@@ -4,6 +4,18 @@ from analytics.security_patterns.data_prep import prepare_security_data
 from analytics.security_patterns.statistical_detection import (
     detect_failure_rate_anomalies,
 )
+from analytics.security_patterns.no_access_detection import detect_no_access_anomalies
+
+
+class DummyBaselineDB:
+    def __init__(self):
+        self.store = {}
+
+    def update_baseline(self, entity_type: str, entity_id: str, metrics):
+        self.store[(entity_type, entity_id)] = metrics
+
+    def get_baseline(self, entity_type: str, entity_id: str):
+        return self.store.get((entity_type, entity_id), {})
 
 
 def test_prepare_security_data_basic():
@@ -44,3 +56,27 @@ def test_detect_failure_rate_anomalies():
     cleaned = prepare_security_data(df)
     threats = detect_failure_rate_anomalies(cleaned)
     assert isinstance(threats, list)
+
+
+def test_detect_no_access_anomalies():
+    rows = []
+    # User u1 has repeated denied events
+    for i in range(5):
+        rows.append(
+            {
+                "timestamp": f"2024-01-02 12:0{i}:00",
+                "person_id": "u1",
+                "door_id": "d1",
+                "access_result": "Denied",
+            }
+        )
+    # Baseline user u1 success mostly
+    baseline_db = DummyBaselineDB()
+    baseline_db.update_baseline("user", "u1", {"failure_rate": 0.05})
+
+    df = pd.DataFrame(rows)
+    cleaned = prepare_security_data(df)
+    threats = detect_no_access_anomalies(cleaned, baseline_db)
+    assert isinstance(threats, list)
+    if threats:
+        assert threats[0].threat_type == "repeated_access_denied"


### PR DESCRIPTION
## Summary
- implement `detect_no_access_anomalies` for spotting repeated denied attempts
- expose it from the package and use it inside `SecurityPatternsAnalyzer`
- test the new detection logic

## Testing
- `PYTHONPATH=. pytest analytics/security_patterns/tests/test_security_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877cba1441083209a5ae3c7fee1cfab