### PR TITLE
Add column validation to security detectors

### DIFF
--- a/analytics/security_patterns/access_no_exit_detection.py
+++ b/analytics/security_patterns/access_no_exit_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_access_no_exit"]
 
@@ -20,6 +21,12 @@ def detect_access_no_exit(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(
+            df,
+            ["timestamp", "person_id", "door_id", "access_granted"],
+            logger,
+        ):
             return threats
         df_sorted = df.sort_values("timestamp")
         for person_id, group in df_sorted.groupby("person_id"):

--- a/analytics/security_patterns/badge_clone_detection.py
+++ b/analytics/security_patterns/badge_clone_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_badge_clone"]
 
@@ -20,6 +21,8 @@ def detect_badge_clone(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["timestamp", "person_id", "door_id"], logger):
             return threats
         df_sorted = df.sort_values("timestamp")
         for person_id, group in df_sorted.groupby("person_id"):

--- a/analytics/security_patterns/clearance_violation_detection.py
+++ b/analytics/security_patterns/clearance_violation_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_clearance_violations"]
 
@@ -21,7 +22,11 @@ def detect_clearance_violations(
     try:
         if len(df) == 0:
             return threats
-        if "user_clearance" not in df.columns or "required_clearance" not in df.columns:
+        if not ensure_columns(
+            df,
+            ["timestamp", "person_id", "door_id", "user_clearance", "required_clearance"],
+            logger,
+        ):
             return threats
         violations = df[df["user_clearance"] < df["required_clearance"]]
         for _, row in violations.iterrows():

--- a/analytics/security_patterns/column_validation.py
+++ b/analytics/security_patterns/column_validation.py
@@ -1,0 +1,14 @@
+import logging
+from typing import Sequence, Optional
+import pandas as pd
+
+__all__ = ["ensure_columns"]
+
+def ensure_columns(df: pd.DataFrame, cols: Sequence[str], logger: Optional[logging.Logger] = None) -> bool:
+    """Return True if all ``cols`` are present in ``df`` else log warning."""
+    logger = logger or logging.getLogger(__name__)
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        logger.warning("Missing required columns: %s", missing)
+        return False
+    return True

--- a/analytics/security_patterns/composite_score.py
+++ b/analytics/security_patterns/composite_score.py
@@ -10,6 +10,7 @@ from utils.sklearn_compat import optional_import
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
 
@@ -30,6 +31,18 @@ def detect_composite_score(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) < 5:
+            return threats
+        if not ensure_columns(
+            df,
+            [
+                "hour",
+                "is_after_hours",
+                "access_granted",
+                "person_id",
+                "door_id",
+            ],
+            logger,
+        ):
             return threats
         features = df[["hour", "is_after_hours", "access_granted"]].astype(float)
         iso = IsolationForest(contamination=0.1, random_state=42)

--- a/analytics/security_patterns/critical_door_detection.py
+++ b/analytics/security_patterns/critical_door_detection.py
@@ -9,6 +9,7 @@ from utils.sklearn_compat import optional_import
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
 
@@ -29,6 +30,12 @@ def detect_critical_door_anomalies(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(
+            df,
+            ["timestamp", "person_id", "door_id", "is_after_hours", "access_granted"],
+            logger,
+        ):
             return threats
 
         door_stats = df.groupby("door_id").agg(

--- a/analytics/security_patterns/forced_entry_detection.py
+++ b/analytics/security_patterns/forced_entry_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_forced_entry"]
 
@@ -21,7 +22,7 @@ def detect_forced_entry(
     try:
         if len(df) == 0:
             return threats
-        if "door_held_open_time" not in df.columns:
+        if not ensure_columns(df, ["door_held_open_time", "door_id"], logger):
             return threats
         suspicious = df[df["door_held_open_time"] > 10]
         for _, row in suspicious.iterrows():

--- a/analytics/security_patterns/multiple_attempts_detection.py
+++ b/analytics/security_patterns/multiple_attempts_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_multiple_attempts"]
 
@@ -20,6 +21,8 @@ def detect_multiple_attempts(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["timestamp", "person_id", "door_id"], logger):
             return threats
         df_sorted = df.sort_values("timestamp")
         window = timedelta(minutes=5)

--- a/analytics/security_patterns/odd_area_detection.py
+++ b/analytics/security_patterns/odd_area_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_odd_area"]
 
@@ -24,6 +25,8 @@ def detect_odd_area(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["door_id", "person_id"], logger):
             return threats
         df = df.copy(deep=False)
         df["area"] = df["door_id"].apply(_door_to_area)

--- a/analytics/security_patterns/odd_area_time_detection.py
+++ b/analytics/security_patterns/odd_area_time_detection.py
@@ -9,6 +9,7 @@ import pandas as pd
 from .types import ThreatIndicator
 from .odd_area_detection import _door_to_area
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_odd_area_time"]
 
@@ -21,6 +22,8 @@ def detect_odd_area_time(
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["door_id", "person_id", "is_after_hours"], logger):
             return threats
         df = df.copy(deep=False)
         df["area"] = df["door_id"].apply(_door_to_area)

--- a/analytics/security_patterns/odd_door_detection.py
+++ b/analytics/security_patterns/odd_door_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 from database.baseline_metrics import BaselineMetricsDB
 
 __all__ = ["detect_odd_door_usage"]
@@ -22,6 +23,8 @@ def detect_odd_door_usage(
     baseline = BaselineMetricsDB()
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["person_id", "door_id"], logger):
             return threats
         for person_id, group in df.groupby("person_id"):
             total = len(group)

--- a/analytics/security_patterns/odd_path_detection.py
+++ b/analytics/security_patterns/odd_path_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_odd_path"]
 
@@ -31,6 +32,8 @@ def detect_odd_path(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
+        if not ensure_columns(df, ["timestamp", "person_id", "door_id"], logger):
+            return threats
         paths = _extract_paths(df)
         if not paths:
             return threats

--- a/analytics/security_patterns/odd_time_detection.py
+++ b/analytics/security_patterns/odd_time_detection.py
@@ -9,6 +9,7 @@ from database.baseline_metrics import BaselineMetricsDB
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_odd_time"]
 
@@ -22,6 +23,8 @@ def detect_odd_time(
     baseline = BaselineMetricsDB()
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["person_id", "hour"], logger):
             return threats
         for person_id, group in df.groupby("person_id"):
             hours = group["hour"]

--- a/analytics/security_patterns/pattern_detection.py
+++ b/analytics/security_patterns/pattern_detection.py
@@ -11,6 +11,7 @@ import yaml
 
 from .types import ThreatIndicator
 from utils.sklearn_compat import optional_import
+from .column_validation import ensure_columns
 
 LogisticRegression = optional_import("sklearn.linear_model.LogisticRegression")
 
@@ -55,6 +56,8 @@ def detect_rapid_attempts(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
+        if not ensure_columns(df, ["timestamp", "person_id", "access_granted"], logger):
+            return threats
         df_sorted = df.sort_values(["person_id", "timestamp"])
         df_sorted["time_diff"] = df_sorted.groupby("person_id")["timestamp"].diff()
         rapid_threshold = pd.Timedelta(seconds=30)
@@ -98,6 +101,8 @@ def detect_after_hours_anomalies(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
+        if not ensure_columns(df, ["person_id", "is_after_hours"], logger):
+            return threats
         after_hours_data = df[df["is_after_hours"] == True]
         if len(after_hours_data) == 0:
             return threats
@@ -137,7 +142,17 @@ def detect_critical_door_risks(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
-        if "door_type" not in df.columns:
+        if not ensure_columns(
+            df,
+            [
+                "timestamp",
+                "person_id",
+                "door_id",
+                "door_type",
+                "access_granted",
+            ],
+            logger,
+        ):
             return threats
 
         critical = df[df["door_type"].astype(str).str.lower() == "critical"]

--- a/analytics/security_patterns/pattern_drift_detection.py
+++ b/analytics/security_patterns/pattern_drift_detection.py
@@ -10,6 +10,7 @@ from database.baseline_metrics import BaselineMetricsDB
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_pattern_drift"]
 
@@ -23,6 +24,8 @@ def detect_pattern_drift(
     baseline = BaselineMetricsDB()
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["is_after_hours", "access_granted"], logger):
             return threats
         overall_after_hours = float(df["is_after_hours"].mean())
         overall_failure_rate = float(1 - df["access_granted"].mean())

--- a/analytics/security_patterns/statistical_detection.py
+++ b/analytics/security_patterns/statistical_detection.py
@@ -10,6 +10,7 @@ from scipy import stats
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = [
     "detect_failure_rate_anomalies",
@@ -25,6 +26,8 @@ def detect_failure_rate_anomalies(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
+        if not ensure_columns(df, ["person_id", "access_granted"], logger):
+            return threats
         overall_failure_rate = 1 - df["access_granted"].mean()
         user_failure_rates = df.groupby("person_id")["access_granted"].agg(
             ["mean", "count"]
@@ -77,6 +80,8 @@ def detect_frequency_anomalies(
     logger = logger or logging.getLogger(__name__)
     threats: List[ThreatIndicator] = []
     try:
+        if not ensure_columns(df, ["person_id"], logger):
+            return threats
         user_access_counts = df.groupby("person_id").size()
         mean_access = user_access_counts.mean()
         std_access = user_access_counts.std()

--- a/analytics/security_patterns/tailgate_detection.py
+++ b/analytics/security_patterns/tailgate_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_tailgate"]
 
@@ -18,6 +19,8 @@ def detect_tailgate(df: pd.DataFrame, logger: Optional[logging.Logger] = None) -
     threats: List[ThreatIndicator] = []
     try:
         if len(df) == 0:
+            return threats
+        if not ensure_columns(df, ["timestamp", "person_id", "door_id"], logger):
             return threats
         df_sorted = df.sort_values("timestamp")
         for door_id, group in df_sorted.groupby("door_id"):

--- a/analytics/security_patterns/tests/test_missing_columns.py
+++ b/analytics/security_patterns/tests/test_missing_columns.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import pytest
+
+from analytics.security_patterns.tailgate_detection import detect_tailgate
+from analytics.security_patterns.multiple_attempts_detection import detect_multiple_attempts
+from analytics.security_patterns.pattern_detection import detect_rapid_attempts
+
+@pytest.mark.parametrize("func", [detect_tailgate, detect_multiple_attempts, detect_rapid_attempts])
+def test_missing_columns_return_empty(func, caplog):
+    df = pd.DataFrame({"timestamp": ["2024-01-01"], "person_id": ["u1"]})
+    with caplog.at_level("WARNING"):
+        result = func(df)
+    assert result == []
+    assert any("Missing required columns" in r.getMessage() for r in caplog.records)

--- a/analytics/security_patterns/unaccompanied_visitor_detection.py
+++ b/analytics/security_patterns/unaccompanied_visitor_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .column_validation import ensure_columns
 
 __all__ = ["detect_unaccompanied_visitors"]
 
@@ -21,7 +22,11 @@ def detect_unaccompanied_visitors(
     try:
         if len(df) == 0:
             return threats
-        if "badge_status" not in df.columns:
+        if not ensure_columns(
+            df,
+            ["timestamp", "person_id", "door_id", "badge_status"],
+            logger,
+        ):
             return threats
         df_sorted = df.sort_values("timestamp")
         visitors = df_sorted[df_sorted["badge_status"].str.lower() == "visitor"]


### PR DESCRIPTION
## Summary
- add helper `ensure_columns` for validating required DataFrame columns
- ensure each security detector checks for required columns
- warn and return empty list when columns missing
- test missing-column scenarios for detectors

## Testing
- `PYTHONPATH=. pytest analytics/security_patterns/tests/test_missing_columns.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68782ab686c483209f759cf881b0945c