### PR TITLE
Add Kubernetes dev setup

### DIFF
--- a/docs/k8s_dev.md
+++ b/docs/k8s_dev.md
@@ -1,0 +1,25 @@
+# Kubernetes Development Environment
+
+This guide explains how to start a local Kubernetes cluster for the Yōsai Intel Dashboard.
+It installs [k3s](https://k3s.io), [Linkerd](https://linkerd.io), the [Strimzi](https://strimzi.io) Kafka operator, and a small observability stack.
+
+## Setup
+
+Run the helper script which installs all dependencies and creates the required namespaces:
+
+```bash
+scripts/setup_k8s_dev.sh
+```
+
+The script installs k3s if it is not already present, then deploys Linkerd, the Strimzi operator, and Prometheus/Grafana via Helm.
+
+## Deploying the Dashboard
+
+After the cluster is ready apply the base manifests and the production manifests:
+
+```bash
+kubectl apply -f k8s/base
+kubectl apply -f k8s/production
+```
+
+The application will be available on the Node IP at port `80` once the pods become ready.

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yosai-config
+  namespace: yosai-dev
+data:
+  YOSAI_ENV: "development"
+  FLASK_ENV: "development"
+  FLASK_DEBUG: "1"
+  DB_HOST: "localhost"
+  DB_PORT: "5432"
+  DB_NAME: "yosai_db"
+  DB_USER: "yosai_user"
+  AUTH0_DOMAIN: "dev-domain.auth0.com"
+  AUTH0_AUDIENCE: "dev-audience"
+  AUTH0_CLIENT_ID: "dev-client-id"
+  WTF_CSRF_ENABLED: "True"

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: yosai-dev

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yosai-secrets
+  namespace: yosai-dev
+type: Opaque
+stringData:
+  DB_PASSWORD: change-me
+  SECRET_KEY: dev-secret-key
+  AUTH0_CLIENT_ID: dev-client-id
+  AUTH0_CLIENT_SECRET: dev-client-secret

--- a/scripts/setup_k8s_dev.sh
+++ b/scripts/setup_k8s_dev.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install k3s (lightweight Kubernetes)
+if ! command -v k3s >/dev/null 2>&1; then
+  curl -sfL https://get.k3s.io | sh -
+fi
+
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# Install Linkerd CLI if missing
+if ! command -v linkerd >/dev/null 2>&1; then
+  curl -sL https://run.linkerd.io/install | sh
+  export PATH=$PATH:$HOME/.linkerd2/bin
+fi
+
+# Install Linkerd control plane and viz extension
+linkerd install --crds | kubectl apply -f -
+linkerd install | kubectl apply -f -
+linkerd viz install | kubectl apply -f -
+
+# Install Strimzi Kafka operator
+kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f https://strimzi.io/install/latest?namespace=kafka -n kafka
+
+# Install observability stack (Prometheus and Grafana via Helm)
+if ! command -v helm >/dev/null 2>&1; then
+  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+fi
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm install monitoring prometheus-community/kube-prometheus-stack \
+  --namespace monitoring --create-namespace
+


### PR DESCRIPTION
## Summary
- add base Kubernetes manifests for a dev namespace
- add helper script to install k3s, Linkerd and observability tools
- document running the setup and applying manifests

## Testing
- `pytest tests/test_config_loader.py::test_yaml_and_env_loading -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb2b4f454832084de99124cc9aa7a