### PR TITLE
Improve mypy compliance for UI helper tests

### DIFF
--- a/tests/components/test_ui_callback_helpers.py
+++ b/tests/components/test_ui_callback_helpers.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Dict, List, Tuple, cast
+
 from unittest import mock
 import pytest
 import dash
@@ -6,11 +8,11 @@ from components.column_verification import (
     register_callbacks as register_column_callbacks,
 )
 from components.column_verification import (
-    toggle_custom_field,
+    toggle_custom_field as toggle_custom_field_untyped,
 )
-from components.device_verification import mark_device_as_edited
+from components.device_verification import mark_device_as_edited as mark_device_as_edited_untyped
 from components.simple_device_mapping import (
-    apply_ai_device_suggestions,
+    apply_ai_device_suggestions as apply_ai_device_suggestions_untyped,
 )
 from components.simple_device_mapping import (
     register_callbacks as register_device_callbacks,
@@ -18,14 +20,28 @@ from components.simple_device_mapping import (
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 
+# Cast imported helpers so mypy treats them as typed callables. The actual
+# implementations are untyped in the source code which would otherwise trigger
+# "no-untyped-call" errors when called from these tests.
+toggle_custom_field = cast(
+    Callable[[str | None], Dict[str, str]], toggle_custom_field_untyped
+)
+apply_ai_device_suggestions = cast(
+    Callable[[Dict[str, Dict[str, Any]], List[str]], Tuple[Any, Any, Any, Any]],
+    apply_ai_device_suggestions_untyped,
+)
+mark_device_as_edited = cast(
+    Callable[[Any, Any, Any, Any], bool], mark_device_as_edited_untyped
+)
 
-def test_toggle_custom_field():
+
+def test_toggle_custom_field() -> None:
     assert toggle_custom_field("other") == {"display": "block"}
     assert toggle_custom_field("person_id") == {"display": "none"}
     assert toggle_custom_field(None) == {"display": "none"}
 
 
-def test_apply_ai_device_suggestions_basic():
+def test_apply_ai_device_suggestions_basic() -> None:
     suggestions = {
         "door1": {"floor_number": 1, "security_level": 2, "is_entry": True},
         "door2": {"floor_number": 2, "security_level": 4, "is_stairwell": True},
@@ -40,22 +56,23 @@ def test_apply_ai_device_suggestions_basic():
     assert security == [2, 4]
 
 
-def test_apply_ai_device_suggestions_empty():
+def test_apply_ai_device_suggestions_empty() -> None:
     result = apply_ai_device_suggestions({}, [])
     assert result == (dash.no_update, dash.no_update, dash.no_update, dash.no_update)
 
 
-def test_mark_device_as_edited():
+def test_mark_device_as_edited() -> None:
     assert mark_device_as_edited(None, None, None, None) is True
 
 
-def test_register_callbacks_invoked():
+def test_register_callbacks_invoked() -> None:
     manager = mock.Mock()
 
-    def fake_register(*args, **kwargs):
-        def decorator(func):
-            decorator.called_with = kwargs.get("callback_id")
-            decorator.func = func
+    def fake_register(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            # record registration details for assertion without type errors
+            setattr(decorator, "called_with", kwargs.get("callback_id"))
+            setattr(decorator, "func", func)
             return func
 
         return decorator

--- a/tests/components/test_verification_modals.py
+++ b/tests/components/test_verification_modals.py
@@ -4,14 +4,27 @@ from dash import dcc, html
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
-from components.column_verification import create_column_verification_modal
+from typing import Any, Callable, List, cast
+
+from components.column_verification import create_column_verification_modal as create_column_verification_modal_untyped
 from components.device_verification import (
-    create_device_verification_modal,
-    toggle_device_verification_modal,
+    create_device_verification_modal as create_device_verification_modal_untyped,
+    toggle_device_verification_modal as toggle_device_verification_modal_untyped,
+)
+
+# Provide typed wrappers for imported helpers
+create_column_verification_modal = cast(
+    Callable[[dict[str, Any]], Any], create_column_verification_modal_untyped
+)
+create_device_verification_modal = cast(
+    Callable[[dict[str, Any], str], Any], create_device_verification_modal_untyped
+)
+toggle_device_verification_modal = cast(
+    Callable[[Any, Any, bool], bool], toggle_device_verification_modal_untyped
 )
 
 
-def _collect(component, cls):
+def _collect(component: Any, cls: type[Any]) -> List[Any]:
     """Recursively collect components of a given class."""
     found = []
     if isinstance(component, cls):
@@ -25,7 +38,7 @@ def _collect(component, cls):
     return found
 
 
-def test_create_column_verification_modal_basic():
+def test_create_column_verification_modal_basic() -> None:
     info = {
         "filename": "sample.csv",
         "columns": ["User", "Door"],
@@ -43,12 +56,12 @@ def test_create_column_verification_modal_basic():
     assert "sample.csv" in "".join(str(c) for c in header.children)
 
 
-def test_create_column_verification_modal_empty():
+def test_create_column_verification_modal_empty() -> None:
     modal = create_column_verification_modal({"filename": "x.csv", "columns": []})
     assert isinstance(modal, html.Div)
 
 
-def test_create_device_verification_modal_basic():
+def test_create_device_verification_modal_basic() -> None:
     mappings = {
         "door1": {"floor_number": 1, "is_entry": True, "confidence": 0.8},
         "door2": {"floor_number": 2, "is_exit": True, "confidence": 0.6},
@@ -61,12 +74,12 @@ def test_create_device_verification_modal_basic():
     assert len(rows) - 1 == len(mappings)
 
 
-def test_create_device_verification_modal_empty():
+def test_create_device_verification_modal_empty() -> None:
     modal = create_device_verification_modal({}, "sess")
     assert isinstance(modal, html.Div)
 
 
-def test_toggle_device_verification_modal():
+def test_toggle_device_verification_modal() -> None:
     # Opens when triggered from a closed state
     assert toggle_device_verification_modal(1, None, False) is True
     # Closes when either button is pressed while open


### PR DESCRIPTION
## Summary
- add return annotations to UI callback helper tests
- cast imported helper functions to avoid `no-untyped-call`
- add type hints for verification modal tests

## Testing
- `mypy --strict --follow-imports=skip tests/components/test_ui_callback_helpers.py tests/components/test_verification_modals.py`

------
https://chatgpt.com/codex/tasks/task_e_6877cbc2395883209b9203b14a3982af