### PR TITLE
Add IntelligentConnectionPool with dynamic scaling

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -57,6 +57,8 @@ class DatabaseConfig:
     initial_pool_size: int = dynamic_config.get_db_pool_size()
     max_pool_size: int = dynamic_config.get_db_pool_size() * 2
     shrink_timeout: int = 60
+    # Use the IntelligentConnectionPool instead of the default pool
+    use_intelligent_pool: bool = False
 
     def __post_init__(self) -> None:
         """Auto-generate connection URL if not explicitly provided."""

--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -277,9 +277,16 @@ class ThreadSafeDatabaseManager(DatabaseManager):
         self._pool: Optional[Any] = None
 
     def _create_pool(self) -> DatabaseConnectionPool:
-        from .connection_pool import DatabaseConnectionPool
+        if getattr(self.config, "use_intelligent_pool", False):
+            from database.intelligent_connection_pool import IntelligentConnectionPool
 
-        return DatabaseConnectionPool(
+            pool_cls = IntelligentConnectionPool
+        else:
+            from .connection_pool import DatabaseConnectionPool
+
+            pool_cls = DatabaseConnectionPool
+
+        return pool_cls(
             self._create_connection,
             getattr(self.config, "initial_pool_size", 1),
             getattr(self.config, "max_pool_size", 1),

--- a/database/intelligent_connection_pool.py
+++ b/database/intelligent_connection_pool.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Dict, List, Tuple, Any
+
+from database.types import DatabaseConnection
+
+
+class IntelligentConnectionPool:
+    """Connection pool with dynamic scaling and simple metrics."""
+
+    def __init__(
+        self,
+        factory: Callable[[], DatabaseConnection],
+        min_size: int,
+        max_size: int,
+        timeout: int,
+        shrink_timeout: int,
+        *,
+        threshold: float = 0.75,
+    ) -> None:
+        self._factory = factory
+        self._min_size = min_size
+        self._max_pool_size = max(max_size, min_size)
+        self._max_size = min_size
+        self._timeout = timeout
+        self._shrink_timeout = shrink_timeout
+        self._threshold = threshold
+
+        self._pool: List[Tuple[DatabaseConnection, float]] = []
+        self._active = 0
+        self._lock = threading.RLock()
+        self._metrics: Dict[str, Any] = {
+            "acquired": 0,
+            "released": 0,
+            "expansions": 0,
+            "shrinks": 0,
+            "acquire_times": [],
+        }
+
+        for _ in range(min_size):
+            conn = self._factory()
+            self._pool.append((conn, time.time()))
+            self._active += 1
+
+    # ------------------------------------------------------------------
+    def _maybe_expand(self) -> None:
+        usage = (self._active - len(self._pool)) / max(self._max_size, 1)
+        if usage >= self._threshold and self._max_size < self._max_pool_size:
+            self._max_size = min(self._max_size * 2, self._max_pool_size)
+            self._metrics["expansions"] += 1
+
+    # ------------------------------------------------------------------
+    def _shrink_idle_connections(self) -> None:
+        now = time.time()
+        new_pool: List[Tuple[DatabaseConnection, float]] = []
+        for conn, ts in self._pool:
+            if (
+                now - ts > self._shrink_timeout
+                and self._max_size > self._min_size
+            ):
+                conn.close()
+                self._active -= 1
+                self._max_size -= 1
+                self._metrics["shrinks"] += 1
+            else:
+                new_pool.append((conn, ts))
+        self._pool = new_pool
+
+    # ------------------------------------------------------------------
+    def get_connection(self) -> DatabaseConnection:
+        start = time.time()
+        deadline = start + self._timeout
+        while True:
+            with self._lock:
+                self._shrink_idle_connections()
+                self._maybe_expand()
+
+                if self._pool:
+                    conn, _ = self._pool.pop()
+                    if not conn.health_check():
+                        conn.close()
+                        self._active -= 1
+                        continue
+                    self._metrics["acquired"] += 1
+                    self._metrics["acquire_times"].append(time.time() - start)
+                    return conn
+
+                if self._active < self._max_size:
+                    conn = self._factory()
+                    self._active += 1
+                    self._metrics["acquired"] += 1
+                    self._metrics["acquire_times"].append(time.time() - start)
+                    return conn
+
+            if time.time() >= deadline:
+                raise TimeoutError("No available connection in pool")
+            time.sleep(0.05)
+
+    # ------------------------------------------------------------------
+    def release_connection(self, conn: DatabaseConnection) -> None:
+        with self._lock:
+            self._shrink_idle_connections()
+            if not conn.health_check():
+                conn.close()
+                self._active -= 1
+                return
+
+            if len(self._pool) >= self._max_size:
+                conn.close()
+                self._active -= 1
+            else:
+                self._pool.append((conn, time.time()))
+            self._metrics["released"] += 1
+
+    # ------------------------------------------------------------------
+    def get_metrics(self) -> Dict[str, Any]:
+        data = self._metrics.copy()
+        times = data.pop("acquire_times")
+        data["avg_acquire_time"] = (sum(times) / len(times)) if times else 0.0
+        data["active"] = self._active
+        data["max_size"] = self._max_size
+        return data
+
+
+__all__ = ["IntelligentConnectionPool"]

--- a/tests/database/test_intelligent_pool.py
+++ b/tests/database/test_intelligent_pool.py
@@ -1,0 +1,29 @@
+from database.intelligent_connection_pool import IntelligentConnectionPool
+from config.database_manager import MockConnection
+
+
+def factory():
+    return MockConnection()
+
+
+def test_pool_resizes_and_reports_metrics():
+    pool = IntelligentConnectionPool(
+        factory, min_size=1, max_size=3, timeout=1, shrink_timeout=0
+    )
+
+    c1 = pool.get_connection()
+    c2 = pool.get_connection()
+
+    # After requesting a second connection utilization should trigger expansion
+    assert pool._max_size >= 2
+
+    pool.release_connection(c1)
+    pool.release_connection(c2)
+
+    # Shrink happens immediately because shrink_timeout=0
+    assert pool._max_size == 1
+
+    metrics = pool.get_metrics()
+    assert metrics["acquired"] == 2
+    assert metrics["released"] == 2
+    assert "avg_acquire_time" in metrics


### PR DESCRIPTION
## Summary
- implement `IntelligentConnectionPool` offering dynamic scaling and metrics
- allow `ThreadSafeDatabaseManager` to use the intelligent pool via config option
- expose `use_intelligent_pool` flag in `DatabaseConfig`
- test intelligent pool behaviour and metrics

## Testing
- `pytest -q tests/test_connection_pool.py tests/test_connection_pool_threadsafe.py tests/test_enhanced_connection_pool.py tests/database/test_intelligent_pool.py`
- `pytest -q tests/database/test_intelligent_pool.py`


------
https://chatgpt.com/codex/tasks/task_e_68783347c0fc83208ec09615b37481a7