### PR TITLE
Update CallbackEvent imports

### DIFF
--- a/file_processing/data_processor.py
+++ b/file_processing/data_processor.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 import pandas as pd
 
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from .format_detector import FormatDetector, UnsupportedFormatError
 from .readers import ArchiveReader, CSVReader, ExcelReader, FWFReader, JSONReader

--- a/file_processing/format_detector.py
+++ b/file_processing/format_detector.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Optional, Tuple, Dict
 
 import pandas as pd
 
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.container import get_unicode_processor
 from core.protocols import UnicodeProcessorProtocol

--- a/file_processing/readers/csv_reader.py
+++ b/file_processing/readers/csv_reader.py
@@ -4,7 +4,7 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 import pandas as pd
 
 from .base import BaseReader
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.protocols import UnicodeProcessorProtocol
 

--- a/file_processing/readers/excel_reader.py
+++ b/file_processing/readers/excel_reader.py
@@ -4,7 +4,7 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 import pandas as pd
 
 from .base import BaseReader
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.protocols import UnicodeProcessorProtocol
 

--- a/file_processing/readers/fwf_reader.py
+++ b/file_processing/readers/fwf_reader.py
@@ -4,7 +4,7 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 import pandas as pd
 
 from .base import BaseReader
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.protocols import UnicodeProcessorProtocol
 

--- a/file_processing/readers/json_reader.py
+++ b/file_processing/readers/json_reader.py
@@ -5,7 +5,7 @@ import json
 import pandas as pd
 
 from .base import BaseReader
-from core.unified_callbacks import CallbackEvent
+from core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 from core.protocols import UnicodeProcessorProtocol
 


### PR DESCRIPTION
## Summary
- import `CallbackEvent` from `core.callback_events`
- remove uses of deprecated `core.unified_callbacks`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 120 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68781a17f25c8320b516b9e2ee15d02b