### PR TITLE
Rewrite AI suggestion requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "recharts": "^2.8.0",
+    "papaparse": "^5.4.1",
     "tailwind-merge": "^1.14.0",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
## Summary
- parse uploaded files in browser to send full data
- request column & device suggestions using parsed file
- store raw `File` for each upload
- use relative API paths
- add `papaparse` dependency for CSV parsing

## Testing
- `pytest -q`
- `mypy .`
- `black . --check`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68797a48095083208398cfe5df6ae353