### PR TITLE
Add tracing initialization to backend apps

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,10 @@ import pandas as pd
 import hashlib
 from werkzeug.utils import secure_filename
 from datetime import datetime
+from tracing import init_tracing
+
+# Initialize tracing before the app is created
+init_tracing("backend")
 
 app = Flask(__name__)
 CORS(app)

--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -2,12 +2,16 @@
 import os
 from flask import Flask, jsonify, request, send_from_directory
 from utils.api_error import error_response
+from tracing import init_tracing
 
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 import pandas as pd
 import json
 from datetime import datetime
+
+# Initialize tracing before the app is created
+init_tracing("backend")
 
 # Create Flask app
 app = Flask(__name__, static_folder="../build", static_url_path="")


### PR DESCRIPTION
## Summary
- initialize tracing in `backend/app_main.py`
- initialize tracing in `backend/app.py`

## Testing
- `pre-commit run --files backend/app.py backend/app_main.py` *(fails: black, isort, flake8, mypy, bandit)*
- `pytest -k nonexistenttestpattern -q` *(fails: ModuleNotFoundError for sklearn and others)*
- `python backend/app_main.py` *(fails: ModuleNotFoundError: flask)*
- `python backend/app.py` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_687f5164de148320b2fab0dee5f429b4