### PR TITLE
Add event ingestion Dockerfile and update deployments

### DIFF
--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install only required dependency for EventStreamingService
+RUN pip install --no-cache-dir kafka-python
+
+COPY services services
+COPY config config
+COPY tools tools
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
+
+CMD ["python", "tools/streaming_producer.py"]

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -151,6 +151,29 @@ services:
       echo 'Topics created successfully!'
       "
 
+  event-ingestion:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingestion
+    environment:
+      KAFKA_BROKERS: kafka1:29092,kafka2:29093,kafka3:29094
+      SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    depends_on:
+      kafka1:
+        condition: service_healthy
+      kafka2:
+        condition: service_healthy
+      kafka3:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
 volumes:
   zookeeper-data:
   zookeeper-logs:

--- a/k8s/microservices/event-ingestion.yaml
+++ b/k8s/microservices/event-ingestion.yaml
@@ -16,8 +16,22 @@ spec:
     spec:
       containers:
         - name: event-ingestion
-          image: yosai-intel-dashboard:latest
+          image: event-ingestion:latest
           command: ["python", "tools/streaming_producer.py"]
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
           envFrom:
             - configMapRef:
                 name: yosai-config


### PR DESCRIPTION
## Summary
- provide a minimal `Dockerfile.ingestion` for the event ingestion service
- build event-ingestion container in `docker-compose.kafka.yml`
- point Kubernetes deployment at the new image and add probes

## Testing
- `pytest -q` *(fails: 58 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f477cd9c88320a679a3dc5c297c45