### PR TITLE
Use start_api as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8050/ || exit 1
 
 # Run application
-CMD ["python", "app.py"]
+CMD ["python", "start_api.py"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The dashboard is extensible through a lightweight plugin system. Plugins live in
 
 ```
 yosai_intel_dashboard/
-├── app.py                     # Main application entry point
+├── start_api.py               # Start the API for development
 ├── config/                    # Configuration management
 │   ├── config.py              # Unified configuration loader
 │   ├── database_manager.py    # Database connections and pooling
@@ -150,7 +150,7 @@ with this Python release and newer.
 7. **Run the application (development only):**
    The app now loads variables from `.env` automatically.
    ```bash
-   python app.py  # use only for local development
+   python start_api.py  # use only for local development
    ```
    For production deployments start a WSGI server instead:
    ```bash
@@ -213,7 +213,7 @@ following steps:
    plain HTTP version from loading. Use the browser's development settings to
    clear site data, including service workers and caches, and remove any HSTS
    entries before reloading the page.
-7. If `python app.py` fails with `NameError: name '_env_file_callback' is not defined`,
+7. If `python start_api.py` fails with `NameError: name '_env_file_callback' is not defined`,
    Flask was likely installed incorrectly. Reinstall it to restore the missing
    function:
    ```bash
@@ -486,7 +486,7 @@ DB_HOST=localhost
 DB_USER=postgres
 REDIS_HOST=localhost
 SECRET_KEY=supersecret
-python app.py
+python start_api.py
 ```
 
 These values override `database.host`, `database.user`, `cache.host` and
@@ -507,10 +507,10 @@ environment variables:
 Example:
 
 ```bash
-YOSAI_ENV=production python app.py
+YOSAI_ENV=production python start_api.py
 # or
-YOSAI_CONFIG_FILE=/path/to/custom.yaml python app.py
-YOSAI_APP_MODE=simple python app.py
+YOSAI_CONFIG_FILE=/path/to/custom.yaml python start_api.py
+YOSAI_APP_MODE=simple python start_api.py
 ```
 
 #### Dynamic Constants

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -63,7 +63,7 @@ This guide walks new contributors through setting up a local development environ
    
 9. **Start the application:**
    ```bash
-   python app.py
+   python start_api.py
    ```
 
 The dashboard will be available at `http://127.0.0.1:8050` once the server starts.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ This guide covers solutions to common issues when setting up or running the dash
 
 ## Flask CLI NameError
 
-If running `python app.py` fails with a traceback ending in:
+If running `python start_api.py` fails with a traceback ending in:
 
 ```
 NameError: name '_env_file_callback' is not defined

--- a/run_api.py
+++ b/run_api.py
@@ -1,13 +1,4 @@
-import sys
-import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
-from api.adapter import app
-from config.constants import API_PORT
+import start_api
 
 if __name__ == "__main__":
-    print("\n🚀 Starting Yosai Intel Dashboard API...")
-    print(f"   Available at: http://localhost:{API_PORT}")
-    print(f"   Health check: http://localhost:{API_PORT}/api/v1/health")
-
-    app.run(host='0.0.0.0', port=API_PORT, debug=True)
+    start_api.main()

--- a/start_api.py
+++ b/start_api.py
@@ -9,12 +9,17 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import api.adapter
 from config.constants import API_PORT
 
-if __name__ == "__main__":
-    # Get the app instance
+
+def main() -> None:
+    """Start the API development server."""
     app = api.adapter.app
-    
+
     print("\n🚀 Starting Yosai Intel Dashboard API...")
     print(f"   Available at: http://localhost:{API_PORT}")
     print(f"   Health check: http://localhost:{API_PORT}/api/v1/health")
 
-    app.run(host='0.0.0.0', port=API_PORT, debug=True)
+    app.run(host="0.0.0.0", port=API_PORT, debug=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/start_api.sh
+++ b/start_api.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 echo "🚀 Starting Yosai Intel Dashboard API..."
-cd api
-python adapter.py
+python start_api.py


### PR DESCRIPTION
## Summary
- make `start_api.py` provide a `main` function
- wrap legacy `run_api.py` to call into `start_api`
- update README and docs to use `start_api.py`
- adjust `start_api.sh` and Dockerfile to run `start_api.py`

## Testing
- `pytest -q` *(fails: Unknown marks and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f756740832081401d2018a63baf