### PR TITLE
Implement intelligent multi-level cache

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -188,6 +188,7 @@ class CacheConfig:
     key_prefix: str = "yosai:"
     compression_enabled: bool = False
     max_memory_mb: int = 100
+    disk_path: str = "/tmp/yosai_cache"
 
 
 @dataclass

--- a/config/cache_manager.py
+++ b/config/cache_manager.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from .constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
+from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 
 
 @dataclass
@@ -15,6 +16,7 @@ class CacheConfig:
     type: str = "memory"
     host: str = DEFAULT_CACHE_HOST
     port: int = DEFAULT_CACHE_PORT
+    disk_path: str = "/tmp/yosai_cache"
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,7 @@ def from_environment() -> CacheConfig:
         type=os.getenv("CACHE_TYPE", "memory"),
         host=os.getenv("CACHE_HOST", DEFAULT_CACHE_HOST),
         port=int(os.getenv("CACHE_PORT", DEFAULT_CACHE_PORT)),
+        disk_path=os.getenv("CACHE_DISK_PATH", "/tmp/yosai_cache"),
     )
 
 
@@ -84,12 +87,15 @@ def get_cache_manager() -> Any:
     cfg = from_environment()
     if cfg.type == "redis":
         return RedisCacheManager(cfg)
+    if cfg.type == "intelligent":
+        return IntelligentMultiLevelCache(cfg)
     return MemoryCacheManager(cfg)
 
 
 __all__ = [
     "MemoryCacheManager",
     "RedisCacheManager",
+    "IntelligentMultiLevelCache",
     "CacheConfig",
     "from_environment",
     "get_cache_manager",

--- a/config/complete_service_registration.py
+++ b/config/complete_service_registration.py
@@ -93,6 +93,13 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=StorageProtocol,
     )
 
+    from config.cache_manager import get_cache_manager
+
+    container.register_singleton(
+        "cache_manager",
+        get_cache_manager(),
+    )
+
 
 def register_analytics_services(container: ServiceContainer) -> None:
     class SimpleAnalyticsService:

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,6 +7,10 @@ from .advanced_cache import (
     cache_with_lock,
     create_advanced_cache_manager,
 )
+from .intelligent_multilevel_cache import (
+    IntelligentMultiLevelCache,
+    create_intelligent_cache_manager,
+)
 from .advanced_query_optimizer import AdvancedQueryOptimizer
 from .cpu_optimizer import CPUOptimizer
 from .hierarchical_cache_manager import HierarchicalCacheManager
@@ -30,4 +34,6 @@ __all__ = [
     "HierarchicalCacheManager",
     "MemoryManager",
     "CPUOptimizer",
+    "IntelligentMultiLevelCache",
+    "create_intelligent_cache_manager",
 ]

