### PR TITLE
Add Alembic migrations and Timescale replication job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Run migration tests
         if: matrix.job == 'migration'
         run: pytest tests/migration tests/test_migrations.py -q
+      - name: Alembic upgrade check
+        if: matrix.job == 'migration'
+        run: alembic -c database/migrations/alembic.ini upgrade head
+      - name: Compile replication script
+        if: matrix.job == 'migration'
+        run: python -m py_compile scripts/replicate_to_timescale.py
   container-build:
     runs-on: ubuntu-latest
     needs: tests

--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,23 @@ TIMESCALE_DB_USER, TIMESCALE_DB_PASSWORD
 
 The default `docker-compose.dev.yml` exposes TimescaleDB on port `5433`.
 
+### Schema Migrations and Replication
+
+Database schema changes are managed with **Alembic** under `database/migrations/`.
+Run migrations with:
+
+```bash
+alembic -c database/migrations/alembic.ini upgrade head
+```
+
+New access events are replicated from PostgreSQL to TimescaleDB by
+`scripts/replicate_to_timescale.py`. Set `SOURCE_DSN` and `TARGET_DSN` to run the
+job periodically (for example via `cron` or a Kubernetes CronJob):
+
+```bash
+python scripts/replicate_to_timescale.py
+```
+
 
 
 ## 🤝 Contributing

--- a/database/migrations/alembic.ini
+++ b/database/migrations/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = database/migrations/alembic
+sqlalchemy.url = postgresql://localhost/yosai_intel
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(name)s:%(lineno)d %(message)s

--- a/database/migrations/alembic/env.py
+++ b/database/migrations/alembic/env.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import os
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+config = context.config
+fileConfig(config.config_file_name)
+
+# allow overriding the DB connection via environment variable
+config.set_main_option(
+    "sqlalchemy.url", os.getenv("DB_DSN", config.get_main_option("sqlalchemy.url"))
+)
+
+target_metadata = None
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/database/migrations/alembic/versions/0001_initial.py
+++ b/database/migrations/alembic/versions/0001_initial.py
@@ -1,0 +1,28 @@
+"""Initial schema using TimescaleDB"""
+from __future__ import annotations
+from pathlib import Path
+from alembic import op
+import sqlalchemy as sa  # noqa:F401
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[2] / "001_init.sql"
+    op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS access_events_5min")
+    op.execute("DROP TABLE IF EXISTS emergency_lockdowns")
+    op.execute("DROP TABLE IF EXISTS anti_passback_state")
+    op.execute("DROP TABLE IF EXISTS time_restrictions")
+    op.execute("DROP TABLE IF EXISTS access_blocklist")
+    op.execute("DROP TABLE IF EXISTS access_permissions")
+    op.execute("DROP TABLE IF EXISTS person_roles")
+    op.execute("DROP TABLE IF EXISTS door_groups")
+    op.execute("DROP TABLE IF EXISTS access_events")
+    op.execute("DROP EXTENSION IF EXISTS timescaledb")

--- a/docs/deployment_diagram.md
+++ b/docs/deployment_diagram.md
@@ -6,7 +6,11 @@ This diagram illustrates how the dashboard container interacts with its database
 flowchart TD
     Browser((User Browser)) -->|HTTPS| Dashboard["Dashboard Container"]
     Dashboard --> Postgres[(PostgreSQL Database)]
