### PR TITLE
Fix event ingestion imports

### DIFF
--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -7,35 +7,11 @@ from yosai_framework.service import BaseService
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 
-import importlib.util
-import pathlib
-import sys
 import os
+import pathlib
 
-try:
-    from services.streaming import StreamingService
-except ModuleNotFoundError:
-    spec = importlib.util.spec_from_file_location(
-        "services.streaming",
-        pathlib.Path(__file__).resolve().parents[1] / "streaming" / "service.py",
-    )
-    streaming_mod = importlib.util.module_from_spec(spec)
-    sys.modules["services.streaming"] = streaming_mod
-    if spec.loader:
-        spec.loader.exec_module(streaming_mod)
-    StreamingService = streaming_mod.StreamingService
-try:
-    from services.security import verify_service_jwt
-except ModuleNotFoundError:
-    spec = importlib.util.spec_from_file_location(
-        "services.security",
-        pathlib.Path(__file__).resolve().parents[1] / "security" / "__init__.py",
-    )
-    security_mod = importlib.util.module_from_spec(spec)
-    sys.modules["services.security"] = security_mod
-    if spec.loader:
-        spec.loader.exec_module(security_mod)
-    verify_service_jwt = security_mod.verify_service_jwt
+from services.streaming.service import StreamingService
+from services.security import verify_service_jwt
 from tracing import trace_async_operation
 
 SERVICE_NAME = "event-ingestion-service"

--- a/tests/services/test_event_ingestion_app.py
+++ b/tests/services/test_event_ingestion_app.py
@@ -1,4 +1,4 @@
-import importlib.util
+import importlib
 import pathlib
 import sys
 import types
@@ -23,13 +23,9 @@ def load_module():
             return self
     prom_stub.Instrumentator = lambda: DummyInstr()
     sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
-    spec = importlib.util.spec_from_file_location(
-        "services.event_ingestion.app",
-        SERVICES_PATH / "event-ingestion" / "app.py",
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore[arg-type]
-    return module
+    sys.path.insert(0, str(SERVICES_PATH / "event-ingestion"))
+    sys.modules.get("services").__path__ = [str(SERVICES_PATH)]
+    return importlib.import_module("app")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- simplify streaming and security imports in event ingestion service
- use standard import in tests and provide proper module paths

## Testing
- `pytest -q tests/services/test_event_ingestion_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68811bc459bc832082e8f28d508ac5cc