### PR TITLE
Add API Gateway planner module

### DIFF
--- a/docs/microservices_plan.md
+++ b/docs/microservices_plan.md
@@ -1,0 +1,13 @@
+# Microservices Gateway and Mesh Plan
+
+This document outlines a proposed architecture for integrating an API gateway and a service mesh.
+
+## API Gateway
+
+The gateway will sit at the edge of the deployment and expose a single entry point for all HTTP traffic. Each service boundary is mapped to a set of routes in the gateway configuration. Security policies such as authentication and rate limiting are applied globally, while observability hooks forward metrics and traces to the monitoring stack.
+
+## Service Mesh
+
+Internal communication between microservices occurs inside a lightweight service mesh. Service entries represent each deployable unit. Traffic policies define how requests flow between them, enabling retries and circuit breaking. Observability is built in through distributed tracing and metrics collection.
+
+The planner in `services/api_gateway_planner.py` produces skeleton configurations that can be expanded as the platform evolves.

--- a/services/api_gateway_planner.py
+++ b/services/api_gateway_planner.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class APIGatewayArchitect:
+    """Plan the API gateway and service mesh configuration."""
+
+    def design_api_gateway(
+        self, service_boundaries: Dict[str, List[str]]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Create a gateway plan for the provided services."""
+        routing = self._create_routing(service_boundaries)
+        security = self._create_security_policies(service_boundaries)
+        observability = self._create_observability_hooks(service_boundaries)
+        return {
+            "routing": routing,
+            "security": security,
+            "observability": observability,
+        }
+
+    def design_service_mesh(self, services: List[str]) -> Dict[str, Any]:
+        """Return a skeleton service mesh configuration."""
+        return {
+            "service_entries": [{"name": name} for name in services],
+            "traffic_policies": [],  # TODO: define mesh traffic policies
+            "observability": [],  # TODO: configure distributed tracing hooks
+        }
+
+    # ------------------------------------------------------------------
+    def _create_routing(
+        self, service_boundaries: Dict[str, List[str]]
+    ) -> Dict[str, Any]:
+        """Stub for dynamic routing configuration."""
+        routes = [
+            {"service": service, "paths": paths}
+            for service, paths in service_boundaries.items()
+        ]
+        return {"rules": routes}
+
+    def _create_security_policies(
+        self, service_boundaries: Dict[str, List[str]]
+    ) -> Dict[str, Any]:
+        """Stub for gateway security policies."""
+        return {"policies": []}
+
+    def _create_observability_hooks(
+        self, service_boundaries: Dict[str, List[str]]
+    ) -> Dict[str, Any]:
+        """Stub for metrics and tracing integration."""
+        return {"hooks": []}
+
+
+__all__ = ["APIGatewayArchitect"]

--- a/tests/services/test_api_gateway_planner.py
+++ b/tests/services/test_api_gateway_planner.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "api_gateway_planner",
+    Path(__file__).resolve().parents[2] / "services" / "api_gateway_planner.py",
+)
+api_gateway_planner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(api_gateway_planner)
+APIGatewayArchitect = api_gateway_planner.APIGatewayArchitect
+
+
+def test_design_api_gateway_keys():
+    architect = APIGatewayArchitect()
+    boundaries = {"users": ["/users", "/users/{id}"], "orders": ["/orders"]}
+    plan = architect.design_api_gateway(boundaries)
+
+    assert set(plan.keys()) == {"routing", "security", "observability"}
+    assert "rules" in plan["routing"]
+    assert "policies" in plan["security"]
+    assert "hooks" in plan["observability"]
+
+
+def test_design_service_mesh_keys():
+    architect = APIGatewayArchitect()
+    mesh = architect.design_service_mesh(["users", "orders"])
+
+    assert set(mesh.keys()) == {"service_entries", "traffic_policies", "observability"}


### PR DESCRIPTION
## Summary
- add `APIGatewayArchitect` for planning gateway and mesh
- document gateway and mesh outline
- test gateway planner dictionary outputs

## Testing
- `pytest tests/services/test_api_gateway_planner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878335801848320af4e701a03db43d7