### PR TITLE
Fix secrets validator export

### DIFF
--- a/core/secrets_validator.py
+++ b/core/secrets_validator.py
@@ -67,6 +67,14 @@ def validate_all_secrets(manager: Optional[SecretsManager] = None) -> Dict[str, 
     return validator.validate_all_secrets()
 
 
+def validate_production_secrets(
+    manager: Optional[SecretsManager] = None,
+) -> list[str]:
+    """Convenience wrapper for :meth:`SecretsValidator.validate_production_secrets`."""
+    validator = SecretsValidator(manager)
+    return validator.validate_production_secrets()
+
+
 __all__ = [
     "SecretsValidator",
     "validate_all_secrets",

--- a/tests/test_core_secrets_validator_import.py
+++ b/tests/test_core_secrets_validator_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_validate_production_secrets_importable():
+    module = importlib.import_module("core.secrets_validator")
+    assert hasattr(module, "validate_production_secrets")


### PR DESCRIPTION
## Summary
- add a convenience function `validate_production_secrets` in `core.secrets_validator`
- expose the helper for easy import in tests
- test that `validate_production_secrets` can be imported

## Testing
- `pytest tests/test_core_secrets_validator_import.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878475c2e748320a7c873340277332d