### PR TITLE
Add Flask-Cors to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,6 @@ openpyxl>=3.1.0
 xlsxwriter>=3.0.0
 python-dateutil>=2.8.0
 
+# Enable cross-origin resource sharing support
+Flask-Cors>=3.0.10
+


### PR DESCRIPTION
## Summary
- ensure Flask-Cors is installed with other dependencies

## Testing
- `pytest -k nonexistenttest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6878c13dd05c832082e1cf29df37246f