### PR TITLE
Fix anomaly detection test imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           set -xe
           pip install -r requirements.lock
+          pip install -r requirements-test.txt
       - name: Generate OpenAPI spec
         working-directory: ./api/openapi
         run: go run .

--- a/analytics/anomaly_detection/tests/conftest.py
+++ b/analytics/anomaly_detection/tests/conftest.py
@@ -1,0 +1,58 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root on path for imports
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Prevent importing the real analytics package during collection
+ANALYTICS_DIR = Path(__file__).resolve().parents[1]
+if "analytics" not in sys.modules:
+    analytics_stub = types.ModuleType("analytics")
+    analytics_stub.__path__ = [str(ANALYTICS_DIR)]
+    sys.modules["analytics"] = analytics_stub
+if "analytics.anomaly_detection" not in sys.modules:
+    ad_stub = types.ModuleType("analytics.anomaly_detection")
+    ad_stub.__path__ = [str(ANALYTICS_DIR / "anomaly_detection")]
+    sys.modules["analytics.anomaly_detection"] = ad_stub
+
+# Minimal stubs for optional dependencies used when importing the analytics package
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))
+
+flask_stub = types.ModuleType("flask")
+flask_stub.request = object()
+flask_stub.url_for = lambda *a, **k: ""
+sys.modules.setdefault("flask", flask_stub)
+
+hvac_stub = types.ModuleType("hvac")
+hvac_stub.Client = object
+sys.modules.setdefault("hvac", hvac_stub)
+
+crypto_stub = types.ModuleType("cryptography")
+fernet_stub = types.ModuleType("cryptography.fernet")
+class DummyFernet:
+    def __init__(self, *args, **kwargs): ...
+    def encrypt(self, data: bytes) -> bytes: return data
+    def decrypt(self, data: bytes) -> bytes: return data
+    @staticmethod
+    def generate_key() -> bytes: return b""
+fernet_stub.Fernet = DummyFernet
+crypto_stub.fernet = fernet_stub
+sys.modules.setdefault("cryptography", crypto_stub)
+sys.modules.setdefault("cryptography.fernet", fernet_stub)
+
+# Minimal opentelemetry stub
+otel_stub = types.ModuleType("opentelemetry")
+otel_trace = types.ModuleType("opentelemetry.trace")
+otel_stub.trace = otel_trace
+sys.modules.setdefault("opentelemetry", otel_stub)
+sys.modules.setdefault("opentelemetry.trace", otel_trace)
+
+# Dash stubs
+from tests.stubs import dash as dash_stub
+sys.modules.setdefault("dash", dash_stub)
+sys.modules.setdefault("dash.dependencies", dash_stub.dependencies)
+dash_stub.no_update = object()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,3 +15,5 @@ tqdm>=4.0
 aiohttp>=3.8
 testcontainers[postgresql,redis]==3.7.1
 prometheus_client==0.22.1
+numpy==1.26.4
+scikit-learn==1.7.1


### PR DESCRIPTION
## Summary
- add numpy and scikit-learn as test dependencies
- load anomaly modules without importing whole package
- stub heavy dependencies for anomaly tests
- ensure CI installs test requirements

## Testing
- `pytest analytics/anomaly_detection/tests/test_anomaly_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688095f0e5d88320bbb9f909a65620a2