### PR TITLE
Remove secrets from repo and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,10 +89,8 @@ temp_*
 .env.staging
 *.key
 localhost+1-key.pem
-secrets/*
-!secrets/
-!secrets/*.txt
-!secrets/README.md
+# Secrets should not be version controlled
+secrets/
 # Training data
 data/training/
 .venv/

--- a/README.md
+++ b/README.md
@@ -231,10 +231,12 @@ Using Docker Compose:
 docker-compose -f docker-compose.prod.yml up -d
 ```
 Whenever you modify the code, rebuild the Docker image with `docker-compose build` (or `docker-compose up --build`) so the running container picks up your changes.
-Docker Compose reads sensitive values from files under the `secrets/`
-directory. Create `secrets/db_password.txt` and `secrets/secret_key.txt`
-containing your database password and Flask secret key before starting the
-services. The files will be mounted into `/run/secrets` automatically.
+Docker Compose expects the database password and Flask secret key to be
+provided via Docker secrets or environment variables. Create
+`secrets/db_password.txt` and `secrets/secret_key.txt` locally if you use
+file-based Docker secrets, set `DB_PASSWORD` and `SECRET_KEY` in the
+environment, or let the `ConfigManager` load them from your secret
+backend. **Do not commit these files to version control.**
 
 Alternatively you can launch the app with Gunicorn or uWSGI. This is the
 recommended approach for any production deployment. A sample Gunicorn

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -32,12 +32,13 @@ to your organization policy.
 ## Docker and Cloud Secret Usage
 
 Secrets can be supplied as Docker secrets when running with Docker
-Compose. The production compose file expects `secrets/db_password.txt`
-and `secrets/secret_key.txt` which are mounted under `/run/secrets`. The
-application reads these files and exposes them through environment
-variables. For cloud deployments the
-`SecretManager` supports `env`, `aws`, and `vault` backends. Set the
-`SECRET_BACKEND` variable to select the desired provider.
+Compose. Provide `DB_PASSWORD` and `SECRET_KEY` via environment
+variables or create `secrets/db_password.txt` and `secrets/secret_key.txt`
+locally so Docker mounts them under `/run/secrets`. **Do not commit
+these files.** You can also rely on the `ConfigManager` to load them from
+your secret backend. For cloud deployments the `SecretManager` supports
+`env`, `aws`, and `vault` backends. Set the `SECRET_BACKEND` variable to
+select the desired provider.
 
 When using the `aws` backend the application reads secrets from AWS
 Secrets Manager. The configured AWS credentials and region are used to

--- a/secrets/db_password.txt
+++ b/secrets/db_password.txt
@@ -1,1 +1,0 @@
-replace-with-db-password

--- a/secrets/secret_key.txt
+++ b/secrets/secret_key.txt
@@ -1,1 +1,0 @@
-replace-with-secret-key


### PR DESCRIPTION
## Summary
- stop tracking secret files
- instruct users on providing DB and Flask secrets securely

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.compliance')*

------
https://chatgpt.com/codex/tasks/task_e_68782682ec508320873d771eccf1eabb