### PR TITLE
Add async upload job processing

### DIFF
--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useCallback } from 'react';
-import { useDropzone } from 'react-dropzone';
-import { Upload as UploadIcon } from 'lucide-react';
-import { FilePreview } from './FilePreview';
-import { ColumnMappingModal } from './ColumnMappingModal';
-import { DeviceMappingModal } from './DeviceMappingModal';
-import { UploadedFile, ProcessingStatus as Status } from './types';
-import axios from 'axios/dist/node/axios.cjs';
+import React, { useState, useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+import { Upload as UploadIcon } from "lucide-react";
+import { FilePreview } from "./FilePreview";
+import { ColumnMappingModal } from "./ColumnMappingModal";
+import { DeviceMappingModal } from "./DeviceMappingModal";
+import { UploadedFile, ProcessingStatus as Status } from "./types";
+import axios from "axios/dist/node/axios.cjs";
 
 const CONCURRENCY_LIMIT = parseInt(
-  process.env.REACT_APP_UPLOAD_CONCURRENCY || '3',
-  10
+  process.env.REACT_APP_UPLOAD_CONCURRENCY || "3",
+  10,
 );
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5001";
 
 const Upload: React.FC = () => {
   const [files, setFiles] = useState<UploadedFile[]>([]);
@@ -30,7 +30,7 @@ const Upload: React.FC = () => {
       name: file.name,
       size: file.size,
       type: file.type,
-      status: 'pending' as Status,
+      status: "pending" as Status,
       progress: 0,
     }));
     setFiles((prev) => [...prev, ...newFiles]);
@@ -39,9 +39,11 @@ const Upload: React.FC = () => {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: {
-      'text/csv': ['.csv'],
-      'application/vnd.ms-excel': ['.xls'],
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+      "text/csv": [".csv"],
+      "application/vnd.ms-excel": [".xls"],
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+        ".xlsx",
+      ],
     },
     multiple: true,
   });
