### PR TITLE
Add Linkerd routing configs

### DIFF
--- a/k8s/linkerd/circuit-breaker.yaml
+++ b/k8s/linkerd/circuit-breaker.yaml
@@ -1,0 +1,10 @@
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: yosai-dashboard.yosai-dev.svc.cluster.local
+  namespace: yosai-dev
+spec:
+  failureAccrual:
+    consecutive:
+      failures: 5
+      window: 1m

--- a/k8s/linkerd/service-profile.yaml
+++ b/k8s/linkerd/service-profile.yaml
@@ -1,0 +1,16 @@
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: yosai-dashboard.yosai-dev.svc.cluster.local
+  namespace: yosai-dev
+spec:
+  routes:
+    - name: GET /api
+      condition:
+        method: GET
+        pathRegex: "/api/.*"
+      isRetryable: true
+  retryBudget:
+    retryRatio: 0.2
+    minRetriesPerSecond: 10
+    ttl: 10s

--- a/k8s/linkerd/traffic-split.yaml
+++ b/k8s/linkerd/traffic-split.yaml
@@ -1,0 +1,12 @@
+apiVersion: split.smi-spec.io/v1alpha2
+kind: TrafficSplit
+metadata:
+  name: yosai-dashboard-split
+  namespace: yosai-dev
+spec:
+  service: yosai-dashboard
+  backends:
+    - service: yosai-dashboard-v1
+      weight: 90
+    - service: yosai-dashboard-v2
+      weight: 10


### PR DESCRIPTION
## Summary
- create `k8s/linkerd` directory
- configure traffic splitting, retries and circuit breaking

## Testing
- `pytest -k "" -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ec3d56450832083d2544ae607d612