### PR TITLE
Add unified platform dashboards and CLI targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ DURATION ?= 60
 
 CLI ?= python -m tools.ops_cli
 
-.PHONY: load-test validate build test deploy format lint clean
+.PHONY: load-test validate build test deploy format lint clean \
+build-all test-all deploy-all logs
 
 load-test:
 	python tools/load_test.py --brokers $(BROKERS) --prom-url $(PROM_URL) --rate $(RATE) --duration $(DURATION)
@@ -21,6 +22,18 @@ test:
 
 deploy:
 	$(CLI) deploy
+
+build-all:
+	$(CLI) build-all
+
+test-all:
+	$(CLI) test-all
+
+deploy-all:
+	$(CLI) deploy-all
+
+logs:
+	$(CLI) logs $(service)
 
 format:
 	$(CLI) format

--- a/docs/unified_platform.md
+++ b/docs/unified_platform.md
@@ -1,3 +1,23 @@
 # Unified Platform
 
 This release introduces a unified service framework shared between Python and Go implementations. The framework provides common configuration loading, logging, metrics, tracing and graceful shutdown handling.
+
+## Operations
+
+The unified platform bundles all services together using `docker-compose.unified.yml`. The following `make` targets wrap common operations and call the `ops_cli` helper under the hood.
+
+## Available Commands
+
+- `make build-all` – Build Docker images for every service.
+- `make test-all` – Run the full test suite.
+- `make deploy-all` – Start the entire stack in the background.
+- `make logs service=<name>` – Tail logs for a specific service.
+
+The same functionality can be invoked directly via the CLI:
+
+```bash
+python -m tools.ops_cli build-all
+python -m tools.ops_cli test-all
+python -m tools.ops_cli deploy-all
+python -m tools.ops_cli logs gateway
+```

--- a/monitoring/grafana/dashboards/unified-platform.json
+++ b/monitoring/grafana/dashboards/unified-platform.json
@@ -1,6 +1,38 @@
 {
+  "uid": "unified-platform",
   "title": "Unified Platform",
-  "panels": [],
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Total HTTP Requests",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total[1m]))", "legendFormat": "req/s"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[1m]))",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "p95 Request Duration",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ]
+    }
+  ],
   "schemaVersion": 36,
   "version": 1
 }

--- a/tools/ops_cli.py
+++ b/tools/ops_cli.py
@@ -12,6 +12,7 @@ COMPOSE_DEV_FILES = [
     "docker-compose.dev.yml",
 ]
 COMPOSE_PROD_FILE = "docker-compose.prod.yml"
+COMPOSE_ALL_FILE = "docker-compose.unified.yml"
 
 
 def run(cmd):
@@ -51,6 +52,39 @@ def build():
 def deploy():
     """Start services using Docker Compose."""
     run(["docker", "compose", *compose_args(COMPOSE_DEV_FILES), "up", "-d"])
+
+
+@cli.command("build-all")
+def build_all():
+    """Build all service images for the unified stack."""
+    run(["docker", "compose", "-f", str(ROOT / COMPOSE_ALL_FILE), "build"])
+
+
+@cli.command("deploy-all")
+def deploy_all():
+    """Start the entire unified stack."""
+    run(["docker", "compose", "-f", str(ROOT / COMPOSE_ALL_FILE), "up", "-d"])
+
+
+@cli.command("test-all")
+def test_all():
+    """Run full test suite."""
+    run(["pytest"])
+
+
+@cli.command()
+@click.argument("service")
+def logs(service):
+    """Tail logs for a specific service."""
+    run([
+        "docker",
+        "compose",
+        "-f",
+        str(ROOT / COMPOSE_ALL_FILE),
+        "logs",
+        "-f",
+        service,
+    ])
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- enhance Grafana unified platform dashboard
- add unified platform operations docs
- add build-all/test-all/deploy-all and logs support
- expose new ops_cli commands

## Testing
- `make test` *(fails: 134 errors)*
- `make lint` *(fails: flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880a6c0a9f0832083179f44b0a46ae8