### PR TITLE
Replace nginx API gateway with Go implementation

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22 AS build
+WORKDIR /src
+COPY gateway/go.mod gateway/go.sum ./
+RUN go mod download
+COPY gateway .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /gateway ./cmd/gateway
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /gateway /usr/local/bin/gateway
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/gateway"]

--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ This starts PostgreSQL, TimescaleDB (port `5433`), the Kafka stack with a
 web UI on `http://localhost:8080`, pgAdmin on `http://localhost:5050`, the
 API gateway on `http://localhost:8081` and the main dashboard on
 `http://localhost:8050`.
+
+### Go API Gateway
+
+The gateway forwards all requests to the dashboard service defined by the
+`APP_HOST` and `APP_PORT` environment variables (defaults are `app` and
+`8050`). Additional middleware can be toggled with:
+
+* `ENABLE_AUTH=1` – require an `Authorization` header
+* `ENABLE_RATELIMIT=1` – enable a simple token bucket rate limiter
+
+The service listens on port `8080` inside the container. You can reach it at
+`http://localhost:8081` when running via Docker Compose.
 Stop all containers with `docker-compose down` when finished.
 
 ## Developer Onboarding

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -84,11 +84,11 @@ services:
     restart: unless-stopped
 
   api-gateway:
-    image: nginx:1.25
-    volumes:
-      - ./nginx/dev_gateway.conf:/etc/nginx/nginx.conf:ro
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
     ports:
-      - "8081:80"
+      - "8081:8080"
     environment:
       APP_HOST: python-monolith
       APP_PORT: 8050

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/WSG23/yosai-gateway/internal/gateway"
+)
+
+func main() {
+	g, err := gateway.New()
+	if err != nil {
+		log.Fatalf("failed to create gateway: %v", err)
+	}
+
+	// enable middleware based on env vars
+	if os.Getenv("ENABLE_AUTH") == "1" {
+		g.UseAuth()
+	}
+	if os.Getenv("ENABLE_RATELIMIT") == "1" {
+		g.UseRateLimit()
+	}
+
+	addr := ":8080"
+	if port := os.Getenv("PORT"); port != "" {
+		addr = ":" + port
+	}
+
+	log.Printf("starting gateway on %s", addr)
+	if err := http.ListenAndServe(addr, g.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,0 +1,5 @@
+module github.com/WSG23/yosai-gateway
+
+go 1.22
+
+require github.com/gorilla/mux v1.8.1

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/gateway/internal/gateway/gateway.go
+++ b/gateway/internal/gateway/gateway.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/WSG23/yosai-gateway/internal/handlers"
+	"github.com/WSG23/yosai-gateway/internal/middleware"
+	"github.com/WSG23/yosai-gateway/internal/proxy"
+)
+
+// Gateway represents the HTTP gateway service.
+type Gateway struct {
+	router *mux.Router
+}
+
+// New creates a configured Gateway.
+func New() (*Gateway, error) {
+	p, err := proxy.NewProxy()
+	if err != nil {
+		return nil, err
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/health", handlers.HealthCheck).Methods(http.MethodGet)
+	r.PathPrefix("/").Handler(p)
+
+	g := &Gateway{router: r}
+
+	return g, nil
+}
+
+// UseAuth enables auth middleware.
+func (g *Gateway) UseAuth() {
+	g.router.Use(middleware.Auth)
+}
+
+// UseRateLimit enables rate limiting middleware.
+func (g *Gateway) UseRateLimit() {
+	g.router.Use(middleware.RateLimit)
+}
+
+// Handler returns the root HTTP handler.
+func (g *Gateway) Handler() http.Handler {
+	return g.router
+}

--- a/gateway/internal/handlers/health.go
+++ b/gateway/internal/handlers/health.go
@@ -1,0 +1,10 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/gateway/internal/middleware/auth.go
+++ b/gateway/internal/middleware/auth.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// Auth middleware checks for an Authorization header.
+func Auth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/gateway/internal/middleware/ratelimit.go
+++ b/gateway/internal/middleware/ratelimit.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+)
+
+// Simple rate limiter using a token bucket.
+func RateLimit(next http.Handler) http.Handler {
+	ticker := time.NewTicker(time.Millisecond * 100)
+	tokens := make(chan struct{}, 10)
+
+	go func() {
+		for range ticker.C {
+			select {
+			case tokens <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-tokens:
+			next.ServeHTTP(w, r)
+		default:
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		}
+	})
+}

--- a/gateway/internal/proxy/proxy.go
+++ b/gateway/internal/proxy/proxy.go
@@ -1,0 +1,24 @@
+package proxy
+
+import (
+	"net/http/httputil"
+	"net/url"
+	"os"
+)
+
+// NewProxy returns a reverse proxy to the target service.
+func NewProxy() (*httputil.ReverseProxy, error) {
+	host := os.Getenv("APP_HOST")
+	if host == "" {
+		host = "app"
+	}
+	port := os.Getenv("APP_PORT")
+	if port == "" {
+		port = "8050"
+	}
+	target, err := url.Parse("http://" + host + ":" + port)
+	if err != nil {
+		return nil, err
+	}
+	return httputil.NewSingleHostReverseProxy(target), nil
+}

--- a/k8s/microservices/api-gateway.yaml
+++ b/k8s/microservices/api-gateway.yaml
@@ -16,24 +16,24 @@ spec:
     spec:
       containers:
         - name: api-gateway
-          image: nginx:1.25
+          image: yosai-gateway:latest
           env:
             - name: APP_HOST
               value: "app"
             - name: APP_PORT
               value: "8050"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /
-              port: 80
+              path: /health
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /
-              port: 80
+              path: /health
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
           resources:


### PR DESCRIPTION
## Summary
- implement new Go-based gateway module under `gateway/`
- add Dockerfile.gateway for building the service
- update docker compose to build and run the Go gateway
- update Kubernetes deployment to use new container image
- document gateway usage and environment variables

## Testing
- `scripts/run_tests_and_smoke.sh` *(fails: ModuleNotFoundError: No module named 'flask_caching')*


------
https://chatgpt.com/codex/tasks/task_e_687ecf8408508320a68a0e732a6327d3