### PR TITLE
Add no access detection module

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -22,6 +22,7 @@ from .pattern_detection import (
     detect_rapid_attempts,
     detect_critical_door_risks,
 )
+from .no_access_detection import detect_no_access
 from .statistical_detection import (
     detect_failure_rate_anomalies,
     detect_frequency_anomalies,
@@ -46,6 +47,7 @@ __all__ = [
     "detect_rapid_attempts",
     "detect_after_hours_anomalies",
     "detect_critical_door_risks",
+    "detect_no_access",
     "ThreatIndicator",
 ]
 

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -72,6 +72,7 @@ from .odd_area_time_detection import detect_odd_area_time
 from .multiple_attempts_detection import detect_multiple_attempts
 from .forced_entry_detection import detect_forced_entry
 from .access_no_exit_detection import detect_access_no_exit
+from .no_access_detection import detect_no_access
 from .pattern_drift_detection import detect_pattern_drift
 from .clearance_violation_detection import detect_clearance_violations
 from .unaccompanied_visitor_detection import detect_unaccompanied_visitors
@@ -208,6 +209,7 @@ class SecurityPatternsAnalyzer:
         threat_indicators.extend(detect_multiple_attempts(df, self.logger))
         threat_indicators.extend(detect_forced_entry(df, self.logger))
         threat_indicators.extend(detect_access_no_exit(df, self.logger))
+        threat_indicators.extend(detect_no_access(df, self.logger))
         threat_indicators.extend(detect_pattern_drift(df, self.logger))
         threat_indicators.extend(detect_clearance_violations(df, self.logger))
         threat_indicators.extend(detect_unaccompanied_visitors(df, self.logger))

--- a/analytics/security_patterns/no_access_detection.py
+++ b/analytics/security_patterns/no_access_detection.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+import pandas as pd
+
+from models.enums import AccessResult, AnomalyType
+from .types import ThreatIndicator
+from .pattern_detection import _attack_info
+
+__all__ = ["detect_no_access"]
+
+
+def detect_no_access(
+    df: pd.DataFrame, logger: Optional[logging.Logger] = None
+) -> List[ThreatIndicator]:
+    """Detect events where access was denied."""
+    logger = logger or logging.getLogger(__name__)
+    threats: List[ThreatIndicator] = []
+    try:
+        if len(df) == 0:
+            return threats
+        denied = df[df["access_result"] == AccessResult.DENIED.value]
+        for _, row in denied.iterrows():
+            threats.append(
+                ThreatIndicator(
+                    threat_type=AnomalyType.NO_ACCESS.value,
+                    severity="medium",
+                    confidence=0.6,
+                    description=(
+                        f"Access denied for user {row['person_id']} at door {row['door_id']}"
+                    ),
+                    evidence={
+                        "user_id": str(row["person_id"]),
+                        "door_id": str(row["door_id"]),
+                    },
+                    timestamp=datetime.now(),
+                    affected_entities=[str(row["person_id"]), str(row["door_id"])],
+                    attack=_attack_info(AnomalyType.NO_ACCESS.value),
+                )
+            )
+    except Exception as exc:  # pragma: no cover - log and continue
+        logger.warning("No access detection failed: %s", exc)
+    return threats

--- a/analytics/security_patterns/tests/test_no_access_detection.py
+++ b/analytics/security_patterns/tests/test_no_access_detection.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import pandas as pd
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_no_access_detection_finds_denied_events(monkeypatch):
+    # Stub minimal services and flask_caching packages required during imports
+    services_mod = types.ModuleType("services")
+    registry_mod = types.ModuleType("services.registry")
+    registry_mod.get_service = lambda name: None
+    services_mod.registry = registry_mod
+    monkeypatch.setitem(sys.modules, "services", services_mod)
+    monkeypatch.setitem(sys.modules, "services.registry", registry_mod)
+    monkeypatch.setitem(sys.modules, "flask_caching", types.ModuleType("flask_caching"))
+
+    data_prep = load_module("analytics.security_patterns.data_prep", MODULE_DIR / "data_prep.py")
+    detector = load_module("analytics.security_patterns.no_access_detection", MODULE_DIR / "no_access_detection.py")
+
+    df = pd.DataFrame([
+        {"timestamp": "2024-01-01 10:00:00", "person_id": "u1", "door_id": "d1", "access_result": "Denied"},
+        {"timestamp": "2024-01-01 10:05:00", "person_id": "u1", "door_id": "d1", "access_result": "Granted"},
+    ])
+    cleaned = data_prep.prepare_security_data(df)
+    threats = detector.detect_no_access(cleaned)
+    assert isinstance(threats, list)
+    assert len(threats) > 0


### PR DESCRIPTION
## Summary
- add `no_access_detection` for events denied by the access control system
- export detector from `analytics.security_patterns`
- call detector inside the security analyzer
- test that denied events are detected

## Testing
- `PYTHONPATH=$PWD pytest analytics/security_patterns/tests/test_no_access_detection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68782ab2464c8320984367ba8da409fc