### PR TITLE
Enable metrics and tracing for analytics service

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -51,6 +51,12 @@ docker run -p 5044:5044 \
 
 Adjust the `elasticsearch` output section if you have a different destination.
 
+### Distributed Tracing
+
+All services export OpenTelemetry traces to Jaeger. Set the `JAEGER_ENDPOINT`
+environment variable to the collector URL (`http://localhost:14268/api/traces`
+by default). Invoke `init_tracing("analytics-microservice")` during startup of
+the analytics microservice so spans are reported correctly.
 
 ## Real-time Performance Tracking
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -108,6 +108,11 @@ openpyxl==3.1.5
 opentelemetry-api==1.35.0
 opentelemetry-sdk==1.35.0
 opentelemetry-exporter-jaeger==1.35.0
+opentelemetry-instrumentation==0.56b0
+opentelemetry-instrumentation-asgi==0.56b0
+opentelemetry-instrumentation-fastapi==0.56b0
+opentelemetry-semantic-conventions==0.56b0
+opentelemetry-util-http==0.56b0
 orjson==3.11.0
 outcome==1.3.0.post0
 packageurl-python==0.17.1
@@ -126,6 +131,7 @@ pluggy==1.6.0
 polars==1.31.0
 prefect==3.2.7
 prometheus_client==0.22.1
+prometheus-fastapi-instrumentator==7.1.0
 protobuf==6.31.1
 psutil==7.0.0
 psycopg2-binary==2.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,5 @@ fastapi==0.116.1
 opentelemetry-api==1.35.0
 opentelemetry-sdk==1.35.0
 opentelemetry-exporter-jaeger==1.35.0
+opentelemetry-instrumentation-fastapi==0.56b0
+prometheus-fastapi-instrumentator==7.1.0

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -1,9 +1,16 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from tracing import init_tracing
 
 from services.analytics_service import create_analytics_service
 
+init_tracing("analytics-microservice")
+
 app = FastAPI(title="Analytics Microservice")
+
 service = create_analytics_service()
 
 class PatternsRequest(BaseModel):
@@ -16,3 +23,6 @@ async def dashboard_summary():
 @app.post("/api/v1/analytics/get_access_patterns_analysis")
 async def access_patterns(req: PatternsRequest):
     return service.get_access_patterns_analysis(days=req.days)
+
+FastAPIInstrumentor.instrument_app(app)
+Instrumentator().instrument(app).expose(app)

--- a/tests/integration/test_analytics_microservice_metrics.py
+++ b/tests/integration/test_analytics_microservice_metrics.py
@@ -1,0 +1,49 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(SERVICES_PATH)]
+sys.modules.setdefault("services", services_stub)
+
+class DummyAnalytics:
+    def get_dashboard_summary(self) -> dict:
+        return {"status": "ok"}
+
+    def get_access_patterns_analysis(self, days: int = 7) -> dict:
+        return {"days": days}
+
+analytics_stub = types.ModuleType("services.analytics_service")
+analytics_stub.create_analytics_service = lambda: DummyAnalytics()
+sys.modules["services.analytics_service"] = analytics_stub
+
+dummy_tracing = types.ModuleType("tracing")
+called = {}
+
+def fake_init(service_name: str) -> None:
+    called["name"] = service_name
+
+dummy_tracing.init_tracing = fake_init
+sys.modules["tracing"] = dummy_tracing
+
+@pytest.mark.integration
+def test_metrics_and_tracing():
+
+    app_spec = importlib.util.spec_from_file_location(
+        "services.analytics_microservice.app",
+        SERVICES_PATH / "analytics_microservice" / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(app_spec)
+    app_spec.loader.exec_module(app_module)
+
+    assert called.get("name") == "analytics-microservice"
+
+    client = TestClient(app_module.app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"python_info" in resp.content


### PR DESCRIPTION
## Summary
- initialize OpenTelemetry tracing in analytics microservice
- expose Prometheus `/metrics` endpoint using `prometheus_fastapi_instrumentator`
- document tracing configuration in performance monitoring docs
- pin instrumentation dependencies
- test metrics endpoint and tracing init

## Testing
- `pytest tests/integration/test_analytics_microservice_metrics.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_687f674f5d088320a7174e98561354a4