### PR TITLE
Add intelligent cache warmer

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,6 +10,7 @@ from .advanced_cache import (
 from .advanced_query_optimizer import AdvancedQueryOptimizer
 from .cpu_optimizer import CPUOptimizer
 from .hierarchical_cache_manager import HierarchicalCacheManager
+from .cache_warmer import IntelligentCacheWarmer
 from .memory_manager import MemoryManager
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
 
@@ -28,6 +29,7 @@ __all__ = [
     "create_advanced_cache_manager",
     "AdvancedQueryOptimizer",
     "HierarchicalCacheManager",
+    "IntelligentCacheWarmer",
     "MemoryManager",
     "CPUOptimizer",
 ]

--- a/core/cache_warmer.py
+++ b/core/cache_warmer.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Utilities for predictive cache warming."""
+
+import asyncio
+from collections import Counter
+from typing import Callable, Iterable, Any, List
+
+from .hierarchical_cache_manager import HierarchicalCacheManager
+
+
+class UsagePatternAnalyzer:
+    """Analyze access patterns to predict frequently used keys."""
+
+    def __init__(self) -> None:
+        self._counter: Counter[str] = Counter()
+
+    def record(self, key: str) -> None:
+        """Record cache access for *key*."""
+        self._counter[key] += 1
+
+    def top_keys(self, limit: int = 5) -> List[str]:
+        """Return the most frequently used keys."""
+        return [k for k, _ in self._counter.most_common(limit)]
+
+
+class IntelligentCacheWarmer:
+    """Warm hierarchical caches based on usage predictions."""
+
+    def __init__(
+        self,
+        cache: HierarchicalCacheManager,
+        loader: Callable[[str], Any],
+        analyzer: UsagePatternAnalyzer | None = None,
+    ) -> None:
+        self.cache = cache
+        self.loader = loader
+        self.analyzer = analyzer or UsagePatternAnalyzer()
+
+    def record_usage(self, key: str) -> None:
+        """Record that *key* was accessed."""
+        self.analyzer.record(key)
+
+    async def warm(self, limit: int = 5) -> None:
+        """Asynchronously prefill caches for the most used keys."""
+        keys = self.analyzer.top_keys(limit)
+        if not keys:
+            return
+
+        loop = asyncio.get_event_loop()
+
+        async def _load(key: str) -> None:
+            if self.cache.get(key) is None:
+                value = await loop.run_in_executor(None, self.loader, key)
+                self.cache.set(key, value, level=1)
+                self.cache.set(key, value, level=2)
+
+        await asyncio.gather(*(_load(k) for k in keys))
+
+
+__all__ = ["UsagePatternAnalyzer", "IntelligentCacheWarmer"]

--- a/core/service_container.py
+++ b/core/service_container.py
@@ -262,6 +262,25 @@ class ServiceContainer:
         return status
 
     # ------------------------------------------------------------------
+    def warm_caches(self) -> None:
+        """Trigger cache warming if a cache warmer service is registered."""
+        if not self.has("cache_warmer"):
+            return
+
+        warmer = self.get("cache_warmer")
+        if not hasattr(warmer, "warm"):
+            return
+
+        try:
+            import asyncio
+
+            asyncio.run(warmer.warm())
+        except RuntimeError:  # event loop already running
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(warmer.warm())
+            loop.close()
+
+    # ------------------------------------------------------------------
     def validate_registrations(self) -> Dict[str, List[str]]:
         results = {
             "valid": [],

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -1,0 +1,23 @@
+import asyncio
+from core.cache_warmer import IntelligentCacheWarmer, UsagePatternAnalyzer
+from core.hierarchical_cache_manager import HierarchicalCacheManager
+
+
+def _loader(key: str) -> str:
+    return f"value-{key}"
+
+
+def test_predicted_keys_cached(async_runner):
+    cache = HierarchicalCacheManager()
+    warmer = IntelligentCacheWarmer(cache, _loader)
+
+    # record some usage patterns
+    warmer.record_usage("a")
+    warmer.record_usage("b")
+    warmer.record_usage("a")
+
+    async_runner(warmer.warm())
+
+    assert cache.get("a") == "value-a"
+    assert cache.get("b") == "value-b"
+


### PR DESCRIPTION
## Summary
- introduce an asynchronous cache warmer
- hook warmer into the service container
- expose new helper from core
- test that predicted keys are pre-cached

## Testing
- `pytest -q tests/test_cache_warmer.py`

------
https://chatgpt.com/codex/tasks/task_e_687838b360848320a026ad13f05d29da