### PR TITLE
Add CSRF protection

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -1,5 +1,9 @@
-from flask import Flask
+import os
+from flask import Flask, jsonify
 from flask_cors import CORS
+from flask_wtf.csrf import CSRFProtect, generate_csrf
+
+csrf = CSRFProtect()
 
 from api.analytics_endpoints import register_analytics_blueprints
 from upload_endpoint import upload_bp
@@ -12,6 +16,9 @@ from config.constants import API_PORT
 def create_api_app() -> Flask:
     """Create Flask API app with all blueprints registered."""
     app = Flask(__name__)
+    app.config.setdefault("SECRET_KEY", os.getenv("SECRET_KEY", "change-me"))
+
+    csrf.init_app(app)
     CORS(app)
 
     # Third-party analytics demo endpoints
@@ -22,6 +29,11 @@ def create_api_app() -> Flask:
     app.register_blueprint(device_bp)
     app.register_blueprint(mappings_bp)
     app.register_blueprint(settings_bp)
+
+    @app.route("/api/v1/csrf-token", methods=["GET"])
+    def get_csrf_token():
+        """Provide CSRF token for clients."""
+        return jsonify({"csrf_token": generate_csrf()})
 
     return app
 

--- a/tests/stubs/flask_cors.py
+++ b/tests/stubs/flask_cors.py
@@ -1,0 +1,3 @@
+class CORS:
+    def __init__(self, app=None, *args, **kwargs):
+        self.app = app

--- a/tests/stubs/flask_wtf.py
+++ b/tests/stubs/flask_wtf.py
@@ -1,0 +1,34 @@
+from itsdangerous import URLSafeTimedSerializer
+from flask import current_app, session, request, abort
+
+class CSRFProtect:
+    def __init__(self, app=None):
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        app.before_request(self._check_csrf)
+
+    def _check_csrf(self):
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            token = request.headers.get("X-CSRFToken") or request.form.get("csrf_token")
+            try:
+                validate_csrf(token)
+            except Exception:
+                abort(400)
+
+def _serializer():
+    secret = current_app.config.get("SECRET_KEY", "secret")
+    return URLSafeTimedSerializer(secret)
+
+def generate_csrf():
+    token = _serializer().dumps("csrf")
+    session["_csrf_token"] = token
+    return token
+
+def validate_csrf(token):
+    if not token:
+        raise ValueError("Missing CSRF token")
+    _serializer().loads(token, max_age=3600)
+    if session.get("_csrf_token") != token:
+        raise ValueError("Invalid CSRF token")

--- a/tests/stubs/services/upload/protocols.py
+++ b/tests/stubs/services/upload/protocols.py
@@ -1,0 +1,14 @@
+class DeviceLearningServiceProtocol:
+    pass
+class UploadProcessingServiceProtocol:
+    pass
+class UploadValidatorProtocol:
+    pass
+class FileProcessorProtocol:
+    pass
+class UploadControllerProtocol:
+    pass
+class UploadStorageProtocol:
+    pass
+class UploadDataServiceProtocol:
+    pass

--- a/tests/test_upload_csrf.py
+++ b/tests/test_upload_csrf.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+
+# Provide stubs when optional dependencies are missing
+if "flask_wtf" not in sys.modules:
+    fw = importlib.import_module("tests.stubs.flask_wtf")
+    sys.modules["flask_wtf"] = fw
+    sys.modules["flask_wtf.csrf"] = fw
+if "flask_caching" not in sys.modules:
+    sys.modules["flask_caching"] = importlib.import_module("tests.stubs.flask_caching")
+if "flask_cors" not in sys.modules:
+    sys.modules["flask_cors"] = importlib.import_module("tests.stubs.flask_cors")
+if "services" not in sys.modules:
+    sys.modules["services"] = importlib.import_module("tests.stubs.services")
+
+from tests.stubs.flask_wtf import CSRFProtect, generate_csrf
+from flask import Flask, jsonify
+import werkzeug
+from core.service_container import ServiceContainer
+
+class DummyUploadService:
+    async def process_uploaded_files(self, contents, filenames):
+        return {"upload_results": [], "file_preview_components": [], "file_info_dict": {}}
+
+def _create_app(monkeypatch):
+    container = ServiceContainer()
+    container.register_singleton("upload_processor", DummyUploadService())
+    monkeypatch.setattr("core.container.container", container, raising=False)
+
+    import upload_endpoint
+    importlib.reload(upload_endpoint)
+
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-key"
+    CSRFProtect(app)
+    if not hasattr(werkzeug, "__version__"):
+        werkzeug.__version__ = "3"
+    app.register_blueprint(upload_endpoint.upload_bp)
+
+    @app.route("/api/v1/csrf-token")
+    def csrf_token():
+        return jsonify({"csrf_token": generate_csrf()})
+
+    return app
+
+
+def test_upload_requires_csrf(monkeypatch):
+    app = _create_app(monkeypatch)
+    client = app.test_client()
+
+    resp = client.post("/api/v1/upload", json={"contents": [], "filenames": []})
+    assert resp.status_code == 400
+
+    with client:
+        token = client.get("/api/v1/csrf-token").get_json()["csrf_token"]
+        resp = client.post(
+            "/api/v1/upload",
+            json={"contents": [], "filenames": []},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 200

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 
 from flask import Blueprint, jsonify, request
+from flask_wtf.csrf import validate_csrf
 
 # Use the shared DI container configured at application startup
 from core.container import container
@@ -17,6 +18,16 @@ upload_bp = Blueprint("upload", __name__)
 def upload_files():
     """Handle file upload and return expected structure for React frontend"""
     try:
+        token = (
+            request.headers.get("X-CSRFToken")
+            or request.headers.get("X-CSRF-Token")
+            or request.form.get("csrf_token")
+        )
+        try:
+            validate_csrf(token)
+        except Exception:
+            return jsonify({"error": "Invalid CSRF token"}), 400
+
         contents = []
         filenames = []
 


### PR DESCRIPTION
## Summary
- enable CSRF middleware in `create_api_app`
- validate tokens in `upload_files`
- add minimal Flask-WTF and CORS stubs for tests
- cover CSRF behavior with unit test

## Testing
- `pytest -q tests/test_upload_csrf.py`

------
https://chatgpt.com/codex/tasks/task_e_687c98b20d548320a6cf4fffc44f5745