### PR TITLE
Add reqErrors metric exposure

### DIFF
--- a/go/framework/service.go
+++ b/go/framework/service.go
@@ -34,6 +34,7 @@ type BaseService struct {
 	metricsLn       net.Listener
 	reqCount        *prometheus.CounterVec
 	reqDuration     *prometheus.HistogramVec
+	reqErrors       *prometheus.CounterVec
 	traceShutdown   func(context.Context) error
 	ready           bool
 	live            bool
@@ -119,7 +120,11 @@ func (s *BaseService) setupMetrics() {
 		Help:    "HTTP request duration in seconds",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"method", "endpoint", "status"})
-	s.registry.MustRegister(s.reqCount, s.reqDuration)
+	s.reqErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "yosai_error_total",
+		Help: "Total errors encountered",
+	}, []string{"endpoint"})
+	s.registry.MustRegister(s.reqCount, s.reqDuration, s.reqErrors)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{}))

--- a/go/framework/service_test.go
+++ b/go/framework/service_test.go
@@ -55,6 +55,7 @@ func TestMetricsInitialization(t *testing.T) {
 	svc.setupMetrics()
 	svc.reqCount.WithLabelValues("GET", "/", "200").Inc()
 	svc.reqDuration.WithLabelValues("GET", "/", "200").Observe(0.1)
+	svc.reqErrors.WithLabelValues("/").Inc()
 	defer svc.Stop()
 	addr := svc.metricsLn.Addr().String()
 	resp, err := http.Get("http://" + addr + "/metrics")
@@ -68,6 +69,9 @@ func TestMetricsInitialization(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "yosai_request_duration_seconds") {
 		t.Fatalf("histogram not exposed: %s", string(body))
+	}
+	if !strings.Contains(string(body), "yosai_error_total") {
+		t.Fatalf("error counter not exposed: %s", string(body))
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose request error metric in base service
- ensure metrics server registers new metric
- verify yosai_error_total metric via unit test

## Testing
- `go test ./... -run TestMetricsInitialization -v`

------
https://chatgpt.com/codex/tasks/task_e_6880c5e7512c83208b452cdf639174cd