### PR TITLE
Add unified UI streamlining task instructions

### DIFF
--- a/tasks/ui_streamlining.md
+++ b/tasks/ui_streamlining.md
@@ -1,0 +1,15 @@
+# Unified UI Streamlining Task
+
+- **Scope**: `components/ui`, `components/analytics`, `components/upload/ui`, `pages`, `assets/css/01-foundation/_variables.css`
+- **Goal**: Replace scattered callback patterns and hardcoded styles with modular components using consolidated callbacks and CSS tokens.
+- **Steps**:
+  1. Analyze existing UI components and callbacks to identify consolidation opportunities.
+  2. Implement `StreamlinedComponent` base class with Unicode-safe data handling.
+  3. Register all component callbacks via `TrulyUnifiedCallbacks` using a `StreamlinedCallbackManager`.
+  4. Replace inline callback definitions (e.g., in `pages/file_upload_simple.py`) with `register_callbacks` methods.
+  5. Replace hardcoded CSS values with tokens from `assets/css/01-foundation/_variables.css`.
+  6. Deduplicate common modal toggles and upload processing logic.
+  7. Provide isolated tests for each component following `tests/` patterns.
+  8. Validate callback conflicts and CSS token usage as part of CI.
+
+**Outcome**: A modular, testable, Unicode-safe UI with consolidated callback registration and consistent styling.


### PR DESCRIPTION
## Summary
- capture new unified UI tasks for consolidating callbacks and CSS tokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_687831aa7c9c8320a2d629360d9c4be8