### PR TITLE
Fix uploaded data store API

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -178,7 +178,7 @@ def get_data_sources():
             filename = option["value"].replace("upload:", "")
             enriched["metadata"] = {
                 "filename": filename,
-                "exists": filename in uploaded_data_store.get_all_files(),
+                "exists": filename in uploaded_data_store.get_filenames(),
             }
 
         enriched_options.append(enriched)
@@ -339,10 +339,11 @@ def get_upload_status(task_id: str):
 def get_uploaded_files():
     """Get list of uploaded files"""
     try:
-        files = uploaded_data_store.get_all_files()
+        filenames = uploaded_data_store.get_filenames()
 
         file_info: List[Dict[str, Any]] = []
-        for filename, df in files.items():
+        for filename in filenames:
+            df = uploaded_data_store.load_dataframe(filename)
             info = {
                 "filename": filename,
                 "rows": len(df),


### PR DESCRIPTION
## Summary
- replace outdated `get_all_files` calls
- build uploaded file info list using `get_filenames` and `load_dataframe`

## Testing
- `pytest -q` *(fails: ImportError: ModuleNotFoundError: No module named 'models.compliance')*
- `mypy .` *(fails: Found 3253 errors)*
- `flake8` *(fails: many style violations)*
- `black --check .` *(fails: would reformat many files)*

------
https://chatgpt.com/codex/tasks/task_e_6878a87b51b883209d0295e18da07a0f