### PR TITLE
Add Go API gateway module

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -41,6 +41,7 @@ jobs:
           path: coverage.xml
       - name: Run Go tests
         if: matrix.job == 'go'
+        working-directory: ./api-gateway
         run: go test ./...
       - name: Run migration tests
         if: matrix.job == 'migration'

--- a/README.md
+++ b/README.md
@@ -193,12 +193,20 @@ API gateway on `http://localhost:8081` and the main dashboard on
 
 ### Go API Gateway
 
-The gateway forwards all requests to the dashboard service defined by the
-`APP_HOST` and `APP_PORT` environment variables (defaults are `app` and
-`8050`). Additional middleware can be toggled with:
+The Go gateway lives in the `api-gateway` directory. It forwards all requests
+to the dashboard service defined by the `APP_HOST` and `APP_PORT` environment
+variables (defaults are `app` and `8050`). Additional middleware can be
+toggled with:
 
 * `ENABLE_AUTH=1` – require an `Authorization` header
 * `ENABLE_RATELIMIT=1` – enable a simple token bucket rate limiter
+
+Run it locally with:
+
+```bash
+cd api-gateway
+go run .
+```
 
 The service listens on port `8080` inside the container. You can reach it at
 `http://localhost:8081` when running via Docker Compose.

--- a/api-gateway/go.mod
+++ b/api-gateway/go.mod
@@ -1,0 +1,8 @@
+module github.com/WSG23/api-gateway
+
+go 1.21
+
+require (
+	github.com/gorilla/mux v1.8.1
+	github.com/rs/cors v1.11.1
+)

--- a/api-gateway/go.sum
+++ b/api-gateway/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/api-gateway/main.go
+++ b/api-gateway/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"net/http/httputil"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/cors"
+)
+
+// Config holds configuration for the gateway
+type Config struct {
+	ListenAddr string
+	AppHost    string
+	AppPort    string
+}
+
+// LoadConfig loads configuration from environment variables with defaults.
+func LoadConfig() Config {
+	return Config{
+		ListenAddr: envOr("GATEWAY_ADDR", ":8080"),
+		AppHost:    envOr("APP_HOST", "app"),
+		AppPort:    envOr("APP_PORT", "8050"),
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// reverseProxy returns a reverse proxy handler to the dashboard service
+func reverseProxy(cfg Config) (http.Handler, error) {
+	target, err := url.Parse(fmt.Sprintf("http://%s:%s", cfg.AppHost, cfg.AppPort))
+	if err != nil {
+		return nil, err
+	}
+	return httputil.NewSingleHostReverseProxy(target), nil
+}
+
+func handleEvents(w http.ResponseWriter, r *http.Request) {
+	// TODO: implement websocket/event forwarding
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+func main() {
+	cfg := LoadConfig()
+
+	proxy, err := reverseProxy(cfg)
+	if err != nil {
+		log.Fatalf("failed to create proxy: %v", err)
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}).Methods(http.MethodGet)
+	r.PathPrefix("/events").HandlerFunc(handleEvents)
+	r.PathPrefix("/").Handler(proxy)
+
+	handler := cors.AllowAll().Handler(r)
+
+	log.Printf("gateway listening on %s", cfg.ListenAddr)
+	if err := http.ListenAndServe(cfg.ListenAddr, handler); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add standalone `api-gateway` Go module
- implement gateway with reverse proxy, CORS and health check
- run Go tests from the new directory in CI
- document gateway location and running instructions

## Testing
- `go test ./...` in `api-gateway`
- `pytest -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ed6d417b0832081b8a17e5b880777