### PR TITLE
Add FileData interface for column mapping

### DIFF
--- a/src/components/upload/ColumnMappingModal.tsx
+++ b/src/components/upload/ColumnMappingModal.tsx
@@ -4,6 +4,7 @@ import { ExclamationTriangleIcon, CheckIcon } from '@heroicons/react/24/outline'
 import { Button } from '../shared/Button';
 import { Select } from '../shared/Select';
 import { Badge } from '../shared/Badge';
+import { FileData } from './types';
 
 interface ColumnMapping {
   originalColumn: string;
@@ -15,7 +16,7 @@ interface ColumnMapping {
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  fileData: any;
+  fileData: FileData | null;
   onConfirm: (mappings: Record<string, string>) => void;
 }
 

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -4,7 +4,7 @@ import { Upload as UploadIcon } from 'lucide-react';
 import { FilePreview } from './FilePreview';
 import { ColumnMappingModal } from './ColumnMappingModal';
 import { DeviceMappingModal } from './DeviceMappingModal';
-import { UploadedFile, ProcessingStatus as Status } from './types';
+import { UploadedFile, ProcessingStatus as Status, FileData } from './types';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';
 
@@ -14,7 +14,7 @@ const Upload: React.FC = () => {
   const [showColumnMapping, setShowColumnMapping] = useState(false);
   const [showDeviceMapping, setShowDeviceMapping] = useState(false);
   const [currentFile, setCurrentFile] = useState<UploadedFile | null>(null);
-  const [fileData, setFileData] = useState<any>(null);
+  const [fileData, setFileData] = useState<FileData | null>(null);
   const [devices, setDevices] = useState<string[]>([]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
@@ -71,7 +71,7 @@ const Upload: React.FC = () => {
       // Show mapping modal based on file type
       if (data.requiresColumnMapping) {
         setCurrentFile(uploadedFile);
-        setFileData(data.fileData || {});
+        setFileData(data.fileData || null);
         setShowColumnMapping(true);
       } else if (data.requiresDeviceMapping) {
         setCurrentFile(uploadedFile);

--- a/src/components/upload/types.ts
+++ b/src/components/upload/types.ts
@@ -29,3 +29,15 @@ export interface DeviceMapping {
   is_restricted: boolean;
   security_level: number;
 }
+
+export interface AISuggestion {
+  field: string;
+  confidence: number;
+}
+
+export interface FileData {
+  filename: string;
+  columns: string[];
+  ai_suggestions: Record<string, AISuggestion>;
+  sample_data?: Record<string, any[]>;
+}

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -22,6 +22,7 @@ import {
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { useSessionStore } from '../state/store';
+import { FileData } from '../components/upload/types';
 
 // Types matching the Python data structures
 interface FileInfo {
@@ -729,7 +730,12 @@ export const Upload: React.FC = () => {
           <AIColumnSuggestions data={data || null} />
         </div>
       ))}
-      <ColumnMappingModal isOpen={false} onClose={() => {}} fileData={{}} onConfirm={() => {}} />
+      <ColumnMappingModal
+        isOpen={false}
+        onClose={() => {}}
+        fileData={{ filename: '', columns: [], ai_suggestions: {} } as FileData}
+        onConfirm={() => {}}
+      />
       <DeviceMappingModal isOpen={false} onClose={() => {}} devices={[]} filename="" onConfirm={() => {}} />
     </div>
   );


### PR DESCRIPTION
## Summary
- define new `FileData` and `AISuggestion` types
- use `FileData` in `ColumnMappingModal` and `Upload`
- update example usage in `pages/Upload`

## Testing
- `npm test --silent -- -w=0`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_687e05c8bbc883209ebedd0986cc8043