### PR TITLE
Add tracing helpers for context propagation

### DIFF
--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List
 
 import requests
+from tracing import propagate_context
 
 import sqlparse
 from sqlparse.sql import Identifier, IdentifierList, Token
@@ -331,9 +332,12 @@ class SecurityValidator(SecurityServiceProtocol):
         service_url = os.environ.get("PERMISSION_SERVICE_URL", "http://localhost:8081")
         url = f"{service_url.rstrip('/')}/permissions/check"
         try:
+            headers: Dict[str, str] = {}
+            propagate_context(headers)
             resp = requests.get(
                 url,
                 params={"user_id": user_id, "resource": resource, "action": action},
+                headers=headers,
                 timeout=5,
             )
             resp.raise_for_status()

--- a/gateway/internal/middleware/ratelimit.go
+++ b/gateway/internal/middleware/ratelimit.go
@@ -1,8 +1,11 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"time"
+
+	"github.com/WSG23/yosai-gateway/tracing"
 )
 
 // Simple rate limiter using a token bucket.
@@ -11,12 +14,15 @@ func RateLimit(next http.Handler) http.Handler {
 	tokens := make(chan struct{}, 10)
 
 	go func() {
-		for range ticker.C {
-			select {
-			case tokens <- struct{}{}:
-			default:
+		tracing.TraceAsyncOperation(context.Background(), "rate_limit_refill", "bucket", func(ctx context.Context) error {
+			for range ticker.C {
+				select {
+				case tokens <- struct{}{}:
+				default:
+				}
 			}
-		}
+			return nil
+		})
 	}()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/gateway/internal/proxy/transport.go
+++ b/gateway/internal/proxy/transport.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"net/http"
 
-	"go.opentelemetry.io/otel"
+	"github.com/WSG23/yosai-gateway/tracing"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -14,8 +14,7 @@ type tracingTransport struct {
 }
 
 func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	propagator := otel.GetTextMapPropagator()
-	propagator.Inject(req.Context(), propagation.HeaderCarrier(req.Header))
+	tracing.PropagateContext(req.Context(), propagation.HeaderCarrier(req.Header))
 	return t.base.RoundTrip(req)
 }
 

--- a/gateway/tracing/enhanced_tracing.go
+++ b/gateway/tracing/enhanced_tracing.go
@@ -5,23 +5,28 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type EnhancedTracer struct {
-	tracer trace.Tracer
+var asyncTracer = otel.Tracer("async-operations")
+
+// PropagateContext injects the trace context from ctx into the provided carrier.
+func PropagateContext(ctx context.Context, carrier propagation.TextMapCarrier) {
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
 }
 
-func NewEnhancedTracer() *EnhancedTracer {
-	return &EnhancedTracer{tracer: otel.Tracer("async-operations")}
-}
-
-func (et *EnhancedTracer) TraceAsyncOperation(ctx context.Context, name string, taskID string, fn func(context.Context) error) error {
-	ctx, span := et.tracer.Start(context.Background(), name, trace.WithAttributes(attribute.String("task.id", taskID)))
+// TraceAsyncOperation runs fn within a new span that is a child of ctx.
+// A task.id attribute is attached to the span for easier correlation.
+func TraceAsyncOperation(ctx context.Context, name, taskID string, fn func(context.Context) error) error {
+	spanCtx := trace.SpanFromContext(ctx)
+	ctx = trace.ContextWithSpan(context.Background(), spanCtx)
+	ctx, span := asyncTracer.Start(ctx, name, trace.WithAttributes(attribute.String("task.id", taskID)))
 	defer span.End()
-	err := fn(ctx)
-	if err != nil {
+
+	if err := fn(ctx); err != nil {
 		span.RecordError(err)
+		return err
 	}
-	return err
+	return nil
 }

--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -4,6 +4,7 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from services.streaming import StreamingService
+from tracing import trace_async_operation
 
 app = FastAPI(title="Event Ingestion Service")
 service = StreamingService()
@@ -17,7 +18,7 @@ async def _consume_loop() -> None:
 @app.on_event("startup")
 async def startup() -> None:
     service.initialize()
-    asyncio.create_task(_consume_loop())
+    asyncio.create_task(trace_async_operation("consume_loop", "ingest", _consume_loop()))
 
 @app.on_event("shutdown")
 async def shutdown() -> None:

--- a/services/registry.py
+++ b/services/registry.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 import os
 import requests
+from tracing import propagate_context
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +50,13 @@ class ServiceDiscovery:
     def resolve(self, name: str) -> Optional[str]:
         """Return ``host:port`` for *name* or ``None`` if lookup fails."""
         try:
+            headers: Dict[str, str] = {}
+            propagate_context(headers)
             resp = self.session.get(
-                f"{self.base_url}/v1/health/service/{name}", params={"passing": 1}, timeout=2
+                f"{self.base_url}/v1/health/service/{name}",
+                params={"passing": 1},
+                headers=headers,
+                timeout=2,
             )
             resp.raise_for_status()
             data = resp.json()

--- a/tracing/__init__.py
+++ b/tracing/__init__.py
@@ -1,5 +1,7 @@
 import os
-from opentelemetry import trace
+from typing import Any, Awaitable, MutableMapping
+
+from opentelemetry import context as ot_context, propagate, trace
 from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -14,3 +16,22 @@ def init_tracing(service_name: str) -> None:
     provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
+
+
+async def trace_async_operation(name: str, task_id: str, coro: Awaitable[Any]) -> Any:
+    """Run *coro* in a new span for background tasks."""
+    tracer = trace.get_tracer("async-operations")
+    token = ot_context.attach(ot_context.get_current())
+    try:
+        with tracer.start_as_current_span(name, attributes={"task.id": task_id}) as span:
+            return await coro
+    except Exception as exc:  # pragma: no cover - error handling
+        span.record_exception(exc)
+        raise
+    finally:
+        ot_context.detach(token)
+
+
+def propagate_context(headers: MutableMapping[str, str]) -> None:
+    """Inject the current trace context into HTTP *headers*."""
+    propagate.inject(headers)


### PR DESCRIPTION
## Summary
- add `TraceAsyncOperation` and `PropagateContext` helpers in Go tracing
- propagate tracing headers when proxying requests
- trace background tasks in rate limiter and Python task queue
- forward trace context in Python service discovery and permission checks
- expose `trace_async_operation` and `propagate_context` helpers for Python services
- instrument ingestion service startup loop with tracing

## Testing
- `go test ./...`
- `pytest -q` *(fails: 109 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687fd4d9b5ac83208de0cfe75d9a909b