### PR TITLE
Add React monitoring component

### DIFF
--- a/docs/react_component_architecture.md
+++ b/docs/react_component_architecture.md
@@ -28,8 +28,9 @@ optional `Sidebar` live under `src/components/layout`.
 
 ## Hooks
 
-Custom hooks live in `src/hooks`. Currently `useWebSocket` provides a simple way
-to subscribe to server‑sent progress updates during uploads. Pages primarily use
+Custom hooks live in `src/hooks`. `useUploadWebSocket` provides a simple way to
+subscribe to server‑sent progress updates during uploads, while
+`useWebSocket` can be used for general real-time feeds. Pages primarily use
 `useState` and `useEffect` for local state management.
 
 ## Data Flow
@@ -54,7 +55,7 @@ graph TD
     UU --> FP(FilePreview)
     UU --> CM(ColumnMappingModal)
     UU --> DM(DeviceMappingModal)
-    UU --> WS(useWebSocket)
+    UU --> WS(useUploadWebSocket)
     AN --> CH(Charts)
 ```
 

--- a/src/hooks/useUploadWebSocket.ts
+++ b/src/hooks/useUploadWebSocket.ts
@@ -1,0 +1,28 @@
+import { useRef } from 'react';
+
+interface ProgressCallback {
+  (progress: number): void;
+}
+
+export const useUploadWebSocket = () => {
+  const sockets = useRef<Record<string, WebSocket>>({});
+
+  const subscribeToUploadProgress = (taskId: string, cb: ProgressCallback) => {
+    if (sockets.current[taskId]) return;
+    const ws = new WebSocket(`ws://localhost:5001/ws/upload/${taskId}`);
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (data.progress !== undefined) {
+        cb(data.progress);
+      }
+    };
+    ws.onclose = () => {
+      delete sockets.current[taskId];
+    };
+    sockets.current[taskId] = ws;
+  };
+
+  return { subscribeToUploadProgress };
+};
+
+export default useUploadWebSocket;

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWebSocket } from './useWebSocket';
+
+class MockSocket {
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public close = jest.fn();
+  constructor(public url: string) {
+    MockSocket.instance = this;
+  }
+  static instance: MockSocket | null = null;
+}
+
+describe('useWebSocket', () => {
+  it('receives websocket messages', () => {
+    const { result, unmount } = renderHook(() =>
+      useWebSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
+    );
+
+    act(() => {
+      MockSocket.instance?.onmessage?.({ data: JSON.stringify({ a: 1 }) });
+    });
+
+    expect(result.current.data).toEqual(JSON.stringify({ a: 1 }));
+
+    unmount();
+    expect(MockSocket.instance?.close).toHaveBeenCalled();
+  });
+});

--- a/src/pages/RealTimeMonitoring.tsx
+++ b/src/pages/RealTimeMonitoring.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Activity, Users, DoorOpen, AlertCircle } from 'lucide-react';
-import { useEventSocket } from '../hooks/useEventSocket';
+import { useWebSocket } from '../hooks/useWebSocket';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
 
 interface AccessEvent {
   eventId: string;
@@ -70,7 +79,7 @@ export const RealTimeMonitoring: React.FC = () => {
     anomaliesDetected: 0,
   });
 
-  const { data } = useEventSocket('ws://localhost:5001/ws/events');
+  const { data, isConnected } = useWebSocket('/ws/events');
 
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
## Summary
- create generic `useWebSocket` hook
- move upload progress hook to `useUploadWebSocket`
- implement `RealTimeMonitoring` React page using new hook
- document hook changes in architecture guide
- add unit test for the new hook

## Testing
- `pytest -q` *(fails: errors during collection)*
- `mypy .` *(fails: found 3533 errors)*
- `flake8 .` *(fails: see /tmp/flake8.log)*
- `black --check .` *(fails: would reformat many files)*

------
https://chatgpt.com/codex/tasks/task_e_687f31e8fa8883208250e8c4fdc9dac5