### PR TITLE
Add missing gunicorn config and event ingestion service

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -153,8 +153,8 @@ services:
 
   event-ingestion:
     build:
-      context: .
-      dockerfile: Dockerfile.ingestion
+      context: ./services/event-ingestion
+      dockerfile: Dockerfile
     environment:
       KAFKA_BROKERS: kafka1:29092,kafka2:29093,kafka3:29094
       SCHEMA_REGISTRY_URL: http://schema-registry:8081

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,4 @@
+bind = "0.0.0.0:8050"
+workers = 4
+worker_class = "gevent"
+loglevel = "info"

--- a/k8s/microservices/event-ingestion.yaml
+++ b/k8s/microservices/event-ingestion.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: event-ingestion
           image: event-ingestion:latest
-          command: ["python", "tools/streaming_producer.py"]
+          command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
           ports:
             - containerPort: 8000
           readinessProbe:

--- a/services/event-ingestion/Dockerfile
+++ b/services/event-ingestion/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir fastapi uvicorn kafka-python prometheus-fastapi-instrumentator opentelemetry-instrumentation-fastapi
+
+COPY . .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -1,0 +1,31 @@
+import asyncio
+from fastapi import FastAPI
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from services.streaming import StreamingService
+
+app = FastAPI(title="Event Ingestion Service")
+service = StreamingService()
+
+async def _consume_loop() -> None:
+    while True:
+        for msg in service.consume(timeout=1.0):
+            app.logger.info("received %s", msg)
+        await asyncio.sleep(0.1)
+
+@app.on_event("startup")
+async def startup() -> None:
+    service.initialize()
+    asyncio.create_task(_consume_loop())
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    service.close()
+
+@app.get("/health")
+async def health() -> dict:
+    return service.health_check()
+
+FastAPIInstrumentor.instrument_app(app)
+Instrumentator().instrument(app).expose(app)

--- a/services/event-ingestion/pyproject.toml
+++ b/services/event-ingestion/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "event-ingestion-service"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["fastapi", "uvicorn", "kafka-python"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add gunicorn.conf.py for production settings
- implement event-ingestion microservice with FastAPI
- provide Dockerfile for the service
- hook event-ingestion build context into docker-compose and k8s

## Testing
- `pytest -q` *(fails: 94 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f7eb017548320907ba31b6c48bdff