### PR TITLE
Add panels for gateway cache miss rate and DB query error rate

### DIFF
--- a/dashboards/grafana/database.json
+++ b/dashboards/grafana/database.json
@@ -17,6 +17,14 @@
       "targets": [
         {"expr": "database_query_errors_total", "legendFormat": "errors"}
       ]
+    },
+    {
+      "type": "graph",
+      "title": "Query Error Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "rate(database_query_errors_total[5m])", "legendFormat": "errors/sec"}
+      ]
     }
   ]
 }

--- a/dashboards/grafana/gateway.json
+++ b/dashboards/grafana/gateway.json
@@ -18,6 +18,25 @@
       "targets": [
         {"expr": "gateway_events_processed_total", "legendFormat": "processed"}
       ]
+    },
+    {
+      "type": "graph",
+      "title": "Cache Miss Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(gateway_cache_misses_total[5m]) / (rate(gateway_cache_hits_total[5m]) + rate(gateway_cache_misses_total[5m]))",
+          "legendFormat": "miss_rate"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "HTTP Requests",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total[5m]))", "legendFormat": "req/s"}
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend gateway dashboard with cache miss rate and HTTP request panels
- show query error rate on database dashboard
- validate JSON formatting

Processing error metrics were not found for the event processor, so that dashboard is unchanged.

## Testing
- `pre-commit run --files dashboards/grafana/gateway.json dashboards/grafana/database.json`
- `pytest -q` *(fails: 92 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f516c148883209d8d41c96ecd24cb