### PR TITLE
Enable Prometheus scraping for all microservices

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -20,6 +20,18 @@ scrape_configs:
   static_configs:
   - targets: ['analytics-service:8001']
 
+- job_name: 'dashboard'
+  static_configs:
+  - targets: ['dashboard:2112']
+
+- job_name: 'event-ingestion'
+  static_configs:
+  - targets: ['event-ingestion:8000']
+
+- job_name: 'event-processing'
+  static_configs:
+  - targets: ['event-processing:2112']
+
 - job_name: 'grafana'
   kubernetes_sd_configs:
   - role: pod


### PR DESCRIPTION
## Summary
- add dashboard, event-ingestion and event-processing jobs to Prometheus config

## Testing
- `pytest tests/resilience/test_circuit_breaker.py::test_circuit_breaker_state_transitions -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*
- `black --check core/__init__.py`
- `flake8 core/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6880eda2ad888320933c4f88597a36c4