### PR TITLE
Inject UploadDataService into AnalyticsService

### DIFF
--- a/services/interfaces.py
+++ b/services/interfaces.py
@@ -130,17 +130,15 @@ def get_device_learning_service(
 
 def get_upload_data_service(
     container: ServiceContainer | None = None,
-) -> UploadDataServiceProtocol:
+) -> UploadDataService:
     """Return the registered :class:`UploadDataService` instance."""
-    from services.protocols.upload_data import UploadDataServiceProtocol
-
     c = _get_container(container)
     if c and c.has("upload_data_service"):
         return c.get("upload_data_service")
-    from services.upload_data_service import UploadDataService
+    from services.upload_data_service import UploadDataService as UploadDataSvc
     from utils.upload_store import uploaded_data_store
 
-    return UploadDataService(uploaded_data_store)
+    return UploadDataSvc(uploaded_data_store)
 
 
 __all__ = [
@@ -148,6 +146,7 @@ __all__ = [
     "ExportServiceProtocol",
     "DoorMappingServiceProtocol",
     "DeviceLearningServiceProtocol",
+    "UploadDataService",
     "get_upload_validator",
     "get_export_service",
     "get_door_mapping_service",
@@ -162,6 +161,25 @@ class UploadDataServiceProtocol(Protocol):
     def get_upload_data(self) -> Dict[str, Any]: ...
     def store_upload_data(self, data: Dict[str, Any]) -> bool: ...
     def clear_data(self) -> None: ...
+
+
+@runtime_checkable
+class UploadDataService(Protocol):
+    """Interface for accessing uploaded dataframes."""
+
+    def get_uploaded_data(self) -> Dict[str, pd.DataFrame]: ...
+
+    def get_uploaded_filenames(self) -> List[str]: ...
+
+    def clear_uploaded_data(self) -> None: ...
+
+    def get_file_info(self) -> Dict[str, Dict[str, Any]]: ...
+
+    def load_dataframe(self, filename: str) -> pd.DataFrame: ...
+
+    def load_mapping(self, filename: str) -> Dict[str, Any]: ...
+
+    def save_mapping(self, filename: str, mapping: Dict[str, Any]) -> None: ...
 
 @runtime_checkable  
 class DeviceLearningServiceProtocol(Protocol):

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -8,15 +8,16 @@ from analytics.file_processing_utils import (
     update_timestamp_range,
 )
 from services import AnalyticsService
+from tests.fakes import FakeUploadDataService, FakeUploadStore
 
 
-def test_load_uploaded_data(monkeypatch):
+def test_load_uploaded_data():
     sample = {"file.csv": DataFrameBuilder().add_column("A", [1]).build()}
-    monkeypatch.setattr(
-        "services.upload_data_service.get_uploaded_data",
-        lambda service=None, container=None: sample,
-    )
-    service = AnalyticsService()
+    store = FakeUploadStore()
+    for name, df in sample.items():
+        store.add_file(name, df)
+    data_service = FakeUploadDataService(store)
+    service = AnalyticsService(upload_data_service=data_service)
     assert service.load_uploaded_data() == sample
 
 


### PR DESCRIPTION
## Summary
- add new `UploadDataService` protocol to `services/interfaces.py`
- inject upload data service into `AnalyticsService`
- update helper test to pass fake upload data service

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_687c6f7a97b88320959c755c18cfcea8