### PR TITLE
Add Kafka topic helper and access event schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,29 @@ reflected until you rebuild the bundle with `npm run build-css` (or
 loads `assets/dist/main.min.css` instead of the source CSS. Gzip or Brotli
 compression is automatically handled at runtime by `flask-compress`.
 
+## Kafka Setup
+
+Kafka topics must exist before starting the streaming service. Use the helper
+script to create them (pass the broker list if not running on localhost):
+
+```bash
+./scripts/create_kafka_topics.sh            # uses localhost:9092
+./scripts/create_kafka_topics.sh kafka:9092 # custom broker
+```
+
+The script requires `kafka-topics.sh` in your `PATH`.
+
+After creating the topics, register the Avro schema with your schema registry:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  --data @schemas/access-event.avsc \
+  http://localhost:8081/subjects/access-events-value/versions
+```
+
+Replace the URL with the address of your registry.
+
 ## 🧪 Testing
 
 Install dependencies before running the tests:

--- a/schemas/access-event.avsc
+++ b/schemas/access-event.avsc
@@ -1,0 +1,17 @@
+{
+  "namespace": "com.yosai.access",
+  "type": "record",
+  "name": "AccessEvent",
+  "fields": [
+    {"name": "event_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "person_id", "type": ["null", "string"], "default": null},
+    {"name": "door_id", "type": ["null", "string"], "default": null},
+    {"name": "badge_id", "type": ["null", "string"], "default": null},
+    {"name": "access_result", "type": "string"},
+    {"name": "badge_status", "type": ["null", "string"], "default": null},
+    {"name": "door_held_open_time", "type": ["null", "double"], "default": 0.0},
+    {"name": "entry_without_badge", "type": ["null", "boolean"], "default": false},
+    {"name": "device_status", "type": ["null", "string"], "default": "normal"}
+  ]
+}

--- a/scripts/create_kafka_topics.sh
+++ b/scripts/create_kafka_topics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Create Kafka topics required by the Y\xC5\x8Dsai Intel Dashboard.
+# Usage: ./scripts/create_kafka_topics.sh [broker-list]
+# Requires kafka-topics.sh from Kafka distribution in your PATH.
+
+set -euo pipefail
+
+BROKERS=${1:-localhost:9092}
+
+create_topic() {
+  local name=$1
+  local partitions=$2
+  local retention=$3
+  echo "Creating topic $name"
+  kafka-topics.sh \
+    --bootstrap-server "$BROKERS" \
+    --create \
+    --if-not-exists \
+    --topic "$name" \
+    --partitions "$partitions" \
+    --replication-factor 1 \
+    --config retention.ms="$retention"
+}
+
+# Access control events, one week retention
+create_topic access-events 3 $((7 * 24 * 60 * 60 * 1000))
+
+# Detected anomalies, one month retention
+create_topic anomaly-events 3 $((30 * 24 * 60 * 60 * 1000))
+
+# Audit logs, one month retention
+create_topic audit-logs 1 $((30 * 24 * 60 * 60 * 1000))


### PR DESCRIPTION
## Summary
- add `schemas/access-event.avsc`
- add `scripts/create_kafka_topics.sh`
- document Kafka topic creation and schema registration

## Testing
- `pre-commit run --files README.md scripts/create_kafka_topics.sh schemas/access-event.avsc`
- `pytest tests/test_connection_pool.py::test_pool_reuse -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb2b2243c8320a6a76ce22897daf5