### PR TITLE
Add Go CLI wrapper for ops_cli

### DIFF
--- a/cli/yosai/go.mod
+++ b/cli/yosai/go.mod
@@ -1,0 +1,3 @@
+module github.com/WSG23/yosai-cli
+
+go 1.23.8

--- a/cli/yosai/main.go
+++ b/cli/yosai/main.go
@@ -1,30 +1,34 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 )
 
-func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("usage: yosai <build|test|deploy|logs>")
-		os.Exit(1)
+const usage = "usage: yosai <build|test|deploy|logs> <service>"
+
+func buildArgs(args []string) ([]string, error) {
+	if len(args) != 2 {
+		return nil, errors.New(usage)
 	}
-	var cmd *exec.Cmd
-	switch os.Args[1] {
-	case "build":
-		cmd = exec.Command("make", "build")
-	case "test":
-		cmd = exec.Command("make", "test")
-	case "deploy":
-		cmd = exec.Command("make", "deploy")
-	case "logs":
-		cmd = exec.Command("make", "logs")
+	command, service := args[0], args[1]
+	switch command {
+	case "build", "test", "deploy", "logs":
+		return []string{"python", "-m", "tools.ops_cli", command, service}, nil
 	default:
-		fmt.Println("unknown command")
+		return nil, fmt.Errorf("unknown command: %s", command)
+	}
+}
+
+func main() {
+	cmdArgs, err := buildArgs(os.Args[1:])
+	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cli/yosai/main_test.go
+++ b/cli/yosai/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArgsValid(t *testing.T) {
+	args, err := buildArgs([]string{"build", "gateway"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expect := []string{"python", "-m", "tools.ops_cli", "build", "gateway"}
+	if !reflect.DeepEqual(args, expect) {
+		t.Fatalf("expected %v, got %v", expect, args)
+	}
+}
+
+func TestBuildArgsUnknown(t *testing.T) {
+	if _, err := buildArgs([]string{"foo", "svc"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestBuildArgsMissing(t *testing.T) {
+	if _, err := buildArgs([]string{"build"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestBuildArgsLogs(t *testing.T) {
+	args, err := buildArgs([]string{"logs", "gateway"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expect := []string{"python", "-m", "tools.ops_cli", "logs", "gateway"}
+	if !reflect.DeepEqual(args, expect) {
+		t.Fatalf("expected %v, got %v", expect, args)
+	}
+}

--- a/docs/unified_platform.md
+++ b/docs/unified_platform.md
@@ -21,3 +21,13 @@ python -m tools.ops_cli test-all
 python -m tools.ops_cli deploy-all
 python -m tools.ops_cli logs gateway
 ```
+
+The repository also includes a small Go wrapper named `yosai` which
+forwards commands to `tools.ops_cli` for a chosen service:
+
+```bash
+yosai build gateway
+yosai test gateway
+yosai deploy gateway
+yosai logs gateway
+```


### PR DESCRIPTION
## Summary
- create a small `yosai` Go module
- implement command parsing for `build`, `test`, `deploy`, `logs`
- forward commands to `tools.ops_cli`
- document usage of the new CLI
- add unit tests

## Testing
- `go test -v` in `cli/yosai`

------
https://chatgpt.com/codex/tasks/task_e_6880b06d13a8832087049101da79a2ad