### PR TITLE
Update Kafka topic setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,11 @@ script to create them (pass the broker list if not running on localhost):
 
 The script requires `kafka-topics.sh` and `curl` in your `PATH`. It
 creates the topics `access-events`, `access-events-enriched`,
-`analytics-requests`, `analytics-responses`, `anomaly-events` and
-`audit-logs` with sensible defaults. It also registers the Avro schema in
-`schemas/access-event.avsc` with your schema registry (set
+`analytics-requests`, `analytics-responses`, `anomaly-events`,
+`alerts`, `system-metrics`, `dead-letter`, `app-state` and
+`audit-logs` with sensible defaults. A replication factor of **3** is
+used with `min.insync.replicas=2`. The script also registers the Avro
+schema in `schemas/access-event.avsc` with your schema registry (set
 `SCHEMA_REGISTRY_URL` to override the default `http://localhost:8081`).
 
 ## 🧪 Testing


### PR DESCRIPTION
## Summary
- set Kafka replication factor to 3 and `min.insync.replicas` to 2
- expose `segment.ms`, `retention.ms`, `max.message.bytes` and compression options
- create analytics, alert, metrics, dead letter and compacted state topics
- document new topics and defaults in README

## Testing
- `pytest tests/test_unicode_handler.py::test_safe_encode_query_surrogates -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebcbb361083208280d1e987fb2163