### PR TITLE
Add React component architecture doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project follows a fully modular design built around a dependency injection 
 - [UI Flows](docs/ui_flows.md)
 - [Upload Interface Guide](docs/upload_interface.md)
 - [UI Design Assets](docs/ui_design/README.md)
+- [React Component Architecture](docs/react_component_architecture.md)
 - [Validation Overview](docs/validation_overview.md)
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ The dashboard is organized around a small core that wires together services and 
 
 The factory builds the container, which then instantiates services. Services operate on models retrieved from the database layer. This layered approach keeps components loosely coupled and easy to test.
 
+See [React Component Architecture](react_component_architecture.md) for an overview of the front-end structure.
+
 ## Latest Changes
 
 - **Unified Validator** – Input and file validation are now handled by the

--- a/docs/react_component_architecture.md
+++ b/docs/react_component_architecture.md
@@ -1,0 +1,63 @@
+# React Component Architecture
+
+The front‑end is written in **React** and organized into feature pages under
+`src/pages`. Shared UI elements live in `src/components` alongside a few utility
+hooks. Each page loads data from the API and manages its own state using React
+hooks.
+
+## Pages
+
+- **Upload** – drag‑and‑drop uploads with column and device mapping modals
+  (`src/pages/Upload.tsx`).
+- **Analytics** – interactive charts and pattern summaries
+  (`src/pages/Analytics.tsx`).
+- **Graphs** – additional visualizations (`src/pages/Graphs.tsx`).
+- **Export** – download processed results (`src/pages/Export.tsx`).
+- **Settings** – application preferences (`src/pages/Settings.tsx`).
+
+Navigation between pages is handled by the **Navbar** component
+(`src/components/layout/Navbar.tsx`) which uses `react-router-dom`.
+
+## Shared Components
+
+Reusable widgets such as `Button`, `Card`, `Input` and `ProgressBar` are defined
+in `src/components/shared`. Complex upload functionality is split into smaller
+components under `src/components/upload` (for example
+`FilePreview` and `ColumnMappingModal`). Layout helpers like `Navbar` and the
+optional `Sidebar` live under `src/components/layout`.
+
+## Hooks
+
+Custom hooks live in `src/hooks`. Currently `useWebSocket` provides a simple way
+to subscribe to server‑sent progress updates during uploads. Pages primarily use
+`useState` and `useEffect` for local state management.
+
+## Data Flow
+
+Pages communicate with the backend via the `apiClient` wrapper in
+`src/api/client.ts`. API calls return JSON which pages store in component state.
+During file uploads the UI opens a WebSocket connection to receive progress
+updates while the file is processed.
+
+## Component Hierarchy
+
+```mermaid
+graph TD
+    A[App] --> B(Navbar)
+    A --> C(Routes)
+    C --> U[UploadPage]
+    C --> AN[AnalyticsPage]
+    C --> G[GraphsPage]
+    C --> E[ExportPage]
+    C --> S[SettingsPage]
+    U --> UU(UploadComponent)
+    UU --> FP(FilePreview)
+    UU --> CM(ColumnMappingModal)
+    UU --> DM(DeviceMappingModal)
+    UU --> WS(useWebSocket)
+    AN --> CH(Charts)
+```
+
+Each page maintains its own slice of state; children update parent state via
+callbacks. The upload flow, for example, stores selected files in `Upload` and
+passes progress information down to `FilePreview` components.


### PR DESCRIPTION
## Summary
- document React component architecture
- link new doc from README and architecture overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c6f7cb55c83208d400638cbd6a252