### PR TITLE
Unify API error format across services

### DIFF
--- a/api/plugin_performance.py
+++ b/api/plugin_performance.py
@@ -1,9 +1,11 @@
 """API endpoints for plugin performance data."""
+
 from __future__ import annotations
 
 from flask import jsonify, request
 
 from utils.api_error import error_response
+from shared.errors.types import ErrorCode
 
 from api.adapter import api_adapter
 from core.security_validator import SecurityValidator
@@ -16,50 +18,66 @@ from advanced_cache import cache_with_lock
 class PluginPerformanceAPI:
     """Expose plugin performance metrics via REST endpoints."""
 
-    @app.route('/v1/plugins/performance', methods=['GET'])
+    @app.route("/v1/plugins/performance", methods=["GET"])
     @cache_with_lock(ttl_seconds=10)
     def get_plugin_performance():
         manager: EnhancedThreadSafePluginManager = app._yosai_plugin_manager  # type: ignore[attr-defined]
-        name = request.args.get('plugin', '')
-        result = SecurityValidator().validate_input(name, 'plugin')
-        if not result['valid']:
-            return error_response('invalid_plugin', 'Invalid plugin', result['issues']), 400
+        name = request.args.get("plugin", "")
+        result = SecurityValidator().validate_input(name, "plugin")
+        if not result["valid"]:
+            return (
+                error_response(
+                    ErrorCode.INVALID_INPUT, "Invalid plugin", result["issues"]
+                ),
+                400,
+            )
         data = manager.get_plugin_performance_metrics(name)
         safe = api_adapter.unicode_processor.process_dict(data)
         return jsonify(safe)
 
-    @app.route('/v1/plugins/performance/alerts', methods=['GET', 'POST'])
+    @app.route("/v1/plugins/performance/alerts", methods=["GET", "POST"])
     @cache_with_lock(ttl_seconds=30)
     def manage_performance_alerts():
         manager: EnhancedThreadSafePluginManager = app._yosai_plugin_manager  # type: ignore[attr-defined]
-        if request.method == 'POST':
+        if request.method == "POST":
             payload = request.json or {}
             for k, v in payload.items():
                 check = SecurityValidator().validate_input(str(v), k)
-                if not check['valid']:
-                    return error_response('invalid_payload', 'Invalid payload', check['issues']), 400
+                if not check["valid"]:
+                    return (
+                        error_response(
+                            ErrorCode.INVALID_INPUT, "Invalid payload", check["issues"]
+                        ),
+                        400,
+                    )
             manager.performance_manager.performance_thresholds.update(payload)
-            return jsonify({'status': 'updated'})
+            return jsonify({"status": "updated"})
         history = manager.performance_manager.alert_history
         safe_history = api_adapter.unicode_processor.process_dict(history)
         return jsonify(safe_history)
 
-    @app.route('/v1/plugins/performance/benchmark', methods=['POST'])
+    @app.route("/v1/plugins/performance/benchmark", methods=["POST"])
     def benchmark_plugin_performance():
-        return jsonify(api_adapter.unicode_processor.process_dict({'status': 'not_implemented'}))
+        return jsonify(
+            api_adapter.unicode_processor.process_dict({"status": "not_implemented"})
+        )
 
-    @app.route('/v1/plugins/performance/config', methods=['GET', 'PUT'])
+    @app.route("/v1/plugins/performance/config", methods=["GET", "PUT"])
     def manage_performance_config():
         manager: EnhancedThreadSafePluginManager = app._yosai_plugin_manager  # type: ignore[attr-defined]
-        if request.method == 'PUT':
+        if request.method == "PUT":
             payload = request.json or {}
             for k, v in payload.items():
                 check = SecurityValidator().validate_input(str(v), k)
-                if not check['valid']:
-                    return error_response('invalid_payload', 'Invalid payload', check['issues']), 400
+                if not check["valid"]:
+                    return (
+                        error_response(
+                            ErrorCode.INVALID_INPUT, "Invalid payload", check["issues"]
+                        ),
+                        400,
+                    )
             manager.performance_manager.performance_thresholds.update(payload)
-            return jsonify({'status': 'updated'})
+            return jsonify({"status": "updated"})
         cfg = manager.performance_manager.performance_thresholds
         safe_cfg = api_adapter.unicode_processor.process_dict(cfg)
         return jsonify(safe_cfg)
-

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Optional
 
+from shared.errors.types import ErrorCode
+
 
 class YosaiBaseException(Exception):
     """Base exception for all Yōsai application errors"""
