### PR TITLE
Improve secure config manager validation

### DIFF
--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -59,7 +59,9 @@ FERNET_KEY=<base64-fernet-key>
 ```
 
 `VAULT_ADDR` and `VAULT_TOKEN` authenticate the Vault client. `FERNET_KEY`
-is used to decrypt any encrypted values returned from Vault.
+is used to decrypt any encrypted values returned from Vault. The
+`SecureConfigManager` will raise a `ConfigurationError` if either credential is
+missing or if a secret cannot be retrieved.
 Update `production.yaml` to reference secrets like:
 
 ```yaml

--- a/tests/test_secure_config_manager.py
+++ b/tests/test_secure_config_manager.py
@@ -1,8 +1,9 @@
 import types
-
+import pytest
 from cryptography.fernet import Fernet
 
 from config.secure_config_manager import SecureConfigManager
+from core.exceptions import ConfigurationError
 
 
 def test_vault_secret_resolution(monkeypatch, tmp_path):
@@ -22,6 +23,8 @@ def test_vault_secret_resolution(monkeypatch, tmp_path):
     monkeypatch.setattr("config.secure_config_manager.hvac.Client", DummyClient)
 
     cfg_yaml = """
+app:
+  title: Test
 database:
   password: vault:secret/data/db#password
 security:
@@ -32,8 +35,48 @@ security:
 
     monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
     monkeypatch.setenv("FERNET_KEY", key.decode())
+    monkeypatch.setenv("VAULT_ADDR", "http://vault")
+    monkeypatch.setenv("VAULT_TOKEN", "token")
+    monkeypatch.delenv("DB_PASSWORD", raising=False)
 
     mgr = SecureConfigManager()
 
     assert mgr.get_database_config().password == "super-secret"
     assert mgr.get_security_config().secret_key == "super-secret"
+
+
+def test_missing_vault_credentials(monkeypatch):
+    monkeypatch.delenv("VAULT_ADDR", raising=False)
+    monkeypatch.delenv("VAULT_TOKEN", raising=False)
+
+    with pytest.raises(ConfigurationError):
+        SecureConfigManager()
+
+
+def test_secret_retrieval_failure(monkeypatch, tmp_path):
+    class DummyKV:
+        def read_secret_version(self, path):
+            raise RuntimeError("fail")
+
+    class DummyClient:
+        def __init__(self, url=None, token=None):  # noqa: D401 - stub
+            self.secrets = types.SimpleNamespace(kv=types.SimpleNamespace(v2=DummyKV()))
+
+    monkeypatch.setattr("config.secure_config_manager.hvac.Client", DummyClient)
+
+    cfg_yaml = """
+app:
+  title: Test
+database:
+  password: vault:secret/data/db#password
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg_yaml, encoding="utf-8")
+
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
+    monkeypatch.setenv("VAULT_ADDR", "http://vault")
+    monkeypatch.setenv("VAULT_TOKEN", "token")
+    monkeypatch.delenv("DB_PASSWORD", raising=False)
+
+    with pytest.raises(ConfigurationError):
+        SecureConfigManager()


### PR DESCRIPTION
## Summary
- validate that Vault credentials are provided
- log and raise `ConfigurationError` when Vault operations fail
- document new behaviour in secret management guide
- test missing credentials and secret fetch failure

## Testing
- `pytest -q tests/test_secure_config_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_687826808e308320af08b1d3fdc1a2e2