### PR TITLE
Track upload progress

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -237,6 +237,12 @@ async def upload_file():
         return jsonify({"error": "No file selected"}), 400
 
     task_id = str(uuid.uuid4())
+    # Track active upload task so status endpoint can report progress
+    api_adapter._active_tasks[task_id] = {
+        "status": "processing",
+        "progress": 0,
+        "result": None,
+    }
 
     results: List[Dict[str, Any]] = []
     for file in files:
@@ -263,6 +269,7 @@ async def upload_file():
 
             def progress_callback(current: int, total: int = 100) -> None:
                 progress = int((current / total) * 100) if total > 0 else 0
+                api_adapter._active_tasks[task_id]["progress"] = progress
                 socketio.emit(
                     "upload_progress",
                     {
@@ -304,6 +311,10 @@ async def upload_file():
                     "message": str(e),
                 }
             )
+
+    api_adapter._active_tasks[task_id].update(
+        {"status": "completed", "progress": 100, "result": results}
+    )
 
     return jsonify(
         {


### PR DESCRIPTION
## Summary
- keep track of active upload tasks
- update progress as files are processed
- mark uploads complete when finished

## Testing
- `pre-commit run --files api/adapter.py` *(fails: mypy, bandit)*

------
https://chatgpt.com/codex/tasks/task_e_6878a87ec0148320a3788da72f85f243