### PR TITLE
Update TimescaleDB initialization

### DIFF
--- a/scripts/init_timescaledb.sql
+++ b/scripts/init_timescaledb.sql
@@ -15,5 +15,26 @@ ALTER TABLE access_events
   SET (timescaledb.compress,
        timescaledb.compress_orderby = 'time DESC',
        timescaledb.compress_segmentby = 'facility_id');
-SELECT add_compression_policy('access_events', INTERVAL '1 day');
-SELECT add_retention_policy('access_events', INTERVAL '7 days');
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
+CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
+
+-- Continuous aggregate for quick 5 minute summaries
+CREATE MATERIALIZED VIEW IF NOT EXISTS access_events_5min
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('5 minutes', time) AS bucket,
+    facility_id,
+    COUNT(*) AS event_count
+FROM access_events
+GROUP BY bucket, facility_id
+WITH NO DATA;
+SELECT add_continuous_aggregate_policy('access_events_5min',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '5 minutes');
+
+SELECT add_compression_policy('access_events', INTERVAL '7 days');
+SELECT add_retention_policy('access_events', INTERVAL '90 days');


### PR DESCRIPTION
## Summary
- add indexes to `access_events`
- create `access_events_5min` continuous aggregate
- configure compression and retention policies

## Testing
- `pytest tests/services/test_optimized_queries.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecf75bba48320b6270cf0176cfd63