### PR TITLE
Add aiohttp to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,3 +12,4 @@ sqlparse==0.5.3
 plotly==5.15.0
 dask[distributed]==2024.4.1
 tqdm>=4.0
+aiohttp>=3.8


### PR DESCRIPTION
## Summary
- include `aiohttp` in `requirements-test.txt` for load testing

## Testing
- `pip install -r requirements-test.txt`
- `pip install -r requirements.txt`
- `pytest tests/test_ai_device_generator.py::TestAIDeviceGenerator::test_floor_extraction_patterns -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2a3a25b883208f026f58a3d523a3