### PR TITLE
Add DEFAULT_CHUNK_SIZE constant

### DIFF
--- a/analytics/chunked_analytics_controller.py
+++ b/analytics/chunked_analytics_controller.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterator, List
 import numpy as np
 import pandas as pd
 
-from config.constants import AnalysisThresholds, AnalyticsConstants
+from config.constants import AnalysisThresholds, AnalyticsConstants, DEFAULT_CHUNK_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -24,16 +24,16 @@ class ChunkedAnalyticsController:
 
             if hasattr(dynamic_config, "analytics"):
                 self.chunk_size = chunk_size or getattr(
-                    dynamic_config.analytics, "chunk_size", 50000
+                    dynamic_config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE
                 )
                 self.max_workers = max_workers or getattr(
                     dynamic_config.analytics, "max_workers", 4
                 )
             else:
-                self.chunk_size = chunk_size or 50000
+                self.chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
                 self.max_workers = max_workers or 4
         except Exception:
-            self.chunk_size = chunk_size or 50000
+            self.chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
             self.max_workers = max_workers or 4
 
         # Ensure chunk size is at least the configured minimum

--- a/analytics/file_processing_utils.py
+++ b/analytics/file_processing_utils.py
@@ -7,12 +7,14 @@ from collections import Counter
 from datetime import datetime
 from typing import Any, Dict, Iterable, Tuple
 
+from config.constants import DEFAULT_CHUNK_SIZE
+
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 
-def stream_uploaded_file(data_loader, source: Any, chunksize: int = 50000):
+def stream_uploaded_file(data_loader, source: Any, chunksize: int = DEFAULT_CHUNK_SIZE):
     """Yield cleaned ``DataFrame`` chunks from ``source`` using ``data_loader``."""
     yield from data_loader.stream_file(source, chunksize)
 

--- a/analytics/security_patterns/analyzer.py
+++ b/analytics/security_patterns/analyzer.py
@@ -18,6 +18,7 @@ import pandas as pd
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from database.baseline_metrics import BaselineMetricsDB
 from utils.sklearn_compat import optional_import
+from config.constants import DEFAULT_CHUNK_SIZE
 
 from .chunk_processor import ChunkedDataProcessor, MemoryConfig
 
@@ -781,7 +782,7 @@ class PaginatedAnalyzer(SecurityPatternsAnalyzer):
     def __init__(
         self,
         *,
-        chunk_size: int = 50000,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
         max_memory_mb: int = 500,
         **kwargs: Any,
     ) -> None:

--- a/config/constants.py
+++ b/config/constants.py
@@ -3,6 +3,9 @@
 from dataclasses import dataclass
 import os
 
+# Default chunk size used across services when reading or uploading large files
+DEFAULT_CHUNK_SIZE: int = 50_000
+
 
 class SecurityLimits:
     """Security-related validation limits."""

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -12,6 +12,7 @@ from .constants import (
     PerformanceConstants,
     SecurityConstants,
     UploadLimits,
+    DEFAULT_CHUNK_SIZE,
 )
 from .environment import select_config_file
 
@@ -276,7 +277,7 @@ class DynamicConfigManager(BaseConfigLoader):
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        return getattr(self.uploads, "DEFAULT_CHUNK_SIZE", 50000)
+        return getattr(self.uploads, "DEFAULT_CHUNK_SIZE", DEFAULT_CHUNK_SIZE)
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)

--- a/core/performance_file_processor.py
+++ b/core/performance_file_processor.py
@@ -7,6 +7,8 @@ import logging
 from pathlib import Path
 from typing import IO, Callable, Iterable, List, Optional, Union
 
+from config.constants import DEFAULT_CHUNK_SIZE
+
 import pandas as pd
 
 try:
@@ -19,7 +21,7 @@ class PerformanceFileProcessor:
     """Process large CSV files in chunks with memory tracking."""
 
     def __init__(
-        self, chunk_size: int = 50000, *, max_memory_mb: int | None = None
+        self, chunk_size: int = DEFAULT_CHUNK_SIZE, *, max_memory_mb: int | None = None
     ) -> None:
         from config.dynamic_config import dynamic_config
 

