### PR TITLE
Implement advanced gateway plugins and async queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ assets/css/*
 translations/**/*.mo
 cache/
 !gateway/internal/cache/
+!gateway/plugins/cache/
 venv
 venv_dashboard/
 

--- a/gateway/config/gateway.yaml
+++ b/gateway/config/gateway.yaml
@@ -1,0 +1,18 @@
+gateway:
+  plugins:
+    - name: rate-limit
+      enabled: true
+      config:
+        rules:
+          - path: /api/v1/events
+            limit_per_min: 100
+            burst_size: 20
+    - name: cache
+      enabled: true
+      config:
+        rules:
+          - path: /api/v1/analytics
+            ttl: 300s
+  queue:
+    type: rabbitmq
+    url: amqp://rabbitmq:5672

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/consul/api v1.32.1
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.22.0
+	github.com/rabbitmq/amqp091-go v1.5.0
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/riferrei/srclient v0.7.3
 	github.com/sirupsen/logrus v1.9.3
@@ -18,6 +19,8 @@ require (
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
 	go.opentelemetry.io/otel/sdk v1.37.0
+	go.opentelemetry.io/otel/trace v1.37.0
+	golang.org/x/time v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
 
 )
@@ -54,7 +57,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
-	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -263,6 +263,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/rabbitmq/amqp091-go v1.5.0 h1:VouyHPBu1CrKyJVfteGknGOGCzmOz0zcv/tONLkb7rg=
+github.com/rabbitmq/amqp091-go v1.5.0/go.mod h1:JsV0ofX5f1nwOGafb8L5rBItt9GyhfQfcJj+oyz0dGg=
 github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
 github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/riferrei/srclient v0.7.3 h1:JRR6jgfINWUcYZhBRHEg/NAFv7giVmjkoouRbWbakgw=
@@ -303,6 +305,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -318,6 +321,7 @@ go.opentelemetry.io/otel/sdk v1.37.0/go.mod h1:VredYzxUvuo2q3WRcDnKDjbdvmO0sCzOv
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -330,7 +334,9 @@ golang.org/x/exp v0.0.0-20250718183923-645b1fa84792/go.mod h1:A+z0yzpGtvnG90cToK
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -396,6 +402,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
+golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -403,6 +411,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/gateway/internal/gateway/gateway.go
+++ b/gateway/internal/gateway/gateway.go
@@ -9,11 +9,13 @@ import (
 	"github.com/WSG23/yosai-gateway/internal/handlers"
 	"github.com/WSG23/yosai-gateway/internal/middleware"
 	"github.com/WSG23/yosai-gateway/internal/proxy"
+	"github.com/WSG23/yosai-gateway/plugins"
 )
 
 // Gateway represents the HTTP gateway service.
 type Gateway struct {
-	router *mux.Router
+	router  *mux.Router
+	plugins plugins.PluginRegistry
 }
 
 // New creates a configured Gateway.
@@ -29,7 +31,7 @@ func New() (*Gateway, error) {
 	r.HandleFunc("/breaker", handlers.BreakerMetrics).Methods(http.MethodGet)
 	r.PathPrefix("/").Handler(p)
 
-	g := &Gateway{router: r}
+	g := &Gateway{router: r, plugins: plugins.PluginRegistry{}}
 
 	return g, nil
 }
