### PR TITLE
Add load testing scripts and workflow

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,0 +1,36 @@
+name: Performance Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  load-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Start stack
+        run: docker-compose -f load-tests/docker-compose.yml up -d && sleep 30
+
+      - name: Run k6 scenarios
+        run: |
+          docker run --network host -v ${{ github.workspace }}/load-tests/k6:/scripts grafana/k6 run /scripts/scenarios/api-gateway-test.js --summary-export=api.json
+          docker run --network host -v ${{ github.workspace }}/load-tests/k6:/scripts grafana/k6 run /scripts/scenarios/event-ingestion-test.js --summary-export=ingest.json
+          docker run --network host -v ${{ github.workspace }}/load-tests/k6:/scripts grafana/k6 run /scripts/scenarios/analytics-queries-test.js --summary-export=analytics.json
+
+      - name: Run Gatling simulations
+        run: |
+          docker run --rm --network host -v ${{ github.workspace }}/load-tests/gatling:/opt/gatling/user-files \
+            -v ${{ github.workspace }}/load-tests/results:/opt/gatling/results gatling/gatling
+
+      - name: Check thresholds
+        run: |
+          load-tests/check_thresholds.sh api.json ingest.json analytics.json

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ venv_dashboard/
 config.zip
 app.log
 callback_audit_results/
+
+!load-tests/thresholds.json

--- a/dashboards/grafana/load_testing.json
+++ b/dashboards/grafana/load_testing.json
@@ -1,0 +1,22 @@
+{
+  "uid": "perf-tests",
+  "title": "Performance Tests",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP p95 Duration",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))", "legendFormat": "p95"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Request Error Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total{status=~\"5..\"}[1m]))", "legendFormat": "errors"}
+      ]
+    }
+  ]
+}

--- a/docs/performance_testing.md
+++ b/docs/performance_testing.md
@@ -1,0 +1,55 @@
+# Performance Testing
+
+This repository includes load tests using **k6** and **Gatling**. The tests
+exercise the API gateway, event ingestion service and analytics endpoints under
+sustained load.
+
+## Running the Stack
+
+Spin up the required services using the compose file in `load-tests`:
+
+```bash
+docker-compose -f load-tests/docker-compose.yml up -d
+```
+
+Kafka brokers and TimescaleDB will be available locally. Once the containers are
+ready you can run the load tests.
+
+## k6 Scenarios
+
+The `load-tests/k6/scenarios` directory contains three scripts:
+
+- `api-gateway-test.js` – queries the gateway health endpoint.
+- `event-ingestion-test.js` – posts synthetic events at 100k events/second.
+- `analytics-queries-test.js` – exercises analytics search endpoints.
+
+Execute a scenario with:
+
+```bash
+k6 run load-tests/k6/scenarios/api-gateway-test.js
+```
+
+Results can be exported as JSON and verified against `load-tests/thresholds.json`
+using the `check_thresholds.sh` helper script.
+
+## Gatling Simulations
+
+Scala simulations live under `load-tests/gatling`. They generate sustained load
+against the gateway and analytics service. Run them with the official Gatling
+Docker image:
+
+```bash
+docker run --rm -v $(pwd)/load-tests/gatling:/opt/gatling/user-files \
+  -v $(pwd)/load-tests/results:/opt/gatling/results gatling/gatling
+```
+
+## Grafana Dashboards
+
+Import the dashboards in `dashboards/grafana` to visualise request rates and
+latency while tests are running. The `load_testing.json` dashboard includes
+panels for error rate and p95 request duration.
+
+## Continuous Integration
+
+The workflow `.github/workflows/performance-tests.yml` executes all scenarios on
+pull requests. The job fails if the metrics in `thresholds.json` are exceeded.

