### PR TITLE
Remove unused callback import

### DIFF
--- a/file_conversion/storage_manager.py
+++ b/file_conversion/storage_manager.py
@@ -1,8 +1,6 @@
 """Manage Parquet file storage with metadata tracking."""
 
 from __future__ import annotations
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-
 import json
 import logging
 from datetime import datetime


### PR DESCRIPTION
## Summary
- clean up unused `TrulyUnifiedCallbacks` import from `StorageManager`

## Testing
- `pytest tests/test_storage_manager.py -q` *(fails: `'UnifiedCallbackManager' object has no attribute 'register_callback'`)*

------
https://chatgpt.com/codex/tasks/task_e_68781a1636bc8320836df729b131019d