### PR TITLE
Require JWT_SECRET for service tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ AUTH0_AUDIENCE=dev-audience
 
 # Security
 WTF_CSRF_ENABLED=True
+# Shared secret used for service tokens
+JWT_SECRET=
 
 # Additional
 DEBUG=1

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The gateway and analytics microservice validate several variables on
 startup:
 
 - `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` and `DB_GATEWAY_NAME` for the gateway
-- `JWT_SECRET` for the analytics microservice
+- `JWT_SECRET` for service authentication and the analytics microservice
 
 ### Production Build
 

--- a/docs/service_authentication.md
+++ b/docs/service_authentication.md
@@ -4,6 +4,9 @@ Microservices communicate using signed JWT tokens. Each service signs a short
 lived token with the shared `JWT_SECRET` environment variable. The token must
 contain an `iss` claim identifying the calling service and an `exp` claim.
 
+The helper module `services.security.jwt_service` raises a `RuntimeError`
+if `JWT_SECRET` is not defined so the secret must always be provided.
+
 Gateway and microservices validate the `Authorization` header on every request.
 If the token is missing, expired or the `iss` claim is empty, the request is
 rejected with HTTP 401.

--- a/services/security/jwt_service.py
+++ b/services/security/jwt_service.py
@@ -2,7 +2,9 @@ import os
 import time
 from jose import jwt
 
-SERVICE_JWT_SECRET = os.getenv("JWT_SECRET", "change-me")
+SERVICE_JWT_SECRET = os.getenv("JWT_SECRET")
+if not SERVICE_JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable must be set")
 
 
 def generate_service_jwt(service_name: str, expires_in: int = 300) -> str:


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when `JWT_SECRET` is absent
- document the required variable in README and docs
- add `JWT_SECRET` to `.env.example`

## Testing
- `pytest -q` *(fails: 160 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688129db47748320a963af286fd2813e