### PR TITLE
Migrate services to unified BaseService

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -1,28 +1,18 @@
 import asyncio
-import logging
 import os
 
-from flask import Flask, Response, jsonify, request
+from fastapi.middleware.wsgi import WSGIMiddleware
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect, generate_csrf
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
+
+from yosai_framework.service import BaseService
 
 from core.rbac import RBACService, create_rbac_service
 from core.secrets_validator import validate_all_secrets
 from services.security import require_token
-from tracing import init_tracing
 
 csrf = CSRFProtect()
-
-logger = logging.getLogger("api")
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter(
-        '{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s"}'
-    )
-)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 from api.analytics_endpoints import register_analytics_blueprints
 from settings_endpoint import settings_bp
@@ -33,17 +23,18 @@ from mappings_endpoint import mappings_bp
 from upload_endpoint import upload_bp
 
 
-def create_api_app() -> Flask:
-    """Create Flask API app with all blueprints registered."""
+def create_api_app() -> "FastAPI":
+    """Create API app registered on a BaseService."""
     validate_all_secrets()
-    init_tracing("api")
+    service = BaseService("api", "")
+    service.start()
     app = Flask(__name__)
 
     # Initialize RBAC service
     try:
         app.config["RBAC_SERVICE"] = asyncio.run(create_rbac_service())
     except Exception as exc:  # pragma: no cover - best effort
-        logger.error("Failed to initialize RBAC service: %s", exc)
+        service.log.error("Failed to initialize RBAC service: %s", exc)
         app.config["RBAC_SERVICE"] = None
 
     app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
@@ -56,19 +47,6 @@ def create_api_app() -> Flask:
             csrf.protect()
 
     CORS(app)
-
-    REQUEST_COUNT = Counter(
-        "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
-    )
-
-    @app.after_request
-    def record_metrics(response):
-        REQUEST_COUNT.labels(request.method, request.path, response.status_code).inc()
-        return response
-
-    @app.route("/metrics")
-    def metrics():
-        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
     # Third-party analytics demo endpoints
     register_analytics_blueprints(app)
@@ -84,7 +62,8 @@ def create_api_app() -> Flask:
         """Provide CSRF token for clients."""
         return jsonify({"csrf_token": generate_csrf()})
 
-    return app
+    service.app.mount("/", WSGIMiddleware(app))
+    return service.app
 
 
 if __name__ == "__main__":
@@ -93,4 +72,6 @@ if __name__ == "__main__":
     print(f"   Available at: http://localhost:{API_PORT}")
     print(f"   Upload endpoint: http://localhost:{API_PORT}/v1/upload")
 
-    app.run(host="0.0.0.0", port=API_PORT, debug=True)
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=API_PORT)

--- a/services/event_streaming_service.py
+++ b/services/event_streaming_service.py
@@ -10,18 +10,16 @@ from typing import Any, Optional
 from kafka import KafkaConsumer, KafkaProducer
 
 from config.kafka_config import KafkaConfig, from_environment
-from services.base import BaseService
-from yosai_framework.service import BaseService as FrameworkService
+from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)
 
 
-class EventStreamingService(BaseService):
+class EventStreamingService:
     """Service managing Kafka producer/consumer threads."""
 
     def __init__(self, config: Optional[KafkaConfig] = None) -> None:
-        super().__init__("event_streaming")
-        self.framework = FrameworkService("event-streaming", "")
+        self.service = BaseService("event-streaming", "")
         self.config = config or from_environment()
         self.producer: KafkaProducer | None = None
         self.consumer: KafkaConsumer | None = None
@@ -29,8 +27,8 @@ class EventStreamingService(BaseService):
         self._stop = threading.Event()
         self.topic = "access-events"
 
