### PR TITLE
Add permission middleware and docs

### DIFF
--- a/api/analytics_endpoints.py
+++ b/api/analytics_endpoints.py
@@ -1,18 +1,20 @@
-import logging
-from typing import Dict, Any, List, Optional
-from flask import Blueprint, request, jsonify, Response
 import asyncio
 import json
+import logging
+from typing import Any, Dict, List, Optional
 
-from core.advanced_cache import AdvancedCacheManager
+from flask import Blueprint, Response, jsonify, request
+
 from config.base import CacheConfig
+from core.advanced_cache import AdvancedCacheManager
 from services.cached_analytics import CachedAnalyticsService
+from services.security import require_permission
 
 logger = logging.getLogger(__name__)
 
-analytics_bp = Blueprint('analytics', __name__, url_prefix='/api/v1/analytics')
-graphs_bp = Blueprint('graphs', __name__, url_prefix='/api/v1/graphs')
-export_bp = Blueprint('export', __name__, url_prefix='/api/v1/export')
+analytics_bp = Blueprint("analytics", __name__, url_prefix="/api/v1/analytics")
+graphs_bp = Blueprint("graphs", __name__, url_prefix="/api/v1/graphs")
+export_bp = Blueprint("export", __name__, url_prefix="/api/v1/export")
 
 # Cached analytics helper
 _cache_manager = AdvancedCacheManager(CacheConfig(timeout_seconds=300))
@@ -25,64 +27,79 @@ MOCK_DATA = {
         "total_records": 1000,
         "unique_users": 50,
         "unique_devices": 25,
-        "date_range": {"start": "2024-01-01", "end": "2024-01-31", "span_days": 30}
+        "date_range": {"start": "2024-01-01", "end": "2024-01-31", "span_days": 30},
     },
     "user_patterns": {
         "power_users": ["user1", "user2", "user3"],
         "regular_users": ["user4", "user5"],
-        "occasional_users": ["user6", "user7", "user8"]
+        "occasional_users": ["user6", "user7", "user8"],
     },
     "device_patterns": {
         "high_traffic_devices": ["device1", "device2"],
         "moderate_traffic_devices": ["device3", "device4"],
-        "low_traffic_devices": ["device5", "device6"]
+        "low_traffic_devices": ["device5", "device6"],
     },
     "temporal_patterns": {
         "peak_hours": ["09:00", "17:00"],
         "peak_days": ["Monday", "Friday"],
-        "hourly_distribution": {"09": 100, "17": 150}
+        "hourly_distribution": {"09": 100, "17": 150},
     },
     "access_patterns": {
         "overall_success_rate": 0.85,
         "users_with_low_success": 5,
-        "devices_with_low_success": 2
-    }
+        "devices_with_low_success": 2,
+    },
 }
 
-@analytics_bp.route('/patterns', methods=['GET'])
+
+@analytics_bp.route("/patterns", methods=["GET"])
+@require_permission("analytics.read")
 def get_patterns_analysis():
-    facility = request.args.get('facility_id', 'default')
-    date_range = request.args.get('range', '30d')
+    facility = request.args.get("facility_id", "default")
+    date_range = request.args.get("range", "30d")
     data = asyncio.run(_cached_service.get_analytics_summary(facility, date_range))
     return jsonify(data)
 
-@analytics_bp.route('/sources', methods=['GET'])
+
+@analytics_bp.route("/sources", methods=["GET"])
+@require_permission("analytics.read")
 def get_data_sources():
     return jsonify({"sources": [{"value": "test", "label": "Test Data Source"}]})
 
-@analytics_bp.route('/health', methods=['GET'])
+
+@analytics_bp.route("/health", methods=["GET"])
+@require_permission("analytics.read")
 def analytics_health():
     return jsonify({"status": "healthy", "service": "minimal"})
 
-@graphs_bp.route('/chart/<chart_type>', methods=['GET'])
+
+@graphs_bp.route("/chart/<chart_type>", methods=["GET"])
+@require_permission("analytics.read")
 def get_chart_data(chart_type):
-    facility = request.args.get('facility_id', 'default')
-    date_range = request.args.get('range', '30d')
+    facility = request.args.get("facility_id", "default")
+    date_range = request.args.get("range", "30d")
     data = asyncio.run(_cached_service.get_analytics_summary(facility, date_range))
     if chart_type == "patterns":
         return jsonify({"type": "patterns", "data": data})
     if chart_type == "timeline":
