### PR TITLE
Add FastAPI imports for service module

### DIFF
--- a/python/yosai_framework/service.py
+++ b/python/yosai_framework/service.py
@@ -2,6 +2,8 @@ import logging
 import signal
 from typing import Any
 
+from fastapi import FastAPI, HTTPException
+
 import structlog
 from opentelemetry import trace
 from opentelemetry.exporter.jaeger.thrift import JaegerExporter


### PR DESCRIPTION
## Summary
- ensure service module imports FastAPI and HTTPException from fastapi

## Testing
- `pytest tests/test_yosai_framework_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c04b41508320aed1bb359a3e6a36