### PR TITLE
Add config schema validation and YOSAI env overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ data/learned_mappings.json
 !package-lock.json
 !dashboards/grafana/*.json
 !dashboards/performance/*.json
+!config/schema.json
+!gateway/internal/config/circuitbreakers_schema.json
 logs/
 # Temporary uploaded files
 temp/

--- a/config/schema.json
+++ b/config/schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "object",
+      "properties": {
+        "title": {"type": "string"},
+        "name": {"type": "string"},
+        "debug": {"type": "boolean"},
+        "host": {"type": "string"},
+        "port": {"type": "integer"}
+      },
+      "required": []
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "type": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "integer"},
+        "name": {"type": "string"},
+        "user": {"type": "string"},
+        "password": {"type": "string"},
+        "url": {"type": "string"}
+      },
+      "required": []
+    },
+    "security": {
+      "type": "object",
+      "properties": {
+        "secret_key": {"type": "string"},
+        "max_upload_mb": {"type": "integer"},
+        "allowed_file_types": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": []
+    }
+  },
+  "required": ["app", "database", "security"]
+}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/riferrei/srclient v0.7.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/sony/gobreaker v1.0.0
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
 	go.opentelemetry.io/otel/sdk v1.37.0
@@ -55,6 +56,8 @@ require (
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -306,6 +306,12 @@ github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/gateway/internal/config/circuitbreakers_schema.json
+++ b/gateway/internal/config/circuitbreakers_schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "defaults": { "$ref": "#/definitions/settings" },
+    "database": { "$ref": "#/definitions/settings" },
+    "external_api": { "$ref": "#/definitions/settings" },
+    "event_processor": { "$ref": "#/definitions/settings" }
+  },
+  "definitions": {
+    "settings": {
+      "type": "object",
+      "properties": {
+        "failure_threshold": {"type": "integer"},
+        "recovery_timeout": {"type": "integer"}
+      },
+      "required": ["failure_threshold", "recovery_timeout"]
+    }
+  }
+}

--- a/gateway/internal/config/circuitbreakers_test.go
+++ b/gateway/internal/config/circuitbreakers_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadValidConfig(t *testing.T) {
+	cfg, err := Load("../../config/circuit-breakers.yaml")
+	if err != nil {
+		t.Fatalf("load valid: %v", err)
+	}
+	if cfg.Database.FailureThreshold == 0 {
+		t.Fatalf("unexpected zero value")
+	}
+}
+
+func TestLoadInvalidConfig(t *testing.T) {
+	tmp, err := os.CreateTemp("", "bad*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("database:\n  failure_threshold: 'x'\n")
+	tmp.Close()
+
+	if _, err := Load(tmp.Name()); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -42,10 +42,11 @@ def test_json_env_rules_parsed(monkeypatch):
 
 
 def test_env_overrides_applied(monkeypatch):
-    monkeypatch.setenv("DB_HOST", "db.example.com")
-    monkeypatch.setenv("DB_PORT", "1234")
+    monkeypatch.setenv("YOSAI_DATABASE_HOST", "db.example.com")
+    monkeypatch.setenv("YOSAI_DATABASE_PORT", "1234")
     monkeypatch.setenv("SECRET_KEY", "s")
-    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", "s")
+    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", "pwd")
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
     monkeypatch.setenv("AUTH0_CLIENT_SECRET", "secret")
     monkeypatch.setenv("AUTH0_DOMAIN", "dom")
@@ -69,7 +70,8 @@ security: {}
 
     monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
     monkeypatch.setenv("SECRET_KEY", "secret")
-    monkeypatch.setenv("DB_PASSWORD", "envpass")
+    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", "secret")
+    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", "envpass")
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
     monkeypatch.setenv("AUTH0_CLIENT_SECRET", "csecret")
     monkeypatch.setenv("AUTH0_DOMAIN", "domain")

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -43,11 +43,24 @@ database: []
 security:
   secret_key: abc
 """
-    path = _write(tmp_path, yaml)
-    monkeypatch.setenv("YOSAI_CONFIG_FILE", path)
-    monkeypatch.setenv("MAX_UPLOAD_MB", "50")
+    data = importlib.import_module("yaml").safe_load(yaml)
     with pytest.raises(ConfigurationError):
-        create_config_manager()
+        ConfigValidator.validate(data)
+
+
+def test_schema_validation(monkeypatch, tmp_path):
+    yaml = """
+app:
+  title: Test
+  port: "oops"
+database:
+  name: test.db
+security:
+  secret_key: xyz
+"""
+    data = importlib.import_module("yaml").safe_load(yaml)
+    with pytest.raises(ConfigurationError):
+        ConfigValidator.validate(data)
 
 
 def test_non_mapping_input():


### PR DESCRIPTION
## Summary
- validate config against `config/schema.json` using `jsonschema`
- allow overrides via `YOSAI_*` environment variables
- add JSON schema validation for Go circuit breaker config
- include new schema files in repository
- test the new functionality

## Testing
- `pytest tests/test_config_loader.py tests/test_config_validator.py -q`
- `go test ./... -run TestLoadValidConfig -run TestLoadInvalidConfig ./internal/config -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6880960f1fec832087c60b4e7f3d0ca5