@@ -52,68 +54,82 @@ const Upload: React.FC = () => {
 
   const uploadFile = async (uploadedFile: UploadedFile) => {
     const formData = new FormData();
-    formData.append('file', uploadedFile.file);
+    formData.append("file", uploadedFile.file);
 
     setFiles((prev) =>
       prev.map((f) =>
         f.id === uploadedFile.id
-          ? { ...f, status: 'uploading' as Status, progress: 0, error: undefined }
-          : f
-      )
+          ? {
+              ...f,
+              status: "uploading" as Status,
+              progress: 0,
+              error: undefined,
+            }
+          : f,
+      ),
     );
 
     try {
-      const response = await axios.post(`${API_URL}/api/v1/upload`, formData, {
-        onUploadProgress: (evt) => {
-          if (evt.total) {
-            const progress = Math.round((evt.loaded * 100) / evt.total);
+      const response = await axios.post(`${API_URL}/api/v1/upload`, formData);
+      const { job_id } = response.data;
+
+      const poll = setInterval(async () => {
+        try {
+          const res = await axios.get(
+            `${API_URL}/api/v1/upload/status/${job_id}`,
+          );
+          const progress = res.data.progress ?? 0;
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.id === uploadedFile.id ? { ...f, progress } : f,
+            ),
+          );
+          if (res.data.done) {
+            clearInterval(poll);
             setFiles((prev) =>
               prev.map((f) =>
-                f.id === uploadedFile.id ? { ...f, progress } : f
-              )
+                f.id === uploadedFile.id
+                  ? { ...f, status: "completed" as Status, progress: 100 }
+                  : f,
+              ),
             );
           }
-        },
-      });
-
-      const data = response.data;
-
-      setFiles((prev) =>
-        prev.map((f) =>
-          f.id === uploadedFile.id
-            ? { ...f, status: 'completed' as Status, progress: 100 }
-            : f
-        )
-      );
-
-      if (data.requiresColumnMapping) {
-        setCurrentFile(uploadedFile);
-        setFileData(data.fileData || null);
-        setShowColumnMapping(true);
-      } else if (data.requiresDeviceMapping) {
-        setCurrentFile(uploadedFile);
-        setDevices(data.devices || []);
-        setShowDeviceMapping(true);
-      }
+        } catch (err) {
+          clearInterval(poll);
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.id === uploadedFile.id
+                ? {
+                    ...f,
+                    status: "error" as Status,
+                    error: "Processing failed",
+                  }
+                : f,
+            ),
+          );
+        }
+      }, 1000);
     } catch (error) {
-      console.error('Upload error:', error);
+      console.error("Upload error:", error);
       setFiles((prev) =>
         prev.map((f) =>
           f.id === uploadedFile.id
             ? {
                 ...f,
-                status: 'error' as Status,
-                error: (error as Error).message || 'Unknown error',
+                status: "error" as Status,
+                error: (error as Error).message || "Unknown error",
               }
-            : f
-        )
+            : f,
+        ),
       );
     }
   };
 
   const uploadAllFiles = async () => {
     setUploading(true);
-    const pendingFiles = files.filter((f) => f.status === 'pending' || f.status === 'error');
+    const pendingFiles = files.filter(
+      (f) => f.status === "pending" || f.status === "error",
+    );
     let index = 0;
 
     const uploadNext = async (): Promise<void> => {
@@ -123,19 +139,22 @@ const Upload: React.FC = () => {
       await uploadNext();
     };
 
-    const workers = Array.from({ length: Math.min(CONCURRENCY_LIMIT, pendingFiles.length) }, () => uploadNext());
+    const workers = Array.from(
+      { length: Math.min(CONCURRENCY_LIMIT, pendingFiles.length) },
+      () => uploadNext(),
+    );
     await Promise.all(workers);
     setUploading(false);
   };
 
   const handleColumnMappingConfirm = (mappings: Record<string, string>) => {
-    console.log('Column mappings confirmed:', mappings);
+    console.log("Column mappings confirmed:", mappings);
     setShowColumnMapping(false);
     setCurrentFile(null);
   };
 
   const handleDeviceMappingConfirm = (mappings: Record<string, any>) => {
-    console.log('Device mappings confirmed:', mappings);
+    console.log("Device mappings confirmed:", mappings);
     setShowDeviceMapping(false);
     setCurrentFile(null);
   };
@@ -144,16 +163,16 @@ const Upload: React.FC = () => {
     <div className="p-6 bg-background">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold mb-6">Upload Files</h1>
-        
+
         <div
           {...getRootProps()}
           className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors
-            ${isDragActive ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/50'}`}
+            ${isDragActive ? "border-primary bg-primary/5" : "border-border hover:border-primary/50"}`}
         >
           <input {...getInputProps()} />
           <UploadIcon className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
           <p className="text-lg mb-2">
-            {isDragActive ? 'Drop files here...' : 'Drag & drop files here'}
+            {isDragActive ? "Drop files here..." : "Drag & drop files here"}
           </p>
           <p className="text-sm text-muted-foreground">
             or click to select files (CSV, XLS, XLSX)
@@ -166,13 +185,15 @@ const Upload: React.FC = () => {
               <h2 className="text-xl font-semibold">Files ({files.length})</h2>
               <button
                 onClick={uploadAllFiles}
-                disabled={uploading || files.every((f) => f.status !== 'pending')}
+                disabled={
+                  uploading || files.every((f) => f.status !== "pending")
+                }
                 className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {uploading ? 'Uploading...' : 'Upload All'}
+                {uploading ? "Uploading..." : "Upload All"}
               </button>
             </div>
-            
+
             <div className="space-y-3">
               {files.map((file) => (
                 <FilePreview
@@ -202,7 +223,7 @@ const Upload: React.FC = () => {
             setCurrentFile(null);
           }}
           devices={devices}
-          filename={currentFile?.name || ''}
+          filename={currentFile?.name || ""}
           onConfirm={handleDeviceMappingConfirm}
         />
       </div>


### PR DESCRIPTION
## Summary
- add async job helpers to `AsyncFileProcessor`
- wire upload endpoint to return a job ID and provide a status route
- poll progress from the React upload component
- tests for the new async job

## Testing
- `pre-commit run --files services/data_processing/async_file_processor.py tests/test_async_file_processor.py` *(fails: mypy issues in repo)*
- `pytest -q tests/test_async_file_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_687e91014d4c8320a1f51d2fa0712cd5