@@ -46,5 +48,10 @@ func (g *Gateway) UseRateLimit() {
 
 // Handler returns the root HTTP handler.
 func (g *Gateway) Handler() http.Handler {
-	return g.router
+	return g.plugins.BuildMiddlewareChain(g.router)
+}
+
+// RegisterPlugin registers a gateway plugin.
+func (g *Gateway) RegisterPlugin(p plugins.Plugin) {
+	g.plugins.Register(p)
 }

--- a/gateway/plugins/cache/api_cache.go
+++ b/gateway/plugins/cache/api_cache.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type CacheRule struct {
+	Path string
+	TTL  time.Duration
+}
+
+type cachedResponse struct {
+	StatusCode int
+	Headers    http.Header
+	Body       []byte
+}
+
+type CachePlugin struct {
+	redis *redis.Client
+	rules []CacheRule
+}
+
+func (c *CachePlugin) Name() string                             { return "api-cache" }
+func (c *CachePlugin) Priority() int                            { return 50 }
+func (c *CachePlugin) Init(config map[string]interface{}) error { return nil }
+
+func (c *CachePlugin) Process(ctx context.Context, req *http.Request, resp http.ResponseWriter, next http.Handler) {
+	var matched *CacheRule
+	for _, r := range c.rules {
+		if r.Path == req.URL.Path {
+			matched = &r
+			break
+		}
+	}
+	if matched == nil || req.Method != http.MethodGet {
+		next.ServeHTTP(resp, req)
+		return
+	}
+
+	key := cacheKey(req)
+	val, err := c.redis.Get(ctx, key).Result()
+	if err == nil {
+		var cr cachedResponse
+		if json.Unmarshal([]byte(val), &cr) == nil {
+			for k, v := range cr.Headers {
+				resp.Header()[k] = v
+			}
+			resp.Header().Set("X-Cache", "HIT")
+			resp.WriteHeader(cr.StatusCode)
+			resp.Write(cr.Body)
+			return
+		}
+	}
+
+	recorder := httptest.NewRecorder()
+	next.ServeHTTP(recorder, req)
+	res := recorder.Result()
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+
+	data, _ := json.Marshal(cachedResponse{StatusCode: res.StatusCode, Headers: res.Header, Body: body})
+	c.redis.Set(ctx, key, data, matched.TTL)
+
+	for k, v := range res.Header {
+		resp.Header()[k] = v
+	}
+	resp.Header().Set("X-Cache", "MISS")
+	resp.WriteHeader(res.StatusCode)
+	resp.Write(body)
+}
+
+func cacheKey(req *http.Request) string {
+	h := sha256.Sum256([]byte(req.Method + "|" + req.URL.String()))
+	return "cache:" + hex.EncodeToString(h[:])
+}

--- a/gateway/plugins/interface.go
+++ b/gateway/plugins/interface.go
@@ -1,0 +1,43 @@
+package plugins
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"sync"
+)
+
+type Plugin interface {
+	Name() string
+	Priority() int
+	Init(config map[string]interface{}) error
+	Process(ctx context.Context, req *http.Request, resp http.ResponseWriter, next http.Handler)
+}
+
+type PluginRegistry struct {
+	plugins []Plugin
+	mu      sync.RWMutex
+}
+
+func (pr *PluginRegistry) Register(p Plugin) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	pr.plugins = append(pr.plugins, p)
+	sort.Slice(pr.plugins, func(i, j int) bool {
+		return pr.plugins[i].Priority() < pr.plugins[j].Priority()
+	})
+}
+
+func (pr *PluginRegistry) BuildMiddlewareChain(final http.Handler) http.Handler {
+	pr.mu.RLock()
+	defer pr.mu.RUnlock()
+	handler := final
+	for i := len(pr.plugins) - 1; i >= 0; i-- {
+		plugin := pr.plugins[i]
+		next := handler
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			plugin.Process(r.Context(), r, w, next)
+		})
+	}
+	return handler
+}

--- a/gateway/plugins/ratelimit/advanced.go
+++ b/gateway/plugins/ratelimit/advanced.go
@@ -1,0 +1,60 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/time/rate"
+)
+
+type RateLimitRule struct {
+	Path        string
+	Method      string
+	LimitPerMin int
+	Burst       int
+}
+
+type RateLimitPlugin struct {
+	redis    *redis.Client
+	limiters sync.Map
+	rules    []RateLimitRule
+}
+
+func (r *RateLimitPlugin) Name() string                             { return "advanced-rate-limit" }
+func (r *RateLimitPlugin) Priority() int                            { return 10 }
+func (r *RateLimitPlugin) Init(config map[string]interface{}) error { return nil }
+
+func (r *RateLimitPlugin) limiter(key string, rule RateLimitRule) *rate.Limiter {
+	val, ok := r.limiters.Load(key)
+	if ok {
+		return val.(*rate.Limiter)
+	}
+	l := rate.NewLimiter(rate.Every(time.Minute/time.Duration(rule.LimitPerMin)), rule.Burst)
+	r.limiters.Store(key, l)
+	return l
+}
+
+func (r *RateLimitPlugin) Process(ctx context.Context, req *http.Request, resp http.ResponseWriter, next http.Handler) {
+	var matched *RateLimitRule
+	for _, rule := range r.rules {
+		if rule.Path == req.URL.Path && (rule.Method == "" || rule.Method == req.Method) {
+			matched = &rule
+			break
+		}
+	}
+	if matched == nil {
+		next.ServeHTTP(resp, req)
+		return
+	}
+	key := fmt.Sprintf("%s:%s", req.RemoteAddr, matched.Path)
+	limiter := r.limiter(key, *matched)
+	if !limiter.Allow() {
+		http.Error(resp, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	next.ServeHTTP(resp, req)
+}

--- a/gateway/plugins/ratelimit/advanced_test.go
+++ b/gateway/plugins/ratelimit/advanced_test.go
@@ -1,0 +1,24 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimitPlugin(t *testing.T) {
+	p := &RateLimitPlugin{rules: []RateLimitRule{{Path: "/", LimitPerMin: 1, Burst: 1}}}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	w1 := httptest.NewRecorder()
+	p.Process(nil, httptest.NewRequest("GET", "/", nil), w1, handler)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w1.Code)
+	}
+
+	w2 := httptest.NewRecorder()
+	p.Process(nil, httptest.NewRequest("GET", "/", nil), w2, handler)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 got %d", w2.Code)
+	}
+}

