### PR TITLE
Add distributed state doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Data Processing](docs/data_processing.md)
 - [Column Verification](docs/column_verification.md)
 - [Service Container](docs/service_container.md)
+- [Distributed State Management](docs/distributed_state.md)
 - [Testing Architecture](docs/test_architecture.md)
 - [Comprehensive Testing Strategy](docs/comprehensive_testing_strategy.md)
 

--- a/docs/distributed_state.md
+++ b/docs/distributed_state.md
@@ -1,0 +1,43 @@
+# Distributed State Management
+
+Yosai deploys analytics, event processing and the API gateway as
+independent services.  Kafka, Redis and database replication keep these
+components in sync even when updates arrive out of order.
+
+## Event Streaming with Kafka
+
+Each service publishes domain events to Kafka topics.  Consumers update
+local caches and write to their databases asynchronously.  Because
+producers never block on consumers, messages may be processed later but
+no data is lost.  Lagging consumers eventually catch up and converge to
+the latest state.
+
+## Caching and Locks in Redis
+
+Redis stores short‑lived data and distributed locks.  The cache is
+replicated between instances so that configuration flags, session data
+and rate limits are visible across the cluster.  Stale entries expire
+quickly, ensuring that all nodes observe the same behaviour within a few
+seconds.
+
+## Database Replication
+
+PostgreSQL uses streaming replication for long‑term persistence.  Each
+microservice writes to its own database while replicas propagate changes
+to standby nodes.  Reads may momentarily return slightly older data but
+the replicas eventually apply the same updates.
+
+## Reverting to the Monolith
+
+Set the migration flags to `false` if you need to disable the
+microservices and route all requests to the built‑in implementations:
+
+```bash
+export USE_ANALYTICS_MICROSERVICE=false
+export USE_KAFKA_EVENTS=false
+export USE_TIMESCALEDB=false
+```
+
+Run `scripts/rollback.sh` to flip the Kubernetes service selector back to
+the previous deployment.  The dashboard will then operate as a
+self‑contained monolith until the microservices are re‑enabled.


### PR DESCRIPTION
## Summary
- document how Kafka, Redis and DB replication provide eventual consistency
- explain how to revert to the monolith and link to rollback script
- reference the doc from the main README

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 136 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68808afa1a808320b4e061fb8397dfaf