### PR TITLE
Update OpenAPI registration and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ data/learned_mappings.json
 *.csv
 *.xlsx
 *.json
+!docs/openapi.json
 !package.json
 !package-lock.json
 !dashboards/grafana/*.json

--- a/api/openapi/generator.go
+++ b/api/openapi/generator.go
@@ -118,6 +118,31 @@ func main() {
 	router.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
 	router.HandleFunc("/events/access", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
 
+	// API endpoints registered in the Python server
+	router.HandleFunc("/v1/csrf-token", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/v1/upload", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/upload/status/{job_id}", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/v1/ai/suggest-devices", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/mappings/columns", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/mappings/devices", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/mappings/save", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/process-enhanced", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/settings", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
+	router.HandleFunc("/v1/plugins/performance", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/v1/plugins/performance/alerts", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/v1/plugins/performance/benchmark", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/v1/plugins/performance/config", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet, http.MethodPut)
+	router.HandleFunc("/api/v1/risk/score", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/analytics/patterns", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/analytics/sources", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/analytics/health", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/analytics/all", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/analytics/{source_type}", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/graphs/chart/{chart_type}", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/export/analytics/json", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/graphs/available-charts", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/export/formats", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+
 	spec := &openapi3.T{
 		OpenAPI: "3.0.2",
 		Info: &openapi3.Info{

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,10 +29,21 @@ under `analytics/clients/event_client`.
 
 ### Regenerating after changes
 
-`docs/openapi.json` is not committed to the repository. Whenever you modify any
-API routes or schemas, run `python tools/generate_openapi.py` and verify the
-file in `docs/` updates. This keeps the interactive documentation in sync with
-the code.
+Run the generator whenever API routes or schemas change:
+
+```bash
+go run ./api/openapi
+```
+
+Commit the updated `docs/openapi.json` so the specification stays in sync with
+the codebase.
+
+## API Versioning
+
+All endpoints are prefixed with a version such as `/v1` or `/api/v1`.
+When backwards-incompatible changes are introduced, a new version path will be
+added while the old one is maintained for a period of time. Clients should
+specify the exact version in requests to avoid unexpected behavior.
 
 ## Database Manager
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,270 @@
+{
+  "components": {
+    "schemas": {
+      "AccessEvent": {
+        "properties": {
+          "access_result": {
+            "type": "string"
+          },
+          "door_id": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "person_id": {
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "timestamp",
+          "person_id",
+          "door_id",
+          "access_result"
+        ],
+        "type": "object"
+      },
+      "ErrorDetails": {
+        "type": "string"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "code": {
+            "enum": [
+              [
+                "bad_request",
+                "invalid_payload",
+                "invalid_plugin",
+                "invalid_type",
+                "missing_file_id",
+                "no_data",
+                "no_file",
+                "no_file_id",
+                "no_file_selected",
+                "no_files",
+                "not_found",
+                "read_error",
+                "server_error",
+                "unsupported_type"
+              ]
+            ],
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/ErrorDetails"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Yōsai Intel API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.2",
+  "paths": {
+    "/api/v1/analytics/all": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/analytics/all"
+      }
+    },
+    "/api/v1/analytics/health": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/analytics/health"
+      }
+    },
+    "/api/v1/analytics/patterns": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/analytics/patterns"
+      }
+    },
+    "/api/v1/analytics/sources": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/analytics/sources"
+      }
+    },
+    "/api/v1/analytics/{source_type}": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/analytics/{source_type}"
+      }
+    },
+    "/api/v1/export/analytics/json": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/export/analytics/json"
+      }
+    },
+    "/api/v1/export/formats": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/export/formats"
+      }
+    },
+    "/api/v1/graphs/available-charts": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/graphs/available-charts"
+      }
+    },
+    "/api/v1/graphs/chart/{chart_type}": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/graphs/chart/{chart_type}"
+      }
+    },
+    "/api/v1/risk/score": {
+      "post": {
+        "responses": null,
+        "summary": "/api/v1/risk/score"
+      }
+    },
+    "/api/v1/settings": {
+      "get": {
+        "responses": null,
+        "summary": "/api/v1/settings"
+      },
+      "post": {
+        "responses": null,
+        "summary": "/api/v1/settings"
+      },
+      "put": {
+        "responses": null,
+        "summary": "/api/v1/settings"
+      }
+    },
+    "/events/access": {
+      "post": {
+        "description": "Submit an access control event for processing",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        },
+        "summary": "Record an access event"
+      }
+    },
+    "/health": {
+      "get": {
+        "responses": null,
+        "summary": "/health"
+      }
+    },
+    "/metrics": {
+      "get": {
+        "responses": null,
+        "summary": "/metrics"
+      }
+    },
+    "/v1/ai/suggest-devices": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/ai/suggest-devices"
+      }
+    },
+    "/v1/csrf-token": {
+      "get": {
+        "responses": null,
+        "summary": "/v1/csrf-token"
+      }
+    },
+    "/v1/mappings/columns": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/mappings/columns"
+      }
+    },
+    "/v1/mappings/devices": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/mappings/devices"
+      }
+    },
+    "/v1/mappings/save": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/mappings/save"
+      }
+    },
+    "/v1/plugins/performance": {
+      "get": {
+        "responses": null,
+        "summary": "/v1/plugins/performance"
+      }
+    },
+    "/v1/plugins/performance/alerts": {
+      "get": {
+        "responses": null,
+        "summary": "/v1/plugins/performance/alerts"
+      },
+      "post": {
+        "responses": null,
+        "summary": "/v1/plugins/performance/alerts"
+      }
+    },
+    "/v1/plugins/performance/benchmark": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/plugins/performance/benchmark"
+      }
+    },
+    "/v1/plugins/performance/config": {
+      "get": {
+        "responses": null,
+        "summary": "/v1/plugins/performance/config"
+      },
+      "put": {
+        "responses": null,
+        "summary": "/v1/plugins/performance/config"
+      }
+    },
+    "/v1/process-enhanced": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/process-enhanced"
+      }
+    },
+    "/v1/upload": {
+      "post": {
+        "responses": null,
+        "summary": "/v1/upload"
+      }
+    },
+    "/v1/upload/status/{job_id}": {
+      "get": {
+        "responses": null,
+        "summary": "/v1/upload/status/{job_id}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- register all API routes in `api/openapi/generator.go`
- generate `docs/openapi.json` using `go run ./api/openapi`
- document API regeneration steps and versioning details
- keep `docs/openapi.json` tracked by updating `.gitignore`

## Testing
- `go run .` within `api/openapi`


------
https://chatgpt.com/codex/tasks/task_e_687f67600db4832081cd5fcc6d618360