### PR TITLE
Add FastAPI wrapper for analytics service

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,13 @@ manager.execute_query_with_retry("SELECT 1")
   
   The `AnalyticsService` conforms to `AnalyticsServiceProtocol`, so you can
   substitute your own implementation during tests.
+
+  A FastAPI wrapper is available for quick testing:
+
+  ```bash
+  uvicorn services.analytics.fastapi_wrapper:app
+  ```
+
 - **device_learning_service.py**: Persists learned device mappings ([docs](docs/device_learning_service.md))
 - Caching and performance optimization
 - Modular and testable

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ xlsxwriter==3.2.5
 python-dateutil==2.9.0.post0
 
 flask-cors==6.0.1
+fastapi==0.116.1

--- a/services/analytics/fastapi_wrapper.py
+++ b/services/analytics/fastapi_wrapper.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import asyncio
+from typing import Dict, Any
+
+app = FastAPI(title="Analytics Service")
+
+class AnalyticsRequest(BaseModel):
+    query_type: str
+    parameters: Dict[str, Any]
+
+@app.post("/analyze")
+async def analyze(request: AnalyticsRequest):
+    from services.analytics_service import AnalyticsService
+    service = AnalyticsService()
+    loop = asyncio.get_event_loop()
+    try:
+        result = await loop.run_in_executor(None, service.process_request, request.dict())
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- expose async `/analyze` endpoint using FastAPI
- require `fastapi` dependency
- document FastAPI wrapper usage

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -k fastapi_wrapper -q` *(fails: ModuleNotFoundError: No module named 'flask_caching')*

------
https://chatgpt.com/codex/tasks/task_e_687ed6ecb8d88320aa9704c9f2b15af0