### PR TITLE
Update Docker Compose dev stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,10 +9,13 @@ services:
       YOSAI_ENV: development
       DB_HOST: postgres
       DB_PORT: 5432
+      SERVICE_DISCOVERY_URL: http://api-gateway
     depends_on:
       - postgres
       - timescaledb
-      - kafka
+      - kafka1
+      - kafka2
+      - kafka3
 
   postgres:
     extends:
@@ -53,19 +56,57 @@ services:
       - ./nginx/dev_gateway.conf:/etc/nginx/nginx.conf:ro
     ports:
       - "8081:80"
+    environment:
+      APP_HOST: app
+      APP_PORT: 8050
     depends_on:
       - app
     restart: unless-stopped
 
-  zookeeper:
+  zookeeper1:
     extends:
       file: docker-compose.kafka.yml
-      service: zookeeper
+      service: zookeeper1
 
-  kafka:
+  zookeeper2:
     extends:
       file: docker-compose.kafka.yml
-      service: kafka
+      service: zookeeper2
+
+  zookeeper3:
+    extends:
+      file: docker-compose.kafka.yml
+      service: zookeeper3
+
+  kafka1:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka1
+
+  kafka2:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka2
+
+  kafka3:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka3
+
+  schema-registry:
+    extends:
+      file: docker-compose.kafka.yml
+      service: schema-registry
+
+  connect:
+    extends:
+      file: docker-compose.kafka.yml
+      service: connect
+
+  kafka-manager:
+    extends:
+      file: docker-compose.kafka.yml
+      service: kafka-manager
 
   kafka-ui:
     extends:


### PR DESCRIPTION
## Summary
- expand Kafka stack in `docker-compose.dev.yml`
- keep TimescaleDB service initialized via SQL script
- expose service discovery variables for the API gateway and dashboard

## Testing
- `pytest -q` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687eb6938770832082b2adf2ba5a4f42