### PR TITLE
Add simple performance load test runner

### DIFF
--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -2,6 +2,6 @@
 set -e
 
 echo "📊 Running load tests..."
-echo "No load tests defined. Skipping."
+python tests/performance/test_event_processing.py
 
 exit 0

--- a/tests/performance/test_event_processing.py
+++ b/tests/performance/test_event_processing.py
@@ -1,0 +1,37 @@
+import time
+import uuid
+import random
+from datetime import datetime
+
+
+class PerformanceTestRunner:
+    """Simple event processing performance benchmark."""
+
+    def __init__(self, num_events: int = 10000):
+        self.num_events = num_events
+
+    def _generate_event(self) -> dict:
+        return {
+            "event_id": str(uuid.uuid4()),
+            "timestamp": datetime.utcnow(),
+            "value": random.random(),
+        }
+
+    def process_event(self, event: dict) -> None:
+        # Placeholder for real event processing logic
+        _ = event["event_id"]
+
+    def run(self) -> float:
+        start = time.perf_counter()
+        for _ in range(self.num_events):
+            event = self._generate_event()
+            self.process_event(event)
+        end = time.perf_counter()
+        total = end - start
+        print(f"Processed {self.num_events} events in {total:.2f} seconds")
+        return total
+
+
+if __name__ == "__main__":
+    runner = PerformanceTestRunner()
+    runner.run()


### PR DESCRIPTION
## Summary
- add minimal performance test runner for event processing
- call new runner from load_test script

## Testing
- `bash scripts/load_test.sh`
- `pytest -q tests/performance/test_event_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_687f2a3a02288320bef91141e0ea38c3