### PR TITLE
Move door_to_area to utils module

### DIFF
--- a/analytics/security_patterns/odd_area_detection.py
+++ b/analytics/security_patterns/odd_area_detection.py
@@ -8,12 +8,9 @@ import pandas as pd
 
 from .types import ThreatIndicator
 from .pattern_detection import _attack_info
+from .utils import _door_to_area
 
 __all__ = ["detect_odd_area"]
-
-
-def _door_to_area(door_id: str) -> str:
-    return str(door_id).split("-")[0]
 
 
 def detect_odd_area(

--- a/analytics/security_patterns/odd_area_time_detection.py
+++ b/analytics/security_patterns/odd_area_time_detection.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pandas as pd
 
 from .types import ThreatIndicator
-from .odd_area_detection import _door_to_area
+from .utils import _door_to_area
 from .pattern_detection import _attack_info
 
 __all__ = ["detect_odd_area_time"]

--- a/analytics/security_patterns/tests/test_security_modules.py
+++ b/analytics/security_patterns/tests/test_security_modules.py
@@ -4,6 +4,7 @@ from analytics.security_patterns.data_prep import prepare_security_data
 from analytics.security_patterns.statistical_detection import (
     detect_failure_rate_anomalies,
 )
+from analytics.security_patterns.utils import _door_to_area
 
 
 def test_prepare_security_data_basic():
@@ -44,3 +45,8 @@ def test_detect_failure_rate_anomalies():
     cleaned = prepare_security_data(df)
     threats = detect_failure_rate_anomalies(cleaned)
     assert isinstance(threats, list)
+
+
+def test_door_to_area_helper():
+    assert _door_to_area("A-1") == "A"
+    assert _door_to_area("B-12") == "B"

--- a/analytics/security_patterns/utils.py
+++ b/analytics/security_patterns/utils.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+__all__ = ["_door_to_area"]
+
+
+def _door_to_area(door_id: str) -> str:
+    """Extract building area prefix from a door identifier."""
+    return str(door_id).split("-")[0]


### PR DESCRIPTION
## Summary
- factor out `_door_to_area` helper into `utils`
- import the helper from `utils` in odd area detectors
- cover the new helper with a unit test

## Testing
- `PYTHONPATH=$PWD pytest analytics/security_patterns/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68782ab7977c83208814a3df5270fed4