### PR TITLE
Add Kubernetes service account and update dev configs

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -3,19 +3,28 @@ kind: ConfigMap
 metadata:
   name: yosai-config
   namespace: yosai-dev
+  annotations:
+    linkerd.io/inject: enabled
 data:
   YOSAI_ENV: "development"
   FLASK_ENV: "development"
   FLASK_DEBUG: "1"
+  DEBUG: "1"
+  YOSAI_CONFIG_FILE: "config/config.yaml"
+  SERVICE_DISCOVERY_URL: "http://api-gateway"
+  DB_TYPE: "postgresql"
   DB_HOST: "localhost"
   DB_PORT: "5432"
   DB_NAME: "yosai_db"
   DB_USER: "yosai_user"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
   AUTH0_DOMAIN: "dev-domain.auth0.com"
   AUTH0_AUDIENCE: "dev-audience"
   AUTH0_CLIENT_ID: "dev-client-id"
   WTF_CSRF_ENABLED: "True"
-  KAFKA_BOOTSTRAP_SERVERS: "kafka:9092"
+  KAFKA_BROKERS: "kafka:9092"
+  SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
   TIMESCALE_HOST: "timescaledb"
   TIMESCALE_PORT: "5432"
   TIMESCALE_DB_NAME: "yosai_timescale"

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: yosai-secrets
   namespace: yosai-dev
+  annotations:
+    linkerd.io/inject: enabled
 type: Opaque
 stringData:
   DB_PASSWORD: change-me

--- a/k8s/base/service-account.yaml
+++ b/k8s/base/service-account.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yosai-dashboard
+  namespace: yosai-dev
+  annotations:
+    linkerd.io/inject: enabled
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yosai-dashboard-role
+  namespace: yosai-dev
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yosai-dashboard-binding
+  namespace: yosai-dev
+subjects:
+  - kind: ServiceAccount
+    name: yosai-dashboard
+    namespace: yosai-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yosai-dashboard-role


### PR DESCRIPTION
## Summary
- extend k8s base configmap with more development variables, Kafka, and Linkerd annotation
- annotate secrets with Linkerd injection
- add service account manifest with RBAC role and binding

## Testing
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails with style violations)*
- `mypy .` *(fails with many errors)*
- `pytest -q` *(fails: missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ec3d3c6bc8320b607718561b22cda