### PR TITLE
Add unified ops CLI and extended Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,30 @@ PROM_URL ?= http://localhost:9090
 RATE ?= 50
 DURATION ?= 60
 
-.PHONY: load-test
+CLI ?= python -m tools.ops_cli
+
+.PHONY: load-test validate build test deploy format lint clean
+
 load-test:
 	python tools/load_test.py --brokers $(BROKERS) --prom-url $(PROM_URL) --rate $(RATE) --duration $(DURATION)
+
+validate:
+	$(CLI) validate-config
+
+build:
+	$(CLI) build
+
+test:
+	$(CLI) test
+
+deploy:
+	$(CLI) deploy
+
+format:
+	$(CLI) format
+
+lint:
+	$(CLI) lint
+
+clean:
+	$(CLI) clean

--- a/README.md
+++ b/README.md
@@ -257,6 +257,28 @@ The service listens on port `8080` inside the container. You can reach it at
 `http://localhost:8081` when running via Docker Compose.
 Stop all containers with `docker-compose down` when finished.
 
+### Unified Operations CLI
+
+Common project tasks can be executed via the unified operations CLI or the
+provided Makefile wrappers:
+
+```bash
+# validate configuration and secrets
+make validate
+
+# build Docker images and start the stack
+make build
+make deploy
+
+# run tests and checks
+make test
+make lint
+make format
+
+# tear everything down and clean caches
+make clean
+```
+
 ### Kafka Event Processor
 
 The gateway starts a Kafka-based `EventProcessor` for publishing `AccessEvent`

--- a/tools/ops_cli.py
+++ b/tools/ops_cli.py
@@ -1,0 +1,84 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_DEV_FILES = [
+    "docker-compose.yml",
+    "docker-compose.kafka.yml",
+    "docker-compose.dev.yml",
+]
+COMPOSE_PROD_FILE = "docker-compose.prod.yml"
+
+
+def run(cmd):
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def compose_args(files):
+    args = []
+    for f in files:
+        args.extend(["-f", str(ROOT / f)])
+    return args
+
+
+@click.group()
+def cli():
+    """Unified Operations Platform helper."""
+
+
+@cli.command("validate-config")
+def validate_config():
+    """Validate environment and configuration."""
+    from scripts.production_setup import validate_environment
+
+    validate_environment()
+    click.echo("Configuration validated")
+
+
+@cli.command()
+def build():
+    """Build Docker images."""
+    run(["docker", "compose", *compose_args(COMPOSE_DEV_FILES), "build"])
+
+
+@cli.command()
+def deploy():
+    """Start services using Docker Compose."""
+    run(["docker", "compose", *compose_args(COMPOSE_DEV_FILES), "up", "-d"])
+
+
+@cli.command()
+def test():
+    """Run the test suite."""
+    run(["pytest"])
+
+
+@cli.command()
+def format():
+    """Format code with black and isort."""
+    run(["isort", "."])
+    run(["black", "."])
+
+
+@cli.command()
+def lint():
+    """Run flake8 lint checks."""
+    run(["flake8", "."])
+
+
+@cli.command()
+def clean():
+    """Remove temporary files and stop containers."""
+    run(["docker", "compose", *compose_args(COMPOSE_DEV_FILES), "down", "-v"])
+    for path in ROOT.rglob("__pycache__"):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    cli()


### PR DESCRIPTION
## Summary
- add operations CLI wrapping common tasks
- extend Makefile with validation, build, test, deploy, format, lint, and clean targets using the new CLI
- document the CLI and Makefile usage in README

## Testing
- `pip install -r requirements-test.txt`
- `pytest -k ops_cli -q` *(fails: ImportError and ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6880960926188320bad3d77b8f93b851