### PR TITLE
Add CI TimescaleDB migration verification

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Compile replication script
         if: matrix.job == 'migration'
         run: python -m py_compile scripts/replicate_to_timescale.py
+      - name: Test Timescale migration
+        if: matrix.job == 'migration'
+        run: python scripts/migrate_to_timescale.py --test-mode
+      - name: Verify Timescale migration
+        if: matrix.job == 'migration'
+        run: python scripts/verify_timescale_migration.py
   container-build:
     runs-on: ubuntu-latest
     needs: tests

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,13 @@ TIMESCALE_DB_USER, TIMESCALE_DB_PASSWORD
 
 The default `docker-compose.dev.yml` exposes TimescaleDB on port `5433`.
 
+### CI/CD Verification
+
+The GitHub Actions workflow runs a dry-run migration using
+`scripts/migrate_to_timescale.py --test-mode` and then executes
+`scripts/verify_timescale_migration.py`. The job fails if verification
+returns a non-zero status.
+
 ### Schema Migrations and Replication
 
 Database schema changes are managed with **Alembic** under `database/migrations/`.

--- a/docs/migrations/analytics_service_unification.md
+++ b/docs/migrations/analytics_service_unification.md
@@ -20,3 +20,16 @@ into a single `services/analytics_service.py` module.
 2. Review the new `AnalyticsService` methods if you relied on
    `working_analytics_service` or `analytics.AnalyticsService`.
 3. Run your tests to ensure compatibility.
+
+## TimescaleDB Migration Checks
+
+Continuous integration now runs a smoke test for the TimescaleDB migration
+scripts. The workflow executes:
+
+```bash
+python scripts/migrate_to_timescale.py --test-mode
+python scripts/verify_timescale_migration.py
+```
+
+The build fails if verification returns a non-zero status, ensuring schema
+changes do not break the migration process.


### PR DESCRIPTION
## Summary
- run Timescale migration in GitHub Actions
- verify migration script as part of CI
- document Timescale checks in migration notes
- mention CI/CD verification in README

## Testing
- `pytest tests/migration tests/test_migrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5c6dc04c83208cfdf4a171e66879