### PR TITLE
Introduce Zustand global state

### DIFF
--- a/docs/state_management.md
+++ b/docs/state_management.md
@@ -1,15 +1,16 @@
 # State Management
 
-State is stored in several `dcc.Store` components placed in the base layout.
-These stores keep the client in sync across pages without relying on global
-variables.
+Legacy pages used several `dcc.Store` components placed in the base layout to
+share data between callbacks. The new React frontend relies on a global Zustand
+store located under `src/state` instead of Dash stores.
 
 - **global-store** – application wide state shared by all users.
 - **session-store** – data scoped to the current user session.
 - **app-state-store** – cross page flags such as the initial load marker.
 - **theme-store** – remembers the selected color theme.
 
-Callbacks read and write to these stores via the `data` property. Example:
+Callbacks previously read and wrote to these stores via the `data` property.
+Example:
 
 ```python
 @app.callback(Output('session-store', 'data'), Input('logout-btn', 'n_clicks'))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "tailwind-merge": "^1.14.0",
     "typescript": "^4.9.5",
     "uuid": "^11.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^5.0.0",
@@ -41,13 +42,13 @@
     "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.21",
     "cssnano": "^6.0.1",
+    "cypress": "^13.7.3",
     "dotenv-cli": "^8.0.0",
     "pa11y": "^9.0.0",
     "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
-    "tailwindcss": "^3.3.0",
-    "cypress": "^13.7.3"
+    "tailwindcss": "^3.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import Papa from 'papaparse';
 import {
@@ -21,6 +21,7 @@ import {
 } from 'reactstrap';
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
+import { useSessionStore } from '../state/store';
 
 // Types matching the Python data structures
 interface FileInfo {
@@ -143,12 +144,18 @@ export const Upload: React.FC = () => {
   const [showColumnModal, setShowColumnModal] = useState(false);
   const [showDeviceModal, setShowDeviceModal] = useState(false);
   const [currentFile, setCurrentFile] = useState<FileInfo | null>(null);
-  const [sessionId] = useState(() => uuidv4());
+  const { sessionId, setSessionId } = useSessionStore();
   const [alerts, setAlerts] = useState<Array<{ id: string; type: string; message: string }>>([]);
 
   // Refs for background processing
   const uploadQueueRef = useRef<Array<{ file: File; taskId: string }>>([]);
   const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setSessionId(uuidv4());
+    }
+  }, [sessionId, setSessionId]);
 
 
   // File validation matching Python's security checks

--- a/src/state/analyticsSlice.ts
+++ b/src/state/analyticsSlice.ts
@@ -1,0 +1,20 @@
+import { StateCreator } from 'zustand';
+
+export interface AnalyticsData {
+  total_records: number;
+  unique_devices: number;
+  date_range: { start: string; end: string };
+  patterns: Array<{ pattern: string; count: number; percentage: number }>;
+  device_distribution: Array<{ device: string; count: number }>;
+}
+
+export interface AnalyticsSlice {
+  analyticsCache: Record<string, AnalyticsData>;
+  setAnalytics: (key: string, data: AnalyticsData) => void;
+}
+
+export const createAnalyticsSlice: StateCreator<AnalyticsSlice, [], [], AnalyticsSlice> = (set) => ({
+  analyticsCache: {},
+  setAnalytics: (key: string, data: AnalyticsData) =>
+    set((state) => ({ analyticsCache: { ...state.analyticsCache, [key]: data } })),
+});

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,3 @@
+export * from './store';
+export * from './sessionSlice';
+export * from './analyticsSlice';

--- a/src/state/sessionSlice.ts
+++ b/src/state/sessionSlice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from 'zustand';
+
+export interface SessionSlice {
+  sessionId: string | null;
+  setSessionId: (id: string) => void;
+}
+
+export const createSessionSlice: StateCreator<SessionSlice, [], [], SessionSlice> = (set) => ({
+  sessionId: null,
+  setSessionId: (id: string) => set({ sessionId: id }),
+});

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import { createSessionSlice, SessionSlice } from './sessionSlice';
+import { createAnalyticsSlice, AnalyticsSlice } from './analyticsSlice';
+
+export type BoundState = SessionSlice & AnalyticsSlice;
+
+export const useBoundStore = create<BoundState>()((...a) => ({
+  ...createSessionSlice(...a),
+  ...createAnalyticsSlice(...a),
+}));
+
+export const useSessionStore = () => useBoundStore((state) => ({
+  sessionId: state.sessionId,
+  setSessionId: state.setSessionId,
+}));
+
+export const useAnalyticsStore = () => useBoundStore((state) => ({
+  analyticsCache: state.analyticsCache,
+  setAnalytics: state.setAnalytics,
+}));


### PR DESCRIPTION
## Summary
- add Zustand store with slices for session and analytics data
- update analytics page to cache results in global state
- reuse session ID from store during file upload
- simplify realtime dashboard callbacks
- document new state system

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_687df8ec3d088320a6696682b864c557