### PR TITLE
Handle baseline update failures gracefully

### DIFF
--- a/analytics/security_patterns/odd_door_detection.py
+++ b/analytics/security_patterns/odd_door_detection.py
@@ -31,7 +31,11 @@ def detect_odd_door_usage(
                 metric = f"door_{door_id}_rate"
                 rate = count / total
                 base_rate = baseline_metrics.get(metric)
-                if base_rate is not None and rate > base_rate * 2 and rate - base_rate > 0.05:
+                if (
+                    base_rate is not None
+                    and rate > base_rate * 2
+                    and rate - base_rate > 0.05
+                ):
                     confidence = min(0.99, rate - base_rate)
                     threats.append(
                         ThreatIndicator(
@@ -52,7 +56,10 @@ def detect_odd_door_usage(
                     )
             # update baseline
             metrics = {f"door_{d}_rate": c / total for d, c in door_counts.items()}
-            baseline.update_baseline("user", str(person_id), metrics)
+            try:
+                baseline.update_baseline("user", str(person_id), metrics)
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.warning("Failed to update baseline metrics: %s", exc)
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("Odd door detection failed: %s", exc)
     return threats

--- a/analytics/security_patterns/odd_time_detection.py
+++ b/analytics/security_patterns/odd_time_detection.py
@@ -32,7 +32,9 @@ def detect_odd_time(
             base_std = baseline_metrics.get("std_hour", std_hour)
             for _, row in group.iterrows():
                 if abs(row["hour"] - base_mean) > 2 * base_std:
-                    confidence = min(0.99, abs(row["hour"] - base_mean) / (base_std + 1e-9))
+                    confidence = min(
+                        0.99, abs(row["hour"] - base_mean) / (base_std + 1e-9)
+                    )
                     threats.append(
                         ThreatIndicator(
                             threat_type="odd_time_anomaly",
@@ -49,11 +51,14 @@ def detect_odd_time(
                             attack=_attack_info("odd_time_anomaly"),
                         )
                     )
-            baseline.update_baseline(
-                "user",
-                str(person_id),
-                {"mean_hour": mean_hour, "std_hour": std_hour},
-            )
+            try:
+                baseline.update_baseline(
+                    "user",
+                    str(person_id),
+                    {"mean_hour": mean_hour, "std_hour": std_hour},
+                )
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.warning("Failed to update baseline metrics: %s", exc)
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("Odd time detection failed: %s", exc)
     return threats

--- a/analytics/security_patterns/pattern_drift_detection.py
+++ b/analytics/security_patterns/pattern_drift_detection.py
@@ -29,7 +29,10 @@ def detect_pattern_drift(
         metrics = baseline.get_baseline("global", "overall")
         base_after_hours = metrics.get("after_hours_rate", overall_after_hours)
         base_failure = metrics.get("failure_rate", overall_failure_rate)
-        drift_score = np.sqrt((overall_after_hours - base_after_hours) ** 2 + (overall_failure_rate - base_failure) ** 2)
+        drift_score = np.sqrt(
+            (overall_after_hours - base_after_hours) ** 2
+            + (overall_failure_rate - base_failure) ** 2
+        )
         if drift_score > 0.2:
             threats.append(
                 ThreatIndicator(
@@ -48,14 +51,17 @@ def detect_pattern_drift(
                     attack=_attack_info("access_pattern_drift_anomaly"),
                 )
             )
-        baseline.update_baseline(
-            "global",
-            "overall",
-            {
-                "after_hours_rate": overall_after_hours,
-                "failure_rate": overall_failure_rate,
-            },
-        )
+        try:
+            baseline.update_baseline(
+                "global",
+                "overall",
+                {
+                    "after_hours_rate": overall_after_hours,
+                    "failure_rate": overall_failure_rate,
+                },
+            )
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.warning("Failed to update baseline metrics: %s", exc)
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("Pattern drift detection failed: %s", exc)
     return threats

--- a/analytics/security_patterns/tests/test_baseline_failures.py
+++ b/analytics/security_patterns/tests/test_baseline_failures.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from analytics.security_patterns.tests.test_additional_detectors import _prepare_df
+from analytics.security_patterns.odd_door_detection import detect_odd_door_usage
+from analytics.security_patterns.odd_time_detection import detect_odd_time
+from analytics.security_patterns.pattern_drift_detection import detect_pattern_drift
+
+
+class FailingBaselineDB:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def update_baseline(self, *args, **kwargs):
+        raise RuntimeError("db error")
+
+    def get_baseline(self, *args, **kwargs):
+        return {}
+
+
+def test_detectors_handle_baseline_update_error(monkeypatch):
+    df = _prepare_df()
+    monkeypatch.setattr(
+        "analytics.security_patterns.odd_door_detection.BaselineMetricsDB",
+        FailingBaselineDB,
+    )
+    monkeypatch.setattr(
+        "analytics.security_patterns.odd_time_detection.BaselineMetricsDB",
+        FailingBaselineDB,
+    )
+    monkeypatch.setattr(
+        "analytics.security_patterns.pattern_drift_detection.BaselineMetricsDB",
+        FailingBaselineDB,
+    )
+
+    assert isinstance(detect_odd_door_usage(df), list)
+    assert isinstance(detect_odd_time(df), list)
+    assert isinstance(detect_pattern_drift(df), list)


### PR DESCRIPTION
## Summary
- catch BaselineMetricsDB update failures in detectors and analyzer
- add tests ensuring detection continues when updates fail

## Testing
- `PYTHONPATH=. pytest analytics/security_patterns/tests/test_baseline_failures.py -q`
- `PYTHONPATH=. pytest analytics/security_patterns/tests/test_additional_detectors.py::test_all_detectors_return_list -q`


------
https://chatgpt.com/codex/tasks/task_e_68782ab9c7288320b5f5282677ea57fb