--- a/core/intelligent_multilevel_cache.py
+++ b/core/intelligent_multilevel_cache.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""Async multi-level cache with memory, Redis and disk layers."""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import redis.asyncio as redis
+
+from config.base import CacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+class CacheLevel(Enum):
+    """Cache storage tiers."""
+
+    L1 = "memory"
+    L2 = "redis"
+    L3 = "disk"
+
+
+@dataclass
+class CacheEntry:
+    """Value stored in cache."""
+
+    value: Any
+    expiry: Optional[float]
+    level: CacheLevel
+
+
+class IntelligentMultiLevelCache:
+    """Coordinate L1 memory, L2 Redis and L3 disk caches."""
+
+    def __init__(self, cache_config: CacheConfig) -> None:
+        self.config = cache_config
+        self.key_prefix = getattr(cache_config, "key_prefix", "yosai:")
+        self.default_ttl = getattr(cache_config, "timeout_seconds", 300)
+        self.disk_path = Path(getattr(cache_config, "disk_path", "/tmp/yosai_cache"))
+        self.memory_limit = 1000
+        self._redis: Optional[redis.Redis] = None
+        self._memory: Dict[str, CacheEntry] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    async def start(self) -> None:
+        """Create Redis connection and ensure disk directory exists."""
+        self.disk_path.mkdir(parents=True, exist_ok=True)
+        if self._redis is None:
+            self._redis = redis.Redis(
+                host=getattr(self.config, "host", "localhost"),
+                port=getattr(self.config, "port", 6379),
+                db=getattr(self.config, "database", 0),
+            )
+        try:
+            await self._redis.ping()
+            logger.info("Intelligent cache connected to Redis")
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Redis unavailable: %s", exc)
+            self._redis = None
+
+    # ------------------------------------------------------------------
+    async def stop(self) -> None:
+        """Close Redis connection and clear memory."""
+        if self._redis is not None:
+            try:
+                await self._redis.close()
+            finally:
+                self._redis = None
+        self._memory.clear()
+        self._locks.clear()
+
+    # ------------------------------------------------------------------
+    def _full_key(self, key: str) -> str:
+        return f"{self.key_prefix}{key}"
+
+    # ------------------------------------------------------------------
+    def _record_memory(self, key: str, value: Any, expiry: Optional[float]) -> None:
+        self._memory[key] = CacheEntry(value=value, expiry=expiry, level=CacheLevel.L1)
+        if len(self._memory) > self.memory_limit:
+            oldest = min(self._memory, key=lambda k: self._memory[k].expiry or 0)
+            del self._memory[oldest]
+
+    # ------------------------------------------------------------------
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store value in all cache layers."""
+        expire = ttl if ttl is not None else self.default_ttl
+        expiry = time.time() + expire if expire else None
+        self._record_memory(key, value, expiry)
+        data = json.dumps({"value": value, "expiry": expiry}).encode("utf-8")
+        if self._redis is not None:
+            try:
+                if expire:
+                    await self._redis.setex(self._full_key(key), expire, data)
+                else:
+                    await self._redis.set(self._full_key(key), data)
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis SET failed for %s: %s", key, exc)
+        try:
+            (self.disk_path / f"{self._full_key(key)}.json").write_bytes(data)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("Disk write failed for %s: %s", key, exc)
+
+    # ------------------------------------------------------------------
+    async def get(
+        self,
+        key: str,
+        loader: Optional[Callable[[], Awaitable[Any]]] = None,
+        ttl: Optional[int] = None,
+    ) -> Optional[Any]:
+        """Retrieve value from caches, optionally using loader."""
+        now = time.time()
+        entry = self._memory.get(key)
+        if entry:
+            if entry.expiry and now > entry.expiry:
+                del self._memory[key]
+            else:
+                return entry.value
+
+        if self._redis is not None:
+            try:
+                raw = await self._redis.get(self._full_key(key))
+                if raw:
+                    obj = json.loads(raw.decode("utf-8"))
+                    expiry = obj.get("expiry")
+                    if expiry and now > expiry:
+                        await self._redis.delete(self._full_key(key))
+                    else:
+                        self._record_memory(key, obj["value"], expiry)
+                        return obj["value"]
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Redis GET failed for %s: %s", key, exc)
+
+        file = self.disk_path / f"{self._full_key(key)}.json"
+        if file.exists():
+            try:
+                obj = json.loads(file.read_text())
+                expiry = obj.get("expiry")
+                if expiry and now > expiry:
+                    file.unlink(missing_ok=True)
+                else:
+                    await self.set(key, obj["value"], ttl=int(expiry - now) if expiry else ttl)
+                    return obj["value"]
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Disk read failed for %s: %s", key, exc)
+
+        if loader:
+            value = await loader()
+            await self.set(key, value, ttl)
+            return value
+        return None
+
+    # ------------------------------------------------------------------
+    def get_lock(self, key: str, timeout: int = 10):
+        if self._redis is not None:
+            return self._redis.lock(self._full_key(f"lock:{key}"), timeout=timeout)
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+    # ------------------------------------------------------------------
+    def report(self) -> Dict[str, Any]:
+        """Return simple cache statistics."""
+        disk_entries = len(list(self.disk_path.glob("*.json")))
+        return {
+            "memory_entries": len(self._memory),
+            "disk_entries": disk_entries,
+            "redis_enabled": self._redis is not None,
+        }
+
+
+async def create_intelligent_cache_manager() -> IntelligentMultiLevelCache:
+    """Initialize cache manager from configuration."""
+    from config.config import get_cache_config
+
+    cfg = get_cache_config()
+    manager = IntelligentMultiLevelCache(cfg)
+    await manager.start()
+    return manager
+
+
+__all__ = [
+    "IntelligentMultiLevelCache",
+    "CacheLevel",
+    "CacheEntry",
+    "create_intelligent_cache_manager",
+]

