### PR TITLE
Add API adapter and TypeScript client

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+"""Complete API adapter bridging React frontend with Python services."""
+
+import asyncio
+import base64
+import logging
+import uuid
+from datetime import datetime
+from functools import wraps
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify, request
+from flask_cors import cross_origin
+from flask_socketio import SocketIO, emit, join_room
+
+from core.security_validator import SecurityValidator
+from core.unicode import UnicodeProcessor
+from services.analytics_service import get_analytics_service
+from services.upload.core.processor import UploadProcessingService
+from utils.upload_store import uploaded_data_store
+
+logger = logging.getLogger(__name__)
+
+# API Blueprint
+api_bp = Blueprint("api", __name__, url_prefix="/api/v1")
+
+# SocketIO instance
+socketio = SocketIO(
+    cors_allowed_origins="*",
+    async_mode="threading",
+    logger=True,
+    engineio_logger=True,
+)
+
+
+class APIAdapter:
+    """Complete API adapter bridging React frontend with Python services."""
+
+    def __init__(self) -> None:
+        self.validator = SecurityValidator()
+        self.unicode_processor = UnicodeProcessor()
+        self.analytics_service = None
+        self.upload_service = None
+        self.container = None
+        self._active_tasks: Dict[str, Dict[str, Any]] = {}
+
+    def initialize(self, app: Any, container: Any) -> None:
+        """Initialize services from app container"""
+        self.container = container
+
+        try:
+            self.analytics_service = container.get("analytics_service")
+            self.upload_service = container.get("upload_service")
+
+            if not self.upload_service:
+                self.upload_service = UploadProcessingService()
+
+            logger.info("API Adapter initialized successfully")
+        except Exception as e:
+            logger.error(f"Failed to initialize API adapter: {e}")
+            raise
+
+
+# Initialize adapter
+api_adapter = APIAdapter()
+
+
+# Error handler decorator
+
+
+def handle_errors(f):
+    @wraps(f)
+    def decorated_function(*args: Any, **kwargs: Any):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            logger.error(f"API error in {f.__name__}: {str(e)}", exc_info=True)
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": str(e),
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+                ),
+                500,
+            )
+
+    return decorated_function
+
+
+# ============= Analytics Endpoints =============
+
+
+@api_bp.route("/analytics/summary", methods=["GET"])
+@cross_origin()
+@handle_errors
+def get_analytics_summary():
+    """Get analytics summary with full compatibility"""
+    data_source = request.args.get("data_source", "uploaded")
+
+    validation_result = api_adapter.validator.validate_input(data_source, "data_source")
+    if not validation_result["valid"]:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": "Invalid data source",
+                    "issues": validation_result["issues"],
+                }
+            ),
+            400,
+        )
+
+    service = get_analytics_service()
+    if not service:
+        return (
+            jsonify({"status": "error", "message": "Analytics service unavailable"}),
+            503,
+        )
+
+    if data_source == "uploaded" or data_source.startswith("upload:"):
+        result = service.get_analytics_from_uploaded_data()
+    else:
+        result = service.get_analytics_by_source(data_source)
+
+    safe_result = api_adapter.unicode_processor.process_dict(result)
+
+    return jsonify(
+        {
+            "status": "success",
+            "data": safe_result,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
+
+
+@api_bp.route("/analytics/patterns", methods=["GET"])
+@cross_origin()
+@handle_errors
+def get_patterns_analysis():
+    """Get unique patterns analysis with progress tracking"""
+    data_source = request.args.get("data_source")
+    force_refresh = request.args.get("force_refresh", "false").lower() == "true"
+
+    service = get_analytics_service()
+    if not service:
+        return jsonify({"status": "error", "message": "Service unavailable"}), 503
+
+    if force_refresh and hasattr(service, "_cache"):
+        service._cache.clear()
+
+    result = service.get_unique_patterns_analysis(data_source)
+    safe_result = api_adapter.unicode_processor.process_dict(result)
+
+    return jsonify(safe_result)
+
+
+@api_bp.route("/analytics/sources", methods=["GET"])
+@cross_origin()
+@handle_errors
+def get_data_sources():
+    """Get all available data sources"""
+    from pages.deep_analytics_complex.analysis import get_data_source_options_safe
+
+    options = get_data_source_options_safe()
+
+    enriched_options: List[Dict[str, Any]] = []
+    for option in options:
+        enriched = {
+            **option,
+            "type": "upload" if option["value"].startswith("upload:") else "service",
+            "available": True,
+        }
+
+        if enriched["type"] == "upload":
+            filename = option["value"].replace("upload:", "")
+            enriched["metadata"] = {
+                "filename": filename,
+                "exists": filename in uploaded_data_store.get_all_files(),
+            }
+
+        enriched_options.append(enriched)
+
+    return jsonify(
+        {
+            "sources": enriched_options,
+            "default": "uploaded",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
+
+
+@api_bp.route("/analytics/analyze", methods=["POST"])
+@cross_origin()
+@handle_errors
+def analyze_data():
+    """Run specific analysis on data"""
+    data = request.get_json()
+
+    if not data:
+        return jsonify({"error": "Request body required"}), 400
+
+    data_source = data.get("data_source", "uploaded")
+    analysis_type = data.get("analysis_type", "summary")
+
+    from services.data_processing.analytics_engine import (
+        analyze_data_with_service,
+        run_ai_analysis,
+        run_quality_analysis,
+    )
+
+    if analysis_type == "ai_suggest":
+        result = run_ai_analysis(data_source)
+    elif analysis_type == "quality":
+        result = run_quality_analysis(data_source)
+    else:
+        result = analyze_data_with_service(data_source, analysis_type)
+
+    return jsonify(result)
+
+
+# ============= File Upload Endpoints =============
+
+
+@api_bp.route("/upload/file", methods=["POST"])
+@cross_origin()
+@handle_errors
+async def upload_file():
+    """Handle file upload with progress tracking"""
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    files = request.files.getlist("file")
+    if not files or files[0].filename == "":
+        return jsonify({"error": "No file selected"}), 400
+
+    task_id = str(uuid.uuid4())
+
+    results: List[Dict[str, Any]] = []
+    for file in files:
+        try:
+            content = file.read()
+
+            validation = api_adapter.validator.validate_file_upload(
+                file.filename,
+                content,
+            )
+            if not validation["valid"]:
+                results.append(
+                    {
+                        "filename": file.filename,
+                        "status": "error",
+                        "message": "Validation failed",
+                        "issues": validation["issues"],
+                    }
+                )
+                continue
+
+            content_b64 = base64.b64encode(content).decode("utf-8")
+            content_str = f"data:{file.content_type};base64,{content_b64}"
+
+            def progress_callback(current: int, total: int = 100) -> None:
+                progress = int((current / total) * 100) if total > 0 else 0
+                socketio.emit(
+                    "upload_progress",
+                    {
+                        "task_id": task_id,
+                        "filename": file.filename,
+                        "progress": progress,
+                        "current": current,
+                        "total": total,
+                    },
+                    room=task_id,
+                )
+
+            processor = api_adapter.upload_service or UploadProcessingService()
+
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+            result = await processor.process_uploaded_files(
+                [content_str],
+                [file.filename],
+                task_progress=progress_callback,
+            )
+
+            results.append(
+                {
+                    "filename": file.filename,
+                    "status": "success",
+                    "task_id": task_id,
+                    "result": result,
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Upload error for {file.filename}: {e}")
+            results.append(
+                {
+                    "filename": file.filename,
+                    "status": "error",
+                    "message": str(e),
+                }
+            )
+
+    return jsonify(
+        {
+            "task_id": task_id,
+            "results": results,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
+
+
+@api_bp.route("/upload/status/<task_id>", methods=["GET"])
+@cross_origin()
+@handle_errors
+def get_upload_status(task_id: str):
+    """Get upload task status"""
+    if task_id in api_adapter._active_tasks:
+        task = api_adapter._active_tasks[task_id]
+        return jsonify(
+            {
+                "task_id": task_id,
+                "status": task.get("status", "processing"),
+                "progress": task.get("progress", 0),
+                "result": task.get("result"),
+            }
+        )
+
+    return jsonify({"task_id": task_id, "status": "not_found"}), 404
+
+
+@api_bp.route("/upload/files", methods=["GET"])
+@cross_origin()
+@handle_errors
+def get_uploaded_files():
+    """Get list of uploaded files"""
+    try:
+        files = uploaded_data_store.get_all_files()
+
+        file_info: List[Dict[str, Any]] = []
+        for filename, df in files.items():
+            info = {
+                "filename": filename,
+                "rows": len(df),
+                "columns": len(df.columns),
+                "size_mb": df.memory_usage(deep=True).sum() / 1024 / 1024,
+                "columns_list": list(df.columns),
+                "uploaded_at": datetime.utcnow().isoformat(),
+            }
+            file_info.append(info)
+
+        return jsonify({"files": file_info, "total": len(file_info)})
+    except Exception as e:
+        logger.error(f"Error getting uploaded files: {e}")
+        return jsonify({"files": [], "total": 0, "error": str(e)})
+
+
+# ============= WebSocket Event Handlers =============
+
+
+@socketio.on("connect")
+def handle_connect():
+    """Handle client connection"""
+    client_id = request.sid
+    logger.info(f"Client connected: {client_id}")
+
+    emit(
+        "connected",
+        {
+            "client_id": client_id,
+            "timestamp": datetime.utcnow().isoformat(),
+            "version": "1.0.0",
+        },
+    )
+
+
+@socketio.on("disconnect")
+def handle_disconnect():
+    """Handle client disconnection"""
+    client_id = request.sid
+    logger.info(f"Client disconnected: {client_id}")
+
+
+@socketio.on("subscribe_analytics")
+def handle_analytics_subscription(data: Dict[str, Any]):
+    """Subscribe to real-time analytics updates"""
+    room = data.get("room", "analytics")
+    join_room(room)
+
+    try:
+        service = get_analytics_service()
+        if service:
+            summary = service.get_dashboard_summary()
+            safe_summary = api_adapter.unicode_processor.process_dict(summary)
+
+            emit(
+                "analytics_update",
+                {
+                    "type": "initial",
+                    "data": safe_summary,
+                    "timestamp": datetime.utcnow().isoformat(),
+                },
+                room=room,
+            )
+    except Exception as e:
+        logger.error(f"Error sending initial analytics: {e}")
+        emit(
+            "analytics_error",
+            {"error": str(e), "timestamp": datetime.utcnow().isoformat()},
+        )
+
+
+@socketio.on("join_upload_room")
+def handle_join_upload(data: Dict[str, Any]):
+    """Join upload progress room"""
+    task_id = data.get("task_id")
+    if task_id:
+        join_room(task_id)
+        logger.debug(f"Client {request.sid} joined upload room {task_id}")
+
+
+@socketio.on("request_data_refresh")
+def handle_data_refresh(data: Dict[str, Any]):
+    """Handle request for data refresh"""
+    data_type = data.get("type", "analytics")
+
+    try:
+        if data_type == "analytics":
+            service = get_analytics_service()
+            if service:
+                if hasattr(service, "_cache"):
+                    service._cache.clear()
+
+                summary = service.get_dashboard_summary()
+                emit(
+                    "data_refreshed",
+                    {
+                        "type": data_type,
+                        "data": summary,
+                        "timestamp": datetime.utcnow().isoformat(),
+                    },
+                )
+    except Exception as e:
+        emit("refresh_error", {"error": str(e), "type": data_type})
+
+
+# ============= Health & Status Endpoints =============
+
+
+@api_bp.route("/health", methods=["GET"])
+@cross_origin()
+def health_check():
+    """API health check"""
+    try:
+        analytics_ok = api_adapter.analytics_service is not None
+        upload_ok = api_adapter.upload_service is not None
+
+        db_ok = False
+        try:
+            if api_adapter.container:
+                db = api_adapter.container.get("database")
+                if db:
+                    db.execute_query("SELECT 1")
+                    db_ok = True
+        except Exception:
+            pass
+
+        return jsonify(
+            {
+                "status": "healthy" if all([analytics_ok, upload_ok]) else "degraded",
+                "services": {
+                    "analytics": analytics_ok,
+                    "upload": upload_ok,
+                    "database": db_ok,
+                },
+                "timestamp": datetime.utcnow().isoformat(),
+                "version": "1.0.0",
+            }
+        )
+    except Exception as e:
+        return jsonify({"status": "unhealthy", "error": str(e)}), 500
+
+
+# Export functions for app integration
+
+
+def initialize_api(app: Any, container: Any) -> None:
+    """Initialize API with app and container"""
+    api_adapter.initialize(app, container)
+    app.register_blueprint(api_bp)
+    socketio.init_app(app)
+    logger.info("API routes registered successfully")

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -1,0 +1,142 @@
+import { api } from './client';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export interface AnalyticsSummary {
+  total_events: number;
+  unique_users: number;
+  unique_doors: number;
+  success_rate: number;
+  analysis_focus?: string;
+  data_summary?: {
+    total_records: number;
+    date_range?: {
+      start: string;
+      end: string;
+    };
+  };
+  patterns?: {
+    power_users: string[];
+    high_traffic_doors: string[];
+    peak_hours: number[];
+  };
+}
+
+export interface DataSource {
+  label: string;
+  value: string;
+  type: 'upload' | 'service';
+  available: boolean;
+  metadata?: {
+    filename?: string;
+    exists?: boolean;
+    rows?: number;
+    columns?: number;
+  };
+}
+
+export interface PatternAnalysis {
+  status: string;
+  data_summary: {
+    total_records: number;
+    unique_users: number;
+    unique_devices: number;
+    date_span_days: number;
+  };
+  user_patterns: {
+    power_users: string[];
+    regular_users: string[];
+    occasional_users: string[];
+  };
+  device_patterns: {
+    high_traffic: string[];
+    moderate_traffic: string[];
+    low_traffic: string[];
+  };
+  temporal_patterns?: {
+    peak_hours: number[];
+    peak_days: string[];
+  };
+}
+
+export interface AnalysisRequest {
+  data_source: string;
+  analysis_type: 'summary' | 'security' | 'trends' | 'behavior' | 'anomaly' | 'ai_suggest' | 'quality';
+  date_range?: {
+    start: string;
+    end: string;
+  };
+  filters?: Record<string, any>;
+}
+
+export const analyticsAPI = {
+  async getSummary(dataSource: string = 'uploaded'): Promise<AnalyticsSummary> {
+    return api.get<AnalyticsSummary>('/analytics/summary', {
+      params: { data_source: dataSource },
+    });
+  },
+
+  async getDataSources(): Promise<DataSource[]> {
+    const response = await api.get<{ sources: DataSource[] }>('/analytics/sources');
+    return response.sources;
+  },
+
+  async getPatterns(dataSource?: string, forceRefresh = false): Promise<PatternAnalysis> {
+    return api.get<PatternAnalysis>('/analytics/patterns', {
+      params: { data_source: dataSource, force_refresh: forceRefresh },
+    });
+  },
+
+  async analyze(request: AnalysisRequest): Promise<any> {
+    return api.post('/analytics/analyze', request);
+  },
+
+  async exportData(format: 'csv' | 'excel' | 'json', dataSource?: string): Promise<Blob> {
+    const response = await api.get('/analytics/export', {
+      params: { format, data_source: dataSource },
+      responseType: 'blob',
+    });
+    return response as unknown as Blob;
+  },
+
+  async getRealtimeMetrics(): Promise<any> {
+    return api.get('/analytics/realtime');
+  },
+
+  async getHistoricalData(metric: string, timeRange: string, granularity: 'hour' | 'day' | 'week' | 'month'): Promise<any> {
+    return api.get('/analytics/historical', {
+      params: { metric, time_range: timeRange, granularity },
+    });
+  },
+};
+
+export const useAnalyticsSummary = (dataSource: string) =>
+  useQuery({
+    queryKey: ['analytics', 'summary', dataSource],
+    queryFn: () => analyticsAPI.getSummary(dataSource),
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+  });
+
+export const useDataSources = () =>
+  useQuery({
+    queryKey: ['analytics', 'sources'],
+    queryFn: analyticsAPI.getDataSources,
+    staleTime: 30 * 60 * 1000,
+  });
+
+export const usePatternAnalysis = (dataSource?: string) =>
+  useQuery({
+    queryKey: ['analytics', 'patterns', dataSource],
+    queryFn: () => analyticsAPI.getPatterns(dataSource),
+    enabled: !!dataSource,
+  });
+
+export const useAnalyze = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: analyticsAPI.analyze,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['analytics'] });
+    },
+  });
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,155 @@
+import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
+import { toast } from 'react-hot-toast';
+
+interface ApiError {
+  message: string;
+  status: number;
+  issues?: string[];
+}
+
+interface ApiResponse<T = any> {
+  status: 'success' | 'error';
+  data?: T;
+  message?: string;
+  timestamp?: string;
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8050/api/v1';
+const TIMEOUT = 30000;
+
+export const apiClient: AxiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: TIMEOUT,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+  withCredentials: true,
+});
+
+const requestQueue: Array<() => Promise<any>> = [];
+let isOnline = navigator.onLine;
+
+window.addEventListener('online', () => {
+  isOnline = true;
+  processQueue();
+});
+
+window.addEventListener('offline', () => {
+  isOnline = false;
+});
+
+const processQueue = async () => {
+  while (requestQueue.length > 0) {
+    const request = requestQueue.shift();
+    if (request) {
+      try {
+        await request();
+      } catch (error) {
+        console.error('Failed to process queued request:', error);
+      }
+    }
+  }
+};
+
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('auth_token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    config.headers['X-Request-ID'] = generateRequestId();
+    config.headers['X-Request-Time'] = new Date().toISOString();
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+apiClient.interceptors.response.use(
+  (response) => {
+    const requestTime = response.config.headers['X-Request-Time'];
+    if (requestTime) {
+      const duration = Date.now() - new Date(requestTime).getTime();
+      console.debug(`API call took ${duration}ms: ${response.config.url}`);
+    }
+    return response;
+  },
+  async (error: AxiosError<ApiError>) => {
+    const { config, response } = error;
+
+    if (!response) {
+      if (!isOnline && config) {
+        toast.error('You are offline. Request will be retried when connection is restored.');
+        requestQueue.push(() => apiClient.request(config));
+        return Promise.reject(error);
+      }
+      toast.error('Network error. Please check your connection.');
+      return Promise.reject(error);
+    }
+
+    switch (response.status) {
+      case 401:
+        localStorage.removeItem('auth_token');
+        window.location.href = '/login';
+        break;
+      case 403:
+        toast.error('You do not have permission to perform this action.');
+        break;
+      case 404:
+        toast.error('The requested resource was not found.');
+        break;
+      case 422:
+        const issues = response.data?.issues || ['Validation failed'];
+        issues.forEach((i) => toast.error(i));
+        break;
+      case 429:
+        toast.error('Too many requests. Please slow down.');
+        break;
+      case 500:
+        toast.error('Server error. Please try again later.');
+        break;
+      default:
+        toast.error(response.data?.message || 'An unexpected error occurred.');
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+function generateRequestId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export async function apiRequest<T = any>(config: AxiosRequestConfig, retries = 3): Promise<T> {
+  let lastError: any;
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await apiClient.request<ApiResponse<T>>(config);
+      if (response.data.status === 'error') {
+        throw new Error(response.data.message || 'Request failed');
+      }
+      return response.data.data as T;
+    } catch (error) {
+      lastError = error;
+      if (axios.isAxiosError(error) && error.response?.status && error.response.status < 500) {
+        throw error;
+      }
+      if (i < retries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, i)));
+      }
+    }
+  }
+  throw lastError;
+}
+
+export const api = {
+  get: <T = any>(url: string, config?: AxiosRequestConfig) => apiRequest<T>({ ...config, method: 'GET', url }),
+  post: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => apiRequest<T>({ ...config, method: 'POST', url, data }),
+  put: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => apiRequest<T>({ ...config, method: 'PUT', url, data }),
+  delete: <T = any>(url: string, config?: AxiosRequestConfig) => apiRequest<T>({ ...config, method: 'DELETE', url }),
+  patch: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => apiRequest<T>({ ...config, method: 'PATCH', url, data }),
+};
+
+export type { ApiError, ApiResponse };


### PR DESCRIPTION
## Summary
- implement new Flask API adapter with websocket support
- add TypeScript Axios client and analytics API service

## Testing
- `black api/adapter.py`
- `isort api/adapter.py`
- `flake8 api/adapter.py`
- `pytest -q` *(fails: 97 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68789dd1d3588320bbfb8d040612b211