### PR TITLE
Add zero downtime update section

### DIFF
--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -60,12 +60,20 @@ The dashboard can be updated without service interruption using either rolling o
 
 ### Rolling Update
 
-Kubernetes performs a rolling update when the container image of a deployment is changed. New pods are created one at a time while the old ones are terminated only after the new pods pass their readiness checks.
+Kubernetes performs a rolling update when the container image of a deployment is changed. New pods are created gradually while the old ones are terminated only after the new pods pass their readiness checks. You can monitor progress and pause if needed.
 
 ```bash
 # replace the image tag to trigger a rolling update
 kubectl set image deployment/yosai-dashboard yosai-dashboard=registry.example.com/yosai-dashboard:<new-tag> -n yosai-dev
 kubectl rollout status deployment/yosai-dashboard -n yosai-dev
+```
+
+To pause the rollout and check health before continuing:
+
+```bash
+kubectl rollout pause deployment/yosai-dashboard -n yosai-dev
+# inspect pods or run smoke tests here
+kubectl rollout resume deployment/yosai-dashboard -n yosai-dev
 ```
 
 ### Blue/Green
@@ -96,6 +104,8 @@ If the new deployment fails its health checks, revert immediately:
 ```bash
 # send traffic back to the previous deployment
 kubectl patch service yosai-dashboard -p '{"spec":{"selector":{"app":"yosai-dashboard","color":"blue"}}}'
+# rollback the deployment to the previous replica set
+kubectl rollout undo deployment/yosai-dashboard -n yosai-dev
 # or use the provided helper script
 scripts/rollback.sh
 ```

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -53,3 +53,51 @@ kubectl rollout restart deployment/yosai-dashboard -n yosai-dev
 
 Verify the pods become healthy and application functionality is restored before
 revoking any previous credentials.
+
+## Zero Downtime Updates
+
+The dashboard can be updated without service interruption using either rolling or blue/green deployments.
+
+### Rolling Update
+
+Kubernetes performs a rolling update when the container image of a deployment is changed. New pods are created one at a time while the old ones are terminated only after the new pods pass their readiness checks.
+
+```bash
+# replace the image tag to trigger a rolling update
+kubectl set image deployment/yosai-dashboard yosai-dashboard=registry.example.com/yosai-dashboard:<new-tag> -n yosai-dev
+kubectl rollout status deployment/yosai-dashboard -n yosai-dev
+```
+
+### Blue/Green
+
+Blue/green deployments run the new version alongside the old one. The manifests under `k8s/bluegreen` define two deployments and a service that targets a `color` label. Deploy the new color and switch the service when ready:
+
+```bash
+kubectl apply -f k8s/bluegreen/dashboard-green.yaml
+kubectl rollout status deployment/yosai-dashboard-green
+# move 10% of traffic for a quick smoke test
+kubectl scale deployment/yosai-dashboard-green --replicas=1
+kubectl scale deployment/yosai-dashboard-blue --replicas=9
+# switch all traffic to green
+kubectl patch service yosai-dashboard -p '{"spec":{"selector":{"app":"yosai-dashboard","color":"green"}}}'
+```
+
+A Helm release can use the same technique:
+
+```bash
+helm upgrade yosai-intel ./helm/yosai-intel \
+  --set image.tag=<new-tag> --set color=green
+```
+
+### Rollback
+
+If the new deployment fails its health checks, revert immediately:
+
+```bash
+# send traffic back to the previous deployment
+kubectl patch service yosai-dashboard -p '{"spec":{"selector":{"app":"yosai-dashboard","color":"blue"}}}'
+# or use the provided helper script
+scripts/rollback.sh
+```
+
+Then scale down or delete the faulty pods once the service is stable.


### PR DESCRIPTION
## Summary
- explain how to do rolling or blue/green deployments for zero downtime
- show `kubectl`/Helm examples and rollback steps

## Testing
- `pre-commit run --files docs/operations_guide.md`

------
https://chatgpt.com/codex/tasks/task_e_687f7ec321ac8320b0a5c0a4e7c9e727