### PR TITLE
Enforce SECRET_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,13 @@ with this Python release and newer.
    python scripts/generate_dev_secrets.py >> .env
    # Edit .env with your configuration (e.g. set HOST and database info)
    ```
-   `setup_dev_mode` checks for the `DB_PASSWORD` variable. The sample
-   `.env.example` includes a placeholder value. If this variable is
-   missing only a warning is emitted on startup, but database features
-   may not function.
+`setup_dev_mode` checks for the `DB_PASSWORD` variable. The sample
+`.env.example` includes a placeholder value. If this variable is
+missing only a warning is emitted on startup, but database features
+may not function.
+
+`SECRET_KEY` **must** be defined. The API will exit with a
+`RuntimeError` if the variable is missing.
 6. **Build the CSS bundle:**
    Ensure `node` and `npm` are available if you use the npm command.
    ```bash

--- a/api/adapter.py
+++ b/api/adapter.py
@@ -19,11 +19,10 @@ def create_api_app() -> Flask:
     """Create Flask API app with all blueprints registered."""
     app = Flask(__name__)
 
-    secret_key = os.getenv("SECRET_KEY")
-    if not secret_key:
-        raise RuntimeError("SECRET_KEY environment variable is required")
-
-    app.config["SECRET_KEY"] = secret_key
+    try:
+        app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
+    except KeyError as exc:
+        raise RuntimeError("SECRET_KEY environment variable is required") from exc
 
     csrf.init_app(app)
     CORS(app)

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -73,8 +73,8 @@ cp .env.example .env
 already defines a placeholder. If you skip this variable the tests will only
 show a warning but any database-dependent checks may fail.
 
-`SECRET_KEY` must also be defined or the API initialization will fail with a
-`RuntimeError` when the tests create the application context.
+`SECRET_KEY` is **mandatory**. If it is missing the API initialization fails
+with a `RuntimeError` when the tests create the application context.
 
 If the CSS bundle has not been built yet, generate it:
 ```bash


### PR DESCRIPTION
## Summary
- guard against missing `SECRET_KEY` in the API adapter
- mention required `SECRET_KEY` when setting up the project
- emphasize the same rule in the test setup docs

## Testing
- `pytest -q` *(fails: 92 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687e85bf5d6483208cdaf88bd4aed40a