### PR TITLE
Add JSON examples for event client docs

### DIFF
--- a/analytics/clients/event_client/README.md
+++ b/analytics/clients/event_client/README.md
@@ -67,7 +67,15 @@ configuration = openapi_client.Configuration(
 with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.DefaultApi(api_client)
-    v1_events_batch_post_request = openapi_client.V1EventsBatchPostRequest() # V1EventsBatchPostRequest | 
+    v1_events_batch_post_request = openapi_client.V1EventsBatchPostRequest(
+        events=[
+            openapi_client.AccessEvent(
+                event_id="12345",
+                timestamp="2024-05-01T12:34:56Z",
+                access_result="GRANTED"
+            )
+        ]
+    )
 
     try:
         # Submit a batch of access events

--- a/analytics/clients/event_client/docs/AccessEvent.md
+++ b/analytics/clients/event_client/docs/AccessEvent.md
@@ -21,8 +21,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.access_event import AccessEvent
 
-# TODO update the JSON string below
-json = "{}"
+# Example JSON describing an access event
+json = "{\n  \"event_id\": \"12345\",\n  \"timestamp\": \"2024-05-01T12:34:56Z\",\n  \"person_id\": \"user-42\",\n  \"door_id\": \"door-1\",\n  \"badge_id\": \"badge-100\",\n  \"access_result\": \"GRANTED\",\n  \"badge_status\": \"ACTIVE\",\n  \"door_held_open_time\": 0.0,\n  \"entry_without_badge\": false,\n  \"device_status\": \"ONLINE\"\n}"
 # create an instance of AccessEvent from a JSON string
 access_event_instance = AccessEvent.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/ApiV1EventsBatchPost200Response.md
+++ b/analytics/clients/event_client/docs/ApiV1EventsBatchPost200Response.md
@@ -12,8 +12,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.api_v1_events_batch_post200_response import ApiV1EventsBatchPost200Response
 
-# TODO update the JSON string below
-json = "{}"
+# Example batch response returned by the server
+json = "{\n  \"results\": [\n    {\n      \"event_id\": \"12345\",\n      \"status\": \"accepted\"\n    },\n    {\n      \"event_id\": \"67890\",\n      \"status\": \"rejected\"\n    }\n  ]\n}"
 # create an instance of ApiV1EventsBatchPost200Response from a JSON string
 api_v1_events_batch_post200_response_instance = ApiV1EventsBatchPost200Response.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/ApiV1EventsBatchPostRequest.md
+++ b/analytics/clients/event_client/docs/ApiV1EventsBatchPostRequest.md
@@ -12,8 +12,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.api_v1_events_batch_post_request import ApiV1EventsBatchPostRequest
 
-# TODO update the JSON string below
-json = "{}"
+# Example request payload for the batch endpoint
+json = "{\n  \"events\": [\n    {\n      \"event_id\": \"12345\",\n      \"timestamp\": \"2024-05-01T12:34:56Z\",\n      \"access_result\": \"GRANTED\"\n    }\n  ]\n}"
 # create an instance of ApiV1EventsBatchPostRequest from a JSON string
 api_v1_events_batch_post_request_instance = ApiV1EventsBatchPostRequest.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/ErrorResponse.md
+++ b/analytics/clients/event_client/docs/ErrorResponse.md
@@ -14,8 +14,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.error_response import ErrorResponse
 
-# TODO update the JSON string below
-json = "{}"
+# Example JSON error returned by the API
+json = "{\n  \"code\": \"INVALID_REQUEST\",\n  \"message\": \"Provided event is invalid\",\n  \"details\": \"Person ID missing\"\n}"
 # create an instance of ErrorResponse from a JSON string
 error_response_instance = ErrorResponse.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/EventResponse.md
+++ b/analytics/clients/event_client/docs/EventResponse.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.event_response import EventResponse
 
-# TODO update the JSON string below
-json = "{}"
+# Example response returned after submitting an event
+json = "{\n  \"event_id\": \"12345\",\n  \"status\": \"accepted\"\n}"
 # create an instance of EventResponse from a JSON string
 event_response_instance = EventResponse.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/V1EventsBatchPost200Response.md
+++ b/analytics/clients/event_client/docs/V1EventsBatchPost200Response.md
@@ -12,8 +12,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.v1_events_batch_post200_response import V1EventsBatchPost200Response
 
-# TODO update the JSON string below
-json = "{}"
+# Example batch response returned by the server
+json = "{\n  \"results\": [\n    {\n      \"event_id\": \"12345\",\n      \"status\": \"accepted\"\n    },\n    {\n      \"event_id\": \"67890\",\n      \"status\": \"rejected\"\n    }\n  ]\n}"
 # create an instance of V1EventsBatchPost200Response from a JSON string
 v1_events_batch_post200_response_instance = V1EventsBatchPost200Response.from_json(json)
 # print the JSON string representation of the object

--- a/analytics/clients/event_client/docs/V1EventsBatchPostRequest.md
+++ b/analytics/clients/event_client/docs/V1EventsBatchPostRequest.md
@@ -12,8 +12,8 @@ Name | Type | Description | Notes
 ```python
 from openapi_client.models.v1_events_batch_post_request import V1EventsBatchPostRequest
 
-# TODO update the JSON string below
-json = "{}"
+# Example request payload for the batch endpoint
+json = "{\n  \"events\": [\n    {\n      \"event_id\": \"12345\",\n      \"timestamp\": \"2024-05-01T12:34:56Z\",\n      \"access_result\": \"GRANTED\"\n    }\n  ]\n}"
 # create an instance of V1EventsBatchPostRequest from a JSON string
 v1_events_batch_post_request_instance = V1EventsBatchPostRequest.from_json(json)
 # print the JSON string representation of the object


### PR DESCRIPTION
## Summary
- update `analytics/clients/event_client` docs with working JSON payloads
- show simple instantiation example in README

## Testing
- `pytest analytics/clients/event_client/test -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68810a85c78883209a7376b6be171389