### PR TITLE
Add Cypress E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
         run: |
           set -xe
           pytest --maxfail=1 --disable-warnings -q --cov=.
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install Node deps
+        run: npm install
+      - name: Cypress Tests
+        run: npx cypress run
       - name: Upload audit report
         uses: actions/upload-artifact@v4
         with:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/e2e/**/*.cy.{js,ts}'
+  }
+})

--- a/cypress/e2e/upload.cy.ts
+++ b/cypress/e2e/upload.cy.ts
@@ -1,0 +1,48 @@
+/// <reference types="cypress" />
+
+describe('File Upload Flow', () => {
+  beforeEach(() => {
+    cy.intercept('POST', '/api/v1/upload', {
+      statusCode: 200,
+      body: {
+        requiresColumnMapping: true,
+        fileData: {
+          filename: 'sample.csv',
+          columns: ['person_id', 'door_id', 'timestamp', 'access_result'],
+          ai_suggestions: {
+            person_id: { field: 'person_id', confidence: 0.95 },
+            door_id: { field: 'door_id', confidence: 0.9 },
+            timestamp: { field: 'timestamp', confidence: 0.9 },
+            access_result: { field: 'access_result', confidence: 0.9 }
+          }
+        }
+      }
+    }).as('upload')
+    cy.visit('/')
+  })
+
+  it('uploads a file and shows mapping modal', () => {
+    cy.get('input[type="file"]').selectFile({
+      contents: 'person_id,door_id,timestamp,access_result\n1,101,2024-01-01T00:00:00Z,granted\n',
+      fileName: 'sample.csv',
+      mimeType: 'text/csv'
+    }, { force: true })
+    cy.contains('Upload All').click()
+    cy.wait('@upload')
+    cy.contains('AI Column Mapping').should('be.visible')
+  })
+
+  it('maps columns and completes upload', () => {
+    cy.get('input[type="file"]').selectFile({
+      contents: 'person_id,door_id,timestamp,access_result\n1,101,2024-01-01T00:00:00Z,granted\n',
+      fileName: 'sample.csv',
+      mimeType: 'text/csv'
+    }, { force: true })
+    cy.contains('Upload All').click()
+    cy.wait('@upload')
+    cy.contains('AI Column Mapping').should('be.visible')
+    cy.contains('Confirm & Continue').click()
+    cy.contains('AI Column Mapping').should('not.exist')
+    cy.get('.progress-bar-large .progress-fill-large').should('have.attr', 'style', 'width: 100%')
+  })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,1 @@
+// Add custom Cypress commands if needed

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+import './commands'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
-    "tailwindcss": "^3.3.0"
+    "tailwindcss": "^3.3.0",
+    "cypress": "^13.7.3"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -51,7 +52,9 @@
     "test": "dotenv -e .env -- react-scripts test",
     "eject": "react-scripts eject",
     "build-css": "sh scripts/build_css.sh",
-    "lint:a11y": "pa11y http://localhost:8050"
+    "lint:a11y": "pa11y http://localhost:8050",
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- install Cypress and expose run/open scripts
- add Cypress config and sample test
- create upload flow E2E tests
- run Cypress in CI
- inline upload sample data in tests and remove CSV fixture

## Testing
- `pytest -q` *(fails: Missing required test dependencies)*
- `npm install` *(fails during Cypress install)*
- `npx cypress run` *(fails: Cypress not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f791f7c8320a2f6a62d0e119948