### PR TITLE
Add health endpoints to Go service

### DIFF
--- a/go/framework/go.mod
+++ b/go/framework/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
+	github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors v0.0.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.37.0
@@ -33,3 +34,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )
+
+replace github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors => ../../shared/errors

--- a/shared/errors/go.mod
+++ b/shared/errors/go.mod
@@ -1,0 +1,3 @@
+module github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors
+
+go 1.23


### PR DESCRIPTION
## Summary
- implement liveness, readiness and startup state tracking in Go BaseService
- expose `/health`, `/health/live`, `/health/ready`, `/health/startup` on the metrics server
- add tests for health endpoints
- provide Go module for shared errors package

## Testing
- `cd go/framework && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880c05473448320a6f0058ce944240f