### PR TITLE
Add RBAC migration

### DIFF
--- a/database/migrations/002_add_rbac.sql
+++ b/database/migrations/002_add_rbac.sql
@@ -1,0 +1,54 @@
+-- RBAC tables
+
+CREATE TABLE IF NOT EXISTS roles (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) UNIQUE NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) UNIQUE NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id INTEGER REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id INTEGER REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id VARCHAR(50) NOT NULL,
+    role_id INTEGER REFERENCES roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, role_id)
+);
+
+-- default data
+INSERT INTO roles (name, description) VALUES
+    ('admin', 'Administrator with full access'),
+    ('basic', 'Basic user with limited access')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO permissions (name, description) VALUES
+    ('view_dashboard', 'View dashboard pages'),
+    ('manage_users', 'Manage user accounts'),
+    ('edit_settings', 'Edit application settings')
+ON CONFLICT (name) DO NOTHING;
+
+-- assign permissions to admin
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.name IN ('view_dashboard', 'manage_users', 'edit_settings')
+WHERE r.name = 'admin'
+ON CONFLICT DO NOTHING;
+
+-- assign basic permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.name = 'view_dashboard'
+WHERE r.name = 'basic'
+ON CONFLICT DO NOTHING;
+

--- a/database/migrations/alembic/versions/0002_add_rbac.py
+++ b/database/migrations/alembic/versions/0002_add_rbac.py
@@ -1,0 +1,22 @@
+"""Add RBAC tables"""
+from __future__ import annotations
+from pathlib import Path
+from alembic import op
+import sqlalchemy as sa  # noqa:F401
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[2] / "002_add_rbac.sql"
+    op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS user_roles")
+    op.execute("DROP TABLE IF EXISTS role_permissions")
+    op.execute("DROP TABLE IF EXISTS permissions")
+    op.execute("DROP TABLE IF EXISTS roles")


### PR DESCRIPTION
## Summary
- add SQL file with RBAC tables, default roles and permissions
- create Alembic script referencing the new SQL file

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 96 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687fd404974c8320bf853d5293fa7058