### PR TITLE
Fix process_file_simple import

### DIFF
--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -18,6 +18,7 @@ from core.unicode import safe_format_number
 from core.performance_file_processor import PerformanceFileProcessor
 from core.unicode_decode import safe_unicode_decode
 from analytics_core.utils.unicode_processor import UnicodeHelper
+from .file_handler import process_file_simple
 
 # Core processing imports only - NO UI COMPONENTS
 
@@ -218,6 +219,7 @@ FileProcessor = UnicodeFileProcessor
 __all__ = [
     "UnicodeFileProcessor",
     "FileProcessor",
+    "process_file_simple",
     "process_uploaded_file",
     "create_file_preview",
 ]


### PR DESCRIPTION
## Summary
- re-export `process_file_simple` from `services.data_processing.file_processor`

## Testing
- `pytest tests/test_unicode_handler_full.py::TestPublicAPI::test_process_file_simple_function -q`


------
https://chatgpt.com/codex/tasks/task_e_68784a2a6f848320a5174e275902fe7c