### PR TITLE
Fix import and startup for event ingestion

### DIFF
--- a/python/config/service.schema.yaml
+++ b/python/config/service.schema.yaml
@@ -1,0 +1,1 @@
+../../config/service.schema.yaml

--- a/services/event-ingestion/service_config.yaml
+++ b/services/event-ingestion/service_config.yaml
@@ -1,0 +1,1 @@
+service_name: event-ingestion-service

--- a/yosai_framework/__init__.py
+++ b/yosai_framework/__init__.py
@@ -1,0 +1,12 @@
+from python.yosai_framework.service import BaseService
+from python.yosai_framework.errors import ServiceError, from_exception, error_response
+from python.yosai_framework.config import ServiceConfig, load_config
+
+__all__ = [
+    "BaseService",
+    "ServiceError",
+    "from_exception",
+    "error_response",
+    "ServiceConfig",
+    "load_config",
+]

--- a/yosai_framework/config.py
+++ b/yosai_framework/config.py
@@ -1,0 +1,1 @@
+from python.yosai_framework.config import *

--- a/yosai_framework/errors.py
+++ b/yosai_framework/errors.py
@@ -1,0 +1,1 @@
+from python.yosai_framework.errors import *

--- a/yosai_framework/service.py
+++ b/yosai_framework/service.py
@@ -1,0 +1,1 @@
+from python.yosai_framework.service import *


### PR DESCRIPTION
## Summary
- add missing BaseService import to event ingestion service
- load streaming and security modules even under test stubs
- set service config path and ensure environment variable
- add fallback when StreamingService can't initialise
- provide lightweight `yosai_framework` wrapper package
- add minimal service config file and schema link for tests

## Testing
- `pytest tests/services/test_event_ingestion_app.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c5e4485483209edd532d09eca817