### PR TITLE
Use AnomalyType enums in detectors

### DIFF
--- a/analytics/security_patterns/access_no_exit_detection.py
+++ b/analytics/security_patterns/access_no_exit_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_access_no_exit"]
 
@@ -32,14 +33,16 @@ def detect_access_no_exit(
                     ):
                         threats.append(
                             ThreatIndicator(
-                                threat_type="access_granted_no_exit_anomaly",
+                                threat_type=AnomalyType.ACCESS_NO_EXIT,
                                 severity="medium",
                                 confidence=0.7,
                                 description=f"User {person_id} access without exit",
                                 evidence={"user_id": str(person_id), "door_id": str(row["door_id"])},
                                 timestamp=datetime.now(),
                                 affected_entities=[str(person_id)],
-                                attack=_attack_info("access_granted_no_exit_anomaly"),
+                                attack=_attack_info(
+                                    AnomalyType.ACCESS_NO_EXIT.value
+                                ),
                             )
                         )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/badge_clone_detection.py
+++ b/analytics/security_patterns/badge_clone_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_badge_clone"]
 
@@ -31,7 +32,7 @@ def detect_badge_clone(
                     if diff < 60:
                         threats.append(
                             ThreatIndicator(
-                                threat_type="badge_clone_suspected",
+                                threat_type=AnomalyType.BADGE_CLONE_SUSPECTED,
                                 severity="high",
                                 confidence=0.8,
                                 description=(
@@ -45,7 +46,9 @@ def detect_badge_clone(
                                 },
                                 timestamp=datetime.now(),
                                 affected_entities=[str(person_id)],
-                                attack=_attack_info("badge_clone_suspected"),
+                                attack=_attack_info(
+                                    AnomalyType.BADGE_CLONE_SUSPECTED.value
+                                ),
                             )
                         )
                         break

--- a/analytics/security_patterns/clearance_violation_detection.py
+++ b/analytics/security_patterns/clearance_violation_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_clearance_violations"]
 
@@ -27,7 +28,7 @@ def detect_clearance_violations(
         for _, row in violations.iterrows():
             threats.append(
                 ThreatIndicator(
-                    threat_type="access_outside_clearance_anomaly",
+                    threat_type=AnomalyType.ACCESS_OUTSIDE_CLEARANCE,
                     severity="high",
                     confidence=0.9,
                     description=f"User {row['person_id']} lacks clearance for door {row['door_id']}",
@@ -39,7 +40,9 @@ def detect_clearance_violations(
                     },
                     timestamp=datetime.now(),
                     affected_entities=[str(row["person_id"]), str(row["door_id"])],
-                    attack=_attack_info("access_outside_clearance_anomaly"),
+                    attack=_attack_info(
+                        AnomalyType.ACCESS_OUTSIDE_CLEARANCE.value
+                    ),
                 )
             )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/composite_score.py
+++ b/analytics/security_patterns/composite_score.py
@@ -10,6 +10,7 @@ from utils.sklearn_compat import optional_import
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
 
@@ -39,7 +40,7 @@ def detect_composite_score(
             row = df.iloc[idx]
             threats.append(
                 ThreatIndicator(
-                    threat_type="composite_anomaly_score",
+                    threat_type=AnomalyType.COMPOSITE_SCORE,
                     severity="low",
                     confidence=0.6,
                     description="Composite anomaly detected",
@@ -49,7 +50,7 @@ def detect_composite_score(
                     },
                     timestamp=datetime.now(),
                     affected_entities=[str(row["person_id"])],
-                    attack=_attack_info("composite_anomaly_score"),
+                    attack=_attack_info(AnomalyType.COMPOSITE_SCORE.value),
                 )
             )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/critical_door_detection.py
+++ b/analytics/security_patterns/critical_door_detection.py
@@ -9,6 +9,7 @@ from utils.sklearn_compat import optional_import
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
 
@@ -48,7 +49,7 @@ def detect_critical_door_anomalies(
             )
             threats.append(
                 ThreatIndicator(
-                    threat_type="critical_door_anomaly",
+                    threat_type=AnomalyType.CRITICAL_DOOR,
                     severity="high",
                     confidence=confidence,
                     description=f"Door {door_id} shows abnormal usage patterns",
@@ -59,7 +60,7 @@ def detect_critical_door_anomalies(
                     },
                     timestamp=datetime.now(),
                     affected_entities=[str(door_id)],
-                    attack=_attack_info("critical_door_anomaly"),
+                    attack=_attack_info(AnomalyType.CRITICAL_DOOR.value),
                 )
             )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/forced_entry_detection.py
+++ b/analytics/security_patterns/forced_entry_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_forced_entry"]
 
@@ -27,7 +28,7 @@ def detect_forced_entry(
         for _, row in suspicious.iterrows():
             threats.append(
                 ThreatIndicator(
-                    threat_type="forced_entry_or_door_held_open",
+                    threat_type=AnomalyType.FORCED_ENTRY,
                     severity="high",
                     confidence=0.9,
                     description=f"Door held open too long at {row['door_id']}",
@@ -37,7 +38,7 @@ def detect_forced_entry(
                     },
                     timestamp=datetime.now(),
                     affected_entities=[str(row["door_id"])],
-                    attack=_attack_info("forced_entry_or_door_held_open"),
+                    attack=_attack_info(AnomalyType.FORCED_ENTRY.value),
                 )
             )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/multiple_attempts_detection.py
+++ b/analytics/security_patterns/multiple_attempts_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_multiple_attempts"]
 
@@ -32,14 +33,16 @@ def detect_multiple_attempts(
                 if i - start_idx + 1 >= 4:
                     threats.append(
                         ThreatIndicator(
-                            threat_type="multiple_attempts_anomaly",
+                            threat_type=AnomalyType.MULTIPLE_ATTEMPTS,
                             severity="high",
                             confidence=0.8,
                             description=f"Multiple attempts by {person_id} at door {door_id}",
                             evidence={"user_id": str(person_id), "door_id": str(door_id)},
                             timestamp=datetime.now(),
                             affected_entities=[str(person_id), str(door_id)],
-                            attack=_attack_info("multiple_attempts_anomaly"),
+                            attack=_attack_info(
+                                AnomalyType.MULTIPLE_ATTEMPTS.value
+                            ),
                         )
                     )
                     break

--- a/analytics/security_patterns/odd_area_detection.py
+++ b/analytics/security_patterns/odd_area_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_odd_area"]
 
@@ -35,14 +36,14 @@ def detect_odd_area(
                 if rate < 0.1 and count <= 2:
                     threats.append(
                         ThreatIndicator(
-                            threat_type="odd_area_anomaly",
+                            threat_type=AnomalyType.ODD_AREA,
                             severity="low",
                             confidence=0.55,
                             description=f"User {person_id} rarely accesses area {area}",
                             evidence={"user_id": str(person_id), "area": area},
                             timestamp=datetime.now(),
                             affected_entities=[str(person_id)],
-                            attack=_attack_info("odd_area_anomaly"),
+                            attack=_attack_info(AnomalyType.ODD_AREA.value),
                         )
                     )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/odd_area_time_detection.py
+++ b/analytics/security_patterns/odd_area_time_detection.py
@@ -9,6 +9,7 @@ import pandas as pd
 from .types import ThreatIndicator
 from .odd_area_detection import _door_to_area
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_odd_area_time"]
 
@@ -31,14 +32,16 @@ def detect_odd_area_time(
                 if count <= 1:
                     threats.append(
                         ThreatIndicator(
-                            threat_type="odd_area_time_anomaly",
+                            threat_type=AnomalyType.ODD_AREA_TIME,
                             severity="medium",
                             confidence=0.65,
                             description=f"After-hours access to unusual area {area} by {person_id}",
                             evidence={"user_id": str(person_id), "area": area},
                             timestamp=datetime.now(),
                             affected_entities=[str(person_id)],
-                            attack=_attack_info("odd_area_time_anomaly"),
+                            attack=_attack_info(
+                                AnomalyType.ODD_AREA_TIME.value
+                            ),
                         )
                     )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/odd_door_detection.py
+++ b/analytics/security_patterns/odd_door_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 from database.baseline_metrics import BaselineMetricsDB
 
 __all__ = ["detect_odd_door_usage"]
@@ -35,7 +36,7 @@ def detect_odd_door_usage(
                     confidence = min(0.99, rate - base_rate)
                     threats.append(
                         ThreatIndicator(
-                            threat_type="odd_door_anomaly",
+                            threat_type=AnomalyType.ODD_DOOR,
                             severity="medium",
                             confidence=confidence,
                             description=f"User {person_id} unusual access to door {door_id}",
@@ -47,7 +48,7 @@ def detect_odd_door_usage(
                             },
                             timestamp=datetime.now(),
                             affected_entities=[str(person_id), str(door_id)],
-                            attack=_attack_info("odd_door_anomaly"),
+                            attack=_attack_info(AnomalyType.ODD_DOOR.value),
                         )
                     )
             # update baseline

--- a/analytics/security_patterns/odd_path_detection.py
+++ b/analytics/security_patterns/odd_path_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_odd_path"]
 
@@ -40,14 +41,14 @@ def detect_odd_path(
         for (pid, prev, nxt), _ in rare_paths.items():
             threats.append(
                 ThreatIndicator(
-                    threat_type="odd_path_anomaly",
+                    threat_type=AnomalyType.ODD_PATH,
                     severity="low",
                     confidence=0.6,
                     description=f"User {pid} rare path {prev}->{nxt}",
                     evidence={"user_id": str(pid), "path": f"{prev}->{nxt}"},
                     timestamp=datetime.now(),
                     affected_entities=[str(pid)],
-                    attack=_attack_info("odd_path_anomaly"),
+                    attack=_attack_info(AnomalyType.ODD_PATH.value),
                 )
             )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/odd_time_detection.py
+++ b/analytics/security_patterns/odd_time_detection.py
@@ -9,6 +9,7 @@ from database.baseline_metrics import BaselineMetricsDB
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_odd_time"]
 
@@ -35,7 +36,7 @@ def detect_odd_time(
                     confidence = min(0.99, abs(row["hour"] - base_mean) / (base_std + 1e-9))
                     threats.append(
                         ThreatIndicator(
-                            threat_type="odd_time_anomaly",
+                            threat_type=AnomalyType.ODD_TIME,
                             severity="medium",
                             confidence=float(confidence),
                             description=f"User {person_id} accessed at unusual hour {row['hour']}",
@@ -46,7 +47,7 @@ def detect_odd_time(
                             },
                             timestamp=datetime.now(),
                             affected_entities=[str(person_id)],
-                            attack=_attack_info("odd_time_anomaly"),
+                            attack=_attack_info(AnomalyType.ODD_TIME.value),
                         )
                     )
             baseline.update_baseline(

--- a/analytics/security_patterns/pattern_detection.py
+++ b/analytics/security_patterns/pattern_detection.py
@@ -11,6 +11,7 @@ import yaml
 
 from .types import ThreatIndicator
 from utils.sklearn_compat import optional_import
+from models.enums import AnomalyType
 
 LogisticRegression = optional_import("sklearn.linear_model.LogisticRegression")
 
@@ -173,7 +174,7 @@ def detect_critical_door_risks(
             severity = "critical" if prob > 0.9 else "high"
             threats.append(
                 ThreatIndicator(
-                    threat_type="critical_door_anomaly",
+                    threat_type=AnomalyType.CRITICAL_DOOR,
                     severity=severity,
                     confidence=float(prob),
                     description=(

--- a/analytics/security_patterns/pattern_drift_detection.py
+++ b/analytics/security_patterns/pattern_drift_detection.py
@@ -10,6 +10,7 @@ from database.baseline_metrics import BaselineMetricsDB
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_pattern_drift"]
 
@@ -33,7 +34,7 @@ def detect_pattern_drift(
         if drift_score > 0.2:
             threats.append(
                 ThreatIndicator(
-                    threat_type="access_pattern_drift_anomaly",
+                    threat_type=AnomalyType.PATTERN_DRIFT,
                     severity="medium",
                     confidence=min(0.99, drift_score * 2),
                     description="Significant drift in overall access patterns",
@@ -45,7 +46,7 @@ def detect_pattern_drift(
                     },
                     timestamp=datetime.now(),
                     affected_entities=[],
-                    attack=_attack_info("access_pattern_drift_anomaly"),
+                    attack=_attack_info(AnomalyType.PATTERN_DRIFT.value),
                 )
             )
         baseline.update_baseline(

--- a/analytics/security_patterns/tailgate_detection.py
+++ b/analytics/security_patterns/tailgate_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_tailgate"]
 
@@ -26,7 +27,7 @@ def detect_tailgate(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -
             for _, row in suspicious.iterrows():
                 threats.append(
                     ThreatIndicator(
-                        threat_type="probable_tailgate",
+                        threat_type=AnomalyType.PROBABLE_TAILGATE,
                         severity="medium",
                         confidence=0.75,
                         description=f"Possible tailgate at door {door_id}",
@@ -36,7 +37,7 @@ def detect_tailgate(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -
                         },
                         timestamp=datetime.now(),
                         affected_entities=[str(row["person_id"]), str(door_id)],
-                        attack=_attack_info("probable_tailgate"),
+                        attack=_attack_info(AnomalyType.PROBABLE_TAILGATE.value),
                     )
                 )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/analytics/security_patterns/unaccompanied_visitor_detection.py
+++ b/analytics/security_patterns/unaccompanied_visitor_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from models.enums import AnomalyType
 
 __all__ = ["detect_unaccompanied_visitors"]
 
@@ -36,14 +37,16 @@ def detect_unaccompanied_visitors(
             if nearby.empty:
                 threats.append(
                     ThreatIndicator(
-                        threat_type="unaccompanied_visitor_anomaly",
+                        threat_type=AnomalyType.UNACCOMPANIED_VISITOR,
                         severity="medium",
                         confidence=0.7,
                         description=f"Visitor badge {row['person_id']} unaccompanied",
                         evidence={"person_id": str(row["person_id"]), "door_id": str(row["door_id"])},
                         timestamp=datetime.now(),
                         affected_entities=[str(row["person_id"])],
-                        attack=_attack_info("unaccompanied_visitor_anomaly"),
+                        attack=_attack_info(
+                            AnomalyType.UNACCOMPANIED_VISITOR.value
+                        ),
                     )
                 )
     except Exception as exc:  # pragma: no cover - log and continue

--- a/tests/test_security_patterns.py
+++ b/tests/test_security_patterns.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from analytics.security_patterns.pattern_detection import detect_critical_door_risks
 from analytics.security_patterns import SecurityPatternsAnalyzer, prepare_security_data
+from models.enums import AnomalyType
 from database.connection import create_database_connection
 
 
@@ -61,4 +62,4 @@ def test_detect_critical_door_risks():
     )
     prepared = prepare_security_data(df)
     threats = detect_critical_door_risks(prepared)
-    assert any(t.threat_type == "critical_door_anomaly" for t in threats)
+    assert any(t.threat_type == AnomalyType.CRITICAL_DOOR for t in threats)


### PR DESCRIPTION
## Summary
- switch security pattern detectors to use `AnomalyType`
- check for the enum in tests

## Testing
- `pytest analytics/security_patterns/tests tests/test_security_patterns.py -q` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_68782ab38b1c832087dff1ba23f7c613