### PR TITLE
Add client regeneration check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: go run .
       - name: Generate client SDKs
         run: ./scripts/generate_clients.sh
+      - name: Check generated clients up to date
+        run: git diff --exit-code docs/openapi.json analytics/clients/event_client pkg/eventclient
       - name: Upload OpenAPI
         uses: actions/upload-artifact@v4
         with:

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,15 +28,17 @@ The script writes the Go client under `pkg/eventclient` and the Python client
 under `analytics/clients/event_client`.
 
 ### Regenerating after changes
-
 Run the generator whenever API routes or schemas change:
 
 ```bash
 go run ./api/openapi
+./scripts/generate_clients.sh docs/openapi.json
 ```
 
-Commit the updated `docs/openapi.json` so the specification stays in sync with
-the codebase.
+Commit the updated `docs/openapi.json`, `analytics/clients/event_client`, and
+`pkg/eventclient` directories so the specification and generated clients stay in
+sync with the codebase. CI will fail if these files differ from the checked in
+versions.
 
 ## API Versioning
 

--- a/scripts/generate_clients.sh
+++ b/scripts/generate_clients.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 SPEC=${1:-docs/openapi.json}
 
-npx openapi-generator-cli generate -i "$SPEC" -g go -o pkg/eventclient --package-name eventclient > /dev/null
-npx openapi-generator-cli generate -i "$SPEC" -g python -o analytics/clients/event_client > /dev/null
+npx openapi-generator-cli generate -i "$SPEC" -g go -o pkg/eventclient --package-name eventclient >/dev/null 2>&1
+npx openapi-generator-cli generate -i "$SPEC" -g python -o analytics/clients/event_client >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- verify OpenAPI clients are generated
- silence generator script output
- document how to regenerate clients

## Testing
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6881105d75848320879f72522a2798c5