### PR TITLE
Add DB migration CLI and integrate with deploy workflow

### DIFF
--- a/.github/workflows/microservices-ci-cd.yml
+++ b/.github/workflows/microservices-ci-cd.yml
@@ -93,11 +93,17 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.lock
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3
       - name: Configure kubeconfig
         run: |
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+      - name: Run migrations
+        run: python scripts/db_migration_cli.py upgrade
       - name: Deploy to cluster
         run: |
           kubectl apply -f k8s/base

--- a/docs/runbooks/database-failover.md
+++ b/docs/runbooks/database-failover.md
@@ -26,3 +26,12 @@ Immediately page the on-call database engineer through Slack `#db-oncall` or pho
 3. Update any load balancers or application configs to point at the new primary.
 4. Monitor replication status once the old primary comes back online.
 5. Plan a switchover back to the original primary during the next maintenance window.
+
+## Database Migrations
+Use the migration CLI to manage schema changes:
+
+```bash
+python scripts/db_migration_cli.py upgrade      # apply latest migrations
+python scripts/db_migration_cli.py downgrade <rev>
+python scripts/db_migration_cli.py rollback
+```

--- a/scripts/db_migration_cli.py
+++ b/scripts/db_migration_cli.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Command line wrapper for :class:`MigrationManager`."""
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import List
+
+from database.migrations import MigrationManager
+
+
+LOG = logging.getLogger(__name__)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Manage database migrations via Alembic"
+    )
+    parser.add_argument(
+        "--config",
+        default="database/migrations/alembic.ini",
+        help="Path to alembic configuration file",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    up = sub.add_parser("upgrade", help="Upgrade to latest or given revision")
+    up.add_argument("revision", nargs="?", default="head")
+
+    down = sub.add_parser("downgrade", help="Downgrade to a specific revision")
+    down.add_argument("revision")
+
+    sub.add_parser("rollback", help="Rollback the last applied migration")
+
+    args = parser.parse_args(argv)
+    mgr = MigrationManager(args.config)
+
+    if args.command == "upgrade":
+        mgr.upgrade(args.revision)
+    elif args.command == "downgrade":
+        mgr.downgrade(args.revision)
+    elif args.command == "rollback":
+        mgr.rollback()
+    else:
+        parser.print_help()
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `db_migration_cli.py` for managing migrations
- document migration usage in failover runbook
- run migrations in deployment job

## Testing
- `pytest tests/test_migrations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687f6751fe9883208c42c16d752f6464