-        return jsonify({"type": "timeline", "data": data.get("hourly_distribution", {})})
+        return jsonify(
+            {"type": "timeline", "data": data.get("hourly_distribution", {})}
+        )
     return jsonify({"error": "Unknown chart type"}), 400
 
-@export_bp.route('/analytics/json', methods=['GET'])
+
+@export_bp.route("/analytics/json", methods=["GET"])
+@require_permission("analytics.read")
 def export_analytics_json():
-    facility = request.args.get('facility_id', 'default')
-    date_range = request.args.get('range', '30d')
+    facility = request.args.get("facility_id", "default")
+    date_range = request.args.get("range", "30d")
     data = asyncio.run(_cached_service.get_analytics_summary(facility, date_range))
     response = Response(json.dumps(data, indent=2), mimetype="application/json")
-    response.headers["Content-Disposition"] = "attachment; filename=analytics_export.json"
+    response.headers["Content-Disposition"] = (
+        "attachment; filename=analytics_export.json"
+    )
     return response
+
 
 def register_analytics_blueprints(app):
     app.register_blueprint(analytics_bp)
@@ -90,36 +107,58 @@ def register_analytics_blueprints(app):
     app.register_blueprint(export_bp)
     logger.info("Analytics blueprints registered")
 
-@graphs_bp.route('/available-charts', methods=['GET'])
+
+@graphs_bp.route("/available-charts", methods=["GET"])
+@require_permission("analytics.read")
 def get_available_charts():
     """Get list of available chart types."""
     charts = [
-        {"type": "patterns", "name": "Pattern Analysis", "description": "User and device pattern analysis"},
-        {"type": "timeline", "name": "Timeline Analysis", "description": "Temporal pattern analysis"},
-        {"type": "user_activity", "name": "User Activity", "description": "User behavior patterns"},
-        {"type": "device_usage", "name": "Device Usage", "description": "Device utilization patterns"}
+        {
+            "type": "patterns",
+            "name": "Pattern Analysis",
+            "description": "User and device pattern analysis",
+        },
+        {
+            "type": "timeline",
+            "name": "Timeline Analysis",
+            "description": "Temporal pattern analysis",
+        },
+        {
+            "type": "user_activity",
+            "name": "User Activity",
+            "description": "User behavior patterns",
+        },
+        {
+            "type": "device_usage",
+            "name": "Device Usage",
+            "description": "Device utilization patterns",
+        },
     ]
     return jsonify({"charts": charts})
 
-@export_bp.route('/formats', methods=['GET'])
+
+@export_bp.route("/formats", methods=["GET"])
+@require_permission("analytics.read")
 def get_export_formats():
     """Get available export formats."""
     formats = [
         {"type": "csv", "name": "CSV", "description": "Comma-separated values"},
         {"type": "json", "name": "JSON", "description": "JavaScript Object Notation"},
-        {"type": "xlsx", "name": "Excel", "description": "Microsoft Excel format"}
+        {"type": "xlsx", "name": "Excel", "description": "Microsoft Excel format"},
     ]
     return jsonify({"formats": formats})
 
-@analytics_bp.route('/all', methods=['GET'])
-@analytics_bp.route('/<source_type>', methods=['GET'])
-def get_analytics_by_source(source_type='all'):
+
+@analytics_bp.route("/all", methods=["GET"])
+@analytics_bp.route("/<source_type>", methods=["GET"])
+@require_permission("analytics.read")
+def get_analytics_by_source(source_type="all"):
     """Get analytics data by source type"""
     try:
