### PR TITLE
Improve API error handling and CLI

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,47 @@
+jest.mock('axios', () => require('axios/dist/node/axios.cjs'));
+import { apiClient } from '../client';
+import { toast } from 'react-hot-toast';
+
+jest.mock('react-hot-toast', () => ({
+  toast: { error: jest.fn() },
+}));
+
+describe('apiClient error interceptor', () => {
+  const handler = apiClient.interceptors.response.handlers[0].rejected!;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps known codes to friendly messages', async () => {
+    const error = {
+      config: { url: '/test', headers: {} },
+      response: {
+        status: 400,
+        data: { code: 'invalid_input', message: 'failed' },
+        config: {},
+        headers: {},
+      },
+    } as any;
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(handler(error)).rejects.toBe(error);
+    expect(toast.error).toHaveBeenCalledWith('Request validation failed');
+  });
+
+  it('uses backend message for unknown codes', async () => {
+    const error = {
+      config: { url: '/test', headers: {} },
+      response: {
+        status: 418,
+        data: { code: 'teapot', message: 'short and stout' },
+        config: {},
+        headers: {},
+      },
+    } as any;
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(handler(error)).rejects.toBe(error);
+    expect(toast.error).toHaveBeenCalledWith('short and stout');
+  });
+});

--- a/tools/ops_cli.py
+++ b/tools/ops_cli.py
@@ -59,6 +59,18 @@ def test():
     run(["pytest"])
 
 
+@cli.command("frontend-build")
+def frontend_build():
+    """Build frontend assets using npm."""
+    run(["npm", "run", "build"])
+
+
+@cli.command("frontend-test")
+def frontend_test():
+    """Run frontend unit tests."""
+    run(["npm", "test", "--", "--watchAll=false"])
+
+
 @cli.command()
 def format():
     """Format code with black and isort."""


### PR DESCRIPTION
## Summary
- parse ServiceError structures for code and message
- map error codes to user-friendly toasts
- log errors as structured JSON for backend compatibility
- add unit tests for client error handling
- support frontend build/test in ops CLI

## Testing
- `npm test -- --runTestsByPath src/api/__tests__/client.test.ts` *(fails: coverage thresholds not met)*
- `npm test -- --watchAll=false` *(fails: missing `@testing-library/dom` module)*

------
https://chatgpt.com/codex/tasks/task_e_6880a6c1aa7883209fe3e11e1d9b2c11