@@ -10,7 +12,7 @@ class YosaiBaseException(Exception):
         self,
         message: str,
         details: Optional[Dict[str, Any]] = None,
-        error_code: Optional[str] = None,
+        error_code: ErrorCode = ErrorCode.INTERNAL,
     ) -> None:
         self.message = message
         self.details = details or {}
@@ -21,18 +23,33 @@ class YosaiBaseException(Exception):
 class ConfigurationError(YosaiBaseException):
     """Configuration-related errors"""
 
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message, details, ErrorCode.INTERNAL)
+
 
 class DatabaseError(YosaiBaseException):
     """Database operation errors"""
+
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message, details, ErrorCode.INTERNAL)
 
 
 class ValidationError(YosaiBaseException):
     """Data validation errors"""
 
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message, details, ErrorCode.INVALID_INPUT)
+
 
 class SecurityError(YosaiBaseException):
     """Security-related errors"""
 
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message, details, ErrorCode.UNAUTHORIZED)
+
 
 class ServiceUnavailableError(YosaiBaseException):
     """Service unavailable errors"""
+
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message, details, ErrorCode.UNAVAILABLE)

--- a/docs/error_contract.md
+++ b/docs/error_contract.md
@@ -1,0 +1,22 @@
+# Error Response Contract
+
+All services return errors in a unified JSON structure:
+
+```json
+{
+  "code": "invalid_input",
+  "message": "human readable message",
+  "details": {"optional": "context"}
+}
+```
+
+The `code` field is one of the following values defined in `shared/errors`:
+
+- `invalid_input` – the request payload failed validation
+- `unauthorized` – the caller is not authorized
+- `not_found` – the requested resource does not exist
+- `internal` – an unexpected server error occurred
+- `unavailable` – the service is temporarily unavailable
+
+Both Python and Go components map internal exceptions to these codes and all
+HTTP handlers use this structure for error responses.

--- a/gateway/internal/middleware/access_control.go
+++ b/gateway/internal/middleware/access_control.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"net/http"
 	"strings"
+
+	sharederrors "github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors"
 )
 
 // RequirePermission checks the X-Permissions header for a permission value.
@@ -16,7 +18,7 @@ func RequirePermissionHeader(perm string) func(http.Handler) http.Handler {
 					return
 				}
 			}
-			http.Error(w, "forbidden", http.StatusForbidden)
+			sharederrors.WriteJSON(w, http.StatusForbidden, sharederrors.Unauthorized, "forbidden", nil)
 		})
 	}
 }
@@ -32,7 +34,7 @@ func RequireRoleHeader(role string) func(http.Handler) http.Handler {
 					return
 				}
 			}
-			http.Error(w, "forbidden", http.StatusForbidden)
+			sharederrors.WriteJSON(w, http.StatusForbidden, sharederrors.Unauthorized, "forbidden", nil)
 		})
 	}
 }

--- a/gateway/internal/middleware/auth.go
+++ b/gateway/internal/middleware/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/WSG23/yosai-gateway/internal/auth"
+	sharederrors "github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors"
 )
 
 // Auth middleware validates a JWT Authorization header.
@@ -18,13 +19,13 @@ func Auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHdr := r.Header.Get("Authorization")
 		if authHdr == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			sharederrors.WriteJSON(w, http.StatusUnauthorized, sharederrors.Unauthorized, "unauthorized", nil)
 			return
 		}
 
 		parts := strings.Fields(authHdr)
 		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			sharederrors.WriteJSON(w, http.StatusUnauthorized, sharederrors.Unauthorized, "unauthorized", nil)
 			return
 		}
 
@@ -37,17 +38,17 @@ func Auth(next http.Handler) http.Handler {
 			return secret, nil
 		})
 		if err != nil || !token.Valid {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			sharederrors.WriteJSON(w, http.StatusUnauthorized, sharederrors.Unauthorized, "unauthorized", nil)
 			return
 		}
 
 		if claims.ExpiresAt != nil && claims.ExpiresAt.Before(time.Now()) {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			sharederrors.WriteJSON(w, http.StatusUnauthorized, sharederrors.Unauthorized, "unauthorized", nil)
 			return
 		}
 
 		if claims.Issuer == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			sharederrors.WriteJSON(w, http.StatusUnauthorized, sharederrors.Unauthorized, "unauthorized", nil)
 			return
 		}
 

--- a/gateway/internal/middleware/ratelimit.go
+++ b/gateway/internal/middleware/ratelimit.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/WSG23/yosai-gateway/tracing"
+	sharederrors "github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors"
 )
 
 // Simple rate limiter using a token bucket.
