### PR TITLE
Rename secrets_manager module

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,28 +17,29 @@ except ImportError:
     )
     sys.exit(1)
 
-from core.exceptions import ConfigurationError
-from utils import debug_dash_asset_serving
-from core.unicode import unicode_safe_callback
-
+# Add Unicode handling
+import locale
 import traceback
 from pathlib import Path
 
 from config import ConfigLoader
+from core.exceptions import ConfigurationError
+from core.unicode import unicode_safe_callback
+from utils import debug_dash_asset_serving
 
 # This import is handled inside the main() function now
 
-# Add Unicode handling
-import locale
+
 try:
-    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 except locale.Error:
     try:
-        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+        locale.setlocale(locale.LC_ALL, "C.UTF-8")
     except locale.Error:
         pass  # Fall back to default locale
 
 logger = logging.getLogger(__name__)
+
 
 # Environment / location check
 def ensure_venv() -> None:
@@ -50,9 +51,10 @@ def ensure_venv() -> None:
         print("\u274c Wrong directory! Navigate to project root.")
         sys.exit(1)
 
-    if not os.environ.get('VIRTUAL_ENV'):
+    if not os.environ.get("VIRTUAL_ENV"):
         print("\u26a0\ufe0f Virtual environment not activated!")
         print("Run: source venv/bin/activate")
+
 
 # Consolidated learning service utilities
 from services.consolidated_learning_service import get_learning_service
@@ -149,10 +151,10 @@ def _consolidate_callbacks(app):
     try:
         # Import callback modules with error handling
         callback_modules = [
-            ('pages.deep_analytics_complex', 'register_callbacks'),
-            ('pages.file_upload', 'register_callbacks'),
-            ('pages.export', 'register_callbacks'),
-            ('pages.settings', 'register_callbacks'),
+            ("pages.deep_analytics_complex", "register_callbacks"),
+            ("pages.file_upload", "register_callbacks"),
+            ("pages.export", "register_callbacks"),
+            ("pages.settings", "register_callbacks"),
         ]
 
         for module_name, func_name in callback_modules:
@@ -184,6 +186,7 @@ def _load_config():
     """Load application configuration and return the app config."""
     load_dotenv()
     from config.dev_mode import setup_dev_mode
+
     setup_dev_mode()
 
     loader = ConfigLoader()
@@ -201,7 +204,7 @@ def _load_config():
 
 def _validate_secrets(app_config):
     """Validate application secrets for the given environment."""
-    from core.secrets_manager import SecretsManager
+    from core.secret_manager import SecretsManager
     from security.secrets_validator import SecretsValidator
 
     secrets_manager = SecretsManager()
@@ -263,6 +266,7 @@ def _run_server(app, ssl_context):
         logger.error(f"❌ Application runtime error: {e}")
         raise
 
+
 def main():
     """Main application entry point."""
     try:
@@ -275,9 +279,13 @@ def main():
         print_startup_info(app_config)
 
         cwd = os.getcwd()
-        icon_path = os.path.normcase(os.path.join(cwd, "assets", "navbar_icons", "analytics.png"))
+        icon_path = os.path.normcase(
+            os.path.join(cwd, "assets", "navbar_icons", "analytics.png")
+        )
         logger.info("Current working directory: %s", cwd)
-        logger.info("Analytics icon exists (%s): %s", icon_path, os.path.exists(icon_path))
+        logger.info(
+            "Analytics icon exists (%s): %s", icon_path, os.path.exists(icon_path)
+        )
 
         ssl_context = ensure_https_certificates()
 
@@ -292,7 +300,6 @@ def main():
         logger.info(f"\n❌ Unexpected Error: {e}")
         logger.info("💡 Check logs for more details")
         sys.exit(1)
-
 
 
 if __name__ == "__main__":

--- a/core/app_factory/health.py
+++ b/core/app_factory/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.secrets_manager import validate_secrets
+from core.secret_manager import validate_secrets
 
 
 def register_health_endpoints(server: Any, progress_events: Any | None = None) -> None:

--- a/core/auth.py
+++ b/core/auth.py
@@ -8,7 +8,6 @@ import os
 import socket
 import time
 from datetime import timedelta
-
 from functools import wraps
 from typing import List, Optional
 from urllib.error import URLError
@@ -25,8 +24,9 @@ from flask_login import (
 )
 from jose import jwt
 
-from .secrets_manager import SecretsManager
 from config import get_security_config
+
+from .secret_manager import SecretsManager
 
 auth_bp = Blueprint("auth", __name__)
 login_manager = LoginManager()

--- a/core/secret_manager.py
+++ b/core/secret_manager.py
@@ -92,4 +92,7 @@ def validate_secrets(manager: Optional[SecretsManager] = None) -> dict[str, Any]
     return summary
 
 
-__all__ = ["SecretMetadata", "SecretsManager", "validate_secrets"]
+# Backwards compatibility alias
+SecretManager = SecretsManager
+
+__all__ = ["SecretMetadata", "SecretsManager", "SecretManager", "validate_secrets"]

--- a/core/secrets_validator.py
+++ b/core/secrets_validator.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 from core.exceptions import ConfigurationError
 
-from .secrets_manager import SecretsManager
+from .secret_manager import SecretsManager
 
 
 class SecretsValidator:

--- a/security/secrets_validator.py
+++ b/security/secrets_validator.py
@@ -1,16 +1,14 @@
 import math
 import re
 from collections import Counter
-from typing import Dict, List, Optional, cast
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from core.flask_protocol import FlaskProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - optional Flask dependency
     from flask import Flask
 
-from core.secrets_manager import SecretsManager
+from core.secret_manager import SecretsManager
 
 
 class SecretsValidator:

