### PR TITLE
Add unified compose and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ The service listens on port `8080` inside the container. You can reach it at
 `http://localhost:8081` when running via Docker Compose.
 Stop all containers with `docker-compose down` when finished.
 
+### Unified Local Stack
+
+To launch all Python and Go services along with Jaeger, Prometheus, Grafana and Loki run:
+
+```bash
+docker compose -f docker-compose.unified.yml up --build
+```
+
+Prometheus will listen on [localhost:9090](http://localhost:9090) and Grafana on [localhost:3000].
+The file mounts `monitoring/prometheus.yml` and the `unified-platform.json` dashboard
+under `monitoring/grafana/dashboards/` so metrics are available immediately.
+Stop the stack with `docker compose down` when done.
+
 ### Unified Operations CLI
 
 Common project tasks can be executed via the unified operations CLI or the

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -1,6 +1,96 @@
 version: '3.8'
+
+x-yosai-env: &yosai-env
+  YOSAI_ENV: development
+  YOSAI_LOG_LEVEL: debug
+  YOSAI_METRICS_ADDR: ':2112'
+  YOSAI_TRACING_ENDPOINT: http://jaeger:14268/api/traces
+
 services:
-  app:
+  dashboard:
     build: .
+    command: ["python", "start_api.py"]
     environment:
-      - LOG_LEVEL=info
+      <<: *yosai-env
+      YOSAI_SERVICE_NAME: dashboard
+    ports:
+      - "8050:8050"
+    depends_on:
+      - analytics-service
+
+  analytics-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
+    environment:
+      <<: *yosai-env
+      YOSAI_SERVICE_NAME: analytics-service
+    ports:
+      - "8001:8001"
+
+  event-ingestion:
+    build:
+      context: ./services/event-ingestion
+      dockerfile: Dockerfile
+    environment:
+      <<: *yosai-env
+      YOSAI_SERVICE_NAME: event-ingestion
+      KAFKA_BROKERS: kafka:9092
+    ports:
+      - "8000:8000"
+
+  event-processing:
+    build:
+      context: ./services/event_processing
+      dockerfile: Dockerfile
+    environment:
+      <<: *yosai-env
+      YOSAI_SERVICE_NAME: event-processing
+      BROKERS: kafka:9092
+    ports:
+      - "2112:2112"
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
+    environment:
+      <<: *yosai-env
+      YOSAI_SERVICE_NAME: gateway
+    ports:
+      - "8081:8080"
+    depends_on:
+      - dashboard
+      - analytics-service
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:10.3.1
+    volumes:
+      - ./monitoring/grafana/dashboards/unified-platform.json:/var/lib/grafana/dashboards/unified-platform.json:ro
+    ports:
+      - "3000:3000"
+
+  loki:
+    image: grafana/loki:2.9.3
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki_data:/loki
+    ports:
+      - "3100:3100"
+
+volumes:
+  loki_data:


### PR DESCRIPTION
## Summary
- add new `docker-compose.unified.yml` with Python and Go services
- mount monitoring configs for Prometheus and Grafana
- document unified stack instructions in README

## Testing
- `docker-compose -f docker-compose.unified.yml up -d` *(fails: cannot connect to Docker daemon)*
- `pytest -k test_dummy` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6880a6bfad008320b3e12d3e5ca72873