### PR TITLE
Fix upload endpoint for multipart

### DIFF
--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -1,59 +1,76 @@
-from flask import Blueprint, request, jsonify
 import asyncio
 import base64
-import io
 
-upload_bp = Blueprint('upload', __name__)
+from flask import Blueprint, jsonify, request
 
-@upload_bp.route('/api/v1/upload', methods=['POST'])
+upload_bp = Blueprint("upload", __name__)
+
+
+@upload_bp.route("/api/v1/upload", methods=["POST"])
 def upload_files():
     """Handle file upload and return expected structure for React frontend"""
     try:
-        data = request.json
-        contents = data.get('contents', [])
-        filenames = data.get('filenames', [])
-        
+        contents = []
+        filenames = []
+
+        # Support both multipart/form-data and raw JSON payloads
+        if request.files:
+            for file in request.files.values():
+                if not file.filename:
+                    continue
+                file_bytes = file.read()
+                b64 = base64.b64encode(file_bytes).decode()
+                mime = file.mimetype or "application/octet-stream"
+                contents.append(f"data:{mime};base64,{b64}")
+                filenames.append(file.filename)
+        else:
+            data = request.get_json(silent=True) or {}
+            contents = data.get("contents", [])
+            filenames = data.get("filenames", [])
+
         # Get services from container
         from core.service_container import ServiceContainer
+
         container = ServiceContainer()
         upload_service = container.get("upload_processor")
-        
+
         # Process files using existing base code
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        
+
         result_dict = loop.run_until_complete(
             upload_service.process_uploaded_files(contents, filenames)
         )
         loop.close()
-        
+
         # Ensure structure matches what React expects
         response = {
-            'upload_results': result_dict.get('upload_results', []),
-            'file_preview_components': result_dict.get('file_preview_components', []),
-            'file_info_dict': {}
+            "upload_results": result_dict.get("upload_results", []),
+            "file_preview_components": result_dict.get("file_preview_components", []),
+            "file_info_dict": {},
         }
-        
+
         # Process each file's info
-        file_info_dict = result_dict.get('file_info_dict', {})
+        file_info_dict = result_dict.get("file_info_dict", {})
         for filename, info in file_info_dict.items():
             # Get AI column suggestions
             from services.data_enhancer import get_ai_column_suggestions
+
             df = upload_service.store.get_all_data().get(filename)
-            
+
             ai_suggestions = {}
             if df is not None:
                 ai_suggestions = get_ai_column_suggestions(df)
-            
-            response['file_info_dict'][filename] = {
-                'filename': filename,
-                'rows': info.get('rows', 0),
-                'columns': info.get('columns', 0),
-                'ai_suggestions': ai_suggestions,
-                'column_names': info.get('column_names', [])
+
+            response["file_info_dict"][filename] = {
+                "filename": filename,
+                "rows": info.get("rows", 0),
+                "columns": info.get("columns", 0),
+                "ai_suggestions": ai_suggestions,
+                "column_names": info.get("column_names", []),
             }
-        
+
         return jsonify(response), 200
-        
+
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- support multipart form-data uploads for `/api/v1/upload`

## Testing
- `pre-commit run --files upload_endpoint.py` *(fails: mypy errors across repo)*
- `python test_endpoints.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687a26d73c008320b3189e6037aee698