### PR TITLE
Clamp analytics memory usage

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -124,8 +125,21 @@ class AnalyticsConfig:
     data_retention_days: int = 30
     query_timeout_seconds: int = 600
     force_full_dataset_analysis: bool = True
-    max_memory_mb: int = 1024
+    max_memory_mb: int = 500
     max_display_rows: int = 10000
+
+    def __post_init__(self) -> None:
+        if self.max_memory_mb > 500:
+            warnings.warn(
+                (
+                    "max_memory_mb %s exceeds security limit of 500 MB; "
+                    "clamping to 500"
+                )
+                % self.max_memory_mb,
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self.max_memory_mb = 500
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- limit `AnalyticsConfig.max_memory_mb` to 500
- warn when a higher value is provided

## Testing
- `pre-commit run --files config/base.py` *(fails: mypy)*
- `pytest` *(fails: 120 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68782682570c8320b97f3b8b5ba204d9