-    def _do_initialize(self) -> None:
-        self.framework.start()
+    def initialize(self) -> None:
+        self.service.start()
         self.producer = KafkaProducer(
             bootstrap_servers=self.config.brokers,
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
@@ -80,7 +78,7 @@ class EventStreamingService(BaseService):
                 pass
         if self._worker is not None:
             self._worker.join(timeout=1)
-        self.framework.stop()
+        self.service.stop()
 
 
 __all__ = ["EventStreamingService"]

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -21,8 +21,7 @@ from services.data_processing.unified_file_validator import (
 from utils.protocols import SafeDecoderProtocol
 from utils.memory_utils import memory_safe
 
-from .base import BaseService
-from yosai_framework.service import BaseService as FrameworkService
+from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +58,8 @@ class FileProcessorService(BaseService):
         config: ConfigurationServiceProtocol,
         decoder: SafeDecoderProtocol = safe_decode_with_unicode_handling,
     ) -> None:
-        super().__init__("file_processor")
-        self.framework = FrameworkService("file-processor", "")
-        self.framework.start()
+        super().__init__("file-processor", "")
+        self.start()
         self.config = config
         self.max_file_size_mb = config.get_max_upload_size_mb()
         self._decoder = decoder

--- a/services/streaming/service.py
+++ b/services/streaming/service.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, Generator, Optional
 
 from config.dynamic_config import dynamic_config
-from services.base import BaseService
+from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)
 
@@ -11,11 +11,21 @@ class StreamingService(BaseService):
     """Manage Kafka or Pulsar streaming connections."""
 
     def __init__(self, config: Optional[Any] = None) -> None:
-        super().__init__("streaming")
+        super().__init__("streaming", "")
         self.config = config or getattr(dynamic_config, "streaming", None)
         self.producer = None
         self.consumer = None
         self._client = None
+
+    def initialize(self) -> bool:
+        try:
+            self.start()
+            self._do_initialize()
+            self.log.info("Service %s initialized", self.name)
+            return True
+        except Exception as exc:  # pragma: no cover - init error
+            self.log.error("Failed to initialize service %s: %s", self.name, exc)
+            return False
 
     def _do_initialize(self) -> None:
         if not self.config:

--- a/start_api.py
+++ b/start_api.py
@@ -10,15 +10,6 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from api.adapter import create_api_app
 from config.constants import API_PORT
 
-logger = logging.getLogger("start")
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter(
-        '{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s"}'
-    )
-)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 
 def main() -> None:
@@ -27,10 +18,11 @@ def main() -> None:
 
     print("\n🚀 Starting Yosai Intel Dashboard API...")
     print(f"   Available at: http://localhost:{API_PORT}")
-    print(f"   Health check: http://localhost:{API_PORT}/v1/health")
+    print(f"   Health check: http://localhost:{API_PORT}/health")
 
+    import uvicorn
 
-    app.run(host="0.0.0.0", port=API_PORT, debug=True)
+    uvicorn.run(app, host="0.0.0.0", port=API_PORT)
 
 
 if __name__ == "__main__":

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -1,6 +1,12 @@
 from types import SimpleNamespace
 from core.protocols import ConfigurationProtocol
-from services.configuration_service import ConfigurationServiceProtocol
+try:
+    from services.configuration_service import ConfigurationServiceProtocol
+except Exception:  # pragma: no cover - optional deps
+    from typing import Protocol
+
+    class ConfigurationServiceProtocol(Protocol):
+        def get_max_upload_size_mb(self) -> int: ...
 
 
 class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):

--- a/tests/test_file_processor_service_surrogates.py
+++ b/tests/test_file_processor_service_surrogates.py
@@ -1,5 +1,17 @@
 from tests.fake_configuration import FakeConfiguration
-from services.file_processor_service import FileProcessorService
+import importlib.util
+import sys
+import types
+
+config_stub = types.SimpleNamespace(ConfigurationServiceProtocol=object)
+sys.modules.setdefault("services.configuration_service", config_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "services.file_processor_service", "services/file_processor_service.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+FileProcessorService = module.FileProcessorService
 from core.unicode import sanitize_unicode_input
 
 


### PR DESCRIPTION
## Summary
- switch services to use `yosai_framework.service.BaseService`
- adapt `api.adapter` to expose FastAPI app via `BaseService`
- run API via uvicorn instead of Flask dev server
- adjust tests for new service initialization

## Testing
- `python -m py_compile api/adapter.py services/event_streaming_service.py services/file_processor_service.py services/streaming/service.py start_api.py tests/fake_configuration.py tests/integration/test_api_csrf.py tests/test_file_processor_service_surrogates.py`
- `LIGHTWEIGHT_SERVICES=1 PYTHONPATH=. pytest tests/test_yosai_framework_service.py tests/test_file_processor_service_surrogates.py tests/integration/test_api_csrf.py -q` *(fails: ModuleNotFoundError: No module named 'services.file_processor_service')*

------
https://chatgpt.com/codex/tasks/task_e_6880c051303c8320a972d3a8794e593f