### PR TITLE
Add consumer lag and cache ratio panels

### DIFF
--- a/dashboards/grafana/event_processor.json
+++ b/dashboards/grafana/event_processor.json
@@ -7,7 +7,21 @@
       "title": "Events Processed",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "event_processor_events_processed_total", "legendFormat": "processed"}
+        {
+          "expr": "event_processor_events_processed_total",
+          "legendFormat": "processed"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Consumer Lag",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kafka_consumer_group_lag{group=\"event-processor\"}) by (topic)",
+          "legendFormat": "{{topic}}"
+        }
       ]
     }
   ]

--- a/monitoring/grafana/dashboards/unified-platform.json
+++ b/monitoring/grafana/dashboards/unified-platform.json
@@ -7,7 +7,10 @@
       "title": "Total HTTP Requests",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "sum(rate(yosai_request_total[1m]))", "legendFormat": "req/s"}
+        {
+          "expr": "sum(rate(yosai_request_total[1m]))",
+          "legendFormat": "req/s"
+        }
       ]
     },
     {
@@ -29,6 +32,17 @@
         {
           "expr": "histogram_quantile(0.95, sum(rate(yosai_request_duration_seconds_bucket[1m])) by (le))",
           "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Cache Hit Ratio",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(dashboard_cache_hits_total[5m]) / (rate(dashboard_cache_hits_total[5m]) + rate(dashboard_cache_misses_total[5m]))",
+          "legendFormat": "hit_ratio"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- extend event processor dashboard with consumer lag graph
- show cache hit ratio on unified platform dashboard

## Testing
- `python -m json.tool dashboards/grafana/event_processor.json`
- `python -m json.tool monitoring/grafana/dashboards/unified-platform.json`


------
https://chatgpt.com/codex/tasks/task_e_6881105be52883209906c5ed04b9c009