### PR TITLE
Add ML threat detection engine

### DIFF
--- a/security/ml_threat_detection.py
+++ b/security/ml_threat_detection.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, List
+
+from core.security import SecurityLevel, security_auditor
+from security_callback_controller import SecurityEvent, emit_security_event
+
+logger = logging.getLogger(__name__)
+
+
+class ThreatLevel(Enum):
+    """Threat severity levels returned by the ML engine."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class SecurityThreat:
+    """Represents a detected security threat."""
+
+    threat_type: str
+    level: ThreatLevel
+    score: float
+    metadata: Dict[str, Any]
+    timestamp: datetime
+
+
+class MLSecurityEngine:
+    """Asynchronous ML-based security threat detection engine."""
+
+    def __init__(self, model: Callable[[List[Dict[str, Any]]], Awaitable[List[Dict[str, Any]]]]):
+        self.model = model
+        self.logger = logging.getLogger(__name__)
+
+    async def _extract_security_features(self, events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Extract features from raw events for model input."""
+        await asyncio.sleep(0)  # allow cooperative scheduling
+        return events
+
+    async def _run_threat_detection_model(self, features: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Run the underlying ML model to detect threats."""
+        return await self.model(features)
+
+    async def analyze_security_events(self, events: List[Dict[str, Any]]) -> List[SecurityThreat]:
+        """Analyze events, emit callbacks, and return detected threats."""
+        if not events:
+            return []
+
+        features = await self._extract_security_features(events)
+        predictions = await self._run_threat_detection_model(features)
+
+        threats: List[SecurityThreat] = []
+        for result in predictions:
+            level_str = str(result.get("level", "low"))
+            try:
+                level = ThreatLevel(level_str)
+            except ValueError:
+                level = ThreatLevel.LOW
+
+            threat = SecurityThreat(
+                threat_type=result.get("type", "unknown"),
+                level=level,
+                score=float(result.get("score", 0.0)),
+                metadata=result.get("metadata", {}),
+                timestamp=datetime.now(),
+            )
+            threats.append(threat)
+
+            # log through SecurityAuditor
+            try:
+                security_auditor.log_security_event(
+                    "ml_threat_detected",
+                    SecurityLevel[level.name],
+                    {"type": threat.threat_type, "score": threat.score},
+                )
+            except Exception:
+                self.logger.exception("Failed to log security event")
+
+            # emit unified callback
+            emit_security_event(
+                SecurityEvent.THREAT_DETECTED,
+                {"type": threat.threat_type, "level": threat.level.value},
+            )
+
+        return threats
+
+
+__all__ = ["SecurityThreat", "ThreatLevel", "MLSecurityEngine"]

--- a/tests/security/test_ml_threat_detection.py
+++ b/tests/security/test_ml_threat_detection.py
@@ -1,0 +1,37 @@
+import pytest
+
+import security.ml_threat_detection as mlt
+from security_callback_controller import SecurityEvent
+
+
+@pytest.mark.asyncio
+async def test_model_invocation_and_threat_creation(monkeypatch):
+    called = {}
+
+    async def dummy_model(features):
+        called['features'] = features
+        return [
+            {
+                'type': 'intrusion',
+                'level': 'high',
+                'score': 0.9,
+                'metadata': {'ip': '1.2.3.4'}
+            }
+        ]
+
+    engine = mlt.MLSecurityEngine(dummy_model)
+    events = [{'ip': '1.2.3.4'}]
+
+    emitted = []
+    monkeypatch.setattr(mlt, 'emit_security_event', lambda e, data=None: emitted.append((e, data)))
+    monkeypatch.setattr(mlt.security_auditor, 'log_security_event', lambda *a, **k: None)
+
+    threats = await engine.analyze_security_events(events)
+
+    assert called['features'] == events
+    assert len(threats) == 1
+    threat = threats[0]
+    assert threat.threat_type == 'intrusion'
+    assert threat.level == mlt.ThreatLevel.HIGH
+    assert threat.metadata['ip'] == '1.2.3.4'
+    assert emitted and emitted[0][0] == SecurityEvent.THREAT_DETECTED


### PR DESCRIPTION
## Summary
- add `security/ml_threat_detection.py` implementing a basic ML security engine
- emit security events and audit logs for detected threats
- add async unit test covering model invocation and threat object creation

## Testing
- `pytest tests/security/test_ml_threat_detection.py -q --cov=. --cov-report=term-missing --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68783354cb808320b5ff679356027906