### PR TITLE
Fix surrogate validator import

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -8,20 +8,26 @@ from core.exceptions import ValidationError
 from .attack_detection import AttackDetection
 from .secrets_validator import SecretsValidator, register_health_endpoint
 from .unicode_security_validator import UnicodeSecurityValidator
-from .unicode_surrogate_validator import (
-    SurrogateHandlingConfig,
-    UnicodeSurrogateValidator,
-)
 from .validation_exceptions import SecurityViolation
 
 
 def __getattr__(name: str):
-    """Lazily provide ``SecurityValidator`` to avoid circular imports."""
+    """Lazily provide heavy validators to avoid circular imports."""
 
     if name == "SecurityValidator":
         from core.security_validator import SecurityValidator as _SV
 
         return _SV
+    if name in {"UnicodeSurrogateValidator", "SurrogateHandlingConfig"}:
+        from .unicode_surrogate_validator import (
+            SurrogateHandlingConfig as _SHC,
+            UnicodeSurrogateValidator as _USV,
+        )
+
+        return {
+            "UnicodeSurrogateValidator": _USV,
+            "SurrogateHandlingConfig": _SHC,
+        }[name]
     raise AttributeError(name)
 
 # Public API - Only current, non-deprecated classes

--- a/security/unicode_surrogate_validator.py
+++ b/security/unicode_surrogate_validator.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from core.exceptions import ValidationError
 from core.unicode import contains_surrogates
-# from security_callback_controller import SecurityEvent, emit_security_event  # Lazy import to break circular
+from security_callback_controller import SecurityEvent, emit_security_event
 
 
 @dataclass
@@ -33,9 +33,6 @@ class UnicodeSurrogateValidator:
 
         if not contains_surrogates(value):
             return value
-
-        from security_callback_controller import emit_security_event  # Lazy import
-
 
         emit_security_event(
             SecurityEvent.VALIDATION_FAILED, {"issue": "unicode_surrogates"}


### PR DESCRIPTION
## Summary
- expose `emit_security_event` and `SecurityEvent` at module import time
- lazily load heavy validators to avoid circular imports

## Testing
- `pytest tests/security/test_surrogate_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878189aeba0832084b41a6aca3c1e50