### PR TITLE
Add timescale migration dry-run check

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -13,3 +13,5 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.lock
       - run: python scripts/migrate.py --dry-run
+      - name: Timescale migrations
+        run: python scripts/migrate.py --config migrations/timescale/alembic.ini --dry-run

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,13 @@
+# Continuous Integration
+
+This repository relies on GitHub Actions workflows to run tests and safety checks for every pull request.
+
+## Migration Check
+
+The `migration-check.yml` workflow installs the Python dependencies and validates the Alembic migrations in dry-run mode. After the standard migration step it now also runs the Timescale migration scripts:
+
+```bash
+python scripts/migrate.py --config migrations/timescale/alembic.ini --dry-run
+```
+
+Both commands must succeed for the job to pass, ensuring the core and Timescale schemas remain in sync.

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -39,7 +39,10 @@ def main(argv: List[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     _check_git_clean()
-    mgr = MigrationManager(args.config)
+    config_path = Path(args.config)
+    if not config_path.is_file():
+        raise SystemExit(f"Config file not found: {config_path}")
+    mgr = MigrationManager(str(config_path))
     try:
         mgr.upgrade(args.revision, dry_run=args.dry_run)
     except Exception as exc:


### PR DESCRIPTION
## Summary
- run Timescale migrations dry run in the workflow
- validate `--config` path in `scripts/migrate.py`
- describe the migration check workflow in `docs/ci.md`

## Testing
- `python -m py_compile scripts/migrate.py`
- `pytest tests/test_migration_adapter.py -q` *(fails: ModuleNotFoundError: No module named 'services.registry')*

------
https://chatgpt.com/codex/tasks/task_e_6881105a6fdc8320a8c4fbc48c313d0d