### PR TITLE
Add streaming CSV processor

### DIFF
--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -12,10 +12,9 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from services.configuration_service import ConfigurationServiceProtocol
-from memory_safe_processor import FileProcessor
+from .stream_processor import StreamProcessor
 from core.unicode import process_large_csv_content
 from analytics_core.utils.unicode_processor import UnicodeHelper
-from config.constants import DEFAULT_CHUNK_SIZE
 from services.data_processing.unified_file_validator import (
     safe_decode_with_unicode_handling,
 )
@@ -142,18 +141,22 @@ class FileProcessorService(BaseService):
             logger.debug("CSV sniffer failed, falling back to manual detection")
 
         try:
-            if len(content) > 10 * 1024 * 1024:
-                processor = FileProcessor(chunk_size=DEFAULT_CHUNK_SIZE)
-                df = processor.read_large_csv(io.StringIO(text_content))
-            else:
-                df = pd.read_csv(io.StringIO(text_content), sep=delimiter, **self.CSV_OPTIONS)
+            df, errors = StreamProcessor.process_large_csv(
+                io.StringIO(text_content), sep=delimiter, **self.CSV_OPTIONS
+            )
+
+            if errors:
+                for msg in errors:
+                    logger.error(msg)
+
             if len(df.columns) <= 1:
-                df_alt = pd.read_csv(
+                df_alt, alt_err = StreamProcessor.process_large_csv(
                     io.StringIO(text_content),
                     engine="python",
                     sep=None,
                     **self.CSV_OPTIONS,
                 )
+                errors.extend(alt_err)
                 if len(df_alt.columns) > len(df.columns):
                     df = df_alt
             return UnicodeHelper.sanitize_dataframe(df)

--- a/services/stream_processor.py
+++ b/services/stream_processor.py
@@ -1,0 +1,48 @@
+import logging
+from typing import IO, Any, List, Tuple, Union
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class StreamProcessor:
+    """Helper utilities for streaming data processing."""
+
+    @staticmethod
+    def process_large_csv(
+        file_like: Union[str, IO[str]],
+        *,
+        chunk_size: int = 10000,
+        **read_kwargs: Any,
+    ) -> Tuple[pd.DataFrame, List[str]]:
+        """Read ``file_like`` CSV in ``chunk_size`` pieces.
+
+        Returns the concatenated DataFrame and a list of chunk error messages.
+        """
+        chunks: List[pd.DataFrame] = []
+        errors: List[str] = []
+        try:
+            reader = pd.read_csv(file_like, chunksize=chunk_size, **read_kwargs)
+        except Exception as exc:  # pragma: no cover - invalid CSV
+            logger.error("Failed to create CSV reader: %s", exc)
+            return pd.DataFrame(), [str(exc)]
+
+        for idx, chunk in enumerate(reader):
+            try:
+                chunks.append(chunk)
+            except Exception as exc:  # pragma: no cover - per-chunk errors
+                msg = f"Chunk {idx} failed: {exc}"
+                logger.error(msg)
+                errors.append(msg)
+
+        try:
+            df = pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+        except Exception as exc:  # pragma: no cover - concat errors
+            logger.error("Failed concatenating chunks: %s", exc)
+            errors.append(str(exc))
+            df = pd.DataFrame()
+        return df, errors
+
+
+__all__ = ["StreamProcessor"]


### PR DESCRIPTION
## Summary
- introduce `StreamProcessor.process_large_csv`
- use new helper in `FileProcessorService._process_csv`

## Testing
- `pytest tests/test_file_processing_service.py::test_process_csv -q` *(fails: ModuleNotFoundError: No module named 'distributed')*
- `pytest tests/test_file_processor.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_687e9102aa6c8320bdc4391a6673a7ac