### PR TITLE
Improve detector tests

### DIFF
--- a/analytics/security_patterns/tests/test_security_modules.py
+++ b/analytics/security_patterns/tests/test_security_modules.py
@@ -22,19 +22,48 @@ def test_prepare_security_data_basic():
 
 def test_detect_failure_rate_anomalies():
     rows = []
-    for i in range(8):
+    for i in range(6):
         rows.append(
             {
-                "timestamp": f"2024-01-01 10:0{i}:00",
-                "person_id": "u1",
+                "timestamp": f"2024-01-01 09:{i:02d}:00",
+                "person_id": "bad",
                 "door_id": "d1",
                 "access_result": "Denied",
             }
         )
-    for i in range(8):
+    for i in range(6):
         rows.append(
             {
-                "timestamp": f"2024-01-01 11:0{i}:00",
+                "timestamp": f"2024-01-01 10:{i:02d}:00",
+                "person_id": f"ok{i}",
+                "door_id": "d1",
+                "access_result": "Granted",
+            }
+        )
+    df = pd.DataFrame(rows)
+    cleaned = prepare_security_data(df)
+    threats = detect_failure_rate_anomalies(cleaned)
+    assert threats
+    indicator = threats[0]
+    assert indicator.threat_type == "unusual_failure_rate"
+    assert indicator.severity == "critical"
+
+
+def test_failure_rate_anomalies_none():
+    rows = []
+    for i in range(6):
+        rows.append(
+            {
+                "timestamp": f"2024-01-01 09:{i:02d}:00",
+                "person_id": "u1",
+                "door_id": "d1",
+                "access_result": "Granted",
+            }
+        )
+    for i in range(6):
+        rows.append(
+            {
+                "timestamp": f"2024-01-01 10:{i:02d}:00",
                 "person_id": "u2",
                 "door_id": "d1",
                 "access_result": "Granted",
@@ -43,4 +72,4 @@ def test_detect_failure_rate_anomalies():
     df = pd.DataFrame(rows)
     cleaned = prepare_security_data(df)
     threats = detect_failure_rate_anomalies(cleaned)
-    assert isinstance(threats, list)
+    assert threats == []


### PR DESCRIPTION
## Summary
- enhance detector tests with baseline values that trigger anomalies
- assert that the detectors emit `ThreatIndicator` objects with expected values
- add negative tests ensuring empty results

## Testing
- `python -m py_compile analytics/security_patterns/tests/test_additional_detectors.py analytics/security_patterns/tests/test_security_modules.py`
- `pytest analytics/security_patterns/tests/test_security_modules.py::test_detect_failure_rate_anomalies -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68782abbabe483209e7d0b6c2839b1b5