### PR TITLE
Add mapping storage to upload data service

### DIFF
--- a/services/protocols/upload_data.py
+++ b/services/protocols/upload_data.py
@@ -31,5 +31,13 @@ class UploadDataServiceProtocol(Protocol):
         """Load a specific uploaded dataframe."""
         ...
 
+    def save_column_mappings(self, file_id: str, mappings: Dict[str, str]) -> None:
+        """Persist column mappings for a file."""
+        ...
+
+    def save_device_mappings(self, file_id: str, mappings: Dict[str, Any]) -> None:
+        """Persist device mappings for a file."""
+        ...
+
 
 __all__ = ["UploadDataServiceProtocol"]

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -33,6 +33,12 @@ class UploadDataService(UploadDataServiceProtocol):
     def load_dataframe(self, filename: str) -> pd.DataFrame:
         return self.store.load_dataframe(filename)
 
+    def save_column_mappings(self, file_id: str, mappings: Dict[str, str]) -> None:
+        self.store.save_column_mappings(file_id, mappings)
+
+    def save_device_mappings(self, file_id: str, mappings: Dict[str, Any]) -> None:
+        self.store.save_device_mappings(file_id, mappings)
+
 
 def _resolve_service(
     service: UploadDataServiceProtocol | None,
@@ -84,6 +90,28 @@ def load_dataframe(
     return svc.load_dataframe(filename)
 
 
+def save_column_mappings(
+    file_id: str,
+    mapping_dict: Dict[str, str],
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> None:
+    svc = _resolve_service(service, container)
+    if hasattr(svc, "save_column_mappings"):
+        svc.save_column_mappings(file_id, mapping_dict)
+
+
+def save_device_mappings(
+    file_id: str,
+    mapping_dict: Dict[str, Any],
+    service: UploadDataServiceProtocol | None = None,
+    container: ServiceContainer | None = None,
+) -> None:
+    svc = _resolve_service(service, container)
+    if hasattr(svc, "save_device_mappings"):
+        svc.save_device_mappings(file_id, mapping_dict)
+
+
 __all__ = [
     "UploadDataService",
     "get_uploaded_data",
@@ -91,4 +119,6 @@ __all__ = [
     "clear_uploaded_data",
     "get_file_info",
     "load_dataframe",
+    "save_column_mappings",
+    "save_device_mappings",
 ]

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -195,6 +195,22 @@ class UploadedDataStore(UploadStorageProtocol):
     def get_file_info(self) -> Dict[str, Dict[str, Any]]:
         return self._file_info_store.copy()
 
+    def save_column_mappings(self, filename: str, mappings: Dict[str, str]) -> None:
+        """Persist column mappings for *filename* to disk."""
+        with self._lock:
+            info = self._file_info_store.setdefault(filename, {})
+            info["column_mappings"] = mappings
+            with open(self._info_path(), "w", encoding="utf-8") as f:
+                json.dump(self._file_info_store, f, indent=2)
+
+    def save_device_mappings(self, filename: str, mappings: Dict[str, Any]) -> None:
+        """Persist device mappings for *filename* to disk."""
+        with self._lock:
+            info = self._file_info_store.setdefault(filename, {})
+            info["device_mappings"] = mappings
+            with open(self._info_path(), "w", encoding="utf-8") as f:
+                json.dump(self._file_info_store, f, indent=2)
+
     def clear_all(self) -> None:
         with self._lock:
             self._data_store.clear()


### PR DESCRIPTION
## Summary
- extend `UploadedDataStore` with methods to persist column and device mappings
- expose mapping save APIs via `UploadDataService`
- update service protocol to support new functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6879908adf748320b3d4138dd138285e