### PR TITLE
Add health endpoint for analytics microservice

### DIFF
--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -15,6 +15,9 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(SERVICES_PATH)]
 sys.modules.setdefault("services", services_stub)
 
+# Ensure JWT_SECRET is set for microservice import
+os.environ.setdefault("JWT_SECRET", "test")
+
 otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
 otel_stub.FastAPIInstrumentor = types.SimpleNamespace(instrument_app=lambda *a, **k: None)
 sys.modules.setdefault("opentelemetry.instrumentation.fastapi", otel_stub)
@@ -24,6 +27,9 @@ class DummyInstr:
     def instrument(self, app):
         return self
     def expose(self, app):
+        @app.get("/metrics")
+        def _metrics():
+            return "python_info 1"
         return self
 prom_stub.Instrumentator = lambda: DummyInstr()
 sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
@@ -36,6 +42,7 @@ class DummyVault:
         pass
 
 common_stub = types.ModuleType("services.common")
+common_stub.__path__ = [str(SERVICES_PATH / "common")]
 secrets_stub = types.ModuleType("services.common.secrets")
 secrets_stub._init_client = lambda: DummyVault()
 secrets_stub.VaultClient = object
@@ -44,6 +51,22 @@ secrets_stub.invalidate_secret = lambda key=None: None
 common_stub.secrets = secrets_stub
 sys.modules["services.common"] = common_stub
 sys.modules["services.common.secrets"] = secrets_stub
+
+# Stub async database module used by the microservice
+async_db_stub = types.ModuleType("services.common.async_db")
+async_db_stub.create_pool = lambda *a, **k: None
+
+class DummyPool:
+    async def fetch(self, *a, **k):
+        return []
+
+
+async def _get_pool() -> DummyPool:
+    return DummyPool()
+
+async_db_stub.get_pool = _get_pool
+async_db_stub.close_pool = lambda: None
+sys.modules["services.common.async_db"] = async_db_stub
 
 tracing_stub = types.ModuleType("tracing")
 tracing_stub.init_tracing = lambda name: None
@@ -61,6 +84,19 @@ class DummyAnalytics:
 analytics_stub = types.ModuleType("services.analytics_service")
 analytics_stub.create_analytics_service = lambda: DummyAnalytics()
 sys.modules["services.analytics_service"] = analytics_stub
+
+# Stub async query functions used by the microservice
+async_queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+
+async def _fetch_summary(pool):
+    return {"status": "ok"}
+
+async def _fetch_patterns(pool, days):
+    return {"days": days}
+
+async_queries_stub.fetch_dashboard_summary = _fetch_summary
+async_queries_stub.fetch_access_patterns = _fetch_patterns
+sys.modules["services.analytics_microservice.async_queries"] = async_queries_stub
 
 app_spec = importlib.util.spec_from_file_location(
     "services.analytics_microservice.app",
@@ -97,3 +133,12 @@ def test_requests_without_valid_token_return_401():
         headers={"Authorization": f"Bearer {good_token}"},
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.integration
+def test_health_endpoint():
+    client = TestClient(app_module.app)
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- raise an error if JWT_SECRET is missing
- add `/health` endpoint and close DB pool on shutdown
- test microservice token validation and health endpoint
- mock dependencies for integration tests

## Testing
- `pytest tests/integration/test_gateway_to_microservice.py::test_requests_without_valid_token_return_401 tests/integration/test_gateway_to_microservice.py::test_health_endpoint tests/integration/test_analytics_microservice_metrics.py::test_metrics_and_tracing -q`

------
https://chatgpt.com/codex/tasks/task_e_6880575393f8832086a4d7066495196a