--- a/core/plugins/config/factories.py
+++ b/core/plugins/config/factories.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Callable, Dict, List, Type
 
 from .interfaces import ICacheManager, IDatabaseManager
+from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ class CacheManagerFactory:
                     "memory": MemoryCacheManager,
                     "redis": RedisCacheManager,
                     "advanced_redis": AdvancedRedisCacheManager,
+                    "intelligent": IntelligentMultiLevelCache,
                 }
             )
 

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -105,6 +105,11 @@ Caching is handled by `MemoryCacheManager` or `RedisCacheManager` from
 `config.cache_manager`. Set `CACHE_TYPE=redis` and specify `CACHE_HOST` and
 `CACHE_PORT` to store results in Redis.
 
+The `IntelligentMultiLevelCache` combines memory, Redis and disk. Enable it with
+`CACHE_TYPE=intelligent` and optionally set `CACHE_DISK_PATH` for the on-disk
+layer. The manager promotes entries between levels automatically and exposes a
+`report()` method for basic statistics.
+
 ```python
 from config.cache_manager import get_cache_manager
 

--- a/tests/test_intelligent_multilevel_cache.py
+++ b/tests/test_intelligent_multilevel_cache.py
@@ -1,0 +1,42 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
+from config.base import CacheConfig
+
+
+@pytest.mark.asyncio
+async def test_disk_promotion(tmp_path: Path):
+    cfg = CacheConfig(timeout_seconds=10, disk_path=str(tmp_path))
+    cache = IntelligentMultiLevelCache(cfg)
+    await cache.start()
+    await cache.set("a", "b")
+    cache._memory.clear()
+    assert await cache.get("a") == "b"
+    assert "a" in cache._memory
+    await cache.stop()
+
+
+@pytest.mark.asyncio
+async def test_expiration(tmp_path: Path):
+    cfg = CacheConfig(timeout_seconds=1, disk_path=str(tmp_path))
+    cache = IntelligentMultiLevelCache(cfg)
+    await cache.start()
+    await cache.set("k", "v", ttl=1)
+    await asyncio.sleep(1.1)
+    assert await cache.get("k") is None
+    await cache.stop()
+
+
+@pytest.mark.asyncio
+async def test_cache_report(tmp_path: Path):
+    cfg = CacheConfig(timeout_seconds=10, disk_path=str(tmp_path))
+    cache = IntelligentMultiLevelCache(cfg)
+    await cache.start()
+    await cache.set("r", 1)
+    report = cache.report()
+    assert report["memory_entries"] == 1
+    assert report["disk_entries"] == 1
+    await cache.stop()


### PR DESCRIPTION
## Summary
- add IntelligentMultiLevelCache with memory/redis/disk tiers
- expose create_intelligent_cache_manager and export via core
- support CACHE_DISK_PATH and new cache type in config loader
- register cache manager in service container
- document usage in performance monitoring docs
- add basic unit tests for promotion and expiration

## Testing
- `pytest tests/test_intelligent_multilevel_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687838b5e81483209fbfb4d3c806e775