### PR TITLE
Add callback graph generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,9 +864,19 @@ common UI components without launching the entire dashboard. Run a script with
 python storybook/navbar_app.py
 python storybook/upload_area_app.py
 ```
-
 Each command starts a small Dash server on port `8050` so you can interact with
 the component in isolation.
+## Callback Graph
+
+Run the helper script to visualize Dash callback dependencies:
+
+```bash
+python scripts/callback_graph.py
+```
+
+The command writes `docs/callback_graph.dot` and `docs/callback_graph.png`
+showing edges from each callback output to its inputs.
+
 
 
 ## 🤝 Contributing

--- a/scripts/callback_graph.py
+++ b/scripts/callback_graph.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Generate a GraphViz diagram of registered Dash callbacks."""
+
+from __future__ import annotations
+
+import os
+from graphviz import Digraph
+from dash import Dash
+
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from services.upload.callbacks import UploadCallbacks
+from services.analytics.callbacks import AnalyticsCallbacks
+
+
+def load_callbacks() -> TrulyUnifiedCallbacks:
+    """Create app, register callbacks and return coordinator."""
+    app = Dash(__name__)
+    coord = TrulyUnifiedCallbacks(app)
+    coord.register_all_callbacks(UploadCallbacks, AnalyticsCallbacks)
+    return coord
+
+
+def build_graph(coord: TrulyUnifiedCallbacks) -> Digraph:
+    """Return GraphViz digraph representing callback dependencies."""
+    graph = Digraph(comment="Callback Graph")
+
+    for reg in coord.registered_callbacks.values():
+        for out in reg.outputs:
+            out_id = f"{out.component_id}.{out.component_property}"
+            for inp in reg.inputs:
+                in_id = f"{inp.component_id}.{inp.component_property}"
+                graph.edge(out_id, in_id)
+    return graph
+
+
+def main() -> None:
+    coord = load_callbacks()
+    graph = build_graph(coord)
+
+    docs_dir = os.path.join(os.path.dirname(__file__), os.pardir, "docs")
+    docs_dir = os.path.abspath(docs_dir)
+    os.makedirs(docs_dir, exist_ok=True)
+
+    dot_path = os.path.join(docs_dir, "callback_graph.dot")
+    with open(dot_path, "w") as f:
+        f.write(graph.source)
+
+    graph.render(os.path.join(docs_dir, "callback_graph"), format="png", cleanup=True)
+    print(f"Wrote {dot_path} and callback_graph.png")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/callback_graph.py` to visualize registered callbacks
- document the helper in the README

## Testing
- `pip install dash==2.14.1 dash-bootstrap-components==1.6.0 pandas numpy redis pyyaml hvac cryptography Flask-Caching psutil`
- `pytest -k nothing` *(fails: ModuleNotFoundError: No module named 'services.configuration_service')*
- `PYTHONPATH=. python scripts/callback_graph.py` *(fails: ModuleNotFoundError: No module named 'dask')*

------
https://chatgpt.com/codex/tasks/task_e_687df8ea42dc832097811838c7dc757e