### PR TITLE
Remove duplicate base64 import

### DIFF
--- a/services/upload/core/validator.py
+++ b/services/upload/core/validator.py
@@ -1,5 +1,4 @@
 import base64
-import base64
 import json
 from typing import Any, Callable, Iterable, List, Mapping
 
@@ -33,8 +32,7 @@ class ClientSideValidator(UploadValidatorProtocol):
         self.magic_numbers: dict[str, List[bytes]] = {}
         for ext, vals in (magic_numbers or {}).items():
             self.magic_numbers[ext.lower()] = [
-                v if isinstance(v, bytes) else bytes.fromhex(v)
-                for v in vals
+                v if isinstance(v, bytes) else bytes.fromhex(v) for v in vals
             ]
         self.track_duplicates = track_duplicates
         self.hooks = list(hooks or [])
@@ -103,8 +101,7 @@ class ClientSideValidator(UploadValidatorProtocol):
                 "max_size": self.max_size,
                 "size_limits": self.size_limits,
                 "magic_numbers": {
-                    k: [m.hex() for m in v]
-                    for k, v in self.magic_numbers.items()
+                    k: [m.hex() for m in v] for k, v in self.magic_numbers.items()
                 },
                 "track_duplicates": self.track_duplicates,
             }


### PR DESCRIPTION
## Summary
- clean up duplicate import statement in validator

## Testing
- `pre-commit run --files services/upload/core/validator.py --hook-stage commit` *(fails: bandit/mypy)*
- `pytest tests/test_upload_protocols.py::test_validator_implements_protocol -q` *(fails: missing heavy optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687840bb8d08832093fc57206c99226f