### PR TITLE
Add OpenAPI artifact to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
         run: |
           set -xe
           pip install -r requirements.txt -r requirements-dev.txt -r requirements-test.txt
+      - name: Generate OpenAPI spec
+        run: python tools/generate_openapi.py
+      - name: Upload OpenAPI
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: docs/openapi.json
       - name: Black
         run: |
           set -xe

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,9 @@ python tools/generate_openapi.py
 The script writes `docs/openapi.json`. Once generated, this file can be served
 by Swagger UI to display the complete API reference.
 
+The CI workflow runs this command and uploads the generated `openapi.json` as an
+artifact so the specification is available from workflow runs.
+
 ### Regenerating after changes
 
 `docs/openapi.json` is not committed to the repository. Whenever you modify any


### PR DESCRIPTION
## Summary
- generate the OpenAPI specification in CI
- upload the spec as an artifact
- document CI generation of `openapi.json`

## Testing
- `black --check . --line-length 88 --verbose` *(fails: would reformat 210 files)*
- `flake8 . --max-line-length 88 -v` *(fails: found 3107 violations)*
- `mypy .` *(fails: found 3492 errors)*
- `bandit -r . --severity-level high`
- `safety check -r requirements.txt -r requirements-dev.txt --full-report`
- `pip-audit -r requirements.txt -r requirements-dev.txt --format=json --output=audit-report.json` *(found 5 vulnerabilities)*
- `pytest --maxfail=1 --disable-warnings -q --cov=` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_687c98af6e988320a4aa6b7df13763e9