### PR TITLE
Add tests and coverage for microservices

### DIFF
--- a/.github/workflows/microservices-ci-cd.yml
+++ b/.github/workflows/microservices-ci-cd.yml
@@ -32,11 +32,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
       - run: pip install -r requirements.lock -r requirements-test.txt
-      - run: pytest -q
+      - run: pytest --cov=services.analytics_microservice --cov=services.event-ingestion --cov-report=xml -q
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-microservices-coverage
+          path: coverage.xml
+      - run: ./scripts/test-coverage.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: go-microservices-coverage
+          path: gateway/coverage.out
 
   security-scan:
     needs: test

--- a/gateway/internal/middleware/auth_test.go
+++ b/gateway/internal/middleware/auth_test.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "testing"
+    "time"
+
+    "github.com/golang-jwt/jwt/v5"
+)
+
+func TestAuthMiddlewareSuccessAndFailure(t *testing.T) {
+    os.Setenv("JWT_SECRET", "test")
+    h := Auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+
+    // missing header
+    req := httptest.NewRequest(http.MethodGet, "/", nil)
+    resp := httptest.NewRecorder()
+    h.ServeHTTP(resp, req)
+    if resp.Code != http.StatusUnauthorized {
+        t.Fatalf("expected 401 got %d", resp.Code)
+    }
+
+    // valid token
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+        "sub": "svc",
+        "exp": time.Now().Add(time.Minute).Unix(),
+    })
+    signed, err := token.SignedString([]byte("test"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    req = httptest.NewRequest(http.MethodGet, "/", nil)
+    req.Header.Set("Authorization", "Bearer "+signed)
+    resp = httptest.NewRecorder()
+    h.ServeHTTP(resp, req)
+    if resp.Code != http.StatusOK {
+        t.Fatalf("expected 200 got %d", resp.Code)
+    }
+}
+
+func TestAuthMiddlewareExpired(t *testing.T) {
+    os.Setenv("JWT_SECRET", "test")
+    h := Auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+        "sub": "svc",
+        "exp": time.Now().Add(-time.Minute).Unix(),
+    })
+    signed, err := token.SignedString([]byte("test"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    req := httptest.NewRequest(http.MethodGet, "/", nil)
+    req.Header.Set("Authorization", "Bearer "+signed)
+    resp := httptest.NewRecorder()
+    h.ServeHTTP(resp, req)
+    if resp.Code != http.StatusUnauthorized {
+        t.Fatalf("expected 401 got %d", resp.Code)
+    }
+}

--- a/gateway/internal/middleware/ratelimit_test.go
+++ b/gateway/internal/middleware/ratelimit_test.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/gorilla/mux"
+)
+
+func TestRateLimitDeniesWithoutTokens(t *testing.T) {
+    r := mux.NewRouter()
+    r.Use(RateLimit)
+    r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+
+    req := httptest.NewRequest(http.MethodGet, "/", nil)
+    resp := httptest.NewRecorder()
+    r.ServeHTTP(resp, req)
+    if resp.Code != http.StatusTooManyRequests {
+        t.Fatalf("expected 429 got %d", resp.Code)
+    }
+}

--- a/gateway/internal/proxy/proxy.go
+++ b/gateway/internal/proxy/proxy.go
@@ -1,10 +1,9 @@
 package proxy
 
 import (
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"os"
+        "net/http/httputil"
+        "net/url"
+        "os"
 )
 
 // NewProxy returns a reverse proxy to the target service.

--- a/gateway/internal/proxy/proxy_error_test.go
+++ b/gateway/internal/proxy/proxy_error_test.go
@@ -1,0 +1,14 @@
+package proxy
+
+import (
+    "os"
+    "testing"
+)
+
+func TestNewProxyInvalidPort(t *testing.T) {
+    os.Setenv("APP_PORT", "badport")
+    os.Unsetenv("APP_HOST")
+    if _, err := NewProxy(); err == nil {
+        t.Fatal("expected error")
+    }
+}

