### PR TITLE
Refactor services to use shared BaseService

### DIFF
--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+       "log"
 	"context"
 	"database/sql"
 	"fmt"
@@ -24,18 +25,27 @@ import (
 	reg "github.com/WSG23/yosai-gateway/internal/registry"
 	"github.com/WSG23/yosai-gateway/internal/tracing"
 	mw "github.com/WSG23/yosai-gateway/middleware"
-	apicache "github.com/WSG23/yosai-gateway/plugins/cache"
-	"github.com/redis/go-redis/v9"
+       apicache "github.com/WSG23/yosai-gateway/plugins/cache"
+       "github.com/redis/go-redis/v9"
+
+       framework "github.com/WSG23/yosai-framework"
 
 	"github.com/sony/gobreaker"
 )
 
 func main() {
+       svc, err := framework.NewBaseService("gateway", "")
+        if err != nil {
+                log.Fatalf("failed to init base service: %v", err)
+        }
+        go svc.Start()
+        defer svc.Stop()
+
        shutdown, err := tracing.InitTracing("gateway")
-	if err != nil {
-		tracing.Logger.Fatalf("failed to init tracing: %v", err)
-	}
-	defer shutdown(context.Background())
+        if err != nil {
+                tracing.Logger.Fatalf("failed to init tracing: %v", err)
+        }
+        defer shutdown(context.Background())
 
 	brokers := os.Getenv("KAFKA_BROKERS")
 	if brokers == "" {

--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -1,17 +1,16 @@
 import asyncio
-from fastapi import FastAPI, Header, HTTPException, status, Depends
+from fastapi import Header, HTTPException, status, Depends
+from yosai_framework.service import BaseService
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from services.streaming import StreamingService
 from services.security import verify_service_jwt
-from tracing import trace_async_operation, init_tracing, configure_logging
+from tracing import trace_async_operation
 
 SERVICE_NAME = "event-ingestion-service"
-init_tracing(SERVICE_NAME)
-configure_logging(SERVICE_NAME)
-
-app = FastAPI(title="Event Ingestion Service")
+service_base = BaseService(SERVICE_NAME, "")
+app = service_base.app
 service = StreamingService()
 
 
@@ -40,16 +39,13 @@ async def startup() -> None:
     asyncio.create_task(
         trace_async_operation("consume_loop", "ingest", _consume_loop())
     )
+    service_base.start()
 
 
 @app.on_event("shutdown")
 async def shutdown() -> None:
     service.close()
-
-
-@app.get("/health")
-async def health(_: None = Depends(verify_token)) -> dict:
-    return service.health_check()
+    service_base.stop()
 
 
 FastAPIInstrumentor.instrument_app(app)

--- a/services/event_streaming_service.py
+++ b/services/event_streaming_service.py
@@ -11,6 +11,7 @@ from kafka import KafkaConsumer, KafkaProducer
 
 from config.kafka_config import KafkaConfig, from_environment
 from services.base import BaseService
+from yosai_framework.service import BaseService as FrameworkService
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ class EventStreamingService(BaseService):
 
     def __init__(self, config: Optional[KafkaConfig] = None) -> None:
         super().__init__("event_streaming")
+        self.framework = FrameworkService("event-streaming", "")
         self.config = config or from_environment()
         self.producer: KafkaProducer | None = None
         self.consumer: KafkaConsumer | None = None
@@ -28,6 +30,7 @@ class EventStreamingService(BaseService):
         self.topic = "access-events"
 
     def _do_initialize(self) -> None:
+        self.framework.start()
         self.producer = KafkaProducer(
             bootstrap_servers=self.config.brokers,
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
@@ -77,6 +80,7 @@ class EventStreamingService(BaseService):
                 pass
         if self._worker is not None:
             self._worker.join(timeout=1)
+        self.framework.stop()
 
 
 __all__ = ["EventStreamingService"]

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -22,6 +22,7 @@ from utils.protocols import SafeDecoderProtocol
 from utils.memory_utils import memory_safe
 
 from .base import BaseService
+from yosai_framework.service import BaseService as FrameworkService
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,8 @@ class FileProcessorService(BaseService):
         decoder: SafeDecoderProtocol = safe_decode_with_unicode_handling,
     ) -> None:
         super().__init__("file_processor")
+        self.framework = FrameworkService("file-processor", "")
+        self.framework.start()
         self.config = config
         self.max_file_size_mb = config.get_max_upload_size_mb()
         self._decoder = decoder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,12 @@ if _missing_packages:
         "Install them with `pip install -r requirements-test.txt`."
     )
 
+# Provide a lightweight 'services' package to avoid importing heavy dependencies
+if "services" not in sys.modules:
+    services_stub = types.ModuleType("services")
+    services_stub.__path__ = []
+    sys.modules["services"] = services_stub
+
 # Optional heavy dependencies used by a subset of tests
 _optional_packages = {"hvac", "cryptography"}
 _missing_optional = [


### PR DESCRIPTION
## Summary
- add health endpoints to `yosai_framework.service.BaseService`
- use `BaseService` in analytics and ingestion apps
- initialize BaseService for streaming and file processing
- bootstrap gateway service with shared base service
- adjust analytics microservice tests
- stub services package early in test config

## Testing
- `pytest services/analytics_microservice/tests/test_endpoints_async.py::test_health_endpoints -q --import-mode=importlib` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6880b06b47b08320a303182876672627