### PR TITLE
Add automated secret rotation

### DIFF
--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -1,12 +1,13 @@
-name: Rotate Staging Secrets
+name: Rotate Secrets
 
 on:
   schedule:
     - cron: '0 3 * * 0'
+    - cron: '30 3 * * 0'
   workflow_dispatch:
 
 jobs:
-  rotate:
+  rotate-staging:
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -24,3 +25,26 @@ jobs:
           echo "$KUBE_CONFIG" | base64 -d > "$HOME/.kube/config"
       - name: Rotate secrets
         run: python scripts/rotate_secrets.py
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/yosai-dashboard -n yosai-dev
+
+  rotate-production:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install PyYAML
+      - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG: ${{ secrets.PRODUCTION_KUBE_CONFIG }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "$KUBE_CONFIG" | base64 -d > "$HOME/.kube/config"
+      - name: Rotate secrets
+        run: python scripts/rotate_secrets.py
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/yosai-dashboard -n yosai-dev

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -35,3 +35,21 @@ kubectl get pods -l track=canary
 ```
 
 If the canary remains healthy the workflow promotes the image by applying the regular manifests in `k8s/production` and then deletes the canary deployment. No manual intervention is required.
+
+## Secret Rotation
+
+Secrets for the dashboard are rotated automatically via GitHub Actions. The
+`Rotate Secrets` workflow runs every Sunday at **03:00 UTC** for the staging
+cluster and **03:30 UTC** for production. It executes
+`scripts/rotate_secrets.py` and restarts the `yosai-dashboard` deployment so the
+new credentials are loaded.
+
+If a rotation fails you can recover manually:
+
+```bash
+python scripts/rotate_secrets.py
+kubectl rollout restart deployment/yosai-dashboard -n yosai-dev
+```
+
+Verify the pods become healthy and application functionality is restored before
+revoking any previous credentials.

--- a/scripts/rotate_secrets.py
+++ b/scripts/rotate_secrets.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import secrets
 import subprocess
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 import yaml
 
@@ -60,12 +60,25 @@ def apply_config(file_path: Path = SECRETS_FILE) -> None:
     subprocess.run(["kubectl", "apply", "-f", str(file_path)], check=True)
 
 
+def restart_deployment(
+    deployment: str = "yosai-dashboard", namespace: str = "yosai-dev"
+) -> None:
+    """Trigger a rolling restart of the given deployment."""
+    if not cluster_reachable():
+        return
+    subprocess.run(
+        ["kubectl", "rollout", "restart", f"deployment/{deployment}", "-n", namespace],
+        check=True,
+    )
+
+
 def main() -> None:
     updates = update_secrets()
     print("Secrets rotated:")
     for key, value in updates.items():
         print(f"- {key}: {value}")
     apply_config()
+    restart_deployment()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- schedule secret rotation for both staging and production
- restart the deployment after secrets are updated
- document the rotation schedule and recovery steps

## Testing
- `pre-commit run --files scripts/rotate_secrets.py .github/workflows/rotate-secrets.yml docs/operations_guide.md` *(fails: bandit issues in repo)*
- `pytest -q` *(fails: 94 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f7999cc248320a4c80d233d022a0f