--- a/tests/services/test_analytics_microservice_app.py
+++ b/tests/services/test_analytics_microservice_app.py
@@ -1,0 +1,97 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from jose import jwt
+
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
+
+
+def load_app():
+    services_stub = types.ModuleType("services")
+    services_stub.__path__ = [str(SERVICES_PATH)]
+    sys.modules.setdefault("services", services_stub)
+
+    otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
+    otel_stub.FastAPIInstrumentor = types.SimpleNamespace(instrument_app=lambda *a, **k: None)
+    sys.modules.setdefault("opentelemetry.instrumentation.fastapi", otel_stub)
+
+    prom_stub = types.ModuleType("prometheus_fastapi_instrumentator")
+    class DummyInstr:
+        def instrument(self, app):
+            return self
+        def expose(self, app):
+            return self
+    prom_stub.Instrumentator = lambda: DummyInstr()
+    sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
+
+    class DummyAnalytics:
+        def __init__(self):
+            self.summary_called = 0
+            self.pattern_calls = []
+
+        def get_dashboard_summary(self) -> dict:
+            self.summary_called += 1
+            return {"status": "ok"}
+
+        def get_access_patterns_analysis(self, days: int = 7) -> dict:
+            self.pattern_calls.append(days)
+            return {"days": days}
+
+    analytics_stub = types.ModuleType("services.analytics_service")
+    dummy = DummyAnalytics()
+    analytics_stub.create_analytics_service = lambda: dummy
+    sys.modules["services.analytics_service"] = analytics_stub
+
+    tracing_stub = types.ModuleType("tracing")
+    tracing_stub.init_tracing = lambda name: None
+    sys.modules["tracing"] = tracing_stub
+
+    spec = importlib.util.spec_from_file_location(
+        "services.analytics_microservice.app",
+        SERVICES_PATH / "analytics_microservice" / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module, dummy
+
+
+@pytest.fixture()
+def app_fixture(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    module, dummy = load_app()
+    client = TestClient(module.app)
+    return client, dummy
+
+
+def _token(secret: str) -> str:
+    return jwt.encode({"sub": "svc", "exp": int(time.time()) + 60}, secret, algorithm="HS256")
+
+
+def test_dashboard_summary_endpoint(app_fixture):
+    client, dummy = app_fixture
+    token = _token("secret")
+    resp = client.post(
+        "/api/v1/analytics/get_dashboard_summary",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert dummy.summary_called == 1
+
+
+def test_access_patterns_endpoint(app_fixture):
+    client, dummy = app_fixture
+    token = _token("secret")
+    resp = client.post(
+        "/api/v1/analytics/get_access_patterns_analysis",
+        json={"days": 3},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"days": 3}
+    assert dummy.pattern_calls == [3]

--- a/tests/services/test_event_ingestion_app.py
+++ b/tests/services/test_event_ingestion_app.py
@@ -1,0 +1,84 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
+
+
+def load_module():
+    otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
+    otel_stub.FastAPIInstrumentor = types.SimpleNamespace(instrument_app=lambda *a, **k: None)
+    sys.modules.setdefault("opentelemetry.instrumentation.fastapi", otel_stub)
+
+    prom_stub = types.ModuleType("prometheus_fastapi_instrumentator")
+    class DummyInstr:
+        def instrument(self, app):
+            return self
+        def expose(self, app):
+            return self
+    prom_stub.Instrumentator = lambda: DummyInstr()
+    sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
+    spec = importlib.util.spec_from_file_location(
+        "services.event_ingestion.app",
+        SERVICES_PATH / "event-ingestion" / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+@pytest.mark.asyncio
+async def test_consume_loop_logs(monkeypatch):
+    module = load_module()
+
+    messages = [b"a", b"b"]
+
+    def fake_consume(timeout: float = 1.0):
+        for m in messages:
+            yield m
+
+    fake_service = types.SimpleNamespace(
+        consume=fake_consume,
+        initialize=lambda: None,
+        close=lambda: None,
+        health_check=lambda: {"ok": True},
+    )
+    module.service = fake_service
+
+    seen = []
+
+    class DummyLogger:
+        def info(self, msg, value):
+            seen.append(value)
+
+    module.app.logger = DummyLogger()
+
+    async def fake_sleep(_):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(module, "asyncio", types.SimpleNamespace(sleep=fake_sleep))
+
+    with pytest.raises(asyncio.CancelledError):
+        await module._consume_loop()
+
+    assert seen == messages
+
+
+def test_health_endpoint(monkeypatch):
+    module = load_module()
+    fake_service = types.SimpleNamespace(
+        consume=lambda timeout=1.0: [],
+        initialize=lambda: None,
+        close=lambda: None,
+        health_check=lambda: {"status": "ok"},
+    )
+    module.service = fake_service
+    client = TestClient(module.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add unit tests for analytics microservice endpoints
- add unit tests for event ingestion service consume loop
- test gateway middleware and proxy error handling
- fix unused import in proxy
- generate coverage artifacts in microservices workflow

## Testing
- `pytest tests/services gateway/internal/middleware gateway/internal/proxy -q`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fbb5c5b408320940c8bdf1af8fcda