### PR TITLE
Add operational runbooks and post-mortem template

### DIFF
--- a/docs/runbooks/cache-flush.md
+++ b/docs/runbooks/cache-flush.md
@@ -1,0 +1,31 @@
+# Cache Flush Runbook
+
+Use this guide when cached data becomes stale or when troubleshooting inconsistent results.
+
+## Overview
+Flushing the cache clears temporary data stored in Redis and forces the service to rebuild it.
+
+## Fetching Logs
+Review the cache logs before and after flushing:
+
+```bash
+sudo journalctl -u redis.service --since "10 minutes ago" > /tmp/redis.log
+```
+
+Include this log in the incident ticket.
+
+## Contacting On-Call Engineers
+Reach the on-call engineer through Slack `#ops-oncall` or phone `+1-555-0100` if the flush does not resolve the issue.
+
+## Resolution Steps
+1. SSH into the server hosting Redis.
+2. Connect to Redis:
+   ```bash
+   redis-cli
+   ```
+3. Flush the cache:
+   ```
+   FLUSHALL
+   ```
+4. Exit Redis and monitor the application logs to verify normal operation.
+5. If performance degrades or errors appear, escalate to the on-call engineer.

--- a/docs/runbooks/database-failover.md
+++ b/docs/runbooks/database-failover.md
@@ -1,0 +1,28 @@
+# Database Failover Runbook
+
+Follow this procedure when the primary PostgreSQL instance becomes unavailable.
+
+## Overview
+High availability is provided through streaming replication. A failover promotes the standby server to primary.
+
+## Fetching Logs
+Collect the latest database logs from both servers:
+
+```bash
+sudo journalctl -u postgres.service --since "10 minutes ago" > /tmp/postgres.log
+```
+
+Include these logs with the incident details.
+
+## Contacting On-Call Engineers
+Immediately page the on-call database engineer through Slack `#db-oncall` or phone `+1-555-0101`.
+
+## Resolution Steps
+1. Confirm that the primary is down and the standby is healthy.
+2. Promote the standby:
+   ```bash
+   sudo -u postgres pg_ctlcluster 14 main promote
+   ```
+3. Update any load balancers or application configs to point at the new primary.
+4. Monitor replication status once the old primary comes back online.
+5. Plan a switchover back to the original primary during the next maintenance window.

--- a/docs/runbooks/kafka-lag-resolution.md
+++ b/docs/runbooks/kafka-lag-resolution.md
@@ -1,0 +1,32 @@
+# Kafka Lag Resolution Runbook
+
+This runbook outlines steps to resolve consumer lag in Kafka topics.
+
+## Overview
+Lag typically indicates that consumers cannot keep up with the incoming message rate.
+
+## Fetching Logs
+Gather broker and consumer logs for the affected topic:
+
+```bash
+kubectl logs deployment/kafka-broker > /tmp/kafka-broker.log
+kubectl logs deployment/kafka-consumer > /tmp/kafka-consumer.log
+```
+
+Attach these files to the incident ticket.
+
+## Contacting On-Call Engineers
+Notify the on-call engineer through Slack `#ops-oncall` or phone `+1-555-0100` if lag exceeds operational thresholds.
+
+## Resolution Steps
+1. Inspect consumer metrics in Grafana to determine if the lag is increasing.
+2. If consumers are stalled, restart the consumer pods:
+   ```bash
+   kubectl rollout restart deployment/kafka-consumer
+   ```
+3. Monitor the lag using `kafka-consumer-groups.sh` until it returns to normal levels.
+4. If the backlog persists, scale out the consumer deployment:
+   ```bash
+   kubectl scale deployment/kafka-consumer --replicas=2
+   ```
+5. Escalate to the on-call engineer if no improvement is observed.

--- a/docs/runbooks/post-mortem-template.md
+++ b/docs/runbooks/post-mortem-template.md
@@ -1,0 +1,28 @@
+# Post-Mortem Template
+
+Use this template to document incidents and ensure consistent reporting.
+
+## Incident Summary
+Provide a brief description of what happened, including start and end times.
+
+## Timeline
+List key events in chronological order.
+
+```
+- 00:00 Incident detected
+- 00:05 PagerDuty alerted on-call engineer
+- 00:15 Mitigation in progress
+```
+
+## Root Cause
+Describe the underlying factors that led to the incident.
+
+## Resolution
+Explain how the issue was resolved and services were restored.
+
+## Action Items
+- [ ] Preventative measure 1
+- [ ] Preventative measure 2
+
+## Lessons Learned
+Capture any insights that can improve future response.

--- a/docs/runbooks/service-restart.md
+++ b/docs/runbooks/service-restart.md
@@ -1,0 +1,28 @@
+# Service Restart Runbook
+
+This guide covers how to safely restart dashboard services.
+
+## Overview
+A restart may be required after configuration changes or when a service becomes unresponsive.
+
+## Fetching Logs
+Before restarting, capture the current logs:
+
+```bash
+sudo journalctl -u dashboard.service --since "10 minutes ago" > /tmp/dashboard.log
+```
+
+Attach this file to any incident ticket for reference.
+
+## Contacting On-Call Engineers
+If you are unsure whether a restart is safe, contact the on-call engineer via Slack `#ops-oncall` or phone `+1-555-0100`.
+
+## Resolution Steps
+1. SSH into the affected server.
+2. Run `sudo systemctl restart dashboard.service`.
+3. Verify the status with `sudo systemctl status dashboard.service`.
+4. Check the logs again to confirm the service started correctly:
+   ```bash
+   sudo journalctl -u dashboard.service -n 50
+   ```
+5. If issues persist, escalate to the on-call engineer.


### PR DESCRIPTION
## Summary
- document restarting services
- add cache flush instructions
- detail Kafka lag resolution
- describe database failover steps
- provide a post-mortem template for incidents

## Testing
- `pre-commit run --files docs/runbooks/service-restart.md docs/runbooks/cache-flush.md docs/runbooks/kafka-lag-resolution.md docs/runbooks/database-failover.md docs/runbooks/post-mortem-template.md`

------
https://chatgpt.com/codex/tasks/task_e_687f47934e6c832099d331ae1c4b3c07