### PR TITLE
Fix rapidfuzz dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,5 @@ cryptography>=45.0.0
 kafka-python>=2.0.2
 pulsar-client>=3.2.0
 dask[distributed]==2024.4.1
+rapidfuzz>=3.0.0
 


### PR DESCRIPTION
## Summary
- include `rapidfuzz` in `requirements.txt`

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68784a290c7c83208a58b9418ad69b06