### PR TITLE
Integrate real permission service

### DIFF
--- a/tests/test_security_validator.py
+++ b/tests/test_security_validator.py
@@ -34,17 +34,33 @@ def test_main_validation_orchestration():
     assert "sanitized" in result
 
 
-def test_check_permissions_allows(tmp_path, monkeypatch):
-    perm_file = tmp_path / "perms.json"
-    perm_file.write_text('{"alice": {"door1": "Granted"}}')
-    monkeypatch.setenv("PERMISSIONS_FILE", str(perm_file))
+def test_check_permissions_allows(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"allowed": True}
+
+        return Resp()
+
+    monkeypatch.setattr("requests.get", fake_get)
     validator = SecurityValidator()
     assert validator.check_permissions("alice", "door1", "open") is True
 
 
-def test_check_permissions_denied(tmp_path, monkeypatch):
-    perm_file = tmp_path / "perms.json"
-    perm_file.write_text('{"alice": {"door1": "Denied"}}')
-    monkeypatch.setenv("PERMISSIONS_FILE", str(perm_file))
+def test_check_permissions_denied(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"allowed": False}
+
+        return Resp()
+
+    monkeypatch.setattr("requests.get", fake_get)
     validator = SecurityValidator()
     assert validator.check_permissions("alice", "door1", "open") is False


### PR DESCRIPTION
## Summary
- hook up SecurityValidator to the permission service instead of JSON file
- adjust permission tests to stub service responses

## Testing
- `pytest tests/test_security_validator.py::test_check_permissions_allows tests/test_security_validator.py::test_check_permissions_denied -q`

------
https://chatgpt.com/codex/tasks/task_e_687eccd179a48320b1c7ce4086375ee8