### PR TITLE
Add API type definitions

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,33 @@
+export interface AnalyticsResponse {
+  status: string;
+  data_summary: {
+    total_records: number;
+    unique_users: number;
+    unique_devices: number;
+    date_range: {
+      start: string;
+      end: string;
+      span_days: number;
+    };
+  };
+  user_patterns: {
+    power_users: string[];
+    regular_users: string[];
+    occasional_users: string[];
+  };
+  // ... other fields
+}
+
+export interface ChartData {
+  type: string;
+  data: any;
+  error?: string;
+}
+
+export interface ExportFormat {
+  type: string;
+  name: string;
+  description: string;
+  mimeType: string;
+  extension: string;
+}


### PR DESCRIPTION
## Summary
- define AnalyticsResponse, ChartData, and ExportFormat interfaces under `src/types/api.ts`

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest tests/test_analytics_controller.py::test_business_service_analysis -q`
- `mypy .` *(fails: Found 3273 errors)*
- `flake8 .` *(command not found)*
- `black --check .` *(fails: would reformat files)*

------
https://chatgpt.com/codex/tasks/task_e_6878b69bef6c83209bb5970f44999ac7