@@ -45,7 +46,7 @@ func RateLimit(next http.Handler) http.Handler {
 		case <-tokens:
 			next.ServeHTTP(w, r)
 		default:
-			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			sharederrors.WriteJSON(w, http.StatusTooManyRequests, sharederrors.Unavailable, "rate limit exceeded", nil)
 		}
 	})
 }

--- a/gateway/internal/middleware/rbac.go
+++ b/gateway/internal/middleware/rbac.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/WSG23/yosai-gateway/internal/auth"
 	"github.com/WSG23/yosai-gateway/internal/rbac"
+	sharederrors "github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors"
 )
 
 // RequirePermission checks that the request's subject has the given permission.
@@ -13,16 +14,16 @@ func RequirePermission(s *rbac.RBACService, perm string) func(http.Handler) http
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := auth.FromContext(r.Context())
 			if !ok {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				sharederrors.WriteJSON(w, http.StatusForbidden, sharederrors.Unauthorized, "forbidden", nil)
 				return
 			}
 			if claims.Subject == "" {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				sharederrors.WriteJSON(w, http.StatusForbidden, sharederrors.Unauthorized, "forbidden", nil)
 				return
 			}
 			allowed, err := s.HasPermission(r.Context(), claims.Subject, perm)
 			if err != nil || !allowed {
-				http.Error(w, "forbidden", http.StatusForbidden)
+				sharederrors.WriteJSON(w, http.StatusForbidden, sharederrors.Unauthorized, "forbidden", nil)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -3,6 +3,7 @@ import os
 import time
 
 from fastapi import Depends, FastAPI, Header, HTTPException, status
+from shared.errors.types import ErrorCode
 from jose import jwt
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -27,23 +28,27 @@ def verify_token(authorization: str = Header("")) -> None:
     """Validate Authorization header using JWT_SECRET."""
     if not authorization.startswith("Bearer "):
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": ErrorCode.UNAUTHORIZED.value, "message": "unauthorized"},
         )
     token = authorization.split(" ", 1)[1]
     try:
         claims = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": ErrorCode.UNAUTHORIZED.value, "message": "unauthorized"},
         ) from exc
     exp = claims.get("exp")
     if exp is not None and exp < time.time():
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": ErrorCode.UNAUTHORIZED.value, "message": "unauthorized"},
         )
     if not claims.get("iss"):
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": ErrorCode.UNAUTHORIZED.value, "message": "unauthorized"},
         )
 
 
@@ -86,7 +91,10 @@ async def health_startup() -> dict[str, str]:
     """Startup probe."""
     if app.state.startup_complete:
         return {"status": "complete"}
-    raise HTTPException(status_code=503, detail="starting")
+    raise HTTPException(
+        status_code=503,
+        detail={"code": ErrorCode.UNAVAILABLE.value, "message": "starting"},
+    )
 
 
 @app.get("/health/ready")
@@ -94,7 +102,10 @@ async def health_ready() -> dict[str, str]:
     """Readiness probe."""
     if app.state.ready:
         return {"status": "ready"}
-    raise HTTPException(status_code=503, detail="not ready")
+    raise HTTPException(
+        status_code=503,
+        detail={"code": ErrorCode.UNAVAILABLE.value, "message": "not ready"},
+    )
 
 
 @app.on_event("shutdown")

--- a/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/services/analytics_microservice/tests/test_endpoints_async.py
@@ -130,3 +130,13 @@ async def test_dashboard_summary_endpoint():
 
     queries_stub.fetch_dashboard_summary.assert_awaited_once()
     db_stub.get_pool.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_request():
+    module, _, _ = load_app()
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/analytics/get_dashboard_summary")
+        assert resp.status_code == 401
+        assert resp.json() == {"code": "unauthorized", "message": "unauthorized"}

--- a/services/data_processing/core/exceptions.py
+++ b/services/data_processing/core/exceptions.py
@@ -1,10 +1,14 @@
 """File processing exception hierarchy."""
 
 from core.exceptions import YosaiBaseException
