### PR TITLE
Add Prometheus scrape jobs

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -20,6 +20,14 @@ scrape_configs:
   static_configs:
   - targets: ['analytics-service:8001']
 
+- job_name: 'event-ingestion'
+  static_configs:
+  - targets: ['event-ingestion:2112']
+
+- job_name: 'event-processing'
+  static_configs:
+  - targets: ['event-processing:2112']
+
 - job_name: 'grafana'
   kubernetes_sd_configs:
   - role: pod


### PR DESCRIPTION
## Summary
- monitor `event-ingestion` and `event-processing` services in Prometheus

## Testing
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'analytics.security_patterns')*

------
https://chatgpt.com/codex/tasks/task_e_6880edbe95888320b43e969eae948cc8