+    Postgres --> Replicator["Replication Job"]
+    Replicator --> Timescale[(TimescaleDB)]
     Dashboard --> Auth0["Auth0 OIDC"]
     Dashboard --> ThreatIntel["Threat Intelligence API"]
     Dashboard --> GeoAPI["Geolocation API"]
 ```
+
+The migration layer uses **Alembic** to manage schema changes. A lightweight replication job keeps the TimescaleDB instance in sync by polling PostgreSQL for new events.

--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Incrementally replicate new access events to TimescaleDB."""
+from __future__ import annotations
+import logging
+import os
+import time
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import DictCursor, execute_values
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+SRC_DSN = os.getenv("SOURCE_DSN", "dbname=yosai_intel")
+TGT_DSN = os.getenv("TARGET_DSN", "dbname=yosai_timescale")
+POLL_INTERVAL = int(os.getenv("REPLICATION_INTERVAL", "60"))
+
+CHECKPOINT_TABLE = "replication_state"
+
+FIELDS = [
+    "time",
+    "event_id",
+    "person_id",
+    "door_id",
+    "facility_id",
+    "access_result",
+    "badge_status",
+    "response_time_ms",
+    "metadata",
+]
+
+
+def ensure_checkpoint(cur: DictCursor) -> None:
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
+            last_ts TIMESTAMPTZ PRIMARY KEY
+        )
+        """
+    )
+    cur.execute(
+        f"INSERT INTO {CHECKPOINT_TABLE} (last_ts) VALUES ('1970-01-01') ON CONFLICT DO NOTHING"
+    )
+
+
+def get_last_timestamp(cur: DictCursor) -> str:
+    cur.execute(f"SELECT last_ts FROM {CHECKPOINT_TABLE}")
+    row = cur.fetchone()
+    return row[0] if row else "1970-01-01"
+
+
+def update_timestamp(cur: DictCursor, ts: str) -> None:
+    cur.execute(f"UPDATE {CHECKPOINT_TABLE} SET last_ts = %s", (ts,))
+
+
+def fetch_new_rows(cur: DictCursor, last_ts: str) -> list[dict[str, Any]]:
+    cur.execute(
+        "SELECT * FROM access_events WHERE time > %s ORDER BY time ASC LIMIT 1000",
+        (last_ts,),
+    )
+    return cur.fetchall()
+
+
+def insert_rows(cur: DictCursor, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    values = [tuple(row[f] for f in FIELDS) for row in rows]
+    cols = ",".join(FIELDS)
+    placeholders = ",".join(["%s"] * len(FIELDS))
+    query = (
+        f"INSERT INTO access_events ({cols}) VALUES ({placeholders})"
+        " ON CONFLICT (event_id) DO NOTHING"
+    )
+    execute_values(cur, query, values)
+
+
+def replicate_once(src, tgt) -> None:
+    with tgt.cursor(cursor_factory=DictCursor) as tcur:
+        ensure_checkpoint(tcur)
+        last_ts = get_last_timestamp(tcur)
+    with src.cursor(cursor_factory=DictCursor) as scur, tgt.cursor(cursor_factory=DictCursor) as tcur:
+        rows = fetch_new_rows(scur, last_ts)
+        if not rows:
+            LOG.info("No new rows")
+            return
+        insert_rows(tcur, rows)
+        new_ts = rows[-1]["time"]
+        update_timestamp(tcur, new_ts)
+        tgt.commit()
+        LOG.info("Replicated %s rows", len(rows))
+
+
+def main() -> None:
+    src_conn = psycopg2.connect(SRC_DSN)
+    tgt_conn = psycopg2.connect(TGT_DSN)
+    try:
+        while True:
+            replicate_once(src_conn, tgt_conn)
+            time.sleep(POLL_INTERVAL)
+    finally:
+        src_conn.close()
+        tgt_conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,3 +19,11 @@ if command -v npm >/dev/null 2>&1; then
 else
     echo "npm is not installed; skipping Node dependency installation" >&2
 fi
+
+# Apply database migrations
+alembic -c "$ROOT_DIR/database/migrations/alembic.ini" upgrade head
+
+# Optionally run a single replication cycle
+if [ "$RUN_REPLICATION" = "1" ]; then
+    python "$ROOT_DIR/scripts/replicate_to_timescale.py" &
+fi


### PR DESCRIPTION
## Summary
- add Alembic environment under `database/migrations`
- create `replicate_to_timescale.py` job for syncing new events
- run migrations and optional replication in `scripts/setup.sh`
- check migrations and script in CI workflow
- update deployment diagram and README with migration/replication info

## Testing
- `pytest tests/test_migrations.py tests/migration -q`

------
https://chatgpt.com/codex/tasks/task_e_687f477e98c48320bdf6799713c6100c