### PR TITLE
Fix unicode upload test encoding function

### DIFF
--- a/tests/integration/test_unicode_upload_endpoint.py
+++ b/tests/integration/test_unicode_upload_endpoint.py
@@ -14,7 +14,7 @@ def test_upload_dataframe_sanitization():
 def test_non_ascii_filename_persistence(fake_upload_storage):
     df = pd.DataFrame({"a": [1]})
     filename = "данные\ud83d.csv"
-    safe_name = safe_encode_text(filename)
+    safe_name = safe_unicode_encode(filename)
 
     store = fake_upload_storage
     store.add_file(safe_name, df)


### PR DESCRIPTION
## Summary
- update unicode upload integration test to use `safe_unicode_encode`

## Testing
- `pytest tests/integration/test_unicode_upload_endpoint.py::test_non_ascii_filename_persistence -q`

------
https://chatgpt.com/codex/tasks/task_e_687856ca9f00832093e78d0363670d65