### PR TITLE
Enable service DB names

### DIFF
--- a/config/environment_processor.py
+++ b/config/environment_processor.py
@@ -64,6 +64,10 @@ class EnvironmentProcessor:
                 db.url = url
             if name := self.env.get("DB_NAME"):
                 db.name = name
+            elif name := self.env.get("DB_GATEWAY_NAME"):
+                db.name = name
+            elif name := self.env.get("DB_EVENTS_NAME"):
+                db.name = name
             if host := self.env.get("DB_HOST"):
                 db.host = host
             if (port := self._to_int("DB_PORT")) is not None:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -10,6 +10,9 @@ database:
   type: postgresql
   host: ${DB_HOST}
   port: ${DB_PORT:5432}
+  # Individual DB names for microservices
+  gateway_name: ${DB_GATEWAY_NAME:yosai_gateway_db}
+  events_name: ${DB_EVENTS_NAME:yosai_events_db}
   name: ${DB_NAME}
   user: ${DB_USER}
   password: vault:secret/data/db#password

--- a/docs/microservices_plan.md
+++ b/docs/microservices_plan.md
@@ -33,3 +33,18 @@ generated roadmap outlines a four phase approach:
 4. **Deployment** – roll out services incrementally while monitoring
    integration points.
 
+## Database Migration for Services
+
+As services split out of the monolith each one now connects to its own
+database. The production configuration exposes new environment variables for
+these names:
+
+```bash
+DB_GATEWAY_NAME=yosai_gateway_db
+DB_EVENTS_NAME=yosai_events_db
+```
+
+During migration set these variables for each service and run the schema
+migrations against the corresponding database. Existing deployments using
+`DB_NAME` continue to work, allowing an incremental rollout.
+

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -26,8 +26,12 @@ func main() {
 	}
 	cacheSvc := cache.NewRedisCache()
 
-	dsn := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
-		os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_USER"), os.Getenv("DB_NAME"), os.Getenv("DB_PASSWORD"))
+       dbName := os.Getenv("DB_GATEWAY_NAME")
+       if dbName == "" {
+               dbName = os.Getenv("DB_NAME")
+       }
+       dsn := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
+               os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_USER"), dbName, os.Getenv("DB_PASSWORD"))
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect db: %v", err)


### PR DESCRIPTION
## Summary
- add `DB_GATEWAY_NAME` and `DB_EVENTS_NAME` defaults in production config
- let `EnvironmentProcessor` read the new variables
- update gateway service to use `DB_GATEWAY_NAME`
- document database migration steps

## Testing
- `pre-commit run --files config/production.yaml config/environment_processor.py gateway/cmd/gateway/main.go docs/microservices_plan.md` *(fails: bandit found many issues)*
- `pytest tests/test_unicode_text_processor.py::test_object_count_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3a33f3348320a7c45b7d2db711c6