### PR TITLE
Add initial migration and env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,10 @@ defaults:
 - `RATE_LIMIT_WINDOW` – rate limit window in minutes
 - `MAX_UPLOAD_MB` – maximum allowed upload size
 - `DB_POOL_SIZE` – database connection pool size
+- `DB_INITIAL_POOL_SIZE` – starting number of pooled connections
+- `DB_MAX_POOL_SIZE` – upper limit for the pool
+- `DB_TIMEOUT` – database connection timeout in seconds
+- `QUERY_TIMEOUT_SECONDS` – analytics query timeout
 
 ### Plugins
 

--- a/database/migrations/001_init.sql
+++ b/database/migrations/001_init.sql
@@ -1,0 +1,97 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- Main access event table using TimescaleDB
+CREATE TABLE IF NOT EXISTS access_events (
+    time TIMESTAMPTZ NOT NULL,
+    event_id UUID PRIMARY KEY,
+    person_id VARCHAR(50),
+    door_id VARCHAR(50),
+    facility_id VARCHAR(50),
+    access_result VARCHAR(20),
+    badge_status VARCHAR(20),
+    response_time_ms INTEGER,
+    metadata JSONB
+);
+
+SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE);
+ALTER TABLE access_events
+  SET (
+       timescaledb.compress,
+       timescaledb.compress_orderby = 'time DESC',
+       timescaledb.compress_segmentby = 'facility_id'
+  );
+
+-- Common indexes for query patterns
+CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
+CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
+
+-- Continuous aggregate for fast summaries
+CREATE MATERIALIZED VIEW IF NOT EXISTS access_events_5min
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('5 minutes', time) AS bucket,
+    facility_id,
+    COUNT(*) AS event_count
+FROM access_events
+GROUP BY bucket, facility_id
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('access_events_5min',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '5 minutes');
+
+SELECT add_compression_policy('access_events', INTERVAL '7 days');
+SELECT add_retention_policy('access_events', INTERVAL '90 days');
+
+-- Authorization related tables
+CREATE TABLE IF NOT EXISTS door_groups (
+    group_id SERIAL PRIMARY KEY,
+    group_name VARCHAR(100) UNIQUE NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS person_roles (
+    person_id VARCHAR(50) NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    PRIMARY KEY (person_id, role)
+);
+
+CREATE TABLE IF NOT EXISTS access_permissions (
+    permission_id SERIAL PRIMARY KEY,
+    person_id VARCHAR(50) NOT NULL,
+    door_id VARCHAR(50) NOT NULL,
+    valid_from TIMESTAMPTZ,
+    valid_to TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_access_permissions_person_id ON access_permissions(person_id);
+CREATE INDEX IF NOT EXISTS idx_access_permissions_door_id ON access_permissions(door_id);
+
+CREATE TABLE IF NOT EXISTS access_blocklist (
+    person_id VARCHAR(50) PRIMARY KEY,
+    reason TEXT,
+    blocked_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS time_restrictions (
+    restriction_id SERIAL PRIMARY KEY,
+    door_id VARCHAR(50),
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    days_of_week INT[]
+);
+CREATE INDEX IF NOT EXISTS idx_time_restrictions_door_id ON time_restrictions(door_id);
+
+CREATE TABLE IF NOT EXISTS anti_passback_state (
+    person_id VARCHAR(50) PRIMARY KEY,
+    last_direction VARCHAR(10),
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS emergency_lockdowns (
+    facility_id VARCHAR(50) PRIMARY KEY,
+    active BOOLEAN DEFAULT FALSE,
+    activated_at TIMESTAMPTZ
+);


### PR DESCRIPTION
## Summary
- add `database/migrations/001_init.sql` containing tables, indexes and materialized view
- document connection pool and query timeout environment variables

## Testing
- `pytest tests/migration/test_init_timescale_sql.py tests/test_migrations.py tests/migration/test_migrate_to_timescale.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3334c990832098997c016b3972a6