### PR TITLE
Add Kafka health CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,12 @@ the stack and detaches from the terminal:
 ```
 
 Monitor the brokers at <http://localhost:8080> while services are running.
+Run the health check tool to verify that all brokers are reachable:
+
+```bash
+python tools/cli_kafka_health.py --brokers localhost:9092
+```
+
 Stop the cluster when finished:
 
 ```bash

--- a/tools/cli_kafka_health.py
+++ b/tools/cli_kafka_health.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""CLI to check Kafka cluster health."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from monitoring import check_cluster_health  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Display Kafka cluster health information"
+    )
+    parser.add_argument(
+        "--brokers",
+        default="localhost:9092",
+        help="Bootstrap servers (host:port list)",
+    )
+    args = parser.parse_args()
+
+    health = check_cluster_health(args.brokers)
+    print(json.dumps(health, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small CLI script to report Kafka cluster health
- document the health check in the Kafka setup section

## Testing
- `pre-commit run --files tools/cli_kafka_health.py README.md` *(fails: mypy)*
- `pytest tests/test_kafka_integration.py::test_produce_consume_access_event -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec96efd0c8320973d4c2d55a6115b