### PR TITLE
Unify callback events

### DIFF
--- a/core/callback_controller.py
+++ b/core/callback_controller.py
@@ -7,38 +7,13 @@ import threading
 import weakref
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum, auto
+from .callback_events import CallbackEvent
 from typing import Any, Callable, Dict, List, Optional, Protocol
 
 from .error_handling import ErrorCategory, ErrorSeverity, error_handler
 
 logger = logging.getLogger(__name__)
 
-
-class CallbackEvent(Enum):
-    """Standardized callback events across the system."""
-
-    FILE_UPLOAD_START = auto()
-    FILE_UPLOAD_COMPLETE = auto()
-    FILE_UPLOAD_ERROR = auto()
-    FILE_PROCESSING_START = auto()
-    FILE_PROCESSING_COMPLETE = auto()
-    FILE_PROCESSING_ERROR = auto()
-    ANALYSIS_START = auto()
-    ANALYSIS_COMPLETE = auto()
-    ANALYSIS_ERROR = auto()
-    ANALYSIS_PROGRESS = auto()
-    DATA_QUALITY_CHECK = auto()
-    DATA_QUALITY_ISSUE = auto()
-    USER_ACTION = auto()
-    UI_UPDATE = auto()
-    SYSTEM_ERROR = auto()
-    SYSTEM_WARNING = auto()
-    # Security events
-    THREAT_DETECTED = auto()
-    ANOMALY_DETECTED = auto()
-    SCORE_CALCULATED = auto()
-    VALIDATION_FAILED = auto()
 
 
 @dataclass(frozen=True)

--- a/file_processing/column_mapper.py
+++ b/file_processing/column_mapper.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Optional
 import pandas as pd
 from rapidfuzz import process
 
-from core.callback_controller import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 REQUIRED_COLUMNS = ["person_id", "door_id", "access_result", "timestamp"]

--- a/file_processing/exporter.py
+++ b/file_processing/exporter.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import pandas as pd
 
-from core.callback_controller import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.container import get_unicode_processor
 from core.protocols import UnicodeProcessorProtocol

--- a/file_processing/readers/archive_reader.py
+++ b/file_processing/readers/archive_reader.py
@@ -13,7 +13,7 @@ from .csv_reader import CSVReader
 from .excel_reader import ExcelReader
 from .fwf_reader import FWFReader
 from .json_reader import JSONReader
-from core.callback_controller import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.protocols import UnicodeProcessorProtocol
 from ..format_detector import FormatDetector

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -2,7 +2,6 @@ import types
 import pytest
 
 from dash import no_update
-from core.callback_controller import CallbackEvent
 from upload_core import UploadCore
 from services.upload.core.processor import UploadProcessingService
 from tests.fakes import (

--- a/tests/file_processing/test_column_mapper.py
+++ b/tests/file_processing/test_column_mapper.py
@@ -2,7 +2,7 @@ import pandas as pd
 from pathlib import Path
 
 from file_processing.column_mapper import map_columns
-from core.callback_controller import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 


### PR DESCRIPTION
## Summary
- drop duplicate `CallbackEvent` enum from `callback_controller`
- use `core.callback_events.CallbackEvent` everywhere

## Testing
- `black . --check` *(fails: would reformat, 173 files would be reformatted)*
- `flake8 .` *(fails with numerous style errors)*
- `mypy .` *(fails: unexpected indent in visual_tester.py)*
- `pytest` *(fails during collection: NameError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68781a1451888320ae79586f5ae3a45a