### PR TITLE
Update microservice dependencies

### DIFF
--- a/services/analytics_microservice/pyproject.toml
+++ b/services/analytics_microservice/pyproject.toml
@@ -1,8 +1,17 @@
 [project]
 name = "analytics-service"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.11"
-dependencies = ["fastapi", "uvicorn"]
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "asyncpg",
+    "redis",
+    "prometheus-fastapi-instrumentator",
+    "python-jose",
+    "opentelemetry-instrumentation-fastapi",
+    "pydantic",
+]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/services/event-ingestion/pyproject.toml
+++ b/services/event-ingestion/pyproject.toml
@@ -1,8 +1,14 @@
 [project]
 name = "event-ingestion-service"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.11"
-dependencies = ["fastapi", "uvicorn", "kafka-python"]
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "kafka-python",
+    "prometheus-fastapi-instrumentator",
+    "opentelemetry-instrumentation-fastapi",
+]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
## Summary
- expand analytics microservice dependencies and bump version
- expand event ingestion dependencies and bump version

## Testing
- `pytest tests/services/test_analytics_microservice_app.py -q` *(fails: ModuleNotFoundError: No module named 'services.common.async_db')*

------
https://chatgpt.com/codex/tasks/task_e_6880616b87fc8320bc90f08c81f488eb