+from shared.errors.types import ErrorCode
 
 
 class FileProcessingError(YosaiBaseException):
     """Base exception for file processing errors."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, details, ErrorCode.INVALID_INPUT)
 
 
 class FileValidationError(FileProcessingError):

--- a/shared/errors/types.go
+++ b/shared/errors/types.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Code represents a standardized error code shared across services.
+type Code string
+
+const (
+	InvalidInput Code = "invalid_input"
+	Unauthorized Code = "unauthorized"
+	NotFound     Code = "not_found"
+	Internal     Code = "internal"
+	Unavailable  Code = "unavailable"
+)
+
+type Error struct {
+	Code    Code        `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+// WriteJSON writes the error as JSON to the http.ResponseWriter.
+func WriteJSON(w http.ResponseWriter, status int, code Code, message string, details interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(Error{Code: code, Message: message, Details: details})
+}

--- a/shared/errors/types.py
+++ b/shared/errors/types.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ErrorCode(str, Enum):
+    """Common error codes returned by services."""
+
+    INVALID_INPUT = "invalid_input"
+    UNAUTHORIZED = "unauthorized"
+    NOT_FOUND = "not_found"
+    INTERNAL = "internal"
+    UNAVAILABLE = "unavailable"

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -21,7 +21,11 @@ class DummyUploadService:
 
     async def process_uploaded_files(self, contents, filenames):
         self.called_args = (contents, filenames)
-        return {"upload_results": [], "file_preview_components": [], "file_info_dict": {}}
+        return {
+            "upload_results": [],
+            "file_preview_components": [],
+            "file_info_dict": {},
+        }
 
 
 def _create_app(monkeypatch):
@@ -69,6 +73,7 @@ def test_upload_files_uses_asyncio_run(monkeypatch):
     assert used.get("called") is True
     assert service.called_args == ([content], ["test.csv"])
 
+
 class FailingUploadService:
     def __init__(self):
         self.store = DummyStore()
@@ -91,6 +96,7 @@ def test_upload_returns_error_on_exception(monkeypatch):
     monkeypatch.setitem(sys.modules, "core.container", container_mod)
 
     import importlib
+
     upload_ep = importlib.import_module("upload_endpoint")
 
     app = Flask(__name__)
@@ -103,4 +109,5 @@ def test_upload_returns_error_on_exception(monkeypatch):
         json={"contents": ["data:text/csv;base64,YSx6"], "filenames": ["t.csv"]},
     )
     assert resp.status_code == 500
-    assert resp.get_json()["message"] == "boom"
+    body = resp.get_json()
+    assert body == {"code": "internal", "message": "boom"}

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -3,6 +3,7 @@ import base64
 from flask import Blueprint, jsonify, request
 
 from utils.api_error import error_response
+from shared.errors.types import ErrorCode
 from flask_wtf.csrf import validate_csrf
 
 from config.service_registration import register_upload_services
@@ -28,7 +29,7 @@ def upload_files():
         try:
             validate_csrf(token)
         except Exception:
-            return error_response("invalid_csrf", "Invalid CSRF token"), 400
+            return error_response(ErrorCode.UNAUTHORIZED, "Invalid CSRF token"), 400
 
         contents = []
         filenames = []
@@ -50,14 +51,14 @@ def upload_files():
 
         file_processor = container.get("file_processor")
         if not contents or not filenames:
-            return error_response("no_file", "No file provided"), 400
+            return error_response(ErrorCode.INVALID_INPUT, "No file provided"), 400
 
         job_id = file_processor.process_file_async(contents[0], filenames[0])
 
         return jsonify({"job_id": job_id}), 202
 
     except Exception as e:
-        return error_response("server_error", str(e)), 500
+        return error_response(ErrorCode.INTERNAL, str(e)), 500
 
 
 @upload_bp.route("/v1/upload/status/<job_id>", methods=["GET"])

--- a/utils/api_error.py
+++ b/utils/api_error.py
@@ -1,8 +1,18 @@
 from flask import jsonify
 from typing import Any, Optional
 
-def error_response(code: str, message: str, details: Optional[Any] = None):
+from core.exceptions import YosaiBaseException
+from shared.errors.types import ErrorCode
+
+
+def error_response(code: ErrorCode | str, message: str, details: Optional[Any] = None):
+    if isinstance(code, ErrorCode):
+        code = code.value
     body = {"code": code, "message": message}
     if details is not None:
         body["details"] = details
     return jsonify(body)
+
+
+def error_from_exception(exc: YosaiBaseException):
+    return error_response(exc.error_code, exc.message, exc.details)


### PR DESCRIPTION
## Summary
- introduce `ErrorCode` enums in `shared/errors`
- map Python exceptions to error codes
- return JSON errors from services and middleware
- document the error contract
- update tests for new error structure

## Testing
- `pytest tests/test_upload_endpoint.py services/analytics_microservice/tests/test_endpoints_async.py::test_unauthorized_request -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_688096124c7883209316b7fdfeca8804