### PR TITLE
Add CI/CD workflow and badges

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,49 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.lock
+      - name: Run tests
+        run: pytest -q
+
+  go-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run Go tests
+        run: go test ./...
+
+  migration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.lock
+      - name: Run migration tests
+        run: pytest tests/test_migrations.py -q
+
+  container-build:
+    runs-on: ubuntu-latest
+    needs: [python-tests, go-tests, migration-tests]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t yosai-intel .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Yōsai Intel Dashboard
 
+[![CI](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci.yml/badge.svg)](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci.yml)
+[![CI/CD](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci-cd.yml)
+
 An AI-powered modular security intelligence dashboard for physical access control monitoring.
 
 ## Architecture Overview


### PR DESCRIPTION
## Summary
- add CI/CD GitHub Actions workflow
- show CI and CI/CD badges in the README

## Testing
- `pytest tests/test_migrations.py -q` *(fails: ModuleNotFoundError: No module named 'pandas.tseries')*

------
https://chatgpt.com/codex/tasks/task_e_687eb2b9bf008320aa40fc8dc5e0725f