### PR TITLE
Add critical door risk detector

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -20,6 +20,7 @@ from .pattern_detection import (
     detect_after_hours_anomalies,
     detect_pattern_threats,
     detect_rapid_attempts,
+    detect_critical_door_risks,
 )
 from .statistical_detection import (
     detect_failure_rate_anomalies,
@@ -44,6 +45,7 @@ __all__ = [
     "detect_pattern_threats",
     "detect_rapid_attempts",
     "detect_after_hours_anomalies",
+    "detect_critical_door_risks",
     "ThreatIndicator",
 ]
 

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -177,6 +177,7 @@ class SecurityPatternsAnalyzer:
 
         threat_indicators.extend(self._detect_statistical_threats(df))
         threat_indicators.extend(self._detect_pattern_threats(df))
+        threat_indicators.extend(self._detect_critical_door_risks(df))
 
         return threat_indicators
 
@@ -396,6 +397,12 @@ class SecurityPatternsAnalyzer:
             self.logger.warning("Baseline after-hours check failed: %s", exc)
 
         return threats
+
+    def _detect_critical_door_risks(self, df: pd.DataFrame) -> List[ThreatIndicator]:
+        """Detect high risk attempts on critical doors"""
+        from .pattern_detection import detect_critical_door_risks
+
+        return detect_critical_door_risks(df, self.logger)
 
     def _calculate_comprehensive_score(
         self, df: pd.DataFrame, threats: List[ThreatIndicator]

--- a/resources/attack_techniques.yaml
+++ b/resources/attack_techniques.yaml
@@ -14,3 +14,7 @@ excessive_access_frequency:
   id: T1021
   name: Remote Services
   url: https://attack.mitre.org/techniques/T1021/
+critical_door_activity:
+  id: T1495
+  name: Active Scanning
+  url: https://attack.mitre.org/techniques/T1495/


### PR DESCRIPTION
## Summary
- implement `detect_critical_door_risks` using logistic regression fallback
- expose detector via `security_patterns` package
- invoke detector from `SecurityPatternsAnalyzer`
- expand ATT&CK mapping for critical door activity
- test critical door detection

## Testing
- `pytest tests/test_security_patterns.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877cba2876083209c5cdf1fc5038dd0