### PR TITLE
Use shared api client and add component tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^7.0.2",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/node": "^24.0.15",
@@ -46,6 +47,7 @@
         "@types/reactstrap": "^8.7.2",
         "@types/uuid": "^10.0.0",
         "autoprefixer": "^10.4.21",
+        "axios-mock-adapter": "^2.1.0",
         "cssnano": "^7.1.0",
         "cypress": "^14.5.2",
         "pa11y": "^9.0.0",
@@ -4935,7 +4937,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5050,8 +5051,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6728,6 +6728,20 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/axobject-query": {
@@ -9807,8 +9821,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -12992,6 +13005,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -15465,7 +15502,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^7.0.2",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^24.0.15",
@@ -41,6 +42,7 @@
     "@types/reactstrap": "^8.7.2",
     "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.21",
+    "axios-mock-adapter": "^2.1.0",
     "cssnano": "^7.1.0",
     "cypress": "^14.5.2",
     "pa11y": "^9.0.0",

--- a/src/api/__tests__/component.client.test.tsx
+++ b/src/api/__tests__/component.client.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+jest.mock('axios', () => require('axios/dist/node/axios.cjs'));
+import { api, apiClient } from '../client';
+import { toast } from 'react-hot-toast';
+
+jest.mock('react-hot-toast', () => ({ toast: { error: jest.fn() } }));
+
+const Greeting: React.FC = () => {
+  const [msg, setMsg] = React.useState('');
+  React.useEffect(() => {
+    api
+      .get<{ message: string }>('/greeting')
+      .then((res) => setMsg(res.message))
+      .catch(() => {});
+  }, []);
+  return <div>{msg}</div>;
+};
+
+describe('component using api client', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders data on success', async () => {
+    jest.spyOn(api, 'get').mockResolvedValueOnce({ message: 'hi' } as any);
+    render(<Greeting />);
+    expect(await screen.findByText('hi')).toBeInTheDocument();
+  });
+
+  it('shows toast on failure', async () => {
+    const error = {
+      config: { url: '/greeting', headers: {} },
+      response: { status: 500, data: { code: 'internal', message: 'oops' }, config: {}, headers: {} },
+    } as any;
+    jest.spyOn(api, 'get').mockRejectedValueOnce(error);
+    const handler = apiClient.interceptors.response.handlers[0].rejected!;
+    render(<Greeting />);
+    await handler(error).catch(() => {});
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Server error. Please try again later.');
+    });
+  });
+});

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAnalyticsStore } from '../state/store';
 import { BarChart3, Filter, Download, AlertCircle } from 'lucide-react';
+import { api } from '../api/client';
 import './Analytics.css';
 
 interface AnalyticsData {
@@ -42,16 +43,7 @@ const Analytics: React.FC = () => {
     setError(null);
 
     try {
-      const port = process.env.REACT_APP_API_PORT || '5001';
-      const response = await fetch(
-        `http://localhost:${port}/api/v1/analytics/${sourceType}`
-      );
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
+      const data = await api.get<AnalyticsData>(`/analytics/${sourceType}`);
       setAnalytics(sourceType, data);
     } catch (err) {
       console.error('Analytics fetch error:', err);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { api } from '../api/client';
 
 interface UserSettings {
   theme: string;
@@ -14,8 +15,8 @@ const Settings: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/v1/settings')
-      .then((res) => res.json())
+    api
+      .get<UserSettings>('/settings')
       .then((data) => setSettings((prev) => ({ ...prev, ...data })))
       .catch(() => {
         /* ignore load errors */
@@ -30,17 +31,8 @@ const Settings: React.FC = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setStatus('saving');
-    fetch('/api/v1/settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(settings),
-    })
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error('Failed to save settings');
-        }
-        return res.json();
-      })
+    api
+      .put('/settings', settings)
       .then(() => {
         setStatus('success');
         setError(null);


### PR DESCRIPTION
## Summary
- refactor pages to use shared api client
- install axios-mock-adapter and testing library DOM utilities
- add component test demonstrating client usage

## Testing
- `npx react-scripts test src/api/__tests__/client.test.ts src/api/__tests__/component.client.test.tsx src/api/upload.test.ts --runInBand --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6880b06f5b308320b382cae9ffbe0594