### PR TITLE
Update analytics API base configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@ WTF_CSRF_ENABLED=True
 
 # Additional
 DEBUG=1
+
+# Frontend Configuration
+REACT_APP_API_BASE=/api/v1
+# Base path for frontend API requests

--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
     "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
-    "tailwindcss": "^3.3.0"
+    "tailwindcss": "^3.3.0",
+    "dotenv-cli": "^8.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "dotenv -e .env -- react-scripts start",
+    "build": "dotenv -e .env -- react-scripts build",
+    "test": "dotenv -e .env -- react-scripts test",
     "eject": "react-scripts eject",
     "build-css": "sh scripts/build_css.sh",
     "lint:a11y": "pa11y http://localhost:8050"

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -35,7 +35,8 @@ const Analytics: React.FC = () => {
     setError(null);
     
     try {
-      const response = await fetch(`http://localhost:5001/api/v1/analytics/${sourceType}`);
+      const apiBase = process.env.REACT_APP_API_BASE || '/api/v1';
+      const response = await fetch(`${apiBase}/analytics/${sourceType}`);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }


### PR DESCRIPTION
## Summary
- expose `REACT_APP_API_BASE` env variable
- use `REACT_APP_API_BASE` in analytics page
- load `.env` for npm scripts

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 115 errors during collection)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_687a5c4e57508320aeb581a1f40c3371