### PR TITLE
Use asyncio.run in upload endpoint

### DIFF
--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -1,0 +1,70 @@
+import asyncio
+import importlib
+import sys
+import types
+import pandas as pd
+from flask import Flask
+
+from core.service_container import ServiceContainer
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
+
+
+class DummyStore:
+    def get_all_data(self):
+        return {}
+
+
+class DummyUploadService:
+    def __init__(self):
+        self.store = DummyStore()
+        self.called_args = None
+
+    async def process_uploaded_files(self, contents, filenames):
+        self.called_args = (contents, filenames)
+        return {"upload_results": [], "file_preview_components": [], "file_info_dict": {}}
+
+
+def _create_app(monkeypatch):
+    # Provide minimal stubs to avoid heavy imports during module load
+    fake_reg = types.ModuleType("config.service_registration")
+    fake_reg.register_upload_services = lambda c: None
+    monkeypatch.setitem(sys.modules, "config.service_registration", fake_reg)
+
+    cont = ServiceContainer()
+    service = DummyUploadService()
+    cont.register_singleton("upload_processor", service)
+
+    container_mod = types.ModuleType("core.container")
+    container_mod.container = cont
+    monkeypatch.setitem(sys.modules, "core.container", container_mod)
+
+    upload_ep = importlib.import_module("upload_endpoint")
+
+    app = Flask(__name__)
+    app.register_blueprint(upload_ep.upload_bp)
+    monkeypatch.setattr(upload_ep, "container", cont, raising=False)
+    return app, service
+
+
+def test_upload_files_uses_asyncio_run(monkeypatch):
+    app, service = _create_app(monkeypatch)
+
+    used = {}
+    orig_run = asyncio.run
+
+    def fake_run(coro):
+        used["called"] = True
+        return orig_run(coro)
+
+    monkeypatch.setattr(asyncio, "run", fake_run)
+
+    df = DataFrameBuilder().add_column("a", [1]).build()
+    content = UploadFileBuilder().with_dataframe(df).as_base64()
+    client = app.test_client()
+    resp = client.post(
+        "/api/v1/upload",
+        json={"contents": [content], "filenames": ["test.csv"]},
+    )
+    assert resp.status_code == 200
+    assert used.get("called") is True
+    assert service.called_args == ([content], ["test.csv"])

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -39,13 +39,9 @@ def upload_files():
         upload_service = container.get("upload_processor")
 
         # Process files using existing base code
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        result_dict = loop.run_until_complete(
+        result_dict = asyncio.run(
             upload_service.process_uploaded_files(contents, filenames)
         )
-        loop.close()
 
         # Ensure structure matches what React expects
         response = {


### PR DESCRIPTION
## Summary
- avoid manual event loop handling in `upload_endpoint.upload_files`
- add unit test verifying `asyncio.run` execution

## Testing
- `pytest tests/test_upload_endpoint.py::test_upload_files_uses_asyncio_run -q`

------
https://chatgpt.com/codex/tasks/task_e_687c98ab4a308320af2106e211c61043