### PR TITLE
Add modular callback registry

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,14 +7,15 @@ from .advanced_cache import (
     cache_with_lock,
     create_advanced_cache_manager,
 )
+from .advanced_query_optimizer import AdvancedQueryOptimizer
+from .cache_warmer import IntelligentCacheWarmer
+from .callback_modules import CallbackModule, CallbackModuleRegistry
+from .cpu_optimizer import CPUOptimizer
+from .hierarchical_cache_manager import HierarchicalCacheManager
 from .intelligent_multilevel_cache import (
     IntelligentMultiLevelCache,
     create_intelligent_cache_manager,
 )
-from .advanced_query_optimizer import AdvancedQueryOptimizer
-from .cpu_optimizer import CPUOptimizer
-from .hierarchical_cache_manager import HierarchicalCacheManager
-from .cache_warmer import IntelligentCacheWarmer
 from .memory_manager import MemoryManager
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
 
@@ -38,4 +39,6 @@ __all__ = [
     "CPUOptimizer",
     "IntelligentMultiLevelCache",
     "create_intelligent_cache_manager",
+    "CallbackModule",
+    "CallbackModuleRegistry",
 ]

--- a/core/callback_modules.py
+++ b/core/callback_modules.py
@@ -33,7 +33,7 @@ class CallbackModuleRegistry:
 
     def __init__(self) -> None:
         self._modules: Dict[str, CallbackModule] = {}
-        self._callback_map: Dict[str, str] = {}
+        self._registered_ids: set[str] = set()
 
     # ------------------------------------------------------------------
     def register_module(self, module: CallbackModule) -> bool:
@@ -45,7 +45,7 @@ class CallbackModuleRegistry:
             return False
 
         callback_ids = module.get_callback_ids()
-        conflicts = [cid for cid in callback_ids if cid in self._callback_map]
+        conflicts = [cid for cid in callback_ids if cid in self._registered_ids]
         if conflicts:
             logger.error(
                 "Module %s has conflicting callbacks: %s", module_id, conflicts
@@ -53,8 +53,7 @@ class CallbackModuleRegistry:
             return False
 
         self._modules[module_id] = module
-        for cid in callback_ids:
-            self._callback_map[cid] = module_id
+        self._registered_ids.update(callback_ids)
 
         return True
 

--- a/tests/test_modular_callbacks.py
+++ b/tests/test_modular_callbacks.py
@@ -1,0 +1,57 @@
+from core.callback_modules import CallbackModuleRegistry
+
+
+class DummyModule:
+    COMPONENT_ID = "mod"
+    NAMESPACE = "test"
+
+    def __init__(self, callback_ids):
+        self.callback_ids = list(callback_ids)
+        self.initialized_with = None
+
+    def register_callbacks(self, manager):
+        self.initialized_with = manager
+
+    def get_callback_ids(self):
+        return self.callback_ids
+
+
+def test_module_registration():
+    registry = CallbackModuleRegistry()
+    module = DummyModule(["a", "b"])
+    assert registry.register_module(module)
+    assert registry.get_module("mod") is module
+
+
+def test_duplicate_component_id():
+    registry = CallbackModuleRegistry()
+    first = DummyModule(["a"])
+    second = DummyModule(["b"])
+    second.COMPONENT_ID = first.COMPONENT_ID
+
+    assert registry.register_module(first)
+    assert not registry.register_module(second)
+    assert registry.get_module(first.COMPONENT_ID) is first
+
+
+def test_callback_id_conflict():
+    registry = CallbackModuleRegistry()
+    mod1 = DummyModule(["a", "b"])
+    mod1.COMPONENT_ID = "m1"
+    mod2 = DummyModule(["b", "c"])
+    mod2.COMPONENT_ID = "m2"
+
+    assert registry.register_module(mod1)
+    assert not registry.register_module(mod2)
+    assert registry.get_module("m2") is None
+
+
+def test_initialize_all_calls_register():
+    registry = CallbackModuleRegistry()
+    module = DummyModule(["x"])
+    registry.register_module(module)
+
+    manager = object()
+    registry.initialize_all(manager)
+
+    assert module.initialized_with is manager


### PR DESCRIPTION
## Summary
- implement modular callback registry and protocol
- expose new registry in core exports
- test callback module registry with module registration and conflicts

## Testing
- `pytest tests/test_modular_callbacks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed6de6b8c8320b186b8a3cddda650