### PR TITLE
Improve CSV parser with Papaparse

### DIFF
--- a/public/workers/upload-processor.js
+++ b/public/workers/upload-processor.js
@@ -1,4 +1,5 @@
 // Web Worker for processing file chunks
+importScripts('https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js');
 self.onmessage = function (e) {
     const { type, taskId, data } = e.data;
 
@@ -43,21 +44,8 @@ function processChunk(data) {
 }
 
 function parseCSVData(content) {
-    // Basic CSV parsing
-    const lines = content.split('\n');
-    const headers = lines[0].split(',');
-    const rows = [];
-
-    for (let i = 1; i < lines.length; i++) {
-        if (lines[i].trim()) {
-            const values = lines[i].split(',');
-            const row = {};
-            headers.forEach((header, index) => {
-                row[header.trim()] = values[index]?.trim() || '';
-            });
-            rows.push(row);
-        }
-    }
-
+    const result = Papa.parse(content, { header: true, skipEmptyLines: true });
+    const headers = result.meta.fields || [];
+    const rows = result.data;
     return { headers, rows };
 }

--- a/src/csvParser.test.ts
+++ b/src/csvParser.test.ts
@@ -1,0 +1,12 @@
+import { parseCSV } from './pages/Upload';
+
+describe('parseCSV', () => {
+  it('handles quoted commas and newlines', () => {
+    const content = 'Name,Note\n"Doe, John","Hello"\n"Jane","Multi\nLine"';
+    const result = parseCSV(content);
+    expect(result.columns).toEqual(['Name', 'Note']);
+    expect(result.rows.length).toBe(2);
+    expect(result.rows[0]['Name']).toBe('Doe, John');
+    expect(result.rows[1]['Note']).toBe('Multi\nLine');
+  });
+});


### PR DESCRIPTION
## Summary
- use Papa.parse for CSV parsing
- expose CSV parsing utilities and sanitize function
- parse CSV in worker with Papa.parse
- add tests for quoted commas and newlines

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687c6f771cd88320930ec76fa64298f0