### PR TITLE
Add replacement string validation for surrogate characters

### DIFF
--- a/security/unicode_surrogate_validator.py
+++ b/security/unicode_surrogate_validator.py
@@ -26,6 +26,11 @@ class UnicodeSurrogateValidator:
         self.config = config or SurrogateHandlingConfig()
         self.logger = logging.getLogger(__name__)
 
+        if contains_surrogates(self.config.replacement):
+            raise ValueError(
+                "Replacement string cannot include surrogate code points"
+            )
+
     def sanitize(self, value: Any) -> str:
         """Return ``value`` with surrogates handled according to configuration."""
         if not isinstance(value, str):

--- a/tests/security/test_surrogate_validator.py
+++ b/tests/security/test_surrogate_validator.py
@@ -53,3 +53,15 @@ def test_strict_mode(validator_module):
     validator = validator_module.UnicodeSurrogateValidator(cfg)
     with pytest.raises(Exception):
         validator.sanitize("bad\ud800")
+
+
+def test_init_allows_valid_replacement(validator_module):
+    cfg = validator_module.SurrogateHandlingConfig(mode="replace", replacement="!")
+    validator = validator_module.UnicodeSurrogateValidator(cfg)
+    assert validator.config.replacement == "!"
+
+
+def test_init_rejects_surrogate_replacement(validator_module):
+    cfg = validator_module.SurrogateHandlingConfig(mode="replace", replacement="\ud800")
+    with pytest.raises(ValueError):
+        validator_module.UnicodeSurrogateValidator(cfg)


### PR DESCRIPTION
## Summary
- detect surrogate code points in the validator replacement string
- fail fast when invalid replacement values are passed
- test valid and invalid replacement configurations

## Testing
- `pytest tests/security/test_surrogate_validator.py::test_init_allows_valid_replacement tests/security/test_surrogate_validator.py::test_init_rejects_surrogate_replacement -q`

------
https://chatgpt.com/codex/tasks/task_e_68781a359c8483209faafe44c491861b