### PR TITLE
Add Envoy example and advanced load balancer

### DIFF
--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -1,0 +1,35 @@
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 10000 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: service_backend }
+          http_filters:
+          - name: envoy.filters.http.router
+  clusters:
+  - name: service_backend
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service_backend
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: app
+                port_value: 8080

--- a/gateway/internal/proxy/proxy.go
+++ b/gateway/internal/proxy/proxy.go
@@ -1,27 +1,55 @@
 package proxy
 
 import (
-        "net/http/httputil"
-        "net/url"
-        "os"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	lb "github.com/WSG23/yosai-gateway/loadbalancer"
 )
 
 // NewProxy returns a reverse proxy to the target service.
 func NewProxy() (*httputil.ReverseProxy, error) {
-	host := os.Getenv("APP_HOST")
-	if host == "" {
-		host = "app"
+	var urls []*url.URL
+	if backends := os.Getenv("APP_BACKENDS"); backends != "" {
+		for _, b := range strings.Split(backends, ",") {
+			b = strings.TrimSpace(b)
+			if b == "" {
+				continue
+			}
+			if !strings.Contains(b, "://") {
+				b = "http://" + b
+			}
+			u, err := url.Parse(b)
+			if err != nil {
+				return nil, err
+			}
+			urls = append(urls, u)
+		}
+	} else {
+		host := os.Getenv("APP_HOST")
+		if host == "" {
+			host = "app"
+		}
+		port := os.Getenv("APP_PORT")
+		if port == "" {
+			port = "8050"
+		}
+		u, err := url.Parse("http://" + host + ":" + port)
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, u)
 	}
-	port := os.Getenv("APP_PORT")
-	if port == "" {
-		port = "8050"
-	}
-	target, err := url.Parse("http://" + host + ":" + port)
-	if err != nil {
-		return nil, err
-	}
-	p := httputil.NewSingleHostReverseProxy(target)
-	p.Transport = newTracingTransport(p.Transport)
 
+	balancer := lb.NewAdvanced(urls)
+
+	p := &httputil.ReverseProxy{
+		Director:       balancer.Director,
+		ModifyResponse: balancer.ModifyResponse,
+		ErrorHandler:   balancer.ErrorHandler,
+	}
+	p.Transport = newTracingTransport(p.Transport)
 	return p, nil
 }

--- a/gateway/loadbalancer/advanced_lb.go
+++ b/gateway/loadbalancer/advanced_lb.go
@@ -1,0 +1,136 @@
+// Package loadbalancer provides advanced backend selection.
+package loadbalancer
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// backend holds metrics about a single backend service.
+type backend struct {
+	url     *url.URL
+	mu      sync.Mutex
+	success int64
+	failure int64
+	latency time.Duration
+}
+
+// record updates the backend metrics with the result of a single request.
+func (b *backend) record(success bool, latency time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if success {
+		b.success++
+	} else {
+		b.failure++
+	}
+	if b.latency == 0 {
+		b.latency = latency
+	} else {
+		// Exponential moving average to smooth latencies
+		const weight = 0.8
+		b.latency = time.Duration(float64(b.latency)*weight + float64(latency)*(1-weight))
+	}
+}
+
+// metrics returns the current success rate and average latency.
+func (b *backend) metrics() (rate float64, lat time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	total := b.success + b.failure
+	if total == 0 {
+		rate = 1
+	} else {
+		rate = float64(b.success) / float64(total)
+	}
+	lat = b.latency
+	if lat == 0 {
+		lat = time.Millisecond
+	}
+	return
+}
+
+// AdvancedLoadBalancer selects the best backend based on success rate and latency.
+type AdvancedLoadBalancer struct {
+	backends []*backend
+}
+
+// NewAdvanced creates a new load balancer from the provided backend URLs.
+func NewAdvanced(urls []*url.URL) *AdvancedLoadBalancer {
+	bks := make([]*backend, 0, len(urls))
+	for _, u := range urls {
+		bks = append(bks, &backend{url: u})
+	}
+	return &AdvancedLoadBalancer{backends: bks}
+}
+
+// Next returns the backend that should handle the next request.
+func (lb *AdvancedLoadBalancer) Next() *backend {
+	if len(lb.backends) == 0 {
+		return nil
+	}
+	best := lb.backends[0]
+	bestRate, bestLat := best.metrics()
+	for _, b := range lb.backends[1:] {
+		r, l := b.metrics()
+		if r > bestRate || (r == bestRate && l < bestLat) {
+			best = b
+			bestRate = r
+			bestLat = l
+		}
+	}
+	return best
+}
+
+// Report updates metrics for a backend after a request is completed.
+func (lb *AdvancedLoadBalancer) Report(b *backend, success bool, lat time.Duration) {
+	if b == nil {
+		return
+	}
+	b.record(success, lat)
+}
+
+// URL returns the URL of the backend.
+func (b *backend) URL() *url.URL { return b.url }
+
+// context keys for storing backend info
+type ctxKey string
+
+const (
+	backendKey ctxKey = "lb_backend"
+	startKey   ctxKey = "lb_start"
+)
+
+// Director selects a backend for the incoming request and rewrites the URL.
+func (lb *AdvancedLoadBalancer) Director(req *http.Request) {
+	b := lb.Next()
+	if b == nil {
+		return
+	}
+	ctx := context.WithValue(req.Context(), backendKey, b)
+	ctx = context.WithValue(ctx, startKey, time.Now())
+	req.URL.Scheme = b.url.Scheme
+	req.URL.Host = b.url.Host
+	req.Host = b.url.Host
+	*req = *req.WithContext(ctx)
+}
+
+// ModifyResponse records successful requests to a backend.
+func (lb *AdvancedLoadBalancer) ModifyResponse(resp *http.Response) error {
+	b, _ := resp.Request.Context().Value(backendKey).(*backend)
+	start, _ := resp.Request.Context().Value(startKey).(time.Time)
+	success := resp.StatusCode < http.StatusInternalServerError
+	lb.Report(b, success, time.Since(start))
+	return nil
+}
+
+// ErrorHandler records failed requests and returns a bad gateway response.
+func (lb *AdvancedLoadBalancer) ErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	b, _ := r.Context().Value(backendKey).(*backend)
+	start, _ := r.Context().Value(startKey).(time.Time)
+	lb.Report(b, false, time.Since(start))
+	http.Error(w, err.Error(), http.StatusBadGateway)
+}


### PR DESCRIPTION
## Summary
- provide example Envoy configuration under `envoy/`
- add `AdvancedLoadBalancer` implementation selecting backends by success rate and latency
- update gateway proxy to use the new load balancer and accept multiple backends

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fd4d8c2a0832094198fd4e078bd62