--- a/tests/security/test_secrets_validator.py
+++ b/tests/security/test_secrets_validator.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from flask import Flask
 
-from core.secrets_manager import SecretsManager
+from core.secret_manager import SecretsManager
 from security.secrets_validator import SecretsValidator, register_health_endpoint
 
 

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -1,7 +1,9 @@
 import types
+
 import pytest
 
 import app
+
 
 class DummyAppConfig:
     host = "127.0.0.1"
@@ -9,15 +11,21 @@ class DummyAppConfig:
     debug = False
     environment = "development"
 
+
 class DummyConfig:
     def get_app_config(self):
         return DummyAppConfig()
 
+
 def test_load_config(monkeypatch):
     calls = {}
-    monkeypatch.setattr(app, "verify_dependencies", lambda: calls.setdefault("deps", True))
+    monkeypatch.setattr(
+        app, "verify_dependencies", lambda: calls.setdefault("deps", True)
+    )
     monkeypatch.setattr(app, "load_dotenv", lambda: calls.setdefault("dotenv", True))
-    monkeypatch.setattr("config.dev_mode.setup_dev_mode", lambda: calls.setdefault("setup", True))
+    monkeypatch.setattr(
+        "config.dev_mode.setup_dev_mode", lambda: calls.setdefault("setup", True)
+    )
 
     class Loader:
         def load(self):
@@ -40,11 +48,14 @@ def test_validate_secrets_production_failure(monkeypatch):
     class DummyValidator:
         def __init__(self, manager=None):
             pass
+
         def validate_secret(self, secret, environment="production"):
             return {"errors": ["bad"]}
 
-    monkeypatch.setattr("core.secrets_manager.SecretsManager", lambda: DummyManager())
-    monkeypatch.setattr("security.secrets_validator.SecretsValidator", lambda m=None: DummyValidator())
+    monkeypatch.setattr("core.secret_manager.SecretsManager", lambda: DummyManager())
+    monkeypatch.setattr(
+        "security.secrets_validator.SecretsValidator", lambda m=None: DummyValidator()
+    )
 
     cfg = types.SimpleNamespace(environment="production")
     with pytest.raises(app.ConfigurationError):
@@ -59,11 +70,14 @@ def test_validate_secrets_non_production(monkeypatch):
     class DummyValidator:
         def __init__(self, manager=None):
             pass
+
         def validate_secret(self, secret, environment="production"):
             return {"errors": []}
 
-    monkeypatch.setattr("core.secrets_manager.SecretsManager", lambda: DummyManager())
-    monkeypatch.setattr("security.secrets_validator.SecretsValidator", lambda m=None: DummyValidator())
+    monkeypatch.setattr("core.secret_manager.SecretsManager", lambda: DummyManager())
+    monkeypatch.setattr(
+        "security.secrets_validator.SecretsValidator", lambda m=None: DummyValidator()
+    )
 
     cfg = types.SimpleNamespace(environment="development")
     app._validate_secrets(cfg)
@@ -74,12 +88,19 @@ def test_create_app(monkeypatch):
         pass
 
     captured = {}
-    monkeypatch.setattr("core.app_factory.create_app", lambda mode, assets_folder: DummyApp())
+    monkeypatch.setattr(
+        "core.app_factory.create_app", lambda mode, assets_folder: DummyApp()
+    )
+
     class DummyMCS:
         def __init__(self, app):
             captured["manager"] = app
+
     monkeypatch.setattr("core.master_callback_system.MasterCallbackSystem", DummyMCS)
-    monkeypatch.setattr("pages.register_all_pages", lambda app, manager: captured.setdefault("pages", True))
+    monkeypatch.setattr(
+        "pages.register_all_pages",
+        lambda app, manager: captured.setdefault("pages", True),
+    )
     monkeypatch.setattr(app, "debug_dash_asset_serving", lambda a: True)
 
     app_obj = app._create_app()
@@ -91,8 +112,14 @@ def test_run_server(monkeypatch):
     class DummyApp:
         def __init__(self):
             self.params = {}
+
         def run(self, host, port, debug, ssl_context=None):
-            self.params = {"host": host, "port": port, "debug": debug, "ssl": ssl_context}
+            self.params = {
+                "host": host,
+                "port": port,
+                "debug": debug,
+                "ssl": ssl_context,
+            }
 
     dummy = DummyApp()
     monkeypatch.setattr("config.get_config", lambda: DummyConfig())

--- a/tests/test_secret_manager.py
+++ b/tests/test_secret_manager.py
@@ -1,5 +1,5 @@
-import os
 import builtins
+import os
 import types
 
 import pytest

--- a/tests/test_secrets_integration.py
+++ b/tests/test_secrets_integration.py
@@ -1,4 +1,4 @@
-from core.secrets_manager import SecretsManager
+from core.secret_manager import SecretsManager
 
 
 def test_env_overrides_docker(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- rename core/secrets_manager.py to core/secret_manager.py
- update imports for the new module name
- expose `SecretManager` alias for backwards compatibility

## Testing
- `black --check core/secret_manager.py core/app_factory/health.py core/auth.py core/secrets_validator.py security/secrets_validator.py tests/security/test_secrets_validator.py tests/test_app_helpers.py tests/test_secret_manager.py tests/test_secrets_integration.py app.py`
- `isort --check core/secret_manager.py core/app_factory/health.py core/auth.py core/secrets_validator.py security/secrets_validator.py tests/security/test_secrets_validator.py tests/test_app_helpers.py tests/test_secret_manager.py tests/test_secrets_integration.py app.py`
- `pytest tests/test_secret_manager.py::test_get_env_secret -q`


------
https://chatgpt.com/codex/tasks/task_e_68784a2da0b08320ab1a2ea6c82e7cc2