### PR TITLE
Add trace header propagation to gateway proxy

### DIFF
--- a/gateway/internal/proxy/proxy.go
+++ b/gateway/internal/proxy/proxy.go
@@ -20,5 +20,7 @@ func NewProxy() (*httputil.ReverseProxy, error) {
 	if err != nil {
 		return nil, err
 	}
-	return httputil.NewSingleHostReverseProxy(target), nil
+	p := httputil.NewSingleHostReverseProxy(target)
+	p.Transport = newTracingTransport(p.Transport)
+	return p, nil
 }

--- a/gateway/internal/proxy/proxy_test.go
+++ b/gateway/internal/proxy/proxy_test.go
@@ -1,0 +1,61 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestProxyInjectsTraceHeaders(t *testing.T) {
+	var received string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	u, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host: %v", err)
+	}
+
+	t.Setenv("APP_HOST", host)
+	t.Setenv("APP_PORT", port)
+
+	tp := sdktrace.NewTracerProvider()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer tp.Shutdown(context.Background())
+
+	p, err := NewProxy()
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "test")
+	defer span.End()
+
+	req := httptest.NewRequest(http.MethodGet, "http://gateway/", nil)
+	req = req.WithContext(ctx)
+
+	resp := httptest.NewRecorder()
+	p.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	if received == "" {
+		t.Fatal("traceparent header not forwarded")
+	}
+}

--- a/gateway/internal/proxy/transport.go
+++ b/gateway/internal/proxy/transport.go
@@ -1,0 +1,28 @@
+package proxy
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// tracingTransport wraps a RoundTripper and injects
+// OpenTelemetry trace headers into each outgoing request.
+type tracingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	propagator := otel.GetTextMapPropagator()
+	propagator.Inject(req.Context(), propagation.HeaderCarrier(req.Header))
+	return t.base.RoundTrip(req)
+}
+
+// newTracingTransport returns a transport that injects trace headers.
+func newTracingTransport(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return &tracingTransport{base: rt}
+}


### PR DESCRIPTION
## Summary
- inject trace context into proxy requests
- use tracing transport in proxy
- test that trace headers are forwarded to backend services

## Testing
- `go test ./...` in `gateway`
- `go test ./...` in `tests`


------
https://chatgpt.com/codex/tasks/task_e_687f674fb6708320af1bfe3cb2c81b99