--- a/data_enhancer.py
+++ b/data_enhancer.py
@@ -29,6 +29,7 @@ import pandas as pd
 from dash import Input, Output, State, callback_context, dash_table, dcc, html
 
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from config.constants import DEFAULT_CHUNK_SIZE
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -83,7 +84,7 @@ except ImportError:
             return 50
 
         def get_upload_chunk_size(self) -> int:
-            return 50000
+            return DEFAULT_CHUNK_SIZE
 
 
 class AdvancedUnicodeHandler:

--- a/memory_safe_processor.py
+++ b/memory_safe_processor.py
@@ -7,6 +7,7 @@ from typing import IO, Iterable, Union
 import pandas as pd
 
 from utils.memory_utils import check_memory_limit
+from config.constants import DEFAULT_CHUNK_SIZE
 
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 class FileProcessor:
     """Process CSV files in chunks while guarding memory usage."""
 
-    def __init__(self, chunk_size: int = 50000, *, max_memory_mb: int = 500) -> None:
+    def __init__(self, chunk_size: int = DEFAULT_CHUNK_SIZE, *, max_memory_mb: int = 500) -> None:
         self.chunk_size = chunk_size
         self.max_memory_mb = max_memory_mb
 

--- a/services/data_processing/dataframe_utils.py
+++ b/services/data_processing/dataframe_utils.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
+from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from utils.file_utils import safe_decode_with_unicode_handling
@@ -26,7 +27,7 @@ def process_dataframe(
     try:
         filename_lower = filename.lower()
         monitor = get_performance_monitor()
-        chunk_size = getattr(config.analytics, "chunk_size", 50000)
+        chunk_size = getattr(config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
 
         if filename_lower.endswith(".csv"):
             for encoding in ["utf-8", "latin-1", "cp1252"]:

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Tuple
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
+from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from core.unicode import process_large_csv_content
@@ -42,7 +43,7 @@ def process_file_simple(
 
     try:
         encoding = "utf-8"
-        chunk_size = getattr(config.analytics, "chunk_size", 50000)
+        chunk_size = getattr(config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
 
         if len(content) > chunk_size:
             text = process_large_csv_content(content, encoding, chunk_size=chunk_size)

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
+from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.unicode import safe_format_number
 from core.performance_file_processor import PerformanceFileProcessor
@@ -63,7 +64,7 @@ class UnicodeFileProcessor:
         """Load a potentially huge CSV file via :class:`PerformanceFileProcessor`."""
 
         if chunk_size is None:
-            chunk_size = getattr(dynamic_config.analytics, "chunk_size", 50000)
+            chunk_size = getattr(dynamic_config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
 
         processor = PerformanceFileProcessor(
             chunk_size=chunk_size, max_memory_mb=max_memory_mb
@@ -87,7 +88,7 @@ class UnicodeFileProcessor:
         """
 
         if chunk_size is None:
-            chunk_size = getattr(dynamic_config.analytics, "chunk_size", 50000)
+            chunk_size = getattr(dynamic_config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
 
         obj_cols = list(df.select_dtypes(include=["object"]).columns)
 
@@ -149,7 +150,7 @@ def process_uploaded_file(
         # Safe Unicode processing
         text_content = UnicodeFileProcessor.safe_decode_content(decoded)
 
-        chunk_size = getattr(config.analytics, "chunk_size", 50000)
+        chunk_size = getattr(config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
         monitor = get_performance_monitor()
 
         # Process based on file type

--- a/services/data_processing/processor.py
+++ b/services/data_processing/processor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
+from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.security_validator import SecurityValidator
 from monitoring.data_quality_monitor import (
@@ -49,7 +50,7 @@ class Processor:
     # ------------------------------------------------------------------
     def load_dataframe(self, source: Any) -> pd.DataFrame:
         """Load ``source`` into a validated and mapped dataframe."""
-        chunk_size = getattr(dynamic_config.analytics, "chunk_size", 50000)
+        chunk_size = getattr(dynamic_config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
         monitor = get_performance_monitor()
 
         if isinstance(source, (str, Path)) or hasattr(source, "read"):
@@ -65,7 +66,7 @@ class Processor:
         return self.mapping_service.column_proc.process(df, "load").data
 
     def stream_file(
-        self, source: Any, chunksize: int = 50000
+        self, source: Any, chunksize: int = DEFAULT_CHUNK_SIZE
     ) -> Iterator[pd.DataFrame]:
         """Yield cleaned chunks from ``source``."""
         monitor = get_performance_monitor()

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -15,6 +15,7 @@ from services.configuration_service import ConfigurationServiceProtocol
 from memory_safe_processor import FileProcessor
 from core.unicode import process_large_csv_content
 from analytics_core.utils.unicode_processor import UnicodeHelper
+from config.constants import DEFAULT_CHUNK_SIZE
 from services.data_processing.unified_file_validator import (
     safe_decode_with_unicode_handling,
 )
@@ -142,7 +143,7 @@ class FileProcessorService(BaseService):
 
         try:
             if len(content) > 10 * 1024 * 1024:
-                processor = FileProcessor(chunk_size=50000)
+                processor = FileProcessor(chunk_size=DEFAULT_CHUNK_SIZE)
                 df = processor.read_large_csv(io.StringIO(text_content))
             else:
                 df = pd.read_csv(io.StringIO(text_content), sep=delimiter, **self.CSV_OPTIONS)

--- a/services/upload/chunked_upload_manager.py
+++ b/services/upload/chunked_upload_manager.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from config.connection_retry import ConnectionRetryManager, RetryConfig
 from config.protocols import ConnectionRetryManagerProtocol, RetryConfigProtocol
+from config.constants import DEFAULT_CHUNK_SIZE
 from utils.upload_store import UploadedDataStore
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ class ChunkedUploadManager:
         store: UploadedDataStore,
         metadata_dir: Optional[Path | str] = None,
         *,
-        initial_chunk_size: int = 50000,
+        initial_chunk_size: int = DEFAULT_CHUNK_SIZE,
         retry_manager_cls: type[ConnectionRetryManager] = ConnectionRetryManager,
     ) -> None:
         self.store = store

--- a/services/upload/chunked_upload_manager_async.py
+++ b/services/upload/chunked_upload_manager_async.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from config.connection_retry import RetryConfig
 from config.database_exceptions import ConnectionRetryExhausted
+from config.constants import DEFAULT_CHUNK_SIZE
 from utils.upload_store import UploadedDataStore
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ class ChunkedUploadManager:
         store: UploadedDataStore,
         metadata_dir: Optional[Path | str] = None,
         *,
-        initial_chunk_size: int = 50000,
+        initial_chunk_size: int = DEFAULT_CHUNK_SIZE,
         bandwidth_limit: float | None = None,
     ) -> None:
         self.store = store

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -17,6 +17,7 @@ from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from core.unicode_decode import safe_unicode_decode
+from config.constants import DEFAULT_CHUNK_SIZE
 
 # Core processing imports only - NO UI COMPONENTS
 from core.unicode_utils import sanitize_for_utf8
@@ -111,7 +112,7 @@ def process_uploaded_file(
         # Safe Unicode processing
         text_content = UnicodeFileProcessor.safe_decode_content(decoded)
 
-        chunk_size = getattr(config.analytics, "chunk_size", 50000)
+        chunk_size = getattr(config.analytics, "chunk_size", DEFAULT_CHUNK_SIZE)
         monitor = get_performance_monitor()
 
         # Process based on file type


### PR DESCRIPTION
## Summary
- add DEFAULT_CHUNK_SIZE constant in config.constants
- use DEFAULT_CHUNK_SIZE across upload and processing services

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `black . --check` *(fails: 216 files would be reformatted)*
- `flake8 .` *(fails with many style errors)*
- `mypy .` *(fails with numerous type errors)*
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687e05c77004832097dab2fb45e440c4