### PR TITLE
Fix README server protocol note

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,9 @@ with this Python release and newer.
    uwsgi --module wsgi:server
    ```
 8. **Access the dashboard:**
-   Open http://127.0.0.1:8050 in your browser. The application runs over
-   plain HTTP by default; configure a reverse proxy with TLS if you need HTTPS.
-   The development server does not support HTTPS, so be sure to visit
-   `http://<host>:<port>` rather than `https://` when testing locally.
-   Using an HTTPS URL will produce "Bad request version" errors because the
-   built-in server is not configured for TLS.
+   Open http://127.0.0.1:8050 in your browser.
+   The server runs over HTTP by default but will automatically serve HTTPS
+   whenever certificates are available.
 
 ## Developer Onboarding
 


### PR DESCRIPTION
## Summary
- update docs to clarify automatic HTTPS usage

## Testing
- `black --check README.md` *(fails: cannot parse)*
- `flake8 README.md` *(fails: SyntaxError)*
- `mypy README.md`
- `pytest -k 'nonexistent' -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6878478009808320a21c01f643deb093