### PR TITLE
Add initial Helm chart

### DIFF
--- a/helm/yosai-intel/Chart.yaml
+++ b/helm/yosai-intel/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: yosai-intel
+description: Helm chart for the Yōsai Intel Dashboard
+version: 0.1.0
+appVersion: "1.0"

--- a/helm/yosai-intel/templates/_helpers.tpl
+++ b/helm/yosai-intel/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "yosai-intel.fullname" -}}
+{{ .Release.Name }}-{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "yosai-intel.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+{{- define "yosai-intel.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "yosai-intel.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/helm/yosai-intel/templates/deployment.yaml
+++ b/helm/yosai-intel/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "yosai-intel.labels" . | nindent 8 }}
+      annotations:
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "yosai-intel.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/yosai-intel/templates/hpa.yaml
+++ b/helm/yosai-intel/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "yosai-intel.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemory }}
+{{- end }}

--- a/helm/yosai-intel/templates/networkpolicy.yaml
+++ b/helm/yosai-intel/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.networkPolicy.allowNamespace }}
+  egress:
+  - {}
+{{- end }}

--- a/helm/yosai-intel/templates/pdb.yaml
+++ b/helm/yosai-intel/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/yosai-intel/templates/service.yaml
+++ b/helm/yosai-intel/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/yosai-intel/templates/serviceaccount.yaml
+++ b/helm/yosai-intel/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "yosai-intel.serviceAccountName" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/helm/yosai-intel/templates/vpa.yaml
+++ b/helm/yosai-intel/templates/vpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "yosai-intel.fullname" . }}
+  labels:
+    {{- include "yosai-intel.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "yosai-intel.fullname" . }}
+  updatePolicy:
+    updateMode: {{ .Values.verticalPodAutoscaler.updatePolicy.updateMode }}
+{{- end }}

--- a/helm/yosai-intel/values.yaml
+++ b/helm/yosai-intel/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 2
+
+image:
+  repository: yosai-intel-dashboard
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8050
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  linkerd.io/inject: enabled
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPU: 70
+  targetMemory: 75
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+verticalPodAutoscaler:
+  enabled: false
+  updatePolicy:
+    updateMode: Auto
+
+networkPolicy:
+  enabled: false
+  allowNamespace: ""


### PR DESCRIPTION
## Summary
- add `helm/yosai-intel` chart
- support autoscaling, PDBs, VPAs, network policies, and service mesh annotations

## Testing
- `helm lint helm/yosai-intel`
- `pytest -k "" -m ""` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f5062d5548320bb26cbbdbc77bf0b