--- a/gateway/plugins/registry_test.go
+++ b/gateway/plugins/registry_test.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testPlugin struct {
+	name     string
+	priority int
+	called   *int
+}
+
+func (t *testPlugin) Name() string                        { return t.name }
+func (t *testPlugin) Priority() int                       { return t.priority }
+func (t *testPlugin) Init(_ map[string]interface{}) error { return nil }
+func (t *testPlugin) Process(ctx context.Context, req *http.Request, resp http.ResponseWriter, next http.Handler) {
+	*t.called = *t.called + 1
+	next.ServeHTTP(resp, req)
+}
+
+func TestRegistryOrder(t *testing.T) {
+	var a, b int
+	reg := &PluginRegistry{}
+	reg.Register(&testPlugin{name: "a", priority: 20, called: &a})
+	reg.Register(&testPlugin{name: "b", priority: 10, called: &b})
+
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	handler := reg.BuildMiddlewareChain(final)
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if b != 1 || a != 1 {
+		t.Fatalf("plugins not executed in priority order")
+	}
+}

--- a/gateway/queue/rabbitmq/client.go
+++ b/gateway/queue/rabbitmq/client.go
@@ -1,0 +1,80 @@
+package rabbitmq
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type QueueClient struct {
+	conn    *amqp.Connection
+	channel *amqp.Channel
+	mu      sync.RWMutex
+}
+
+type Task struct {
+	ID         string          `json:"id"`
+	Type       string          `json:"type"`
+	Payload    json.RawMessage `json:"payload"`
+	Priority   int             `json:"priority"`
+	MaxRetries int             `json:"max_retries"`
+	RetryCount int             `json:"retry_count"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+func NewQueueClient(url string) (*QueueClient, error) {
+	conn, err := amqp.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := conn.Channel()
+	if err != nil {
+		return nil, err
+	}
+	return &QueueClient{conn: conn, channel: ch}, nil
+}
+
+func (q *QueueClient) DeclareQueue(name string, durable bool) error {
+	_, err := q.channel.QueueDeclare(name, durable, false, false, false, nil)
+	return err
+}
+
+func (q *QueueClient) PublishTask(ctx context.Context, queue string, task *Task) error {
+	body, err := json.Marshal(task)
+	if err != nil {
+		return err
+	}
+	return q.channel.PublishWithContext(ctx, "", queue, false, false, amqp.Publishing{
+		ContentType:  "application/json",
+		Body:         body,
+		DeliveryMode: amqp.Persistent,
+		Timestamp:    time.Now(),
+	})
+}
+
+func (q *QueueClient) ConsumeQueue(ctx context.Context, queue string, handler func(context.Context, *Task) error) error {
+	msgs, err := q.channel.Consume(queue, "", false, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg := <-msgs:
+			var t Task
+			if err := json.Unmarshal(msg.Body, &t); err != nil {
+				msg.Nack(false, false)
+				continue
+			}
+			if err := handler(ctx, &t); err != nil {
+				msg.Nack(false, true)
+			} else {
+				msg.Ack(false)
+			}
+		}
+	}
+}

--- a/gateway/services/taskprocessor/processor.go
+++ b/gateway/services/taskprocessor/processor.go
@@ -1,0 +1,43 @@
+package taskprocessor
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/WSG23/yosai-gateway/queue/rabbitmq"
+)
+
+type TaskHandler func(context.Context, json.RawMessage) error
+
+type TaskProcessor struct {
+	queue    *rabbitmq.QueueClient
+	handlers map[string]TaskHandler
+}
+
+type TaskMetrics struct {
+	processed *prometheus.CounterVec
+}
+
+func New(queueURL string) (*TaskProcessor, error) {
+	q, err := rabbitmq.NewQueueClient(queueURL)
+	if err != nil {
+		return nil, err
+	}
+	return &TaskProcessor{queue: q, handlers: make(map[string]TaskHandler)}, nil
+}
+
+func (tp *TaskProcessor) RegisterHandler(t string, h TaskHandler) {
+	tp.handlers[t] = h
+}
+
+func (tp *TaskProcessor) Start(ctx context.Context, queue string) error {
+	return tp.queue.ConsumeQueue(ctx, queue, func(c context.Context, t *rabbitmq.Task) error {
+		h, ok := tp.handlers[t.Type]
+		if !ok {
+			return nil
+		}
+		return h(c, t.Payload)
+	})
+}

--- a/gateway/tracing/enhanced_tracing.go
+++ b/gateway/tracing/enhanced_tracing.go
@@ -1,0 +1,27 @@
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type EnhancedTracer struct {
+	tracer trace.Tracer
+}
+
+func NewEnhancedTracer() *EnhancedTracer {
+	return &EnhancedTracer{tracer: otel.Tracer("async-operations")}
+}
+
+func (et *EnhancedTracer) TraceAsyncOperation(ctx context.Context, name string, taskID string, fn func(context.Context) error) error {
+	ctx, span := et.tracer.Start(context.Background(), name, trace.WithAttributes(attribute.String("task.id", taskID)))
+	defer span.End()
+	err := fn(ctx)
+	if err != nil {
+		span.RecordError(err)
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- create plugin architecture for gateway
- add advanced rate limit plugin
- add API caching plugin
- add RabbitMQ queue client and task processor service
- enhance tracing utilities
- register plugins with the gateway
- provide sample gateway configuration
- test plugin registry and rate limiter

## Testing
- `go test ./...` in gateway module

------
https://chatgpt.com/codex/tasks/task_e_687fd0f456b48320818156f383e44f3e