### PR TITLE
Add Kafka connector config

### DIFF
--- a/kafka-connect/postgres-cdc-connector.json
+++ b/kafka-connect/postgres-cdc-connector.json
@@ -1,0 +1,21 @@
+{
+  "name": "timescaledb-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "timescaledb",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "${DB_PASSWORD}",
+    "database.dbname": "postgres",
+    "topic.prefix": "dbserver1",
+    "plugin.name": "pgoutput",
+    "schema.include.list": "_timescaledb_internal",
+    "transforms": "timescaledb",
+    "transforms.timescaledb.type": "io.debezium.connector.postgresql.transforms.timescaledb.TimescaleDb",
+    "transforms.timescaledb.database.hostname": "timescaledb",
+    "transforms.timescaledb.database.port": "5432",
+    "transforms.timescaledb.database.user": "postgres",
+    "transforms.timescaledb.database.password": "${DB_PASSWORD}",
+    "transforms.timescaledb.database.dbname": "postgres"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Debezium config for capturing TimescaleDB changes

## Testing
- `pytest -k 'nonexistent_test' -q` *(fails: ModuleNotFoundError: No module named 'distributed')*
- `mypy --strict .` *(fails: Found 4119 errors)*
- `black --check .` *(fails: 216 files would be reformatted)*
- `flake8 .` *(fails with many style errors)*
- `isort --check .` *(fails: imports not correctly sorted)*
- `bandit -r .`

------
https://chatgpt.com/codex/tasks/task_e_687ebcbdaf7c83209d78ae4837ba24ba