### PR TITLE
Add JWT auth to analytics microservice

### DIFF
--- a/gateway/internal/proxy/proxy.go
+++ b/gateway/internal/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
@@ -20,5 +21,14 @@ func NewProxy() (*httputil.ReverseProxy, error) {
 	if err != nil {
 		return nil, err
 	}
-	return httputil.NewSingleHostReverseProxy(target), nil
+	p := httputil.NewSingleHostReverseProxy(target)
+	orig := p.Director
+	p.Director = func(req *http.Request) {
+		auth := req.Header.Get("Authorization")
+		orig(req)
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+	}
+	return p, nil
 }

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -1,4 +1,8 @@
-from fastapi import FastAPI
+import os
+import time
+
+from fastapi import FastAPI, Depends, Header, HTTPException, status
+from jose import jwt
 from pydantic import BaseModel
 
 from services.analytics_service import create_analytics_service
@@ -6,13 +10,37 @@ from services.analytics_service import create_analytics_service
 app = FastAPI(title="Analytics Microservice")
 service = create_analytics_service()
 
+
+def verify_token(authorization: str = Header("")) -> None:
+    """Validate Authorization header using JWT_SECRET."""
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+        )
+    token = authorization.split(" ", 1)[1]
+    secret = os.getenv("JWT_SECRET", "")
+    try:
+        claims = jwt.decode(token, secret, algorithms=["HS256"])
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+        ) from exc
+    exp = claims.get("exp")
+    if exp is not None and exp < time.time():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+        )
+
+
 class PatternsRequest(BaseModel):
     days: int = 7
 
+
 @app.post("/api/v1/analytics/get_dashboard_summary")
-async def dashboard_summary():
+async def dashboard_summary(_: None = Depends(verify_token)):
     return service.get_dashboard_summary()
 
+
 @app.post("/api/v1/analytics/get_access_patterns_analysis")
-async def access_patterns(req: PatternsRequest):
+async def access_patterns(req: PatternsRequest, _: None = Depends(verify_token)):
     return service.get_access_patterns_analysis(days=req.days)

--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -1,0 +1,66 @@
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from jose import jwt
+
+# Stub lightweight services package for microservice import
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(SERVICES_PATH)]
+sys.modules.setdefault("services", services_stub)
+
+
+class DummyAnalytics:
+    def get_dashboard_summary(self) -> dict:
+        return {"status": "ok"}
+
+    def get_access_patterns_analysis(self, days: int = 7) -> dict:
+        return {"days": days}
+
+
+analytics_stub = types.ModuleType("services.analytics_service")
+analytics_stub.create_analytics_service = lambda: DummyAnalytics()
+sys.modules["services.analytics_service"] = analytics_stub
+
+app_spec = importlib.util.spec_from_file_location(
+    "services.analytics_microservice.app",
+    SERVICES_PATH / "analytics_microservice" / "app.py",
+)
+app_module = importlib.util.module_from_spec(app_spec)
+app_spec.loader.exec_module(app_module)
+
+
+@pytest.mark.integration
+def test_requests_without_valid_token_return_401(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "test")
+    client = TestClient(app_module.app)
+
+    # No Authorization header
+    resp = client.post("/api/v1/analytics/get_dashboard_summary")
+    assert resp.status_code == 401
+
+    # Expired token
+    bad_token = jwt.encode(
+        {"sub": "svc", "exp": int(time.time()) - 1}, "test", algorithm="HS256"
+    )
+    resp = client.post(
+        "/api/v1/analytics/get_dashboard_summary",
+        headers={"Authorization": f"Bearer {bad_token}"},
+    )
+    assert resp.status_code == 401
+
+    # Valid token succeeds
+    good_token = jwt.encode(
+        {"sub": "svc", "exp": int(time.time()) + 60}, "test", algorithm="HS256"
+    )
+    resp = client.post(
+        "/api/v1/analytics/get_dashboard_summary",
+        headers={"Authorization": f"Bearer {good_token}"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- verify JWT auth header in analytics microservice
- forward Authorization header in gateway proxy
- test JWT auth enforcement for analytics microservice

## Testing
- `go test ./...`
- `pytest tests/integration/test_gateway_to_microservice.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6754d48883209cdb0738369a75c5