### PR TITLE
Add Kafka startup helper scripts

### DIFF
--- a/scripts/check_kafka_health.sh
+++ b/scripts/check_kafka_health.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Wait until Kafka docker-compose stack becomes healthy.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.kafka.yml}"
+
+SERVICES=(
+  zookeeper-1 zookeeper-2 zookeeper-3
+  kafka-1 kafka-2 kafka-3
+  schema-registry kafka-connect kafka-ui
+)
+
+MAX_RETRIES=${MAX_RETRIES:-30}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-5}
+
+for ((i=1;i<=MAX_RETRIES;i++)); do
+  all_up=true
+  for svc in "${SERVICES[@]}"; do
+    cid=$(docker compose -f "$ROOT_DIR/$COMPOSE_FILE" ps -q "$svc")
+    if [ -z "$cid" ]; then
+      all_up=false
+      break
+    fi
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$cid" 2>/dev/null || echo "")
+    state=$(docker inspect -f '{{.State.Status}}' "$cid")
+    if [[ "$status" == "healthy" || "$state" == "running" ]]; then
+      continue
+    else
+      all_up=false
+      break
+    fi
+  done
+  if $all_up; then
+    echo "✅ Kafka services healthy"
+    exit 0
+  fi
+  echo "⏳ Waiting for Kafka stack to become healthy ($i/$MAX_RETRIES)"
+  sleep "$SLEEP_INTERVAL"
+done
+
+echo "❌ Kafka stack did not become healthy in time"
+exit 1
+

--- a/scripts/start_kafka.sh
+++ b/scripts/start_kafka.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Start the Kafka compose stack and deploy the CDC connector.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.kafka.yml}"
+CONNECTOR_CONFIG="${1:-${CONNECTOR_CONFIG:-}}"
+
+# Start compose stack
+echo "🚀 Starting Kafka stack using $COMPOSE_FILE"
+docker compose -f "$ROOT_DIR/$COMPOSE_FILE" up -d
+
+# Wait until containers are ready
+"$SCRIPT_DIR/check_kafka_health.sh"
+
+# Create topics and register schemas
+"$SCRIPT_DIR/create_kafka_topics.sh"
+
+# Deploy CDC connector when a config file is provided
+if [ -n "$CONNECTOR_CONFIG" ] && [ -f "$CONNECTOR_CONFIG" ]; then
+  echo "📨 Deploying CDC connector"
+  curl -s -X POST \
+    -H "Content-Type: application/json" \
+    --data "@$CONNECTOR_CONFIG" \
+    http://localhost:8083/connectors >/dev/null
+else
+  echo "⚠️  No connector config supplied; skipping deployment"
+fi
+
+echo "✅ Kafka stack ready"
+


### PR DESCRIPTION
## Summary
- add `start_kafka.sh` to spin up the Kafka compose stack
- add `check_kafka_health.sh` to wait until the stack is ready

## Testing
- `./scripts/run_tests_and_smoke.sh` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_687ebcc380a08320a571fc207732445c