### PR TITLE
Add replication lag metric to timescale replicator

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -38,6 +38,14 @@ counts as JSON and the same metrics are also available via `/metrics` for
 Prometheus scraping. Configuration for the breakers lives in
 `config/circuit-breakers.yaml` and is loaded by both services.
 
+### Replication Lag Metric
+
+`scripts/replicate_to_timescale.py` exposes a gauge named
+`replication_lag_seconds` via Prometheus. The metric records the difference in
+seconds between `NOW()` and the timestamp of the most recently replicated access
+event. Set the `REPLICATION_METRICS_PORT` environment variable to change the
+HTTP port (defaults to `8004`).
+
 ### Logstash
 
 `logging/logstash.conf` reads the application, Postgres and Redis logs and can


### PR DESCRIPTION
## Summary
- track replication lag in scripts/replicate_to_timescale.py
- expose metrics via prometheus_client on configurable port
- document new `replication_lag_seconds` gauge in performance monitoring docs

## Testing
- `python -m py_compile scripts/replicate_to_timescale.py`

------
https://chatgpt.com/codex/tasks/task_e_687f675c5a008320bb17a94876ce0769