### PR TITLE
Add create_api_app helper

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List
 
 import json
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Flask, jsonify, request
 from flask_cors import cross_origin
 from flask_socketio import SocketIO, emit, join_room
 
@@ -697,3 +697,15 @@ def initialize_api(app: Any, container: Any) -> None:
     register_analytics_blueprints(app)
     socketio.init_app(app)
     logger.info("API routes registered successfully")
+
+
+def create_api_app(container: Any | None = None) -> Flask:
+    """Create a Flask application with API routes registered."""
+    if container is None:
+        from core.container import container as default_container
+
+        container = default_container
+
+    app = Flask(__name__)
+    initialize_api(app, container)
+    return app

--- a/api/api_app.py
+++ b/api/api_app.py
@@ -1,0 +1,6 @@
+from api.adapter import create_api_app
+
+app = create_api_app()
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- implement `create_api_app` in `api.adapter`
- provide runnable `api_app.py` for standalone API server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6878b684c66c8320b1e89ec75c9ff95e