### PR TITLE
Use env DB_PASSWORD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ DB_PORT=5432
 DB_NAME=yosai_db
 DB_USER=yosai_user
 DB_PASSWORD=change-me
+# Password for the database user
 
 # Auth0 Configuration (Development)
 AUTH0_CLIENT_ID=dev-client-id

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,7 +12,6 @@ database:
   port: 5432
   name: "yosai"
   user: "postgres"
-  password: "postgres"
   echo: false
   pool_size: 10
   max_overflow: 20

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pathlib import Path
-
+from .base_loader import BaseConfigLoader
 from .environment import select_config_file
 from .protocols import ConfigLoaderProtocol
-from .base_loader import BaseConfigLoader
 
 
 def validate_uploads_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -61,6 +60,11 @@ class ConfigLoader(BaseConfigLoader, ConfigLoaderProtocol):
                 self.log.warning("Failed to parse YOSAI_CONFIG_JSON: %s", exc)
 
         data = self._sanitize(data)
+
+        if "database" in data and not data["database"].get("password"):
+            if env_pwd := os.getenv("DB_PASSWORD"):
+                data.setdefault("database", {})["password"] = env_pwd
+
         return validate_uploads_config(data)
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -55,3 +55,25 @@ def test_env_overrides_applied(monkeypatch):
     db = cfg.get_database_config()
     assert db.host == "db.example.com"
     assert db.port == 1234
+
+
+def test_password_from_env(monkeypatch, tmp_path):
+    yaml_text = """
+app: {}
+database:
+  user: demo
+security: {}
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("DB_PASSWORD", "envpass")
+    monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("AUTH0_DOMAIN", "domain")
+    monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
+
+    cfg = create_config_manager()
+    assert cfg.get_database_config().password == "envpass"


### PR DESCRIPTION
## Summary
- remove hardcoded DB password from default config
- read DB_PASSWORD from environment during config loading
- document DB_PASSWORD in `.env.example`
- test loading password from environment

## Testing
- `pytest -q tests/test_config_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_687e05c6a1ec83209e6b863d22fa3ac7