### PR TITLE
Integrate React UI with unified platform

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -95,8 +95,42 @@ jobs:
           name: go-coverage
           path: gateway/coverage.out
 
+  frontend-test:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: yosai-upload/package-lock.json
+      - name: Install deps
+        run: npm ci --prefix yosai-upload
+      - name: Run frontend tests
+        run: npm test --prefix yosai-upload -- --watchAll=false
+
+  frontend-build:
+    needs: frontend-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: yosai-upload/package-lock.json
+      - name: Install deps
+        run: npm ci --prefix yosai-upload
+      - name: Build frontend
+        run: npm run build --prefix yosai-upload
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: yosai-upload/build
+
   build-images:
-    needs: test
+    needs: [test, frontend-build]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project follows a fully modular design built around a dependency injection 
 - [UI Design Assets](docs/ui_design/README.md)
 - [React Component Architecture](docs/react_component_architecture.md)
 - [Validation Overview](docs/validation_overview.md)
+- [Error Response Contract](docs/error_contract.md)
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)
 - [Data Processing](docs/data_processing.md)

--- a/docs/unified_platform.md
+++ b/docs/unified_platform.md
@@ -12,6 +12,8 @@ The unified platform bundles all services together using `docker-compose.unified
 - `make test-all` – Run the full test suite.
 - `make deploy-all` – Start the entire stack in the background.
 - `make logs service=<name>` – Tail logs for a specific service.
+- `tools.ops_cli frontend-build` – Build the React upload UI assets.
+- `tools.ops_cli frontend-test` – Run unit tests for the upload UI.
 
 The same functionality can be invoked directly via the CLI:
 

--- a/yosai-upload/src/App.tsx
+++ b/yosai-upload/src/App.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import logo from './logo.svg';
 import './App.css';
+import { request } from './api';
+import { log } from './logger';
 
 function App() {
+  useEffect(() => {
+    request('/api/ping')
+      .then(() => log('info', 'ping ok'))
+      .catch(err => log('error', 'ping failed', err));
+  }, []);
   return (
     <div className="App">
       <header className="App-header">

--- a/yosai-upload/src/ErrorBoundary.tsx
+++ b/yosai-upload/src/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { log } from './logger';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    log('error', 'render error', { error: error.message, componentStack: info.componentStack });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Something went wrong.</p>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/yosai-upload/src/api.ts
+++ b/yosai-upload/src/api.ts
@@ -1,0 +1,18 @@
+import { log } from './logger';
+
+export interface ServiceError {
+  code: string;
+  message: string;
+  details?: any;
+}
+
+export async function request<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  const data = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const err: ServiceError = data || { code: 'internal', message: 'Unknown error' };
+    log('error', 'API request failed', { url: String(input), ...err });
+    throw err;
+  }
+  return data as T;
+}

--- a/yosai-upload/src/index.tsx
+++ b/yosai-upload/src/index.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import ErrorBoundary from './ErrorBoundary';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );
 

--- a/yosai-upload/src/logger.ts
+++ b/yosai-upload/src/logger.ts
@@ -1,0 +1,20 @@
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  [key: string]: any;
+}
+
+export function log(level: LogLevel, message: string, context: Record<string, any> = {}): void {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...context,
+  };
+  const method = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'log';
+  // eslint-disable-next-line no-console
+  console[method](JSON.stringify(entry));
+}

--- a/yosai-upload/src/reportWebVitals.ts
+++ b/yosai-upload/src/reportWebVitals.ts
@@ -1,13 +1,18 @@
 import { ReportHandler } from 'web-vitals';
+import { log } from './logger';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
+      const handler: ReportHandler = metric => {
+        log('info', 'web-vital', { name: metric.name, value: metric.value });
+        onPerfEntry(metric);
+      };
+      getCLS(handler);
+      getFID(handler);
+      getFCP(handler);
+      getLCP(handler);
+      getTTFB(handler);
     });
   }
 };

--- a/yosai-upload/tsconfig.json
+++ b/yosai-upload/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- handle unified ServiceError objects in the upload UI
- output structured logs from the React app
- wrap the app with an error boundary
- build and test the upload UI in unified CI
- document new frontend commands and link to the error response contract

## Testing
- `npm test --prefix yosai-upload -- --watchAll=false`
- `npm run build --prefix yosai-upload`
- `pytest -k test_fastapi_error_handler.py` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed64a0a88320a53f55c68569f029