### PR TITLE
Sanitize API outputs and validate request inputs

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Dict, List
 
+import json
 from flask import Blueprint, jsonify, request
 from flask_cors import cross_origin
 from flask_socketio import SocketIO, emit, join_room
@@ -32,6 +33,42 @@ socketio = SocketIO(
     logger=True,
     engineio_logger=True,
 )
+
+
+def safe_emit(event: str, data: Any | None = None, **kwargs: Any) -> None:
+    """Emit Socket.IO data after Unicode sanitization."""
+    payload = api_adapter.unicode_processor.process_dict(data or {})
+    socketio.emit(event, payload, **kwargs)
+
+
+@api_bp.before_request
+def _validate_request_params() -> Any | None:
+    """Validate query string and JSON payload using ``SecurityValidator``."""
+    for key, value in request.args.items():
+        result = api_adapter.validator.validate_input(value, key)
+        if not result["valid"]:
+            return jsonify({"status": "error", "message": f"Invalid parameter: {key}", "issues": result["issues"]}), 400
+
+    if request.is_json:
+        data = request.get_json(silent=True) or {}
+        for key, value in data.items():
+            result = api_adapter.validator.validate_input(str(value), key)
+            if not result["valid"]:
+                return jsonify({"status": "error", "message": f"Invalid parameter: {key}", "issues": result["issues"]}), 400
+    return None
+
+
+@api_bp.after_request
+def _sanitize_response(response: Any) -> Any:
+    """Sanitize JSON responses using the Unicode processor."""
+    try:
+        if response.is_json:
+            data = response.get_json()
+            sanitized = api_adapter.unicode_processor.process_dict(data)
+            response.set_data(json.dumps(sanitized))
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Response sanitization failed: %s", exc)
+    return response
 
 
 class APIAdapter:
@@ -263,7 +300,7 @@ async def upload_file():
 
             def progress_callback(current: int, total: int = 100) -> None:
                 progress = int((current / total) * 100) if total > 0 else 0
-                socketio.emit(
+                safe_emit(
                     "upload_progress",
                     {
                         "task_id": task_id,
@@ -368,7 +405,7 @@ def handle_connect():
     client_id = request.sid
     logger.info(f"Client connected: {client_id}")
 
-    emit(
+    safe_emit(
         "connected",
         {
             "client_id": client_id,
@@ -397,7 +434,7 @@ def handle_analytics_subscription(data: Dict[str, Any]):
             summary = service.get_dashboard_summary()
             safe_summary = api_adapter.unicode_processor.process_dict(summary)
 
-            emit(
+            safe_emit(
                 "analytics_update",
                 {
                     "type": "initial",
@@ -408,7 +445,7 @@ def handle_analytics_subscription(data: Dict[str, Any]):
             )
     except Exception as e:
         logger.error(f"Error sending initial analytics: {e}")
-        emit(
+        safe_emit(
             "analytics_error",
             {"error": str(e), "timestamp": datetime.utcnow().isoformat()},
         )
@@ -436,7 +473,7 @@ def handle_data_refresh(data: Dict[str, Any]):
                     service._cache.clear()
 
                 summary = service.get_dashboard_summary()
-                emit(
+                safe_emit(
                     "data_refreshed",
                     {
                         "type": data_type,
@@ -445,7 +482,7 @@ def handle_data_refresh(data: Dict[str, Any]):
                     },
                 )
     except Exception as e:
-        emit("refresh_error", {"error": str(e), "type": data_type})
+        safe_emit("refresh_error", {"error": str(e), "type": data_type})
 
 
 # ============= Health & Status Endpoints =============

--- a/api/risk_scoring.py
+++ b/api/risk_scoring.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from flask import jsonify, request
 
+from api.adapter import api_adapter
+from core.security_validator import SecurityValidator
+
 from analytics.risk_scoring import calculate_risk_score
 from app import app
 
@@ -12,9 +15,15 @@ from app import app
 def calculate_score_endpoint():
     """Return aggregated risk score from provided values."""
     payload = request.get_json(silent=True) or {}
+    for key, value in payload.items():
+        check = SecurityValidator().validate_input(str(value), key)
+        if not check['valid']:
+            return jsonify({"error": "Invalid parameter", "issues": check['issues']}), 400
+
     anomaly = float(payload.get("anomaly_score", 0))
     patterns = float(payload.get("pattern_score", 0))
     behavior = float(payload.get("behavior_deviation", 0))
 
     result = calculate_risk_score(anomaly, patterns, behavior)
-    return jsonify({"score": result.score, "level": result.level})
+    safe = api_adapter.unicode_processor.process_dict({"score": result.score, "level": result.level})
+    return jsonify(safe)


### PR DESCRIPTION
## Summary
- add recursive `process_dict` helper for sanitizing response data
- validate request parameters and sanitize all API responses
- sanitize Socket.IO events with `safe_emit`
- enforce validation and sanitization in plugin performance and risk scoring APIs

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6878a87e22788320b331edc4b0ca1439