### PR TITLE
Implement create_manager helper

### DIFF
--- a/analytics_core/__init__.py
+++ b/analytics_core/__init__.py
@@ -1,6 +1,37 @@
-"""Central analytics utilities and services."""
+"""Central analytics utilities and convenience helpers.
 
-# from .centralized_analytics_manager import CentralizedAnalyticsManager  # Circular import - import locally when needed
+This module exposes :func:`create_manager` which instantiates a
+``CentralizedAnalyticsManager`` wired with the default stub services used
+throughout the tests and documentation.
+"""
 
-__all__ = ["CentralizedAnalyticsManager"]
+# ``CentralizedAnalyticsManager`` is imported lazily inside ``create_manager`` to
+# avoid circular imports when ``analytics_core`` is imported from submodules.
+
+__all__ = ["CentralizedAnalyticsManager", "create_manager"]
+
+
+def create_manager():
+    """Create a :class:`CentralizedAnalyticsManager` with default services.
+
+    Services are imported within the function body so that importing this module
+    does not trigger any heavy imports or circular dependencies.
+    """
+
+    # Local imports to prevent circular dependencies
+    from .centralized_analytics_manager import CentralizedAnalyticsManager
+    from .services import (
+        CoreAnalyticsService,
+        AIAnalyticsService,
+        PerformanceAnalyticsService,
+        DataProcessingService,
+    )
+
+    return CentralizedAnalyticsManager(
+        core_service=CoreAnalyticsService(),
+        ai_service=AIAnalyticsService(),
+        performance_service=PerformanceAnalyticsService(),
+        data_service=DataProcessingService(),
+    )
+
 

--- a/docs/analytics_service.md
+++ b/docs/analytics_service.md
@@ -7,18 +7,10 @@ services while exposing a single entry point for triggering analytics flows.
 ## Example Usage
 
 ```python
-from analytics_core.centralized_analytics_manager import CentralizedAnalyticsManager
-from analytics_core.services.core_service import CoreAnalyticsService
-from analytics_core.services.ai_service import AIAnalyticsService
-from analytics_core.services.performance_service import PerformanceAnalyticsService
-from analytics_core.services.data_processing_service import DataProcessingService
+from analytics_core import create_manager
 
-manager = CentralizedAnalyticsManager(
-    core_service=CoreAnalyticsService(),
-    ai_service=AIAnalyticsService(),
-    performance_service=PerformanceAnalyticsService(),
-    data_service=DataProcessingService(),
-)
+# Build a manager with the default stub services
+manager = create_manager()
 
 manager.run_full_pipeline(raw_data)
 ```

--- a/tests/docs/test_documentation_examples.py
+++ b/tests/docs/test_documentation_examples.py
@@ -1,10 +1,4 @@
-from analytics_core.centralized_analytics_manager import (
-    CentralizedAnalyticsManager,
-)
-from analytics_core.services.ai_service import AIAnalyticsService
-from analytics_core.services.core_service import CoreAnalyticsService
-from analytics_core.services.data_processing_service import DataProcessingService
-from analytics_core.services.performance_service import PerformanceAnalyticsService
+from analytics_core import create_manager
 from core.service_container import ServiceContainer
 
 
@@ -21,10 +15,5 @@ def test_service_container_example():
 
 
 def test_centralized_analytics_manager_example():
-    manager = CentralizedAnalyticsManager(
-        core_service=CoreAnalyticsService(),
-        ai_service=AIAnalyticsService(),
-        performance_service=PerformanceAnalyticsService(),
-        data_service=DataProcessingService(),
-    )
+    manager = create_manager()
     manager.run_full_pipeline({"sample": 123})


### PR DESCRIPTION
## Summary
- expose create_manager in analytics_core and wire up default services
- update documentation to showcase new helper
- adjust doc-based tests to use create_manager

## Testing
- `pytest tests/analytics_core/test_manager_import.py -q`
- `pytest tests/docs/test_documentation_examples.py -q`
- `pytest -q tests/analytics_core/test_manager_import.py tests/docs/test_documentation_examples.py`

------
https://chatgpt.com/codex/tasks/task_e_6878475d5cb8832088806d3e29e2a530