--- a/load-tests/check_thresholds.sh
+++ b/load-tests/check_thresholds.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THRESHOLDS_FILE="$(dirname "$0")/thresholds.json"
+FAILED_RATE=$(jq -r '.http_req_failed_rate' "$THRESHOLDS_FILE")
+DURATION_P95=$(jq -r '.http_req_duration_p95' "$THRESHOLDS_FILE")
+
+for f in "$@"; do
+  rate=$(jq -r '.metrics.http_req_failed.rate' "$f")
+  p95=$(jq -r '.metrics.http_req_duration["p(95)"]' "$f")
+
+  if (( $(echo "$rate > $FAILED_RATE" | bc -l) )); then
+    echo "Failure rate $rate exceeds threshold $FAILED_RATE for $f" >&2
+    exit 1
+  fi
+
+  if (( $(echo "$p95 > $DURATION_P95" | bc -l) )); then
+    echo "p95 duration $p95 exceeds threshold $DURATION_P95 for $f" >&2
+    exit 1
+  fi
+
+done

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  timescaledb:
+    image: timescale/timescaledb:2.13.0-pg15
+    environment:
+      POSTGRES_DB: yosai_intel
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  analytics-service:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
+    depends_on:
+      - kafka
+      - timescaledb
+
+  api-gateway:
+    build:
+      context: ..
+      dockerfile: Dockerfile.gateway
+    ports:
+      - "8080:8080"
+    depends_on:
+      - analytics-service
+
+  event-ingestion:
+    build:
+      context: ../services/event-ingestion
+      dockerfile: Dockerfile
+    environment:
+      KAFKA_BROKERS: kafka:9092
+    depends_on:
+      - kafka

--- a/load-tests/gatling/src/test/scala/com/example/AnalyticsSimulation.scala
+++ b/load-tests/gatling/src/test/scala/com/example/AnalyticsSimulation.scala
@@ -1,0 +1,16 @@
+package com.example
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class AnalyticsSimulation extends Simulation {
+  val httpProtocol = http.baseUrl("http://localhost:8001")
+
+  val scn = scenario("Analytics load")
+    .exec(http("query").get("/analytics?q=latest"))
+    .pause(1)
+
+  setUp(
+    scn.inject(constantUsersPerSec(30).during(60))
+  ).protocols(httpProtocol)
+}

--- a/load-tests/gatling/src/test/scala/com/example/ApiGatewaySimulation.scala
+++ b/load-tests/gatling/src/test/scala/com/example/ApiGatewaySimulation.scala
@@ -1,0 +1,16 @@
+package com.example
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class ApiGatewaySimulation extends Simulation {
+  val httpProtocol = http.baseUrl("http://localhost:8080")
+
+  val scn = scenario("Gateway load")
+    .exec(http("health").get("/health"))
+    .pause(1)
+
+  setUp(
+    scn.inject(constantUsersPerSec(50).during(60))
+  ).protocols(httpProtocol)
+}

--- a/load-tests/k6/scenarios/analytics-queries-test.js
+++ b/load-tests/k6/scenarios/analytics-queries-test.js
@@ -1,0 +1,23 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    analytics: {
+      executor: 'constant-arrival-rate',
+      rate: 50,
+      timeUnit: '1s',
+      duration: '1m',
+      preAllocatedVUs: 20,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:8001/analytics?q=latest');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/load-tests/k6/scenarios/api-gateway-test.js
+++ b/load-tests/k6/scenarios/api-gateway-test.js
@@ -1,0 +1,23 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    gateway: {
+      executor: 'constant-arrival-rate',
+      rate: 100,
+      timeUnit: '1s',
+      duration: '1m',
+      preAllocatedVUs: 20,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<300'],
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:8080/health');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/load-tests/k6/scenarios/event-ingestion-test.js
+++ b/load-tests/k6/scenarios/event-ingestion-test.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    ingestion: {
+      executor: 'constant-arrival-rate',
+      rate: 100000,
+      timeUnit: '1s',
+      duration: '10s',
+      preAllocatedVUs: 2000,
+      maxVUs: 2000,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const payload = JSON.stringify({ deviceId: __VU, ts: Date.now(), value: 1 });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  const res = http.post('http://localhost:8000/events', payload, params);
+  check(res, { 'accepted': (r) => r.status === 202 });
+}

--- a/load-tests/thresholds.json
+++ b/load-tests/thresholds.json
@@ -1,0 +1,4 @@
+{
+  "http_req_failed_rate": 0.01,
+  "http_req_duration_p95": 500
+}


### PR DESCRIPTION
## Summary
- add k6 scenarios and Gatling simulations under `load-tests`
- provide Docker Compose stack for Kafka and TimescaleDB
- include threshold checks and CI workflow
- add Grafana dashboard and performance testing docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880043ed2988320a9683ccca8a88749