### PR TITLE
Add Avro schemas and registration script

### DIFF
--- a/schemas/analytics-request.avsc
+++ b/schemas/analytics-request.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "com.yosai.analytics",
+  "type": "record",
+  "name": "AnalyticsRequest",
+  "fields": [
+    {"name": "request_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "analysis_type", "type": "string"},
+    {"name": "parameters", "type": ["null", "string"], "default": null}
+  ]
+}

--- a/schemas/analytics-result.avsc
+++ b/schemas/analytics-result.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "com.yosai.analytics",
+  "type": "record",
+  "name": "AnalyticsResult",
+  "fields": [
+    {"name": "request_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "result", "type": "string"},
+    {"name": "success", "type": "boolean"}
+  ]
+}

--- a/schemas/anomaly-alert.avsc
+++ b/schemas/anomaly-alert.avsc
@@ -1,0 +1,12 @@
+{
+  "namespace": "com.yosai.anomaly",
+  "type": "record",
+  "name": "AnomalyAlert",
+  "fields": [
+    {"name": "alert_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "device_id", "type": ["null", "string"], "default": null},
+    {"name": "severity", "type": "string"},
+    {"name": "description", "type": ["null", "string"], "default": null}
+  ]
+}

--- a/schemas/audit-event.avsc
+++ b/schemas/audit-event.avsc
@@ -1,0 +1,13 @@
+{
+  "namespace": "com.yosai.audit",
+  "type": "record",
+  "name": "AuditEvent",
+  "fields": [
+    {"name": "event_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "user_id", "type": ["null", "string"], "default": null},
+    {"name": "action", "type": "string"},
+    {"name": "resource", "type": ["null", "string"], "default": null},
+    {"name": "status", "type": "string"}
+  ]
+}

--- a/scripts/register_schemas.py
+++ b/scripts/register_schemas.py
@@ -1,0 +1,65 @@
+"""Register Avro schemas with the Confluent Schema Registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+SCHEMA_REGISTRY_URL = os.getenv("SCHEMA_REGISTRY_URL", "http://localhost:8081")
+HEADERS = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
+
+
+def register_schema(file_path: Path) -> bool:
+    """Register a single schema file.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the ``.avsc`` file.
+    Returns
+    -------
+    bool
+        ``True`` on success, ``False`` otherwise.
+    """
+    subject = f"{file_path.stem}-value"
+    with open(file_path, "r", encoding="utf-8") as fh:
+        schema_str = fh.read()
+
+    payload = json.dumps({"schema": schema_str})
+    url = f"{SCHEMA_REGISTRY_URL}/subjects/{subject}/versions"
+    response = requests.post(url, headers=HEADERS, data=payload, timeout=10)
+    if response.status_code >= 300:
+        print(f"Failed to register {subject}: {response.status_code} {response.text}", file=sys.stderr)
+        return False
+
+    # Try to read version from response, otherwise fetch it
+    version = response.json().get("version")
+    if version is None:
+        vers_resp = requests.get(url.rsplit("/", 1)[0] + "/versions", timeout=10)
+        if vers_resp.status_code >= 300:
+            print(
+                f"Failed retrieving version for {subject}: {vers_resp.status_code} {vers_resp.text}",
+                file=sys.stderr,
+            )
+            return False
+        version = max(vers_resp.json())
+
+    print(f"Registered {subject} version {version}")
+    return True
+
+
+def main() -> int:
+    schema_dir = Path(__file__).resolve().parent.parent / "schemas"
+    ok = True
+    for path in sorted(schema_dir.glob("*.avsc")):
+        if not register_schema(path):
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add analytics-request, analytics-result, anomaly-alert and audit-event schemas
- implement `scripts/register_schemas.py` for posting all schemas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distributed')*

------
https://chatgpt.com/codex/tasks/task_e_687ebcbc6a3083208511237994b43c9c