### PR TITLE
Update analytics service instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ manager.execute_query_with_retry("SELECT 1")
 - **Guide**: [docs/models_guide.md](docs/models_guide.md) explains each model file
 
 -### Services Layer (`services/`)
+- All services rely on `yosai_framework.BaseService` for metrics, tracing and health endpoints.
 - **analytics_service.py**: Business logic for analytics ([docs](docs/analytics_service.md))
   
   Register an instance with the container to access analytics operations:
@@ -903,10 +904,10 @@ manager.execute_query_with_retry("SELECT 1")
   The `AnalyticsService` conforms to `AnalyticsServiceProtocol`, so you can
   substitute your own implementation during tests.
 
-  A FastAPI wrapper is available for quick testing:
+  Run the analytics microservice via the unified BaseService:
 
   ```bash
-  uvicorn services.analytics.fastapi_wrapper:app
+  python -m uvicorn services.analytics_microservice.app:app --host 0.0.0.0 --port 8001
   ```
 
 - **device_learning_service.py**: Persists learned device mappings ([docs](docs/device_learning_service.md))


### PR DESCRIPTION
## Summary
- update docs to run analytics microservice via BaseService
- note that all services use BaseService for metrics, tracing and health endpoints

## Testing
- `pytest -k analytics_microservice_app -q` *(fails: ModuleNotFoundError: No module named 'services.data_processing')*

------
https://chatgpt.com/codex/tasks/task_e_6880d75f5d688320b84401a8d806a7ad