### PR TITLE
Add real-time monitoring page

### DIFF
--- a/src/hooks/useEventSocket.test.ts
+++ b/src/hooks/useEventSocket.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react';
+import { useEventSocket } from './useEventSocket';
+
+class MockSocket {
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public close = jest.fn();
+  constructor(public url: string) {
+    MockSocket.instance = this;
+  }
+  static instance: MockSocket | null = null;
+}
+
+describe('useEventSocket', () => {
+  it('receives websocket messages', () => {
+    const { result, unmount } = renderHook(() =>
+      useEventSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
+    );
+
+    act(() => {
+      MockSocket.instance?.onmessage?.({ data: JSON.stringify({ a: 1 }) });
+    });
+
+    expect(result.current.data).toEqual(JSON.stringify({ a: 1 }));
+
+    unmount();
+    expect(MockSocket.instance?.close).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEventSocket.ts
+++ b/src/hooks/useEventSocket.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useEventSocket = (
+  url: string,
+  socketFactory?: (url: string) => WebSocket,
+) => {
+  const [data, setData] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onopen = () => setIsConnected(true);
+    ws.onclose = () => setIsConnected(false);
+    ws.onmessage = (ev) => setData(ev.data);
+
+    return () => {
+      ws.close();
+    };
+  }, [url]);
+
+  return { data, isConnected };
+};

--- a/src/pages/RealTimeMonitoring.tsx
+++ b/src/pages/RealTimeMonitoring.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Activity, Users, DoorOpen, AlertCircle } from 'lucide-react';
+import { useEventSocket } from '../hooks/useEventSocket';
+
+interface AccessEvent {
+  eventId: string;
+  personName: string;
+  doorName: string;
+  timestamp: string;
+  decision: 'GRANTED' | 'DENIED';
+  processingTime: number;
+}
+
+interface Metrics {
+  eventsPerSecond: number;
+  averageLatency: number;
+  activeUsers: number;
+  anomaliesDetected: number;
+}
+
+const MetricCard: React.FC<{
+  title: string;
+  value: string;
+  icon: React.ElementType;
+  trend?: 'up' | 'down' | 'good' | 'warning' | 'alert' | 'stable';
+}> = ({ title, value, icon: Icon, trend }) => {
+  const trendColor =
+    trend === 'up'
+      ? 'text-green-600'
+      : trend === 'down'
+        ? 'text-red-600'
+        : trend === 'alert'
+          ? 'text-red-600'
+          : trend === 'warning'
+            ? 'text-yellow-600'
+            : 'text-gray-600';
+  return (
+    <Card className="text-center p-4">
+      <CardHeader>
+        <Icon className="mx-auto mb-2" size={20} />
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <span className={`text-xl font-semibold ${trendColor}`}>{value}</span>
+      </CardContent>
+    </Card>
+  );
+};
+
+const EventRow: React.FC<{ event: AccessEvent }> = ({ event }) => (
+  <div className="flex items-center justify-between py-2 border-b text-sm">
+    <span className="font-medium">{event.personName}</span>
+    <span className="text-gray-500">{event.doorName}</span>
+    <span className={event.decision === 'GRANTED' ? 'text-green-600' : 'text-red-600'}>
+      {event.decision}
+    </span>
+    <span className="text-gray-400">
+      {new Date(event.timestamp).toLocaleTimeString()}
+    </span>
+  </div>
+);
+
+export const RealTimeMonitoring: React.FC = () => {
+  const [events, setEvents] = useState<AccessEvent[]>([]);
+  const [metrics, setMetrics] = useState<Metrics>({
+    eventsPerSecond: 0,
+    averageLatency: 0,
+    activeUsers: 0,
+    anomaliesDetected: 0,
+  });
+
+  const { data } = useEventSocket('ws://localhost:5001/ws/events');
+
+  useEffect(() => {
+    if (data) {
+      const event = JSON.parse(data) as AccessEvent;
+      setEvents((prev) => [event, ...prev].slice(0, 100));
+      updateMetrics(event);
+    }
+  }, [data]);
+
+  const updateMetrics = (event: AccessEvent) => {
+    setMetrics((prev) => ({
+      ...prev,
+      averageLatency: prev.averageLatency * 0.9 + event.processingTime * 0.1,
+      eventsPerSecond: prev.eventsPerSecond + 1,
+    }));
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <MetricCard
+          title="Events/Second"
+          value={metrics.eventsPerSecond.toFixed(1)}
+          icon={Activity}
+          trend={metrics.eventsPerSecond > 100 ? 'up' : 'stable'}
+        />
+        <MetricCard
+          title="Avg Latency"
+          value={`${metrics.averageLatency.toFixed(1)}ms`}
+          icon={Activity}
+          trend={metrics.averageLatency < 100 ? 'good' : 'warning'}
+        />
+        <MetricCard
+          title="Active Users"
+          value={metrics.activeUsers.toString()}
+          icon={Users}
+        />
+        <MetricCard
+          title="Anomalies"
+          value={metrics.anomaliesDetected.toString()}
+          icon={AlertCircle}
+          trend={metrics.anomaliesDetected > 0 ? 'alert' : 'good'}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Live Access Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-96 overflow-y-auto">
+            {events.map((event) => (
+              <EventRow key={event.eventId} event={event} />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default RealTimeMonitoring;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,3 +4,4 @@ export { default as Graphs } from './Graphs';
 export { default as Export } from './Export';
 export { default as Settings } from './Settings';
 export { default as RealTimeAnalyticsPage } from './RealTimeAnalyticsPage';
+export { default as RealTimeMonitoring } from './RealTimeMonitoring';


### PR DESCRIPTION
## Summary
- implement RealTimeMonitoring React page
- create WebSocket hook with test
- export new page from pages index

## Testing
- `npm test -- src/hooks/useEventSocket.test.ts --watchAll=false`
- `npm test -- src/hooks/useRealTimeAnalytics.test.ts src/hooks/useEventSocket.test.ts --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687f27de54e08320be5c25db70df88af