### PR TITLE
Fix isolated security testing controller

### DIFF
--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -902,7 +902,7 @@ def setup_isolated_security_testing(
 ) -> tuple[SecurityCallbackController, Optional[Callable[[Dict[str, Any]], None]]]:
     """Return a cleared controller and optional test handler."""
 
-    controller = SecurityTrulyUnifiedCallbacks()
+    controller = SecurityCallbackController()
     controller._callbacks.clear()
     controller.history = []
     handler: Optional[Callable[[Dict[str, Any]], None]] = None


### PR DESCRIPTION
## Summary
- use `SecurityCallbackController` when creating isolated security testing controller

## Testing
- `pytest tests/callbacks/test_security_callback_controller.py::test_callback_registration_and_fire -q` *(fails: AttributeError: 'UnifiedCallbackManager' object has no attribute 'clear_all_callbacks')*

------
https://chatgpt.com/codex/tasks/task_e_6878194f3db48320bf084124a10676b5