### PR TITLE
Add blue/green deployment and rollback

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,11 +60,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine image tag
+        id: vars
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,19 @@
+# Kubernetes Rollback Procedure
+
+This project uses a blue/green deployment strategy so that old and new versions can run at the same time. The `yosai-dashboard` service routes traffic to pods labeled with a `color` selector.
+
+1. Deploy the new version using the *green* deployment (`k8s/bluegreen/dashboard-green.yaml`).
+2. Verify the new pods are healthy.
+3. Switch the service selector from blue to green:
+   ```bash
+   scripts/rollback.sh
+   ```
+4. Monitor the deployment. If problems occur, run the script again to switch back to the previous color.
+
+The script accepts the service name and namespace as optional arguments:
+
+```bash
+scripts/rollback.sh <service> <namespace>
+```
+
+By default it operates on the `yosai-dashboard` service in the `default` namespace.

--- a/k8s/bluegreen/dashboard-blue.yaml
+++ b/k8s/bluegreen/dashboard-blue.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yosai-dashboard-blue
+  labels:
+    app: yosai-dashboard
+    color: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: yosai-dashboard
+      color: blue
+  template:
+    metadata:
+      labels:
+        app: yosai-dashboard
+        color: blue
+    spec:
+      containers:
+        - name: yosai-dashboard
+          image: yosai-intel-dashboard:latest
+          ports:
+            - containerPort: 8050
+          env:
+            - name: YOSAI_ENV
+              value: "production"
+            - name: DB_TYPE
+              value: "postgresql"
+            - name: DB_HOST
+              value: "db"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "yosai_intel"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: DB_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: SECRET_KEY
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/bluegreen/dashboard-green.yaml
+++ b/k8s/bluegreen/dashboard-green.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yosai-dashboard-green
+  labels:
+    app: yosai-dashboard
+    color: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: yosai-dashboard
+      color: green
+  template:
+    metadata:
+      labels:
+        app: yosai-dashboard
+        color: green
+    spec:
+      containers:
+        - name: yosai-dashboard
+          image: yosai-intel-dashboard:latest
+          ports:
+            - containerPort: 8050
+          env:
+            - name: YOSAI_ENV
+              value: "production"
+            - name: DB_TYPE
+              value: "postgresql"
+            - name: DB_HOST
+              value: "db"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "yosai_intel"
+            - name: DB_USER
+              value: "postgres"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: DB_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: yosai-secrets
+                  key: SECRET_KEY
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8050
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/bluegreen/dashboard-service.yaml
+++ b/k8s/bluegreen/dashboard-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: yosai-dashboard
+spec:
+  selector:
+    app: yosai-dashboard
+    color: blue
+  ports:
+    - port: 80
+      targetPort: 8050

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${1:-yosai-dashboard}"
+NAMESPACE="${2:-default}"
+
+CURRENT_COLOR=$(kubectl get service "$SERVICE_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.selector.color}')
+if [[ "$CURRENT_COLOR" == "green" ]]; then
+  NEW_COLOR="blue"
+else
+  NEW_COLOR="green"
+fi
+
+echo "Switching $SERVICE_NAME selector to color=$NEW_COLOR in namespace $NAMESPACE"
+kubectl patch service "$SERVICE_NAME" -n "$NAMESPACE" -p "{\"spec\":{\"selector\":{\"app\":\"yosai-dashboard\",\"color\":\"$NEW_COLOR\"}}}"


### PR DESCRIPTION
## Summary
- add versioned Docker tags in CI workflow
- support blue/green Kubernetes deployments
- add rollback script for swapping service selectors
- document how to rollback a release

## Testing
- `pip install -r requirements.lock -r requirements-test.txt`
- `pytest -q` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f4786f018832087141fb423c2c6b3