### PR TITLE
Add Docker Compose dev stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ may not function.
    The server runs over HTTP by default but will automatically serve HTTPS
    whenever certificates are available.
 
+### Docker Compose Development Environment
+
+To spin up the monolith together with the new microservices run:
+
+```bash
+docker-compose \
+  -f docker-compose.yml \
+  -f docker-compose.kafka.yml \
+  -f docker-compose.dev.yml up --build
+```
+
+This starts PostgreSQL, TimescaleDB (port `5433`), the Kafka stack with a
+web UI on `http://localhost:8080`, pgAdmin on `http://localhost:5050`, the
+API gateway on `http://localhost:8081` and the main dashboard on
+`http://localhost:8050`.
+Stop all containers with `docker-compose down` when finished.
+
 ## Developer Onboarding
 
 For a more detailed walkthrough of the environment setup and testing workflow,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,81 @@
+version: '3.8'
+
+services:
+  app:
+    extends:
+      file: docker-compose.yml
+      service: app
+    environment:
+      YOSAI_ENV: development
+      DB_HOST: postgres
+      DB_PORT: 5432
+    depends_on:
+      - postgres
+      - timescaledb
+      - kafka
+
+  postgres:
+    extends:
+      file: docker-compose.yml
+      service: postgres
+
+  timescaledb:
+    image: timescale/timescaledb:2.13.0-pg15
+    environment:
+      POSTGRES_DB: yosai_intel
+      POSTGRES_USER: postgres
+    secrets:
+      - db_password
+    volumes:
+      - timescaledb_data:/var/lib/postgresql/data
+      - ./scripts/init_timescaledb.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "5433:5432"
+    restart: unless-stopped
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@local.dev
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    depends_on:
+      - postgres
+      - timescaledb
+    restart: unless-stopped
+
+  api-gateway:
+    image: nginx:1.25
+    volumes:
+      - ./nginx/dev_gateway.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8081:80"
+    depends_on:
+      - app
+    restart: unless-stopped
+
+  zookeeper:
+    extends:
+      file: docker-compose.kafka.yml
+      service: zookeeper
+
+  kafka:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka
+
+  kafka-ui:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka-ui
+
+volumes:
+  timescaledb_data:
+  pgadmin_data:
+
+secrets:
+  db_password:
+    file: ./secrets/db_password

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    restart: unless-stopped
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    restart: unless-stopped
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/nginx/dev_gateway.conf
+++ b/nginx/dev_gateway.conf
@@ -1,0 +1,22 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    upstream dashboard {
+        server app:8050;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://dashboard;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `docker-compose.dev.yml` with dev services
- include Kafka stack in new `docker-compose.kafka.yml`
- add pgAdmin and api-gateway for local testing
- document Compose development workflow in `README.md`

## Testing
- `pip install -r requirements-test.txt` *(failed: ModuleNotFoundError: No module named 'scipy')*
- `pytest -q` *(failed: 92 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687eb2b3ac408320ac696e9b61957cb3