### PR TITLE
Add threat intelligence skeleton

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,3 +119,12 @@ sequenceDiagram
     CB->>REG: register(callback_id)
     REG-->>CB: confirmation
 ```
+
+## Threat Intelligence Integration
+
+Security callbacks can subscribe to updates from `ThreatIntelligenceSystem`.
+External feeds are gathered asynchronously and correlated with internal
+logs.  When suspicious patterns are found the
+`AutomatedResponseOrchestrator` queues response actions using the global
+`task_queue`.  Callback handlers may listen for these queued actions and
+respond accordingly.

--- a/security/threat_intelligence.py
+++ b/security/threat_intelligence.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Threat intelligence integration skeleton."""
+
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class ThreatIntelligenceSystem:
+    """Gather external feeds and correlate internal patterns."""
+
+    async def gather_external_feeds(self) -> List[Dict[str, Any]]:
+        """Retrieve external threat intelligence feeds."""
+        return []
+
+    async def correlate_internal_patterns(
+        self, feed_data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Correlate feed indicators with internal events."""
+        return []
+
+
+class AutomatedResponseOrchestrator:
+    """Queue automated responses based on correlations."""
+
+    def __init__(self) -> None:
+        self.queued_actions: List[asyncio.Task] = []
+
+    async def orchestrate_responses(self, correlations: List[Dict[str, Any]]) -> None:
+        """Queue response actions for each correlation."""
+        for correlation in correlations:
+            task = asyncio.create_task(self._respond(correlation))
+            self.queued_actions.append(task)
+
+    async def _respond(self, correlation: Dict[str, Any]) -> None:
+        """Placeholder response handler."""
+        logger.info("Responding to correlation: %s", correlation)
+
+
+__all__ = ["ThreatIntelligenceSystem", "AutomatedResponseOrchestrator"]

--- a/tests/security/test_threat_intelligence.py
+++ b/tests/security/test_threat_intelligence.py
@@ -1,0 +1,39 @@
+import pytest
+
+from security.threat_intelligence import (
+    ThreatIntelligenceSystem,
+    AutomatedResponseOrchestrator,
+)
+
+
+@pytest.mark.asyncio
+async def test_responses_are_queued(monkeypatch):
+    system = ThreatIntelligenceSystem()
+    orchestrator = AutomatedResponseOrchestrator()
+
+    async def fake_gather():
+        return [{"indicator": "malware"}]
+
+    async def fake_correlate(data):
+        assert data == [{"indicator": "malware"}]
+        return [{"action": "isolate"}]
+
+    monkeypatch.setattr(system, "gather_external_feeds", fake_gather)
+    monkeypatch.setattr(system, "correlate_internal_patterns", fake_correlate)
+
+    recorded = []
+
+    def fake_create_task(coro):
+        recorded.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()
+        return f"tid-{len(recorded)}"
+
+    monkeypatch.setattr("asyncio.create_task", fake_create_task)
+
+    feeds = await system.gather_external_feeds()
+    corrs = await system.correlate_internal_patterns(feeds)
+    await orchestrator.orchestrate_responses(corrs)
+
+    assert len(recorded) == len(corrs)
+    assert orchestrator.queued_actions == ["tid-1"]


### PR DESCRIPTION
## Summary
- add threat intelligence skeleton with async methods
- integrate new section in architecture docs
- test that response actions are queued

## Testing
- `pytest -q tests/security/test_threat_intelligence.py`

------
https://chatgpt.com/codex/tasks/task_e_68783355c8bc8320b7b95c68bc110dfd