### PR TITLE
Use model_dump_json in event client models

### DIFF
--- a/analytics/clients/event_client/openapi_client/models/access_event.py
+++ b/analytics/clients/event_client/openapi_client/models/access_event.py
@@ -52,8 +52,7 @@ class AccessEvent(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/api_v1_events_batch_post200_response.py
+++ b/analytics/clients/event_client/openapi_client/models/api_v1_events_batch_post200_response.py
@@ -43,8 +43,7 @@ class ApiV1EventsBatchPost200Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/api_v1_events_batch_post_request.py
+++ b/analytics/clients/event_client/openapi_client/models/api_v1_events_batch_post_request.py
@@ -43,8 +43,7 @@ class ApiV1EventsBatchPostRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/error_response.py
+++ b/analytics/clients/event_client/openapi_client/models/error_response.py
@@ -44,8 +44,7 @@ class ErrorResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/event_response.py
+++ b/analytics/clients/event_client/openapi_client/models/event_response.py
@@ -43,8 +43,7 @@ class EventResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/v1_events_batch_post200_response.py
+++ b/analytics/clients/event_client/openapi_client/models/v1_events_batch_post200_response.py
@@ -43,8 +43,7 @@ class V1EventsBatchPost200Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/analytics/clients/event_client/openapi_client/models/v1_events_batch_post_request.py
+++ b/analytics/clients/event_client/openapi_client/models/v1_events_batch_post_request.py
@@ -43,8 +43,7 @@ class V1EventsBatchPostRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:


### PR DESCRIPTION
## Summary
- use `model_dump_json(by_alias=True, exclude_unset=True)` in analytics event client models

## Testing
- `pytest analytics/clients/event_client/openapi_client/tests`
- `pytest -k openapi_client` *(fails: 189 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68811bcaa9808320b7fd22a5c8ddca98