### PR TITLE
Update metric names in framework service

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -58,7 +58,7 @@ def create_api_app() -> Flask:
     CORS(app)
 
     REQUEST_COUNT = Counter(
-        "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
+        "yosai_request_total", "Total HTTP requests", ["method", "endpoint", "status"]
     )
 
     @app.after_request

--- a/archive/legacy_backend/backend/app.py
+++ b/archive/legacy_backend/backend/app.py
@@ -18,7 +18,7 @@ app = Flask(__name__)
 CORS(app)
 
 REQUEST_COUNT = Counter(
-    "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
+    "yosai_request_total", "Total HTTP requests", ["method", "endpoint", "status"]
 )
 
 

--- a/archive/legacy_backend/backend/app_main.py
+++ b/archive/legacy_backend/backend/app_main.py
@@ -19,7 +19,7 @@ app = Flask(__name__, static_folder="../build", static_url_path="")
 CORS(app, origins=["http://localhost:3000", "http://localhost:3001"])
 
 REQUEST_COUNT = Counter(
-    "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
+    "yosai_request_total", "Total HTTP requests", ["method", "endpoint", "status"]
 )
 
 

--- a/dashboards/grafana/gateway.json
+++ b/dashboards/grafana/gateway.json
@@ -35,7 +35,7 @@
       "title": "HTTP Requests",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "sum(rate(http_requests_total[5m]))", "legendFormat": "req/s"}
+        {"expr": "sum(rate(yosai_request_total[5m]))", "legendFormat": "req/s"}
       ]
     }
   ]

--- a/dashboards/grafana/load_testing.json
+++ b/dashboards/grafana/load_testing.json
@@ -7,7 +7,7 @@
       "title": "HTTP p95 Duration",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))", "legendFormat": "p95"}
+        {"expr": "histogram_quantile(0.95, sum(rate(yosai_request_duration_seconds_bucket[1m])) by (le))", "legendFormat": "p95"}
       ]
     },
     {
@@ -15,7 +15,7 @@
       "title": "Request Error Rate",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "sum(rate(http_requests_total{status=~\"5..\"}[1m]))", "legendFormat": "errors"}
+        {"expr": "sum(rate(yosai_request_total{status=~\"5..\"}[1m]))", "legendFormat": "errors"}
       ]
     }
   ]

--- a/dashboards/performance/load_test.json
+++ b/dashboards/performance/load_test.json
@@ -15,7 +15,7 @@
       "title": "HTTP Requests/s",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "sum(rate(http_requests_total[1m]))", "legendFormat": "req"}
+        {"expr": "sum(rate(yosai_request_total[1m]))", "legendFormat": "req"}
       ]
     }
   ]

--- a/go/framework/go.mod
+++ b/go/framework/go.mod
@@ -14,7 +14,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors => ../../shared/errors
+
 require (
+	github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors v0.0.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/framework/service.go
+++ b/go/framework/service.go
@@ -97,11 +97,11 @@ func (s *BaseService) setupMetrics() {
 	}
 	s.registry = prometheus.NewRegistry()
 	s.reqCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "http_requests_total",
+		Name: "yosai_request_total",
 		Help: "Total HTTP requests",
 	}, []string{"method", "endpoint", "status"})
 	s.reqDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "http_request_duration_seconds",
+		Name:    "yosai_request_duration_seconds",
 		Help:    "HTTP request duration in seconds",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"method", "endpoint", "status"})

--- a/go/framework/service_test.go
+++ b/go/framework/service_test.go
@@ -63,10 +63,10 @@ func TestMetricsInitialization(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "http_requests_total") {
+	if !strings.Contains(string(body), "yosai_request_total") {
 		t.Fatalf("counter not exposed: %s", string(body))
 	}
-	if !strings.Contains(string(body), "http_request_duration_seconds") {
+	if !strings.Contains(string(body), "yosai_request_duration_seconds") {
 		t.Fatalf("histogram not exposed: %s", string(body))
 	}
 }

--- a/monitoring/grafana/dashboards/unified-platform.json
+++ b/monitoring/grafana/dashboards/unified-platform.json
@@ -7,7 +7,7 @@
       "title": "Total HTTP Requests",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "sum(rate(http_requests_total[1m]))", "legendFormat": "req/s"}
+        {"expr": "sum(rate(yosai_request_total[1m]))", "legendFormat": "req/s"}
       ]
     },
     {
@@ -16,7 +16,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[1m]))",
+          "expr": "sum(rate(yosai_request_total{status=~\"5..\"}[1m]))",
           "legendFormat": "errors/s"
         }
       ]
@@ -27,7 +27,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(yosai_request_duration_seconds_bucket[1m])) by (le))",
           "legendFormat": "p95"
         }
       ]

--- a/shared/errors/go.mod
+++ b/shared/errors/go.mod
@@ -1,0 +1,3 @@
+module github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors
+
+go 1.23

--- a/tests/integration/test_e2e_gateway.py
+++ b/tests/integration/test_e2e_gateway.py
@@ -10,7 +10,7 @@ from testcontainers.core.container import DockerContainer
 def get_total_requests(metrics: str) -> float:
     total = 0.0
     for line in metrics.splitlines():
-        if line.startswith("http_requests_total"):
+        if line.startswith("yosai_request_total"):
             parts = line.split()
             if len(parts) == 2:
                 try:


### PR DESCRIPTION
## Summary
- rename metrics to `yosai_request_total` and `yosai_request_duration_seconds`
- adjust tests and integration helpers for new names
- update dashboards and adapter references
- add go module for shared errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880c04dded08320b24731c98ba90ada