### PR TITLE
Update dev k8s setup

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -15,3 +15,8 @@ data:
   AUTH0_AUDIENCE: "dev-audience"
   AUTH0_CLIENT_ID: "dev-client-id"
   WTF_CSRF_ENABLED: "True"
+  KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+  TIMESCALE_HOST: "timescaledb"
+  TIMESCALE_PORT: "5432"
+  TIMESCALE_DB_NAME: "yosai_timescale"
+  TIMESCALE_DB_USER: "postgres"

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: yosai-dev
+  annotations:
+    linkerd.io/inject: enabled

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -9,3 +9,6 @@ stringData:
   SECRET_KEY: dev-secret-key
   AUTH0_CLIENT_ID: dev-client-id
   AUTH0_CLIENT_SECRET: dev-client-secret
+  KAFKA_USERNAME: ""
+  KAFKA_PASSWORD: ""
+  TIMESCALE_DB_PASSWORD: change-me

--- a/scripts/setup_k8s_dev.sh
+++ b/scripts/setup_k8s_dev.sh
@@ -32,3 +32,11 @@ helm repo update
 helm install monitoring prometheus-community/kube-prometheus-stack \
   --namespace monitoring --create-namespace
 
+# Create application namespaces
+for ns in yosai-prod yosai-staging yosai-dev; do
+  kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
+done
+
+# Apply base manifests
+kubectl apply -f k8s/base
+


### PR DESCRIPTION
## Summary
- create namespaces automatically in `setup_k8s_dev.sh`
- apply base manifests from the setup script
- enable linkerd injection on dev namespace
- add Kafka and Timescale configuration

## Testing
- `pre-commit run --files scripts/setup_k8s_dev.sh k8s/base/namespace.yaml k8s/base/configmap.yaml k8s/base/secrets.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687eb69532d48320ab2d5f4b7a2cab43