### PR TITLE
Fix upload endpoints use global container

### DIFF
--- a/device_endpoint.py
+++ b/device_endpoint.py
@@ -1,6 +1,13 @@
 from flask import Blueprint, request, jsonify
 import pandas as pd
 
+# Use the shared DI container for dependency resolution
+from core.container import container
+from config.service_registration import register_upload_services
+
+if not container.has("upload_processor"):
+    register_upload_services(container)
+
 device_bp = Blueprint('device', __name__)
 
 @device_bp.route('/api/v1/ai/suggest-devices', methods=['POST'])
@@ -11,10 +18,7 @@ def suggest_devices():
         filename = data.get('filename')
         column_mappings = data.get('column_mappings', {})
         
-        # Get services from container
-        from core.service_container import ServiceContainer
-        container = ServiceContainer()
-        
+        # Get services from shared container
         device_service = container.get("device_learning_service")
         upload_service = container.get("upload_processor")
         

--- a/mappings_endpoint.py
+++ b/mappings_endpoint.py
@@ -1,5 +1,12 @@
 from flask import Blueprint, request, jsonify
 
+# Shared container ensures services are available across blueprints
+from core.container import container
+from config.service_registration import register_upload_services
+
+if not container.has("upload_processor"):
+    register_upload_services(container)
+
 mappings_bp = Blueprint('mappings', __name__)
 
 @mappings_bp.route('/api/v1/mappings/columns', methods=['POST'])
@@ -13,8 +20,6 @@ def save_column_mappings_route():
         if not file_id:
             return jsonify({'error': 'file_id is required'}), 400
 
-        from core.service_container import ServiceContainer
-        container = ServiceContainer()
         service = container.get('consolidated_learning_service')
         service.save_column_mappings(file_id, mappings)
 
@@ -35,8 +40,6 @@ def save_device_mappings_route():
         if not file_id:
             return jsonify({'error': 'file_id is required'}), 400
 
-        from core.service_container import ServiceContainer
-        container = ServiceContainer()
         service = container.get('device_learning_service')
         service.save_device_mappings(file_id, mappings)
 
@@ -55,9 +58,7 @@ def save_mappings():
         mapping_type = data.get('mapping_type')
         
         # Get services
-        from core.service_container import ServiceContainer
-        container = ServiceContainer()
-        
+
         if mapping_type == 'column':
             # Save column mappings
             column_mappings = data.get('column_mappings', {})
@@ -98,8 +99,6 @@ def process_enhanced_data():
         device_mappings = data.get('device_mappings', {})
         
         # Get services
-        from core.service_container import ServiceContainer
-        container = ServiceContainer()
         upload_service = container.get("upload_processor")
         
         # Get the dataframe

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -146,10 +146,19 @@ const Upload: React.FC = () => {
       console.log("Response received:", response.status);
 
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(
-          errorData.error || `Upload failed: ${response.statusText}`,
-        );
+        let message = `Upload failed: ${response.statusText}`;
+        try {
+          const errorData = await response.json();
+          if (errorData && errorData.error) {
+            message = errorData.error;
+          }
+        } catch (_e) {
+          const text = await response.text();
+          if (text) {
+            message = `${message} - ${text}`;
+          }
+        }
+        throw new Error(message);
       }
 
       const data = await response.json();

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -3,6 +3,13 @@ import base64
 
 from flask import Blueprint, jsonify, request
 
+# Use the shared DI container configured at application startup
+from core.container import container
+from config.service_registration import register_upload_services
+
+if not container.has("upload_processor"):
+    register_upload_services(container)
+
 upload_bp = Blueprint("upload", __name__)
 
 
@@ -28,10 +35,7 @@ def upload_files():
             contents = data.get("contents", [])
             filenames = data.get("filenames", [])
 
-        # Get services from container
-        from core.service_container import ServiceContainer
-
-        container = ServiceContainer()
+        # Get services from shared container
         upload_service = container.get("upload_processor")
 
         # Process files using existing base code


### PR DESCRIPTION
## Summary
- use shared ServiceContainer across upload-related endpoints
- guard container registration for upload services
- improve error handling when upload responses aren't JSON

## Testing
- `pytest -k upload_endpoint` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_687a55e86984832096c77ca98cd5c6f2