### PR TITLE
Use memory safe CSV reader

### DIFF
--- a/memory_safe_processor.py
+++ b/memory_safe_processor.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import io
+import logging
+from typing import IO, Iterable, Union
+
+import pandas as pd
+
+from utils.memory_utils import check_memory_limit
+
+logger = logging.getLogger(__name__)
+
+
+class FileProcessor:
+    """Process CSV files in chunks while guarding memory usage."""
+
+    def __init__(self, chunk_size: int = 50000, *, max_memory_mb: int = 500) -> None:
+        self.chunk_size = chunk_size
+        self.max_memory_mb = max_memory_mb
+
+    def read_large_csv(self, file_like: Union[str, IO[str]]) -> pd.DataFrame:
+        """Read ``file_like`` in chunks and concatenate safely."""
+        reader = pd.read_csv(file_like, chunksize=self.chunk_size)
+        chunks: list[pd.DataFrame] = []
+        for chunk in reader:
+            check_memory_limit(self.max_memory_mb, logger)
+            chunks.append(chunk)
+        return pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+
+
+__all__ = ["FileProcessor"]

--- a/utils/memory_utils.py
+++ b/utils/memory_utils.py
@@ -2,6 +2,7 @@
 """Utility helpers for monitoring process memory usage."""
 
 import logging
+from functools import wraps
 
 try:
     import psutil
@@ -21,3 +22,23 @@ def check_memory_limit(max_mb: int, logger: logging.Logger) -> None:
         raise MemoryError(
             f"Memory usage {mem_mb:.1f} MB exceeds limit {max_mb} MB"
         )
+
+
+def memory_safe(max_memory_mb: int) -> callable:
+    """Decorator to abort execution when memory usage exceeds ``max_memory_mb``."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger = logging.getLogger(func.__module__)
+            check_memory_limit(max_memory_mb, logger)
+            result = func(*args, **kwargs)
+            check_memory_limit(max_memory_mb, logger)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["check_memory_limit", "memory_safe"]


### PR DESCRIPTION
## Summary
- add a lightweight `memory_safe_processor.FileProcessor`
- enforce memory limits with new `memory_safe` decorator
- use `FileProcessor.read_large_csv` for big CSV files

## Testing
- `pytest tests/test_memory_abort.py::test_abort_on_memory_limit -q` *(fails: DID NOT RAISE MemoryError)*

------
https://chatgpt.com/codex/tasks/task_e_6878263327548320b6c2806e50de78fe