-        facility = request.args.get('facility_id', 'default')
-        date_range = request.args.get('range', '30d')
+        facility = request.args.get("facility_id", "default")
+        date_range = request.args.get("range", "30d")
         data = asyncio.run(_cached_service.get_analytics_summary(facility, date_range))
         return jsonify(data)
     except Exception as e:
         logger.error(f"Analytics error: {str(e)}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,3 +99,14 @@ container.register_factory("db", DatabaseManager)
 if container.has("db"):
     db = container.get("db")
 ```
+
+## Route Permissions
+
+The following table lists the required role or permission for key API route groups.
+
+| Route Prefix | Required Role | Required Permission |
+|--------------|---------------|--------------------|
+| `/admin` | `admin` | - |
+| `/api/v1/analytics` | - | `analytics.read` |
+| `/api/v1/events` | - | `events.write` |
+| `/api/v1/doors` | - | `doors.control` |

--- a/gateway/internal/gateway/gateway.go
+++ b/gateway/internal/gateway/gateway.go
@@ -27,6 +27,24 @@ func New() (*Gateway, error) {
 	r.HandleFunc("/health", handlers.HealthCheck).Methods(http.MethodGet)
 	r.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 	r.HandleFunc("/breaker", handlers.BreakerMetrics).Methods(http.MethodGet)
+
+	// Sensitive endpoint subrouters with access control
+	doors := r.PathPrefix("/api/v1/doors").Subrouter()
+	doors.Use(middleware.RequirePermission("doors.control"))
+	doors.PathPrefix("/").Handler(p)
+
+	analytics := r.PathPrefix("/api/v1/analytics").Subrouter()
+	analytics.Use(middleware.RequirePermission("analytics.read"))
+	analytics.PathPrefix("/").Handler(p)
+
+	events := r.PathPrefix("/api/v1/events").Subrouter()
+	events.Use(middleware.RequirePermission("events.write"))
+	events.PathPrefix("/").Handler(p)
+
+	admin := r.PathPrefix("/admin").Subrouter()
+	admin.Use(middleware.RequireRole("admin"))
+	admin.PathPrefix("/").Handler(p)
+
 	r.PathPrefix("/").Handler(p)
 
 	g := &Gateway{router: r}

--- a/gateway/internal/middleware/access_control.go
+++ b/gateway/internal/middleware/access_control.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// RequirePermission checks the X-Permissions header for a permission value.
+func RequirePermission(perm string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			perms := strings.Split(r.Header.Get("X-Permissions"), ",")
+			for _, p := range perms {
+				if strings.TrimSpace(p) == perm {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			http.Error(w, "forbidden", http.StatusForbidden)
+		})
+	}
+}
+
+// RequireRole checks the X-Roles header for a role value.
+func RequireRole(role string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			roles := strings.Split(r.Header.Get("X-Roles"), ",")
+			for _, rle := range roles {
+				if strings.TrimSpace(rle) == role {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			http.Error(w, "forbidden", http.StatusForbidden)
+		})
+	}
+}

--- a/plugins/compliance_plugin/compliance_controller.py
+++ b/plugins/compliance_plugin/compliance_controller.py
@@ -6,16 +6,18 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
-from flask import Blueprint, request, jsonify, current_app
-from flask_login import login_required, current_user
 
-from core.auth import role_required
-from models.compliance import ConsentType, DSARRequestType, DataSensitivityLevel
-from services.compliance.consent_service import ConsentService
-from services.compliance.dsar_service import DSARService
+from flask import Blueprint, current_app, jsonify, request
+from flask_login import current_user, login_required
+
 from core.audit_logger import ComplianceAuditLogger
+from core.auth import role_required
 from core.container import Container
 from core.security_validator import SecurityValidator
+from models.compliance import ConsentType, DataSensitivityLevel, DSARRequestType
+from services.compliance.consent_service import ConsentService
+from services.compliance.dsar_service import DSARService
+from services.security import require_role
 
 logger = logging.getLogger(__name__)
 
@@ -385,7 +387,7 @@ def get_user_dsar_requests():
 
 @compliance_bp.route("/admin/dsar/pending", methods=["GET"])
 @login_required
-@role_required("admin")
+@require_role("admin")
 def get_pending_dsar_requests():
     """
     Get pending DSAR requests (admin only)
@@ -437,7 +439,7 @@ def get_pending_dsar_requests():
 
 @compliance_bp.route("/admin/dsar/<request_id>/process", methods=["POST"])
 @login_required
-@role_required("admin")
+@require_role("admin")
 def process_dsar_request(request_id: str):
     """
     Process a DSAR request (admin only)
@@ -540,7 +542,7 @@ def get_my_audit_trail():
 
 @compliance_bp.route("/admin/compliance-report", methods=["GET"])
 @login_required
-@role_required("admin")
+@require_role("admin")
 def generate_compliance_report():
     """
     Generate compliance report (admin only)


### PR DESCRIPTION
## Summary
- implement `RequirePermission` and `RequireRole` middleware in Go gateway
- secure analytics and admin endpoints using new decorators
- document which permissions/roles protect each route

## Testing
- `pre-commit run --files gateway/internal/gateway/gateway.go gateway/internal/middleware/access_control.go services/security/__init__.py api/analytics_endpoints.py plugins/compliance_plugin/compliance_controller.py docs/api.md`
- `pytest -k 'analytics'` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fd409ebc883208db4fc120a6f7818