### PR TITLE
Add timescale replication CronJob

### DIFF
--- a/k8s/microservices/timescale-dsns-secret.yaml
+++ b/k8s/microservices/timescale-dsns-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: timescale-dsns
+  namespace: yosai-dev
+  annotations:
+    linkerd.io/inject: enabled
+stringData:
+  SOURCE_DSN: postgresql://yosai_user:change-me@postgres:5432/yosai_intel
+  TARGET_DSN: postgresql://postgres:change-me@timescaledb:5432/yosai_timescale
+

--- a/k8s/microservices/timescale-replication-cronjob.yaml
+++ b/k8s/microservices/timescale-replication-cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: timescale-replication
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: replicate-to-timescale
+              image: yosai-intel-dashboard:latest
+              command: ["python", "scripts/replicate_to_timescale.py"]
+              envFrom:
+                - configMapRef:
+                    name: yosai-config
+                - secretRef:
+                    name: yosai-secrets
+              env:
+                - name: SOURCE_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescale-dsns
+                      key: SOURCE_DSN
+                - name: TARGET_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescale-dsns
+                      key: TARGET_DSN
+


### PR DESCRIPTION
## Summary
- replicate access events to TimescaleDB on a schedule
- store DSNs in a new secret
- document the CronJob in Timescale integration docs

## Testing
- `python -m py_compile scripts/replicate_to_timescale.py`
- `pytest -q` *(fails: 110 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6880575846bc8320b471dbc923f24417