### PR TITLE
Refactor unicode helpers

### DIFF
--- a/core/plugins/decorators.py
+++ b/core/plugins/decorators.py
@@ -5,7 +5,7 @@ import logging
 from functools import wraps
 from typing import Any, Callable, Optional
 
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import sanitize_for_utf8
 
 logger = logging.getLogger(__name__)
 

--- a/core/unicode_decode.py
+++ b/core/unicode_decode.py
@@ -1,50 +1,21 @@
 from __future__ import annotations
 
-"""Lightweight Unicode decoding helpers."""
+"""Deprecated: use :mod:`core.unicode` instead."""
 
-import logging
+import warnings
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from .unicode import safe_unicode_decode as _safe_unicode_decode
 
-
-def _remove_invalid_surrogates(text: str) -> str:
-    """Return ``text`` without lone surrogate code points."""
-    out = []
-    i = 0
-    while i < len(text):
-        ch = text[i]
-        code = ord(ch)
-        if 0xD800 <= code <= 0xDBFF:
-            if i + 1 < len(text) and 0xDC00 <= ord(text[i + 1]) <= 0xDFFF:
-                out.append(ch)
-                out.append(text[i + 1])
-                i += 2
-                continue
-            i += 1
-            continue
-        if 0xDC00 <= code <= 0xDFFF:
-            i += 1
-            continue
-        out.append(ch)
-        i += 1
-    return "".join(out)
+warnings.warn(
+    "core.unicode_decode is deprecated; use core.unicode.safe_unicode_decode",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def safe_unicode_decode(data: Any, encoding: str = "utf-8") -> str:
-    """Decode ``data`` safely removing invalid surrogates."""
-    if isinstance(data, str):
-        return _remove_invalid_surrogates(data)
-
-    try:
-        text = data.decode(encoding, errors="surrogatepass")
-    except UnicodeError as exc:
-        logger.warning("Primary decode failed: %s", exc)
-        try:
-            text = data.decode(encoding, errors="replace")
-        except Exception:
-            text = data.decode("utf-8", errors="ignore")
-    return _remove_invalid_surrogates(text)
+    return _safe_unicode_decode(data, encoding)
 
 
 __all__ = ["safe_unicode_decode"]

--- a/core/unicode_enhanced.py
+++ b/core/unicode_enhanced.py
@@ -1,66 +1,20 @@
+"""Deprecated compatibility layer for :mod:`core.unicode`."""
+
 from __future__ import annotations
 
-"""Enhanced Unicode processing utilities with surrogate handling."""
+import warnings
 
-from dataclasses import dataclass
-from enum import Enum
-import logging
-import re
-import unicodedata
-from typing import Optional
+from .unicode import (
+    EnhancedUnicodeProcessor,
+    SurrogateHandlingConfig,
+    SurrogateHandlingStrategy,
+)
 
-from .unicode import contains_surrogates
-
-logger = logging.getLogger(__name__)
-
-
-class SurrogateHandlingStrategy(Enum):
-    """Strategies for handling surrogate characters."""
-
-    REPLACE = "replace"
-    REJECT = "reject"
-    STRIP = "strip"
-
-
-@dataclass
-class SurrogateHandlingConfig:
-    """Configuration for :class:`EnhancedUnicodeProcessor`."""
-
-    strategy: SurrogateHandlingStrategy = SurrogateHandlingStrategy.REPLACE
-    replacement_char: str = "\ufffd"
-    normalize_form: str = "NFC"
-    log_errors: bool = True
-
-
-_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
-
-
-class EnhancedUnicodeProcessor:
-    """Process text with configurable surrogate handling."""
-
-    def __init__(self, config: Optional[SurrogateHandlingConfig] = None) -> None:
-        self.config = config or SurrogateHandlingConfig()
-
-    def process_text(self, text: str) -> str:
-        if not text:
-            return ""
-
-        if contains_surrogates(text):
-            if self.config.strategy is SurrogateHandlingStrategy.REJECT:
-                raise UnicodeError("Surrogate characters not allowed")
-            elif self.config.strategy is SurrogateHandlingStrategy.STRIP:
-                text = _SURROGATE_RE.sub("", text)
-            else:  # REPLACE
-                text = _SURROGATE_RE.sub(self.config.replacement_char, text)
-
-        try:
-            text = unicodedata.normalize(self.config.normalize_form, text)
-        except Exception as exc:  # pragma: no cover - defensive
-            if self.config.log_errors:
-                logger.warning("Unicode normalization failed: %s", exc)
-
-        return text
-
+warnings.warn(
+    "core.unicode_enhanced is deprecated; use core.unicode instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "EnhancedUnicodeProcessor",

--- a/core/unicode_utils.py
+++ b/core/unicode_utils.py
@@ -1,59 +1,22 @@
-"""Simplified Unicode helpers used across the code base."""
+"""Deprecated compatibility layer for :mod:`core.unicode`."""
 
 from __future__ import annotations
 
-import logging
-import unicodedata
+import warnings
 from typing import Any
 
-from security.unicode_security_validator import (
-    UnicodeSecurityValidator,
-    SecurityError,
+from .unicode import (
+    UnicodeNormalizationError,
+    normalize_unicode_safely,
+    detect_surrogate_pairs,
+    sanitize_for_utf8,
 )
 
-_validator = UnicodeSecurityValidator()
-
-logger = logging.getLogger(__name__)
-
-
-class UnicodeNormalizationError(Exception):
-    """Raised when Unicode normalization fails."""
-
-
-def normalize_unicode_safely(text: Any, form: str = "NFKC") -> str:
-    """Return ``text`` normalised using ``form`` with robust error handling."""
-
-    if not isinstance(text, str):
-        try:
-            text = str(text)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to convert %r to str: %s", text, exc)
-            raise UnicodeNormalizationError(str(exc)) from exc
-
-    try:
-        return unicodedata.normalize(form, text)
-    except Exception as exc:  # pragma: no cover - best effort
-        logger.error("Unicode normalization failed: %s", exc)
-        raise UnicodeNormalizationError(str(exc)) from exc
-
-
-def detect_surrogate_pairs(text: Any) -> bool:
-    """Return ``True`` if ``text`` contains any UTF-16 surrogate pair."""
-
-    return _validator._contains_surrogates(str(text))
-
-
-def sanitize_for_utf8(value: Any) -> str:
-    """Return ``value`` cleaned and safe for UTF-8."""
-
-    try:
-        return _validator.validate_and_sanitize(value)
-    except SecurityError:
-        raise
-    except Exception as exc:  # pragma: no cover - best effort
-        logger.error("Unicode sanitization failed: %s", exc)
-        return _validator.validate_and_sanitize(str(value))
-
+warnings.warn(
+    "core.unicode_utils is deprecated; use core.unicode instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "normalize_unicode_safely",

--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -72,8 +72,7 @@ class ValidationMiddleware:
             ):
                 return None
             try:
-                from core.unicode_decode import safe_unicode_decode
-                from core.unicode_utils import sanitize_for_utf8
+                from core.unicode import safe_unicode_decode, sanitize_for_utf8
 
                 raw_text = safe_unicode_decode(request.data, "utf-8")
                 sanitized = sanitize_for_utf8(raw_text)

--- a/services/analytics_processing.py
+++ b/services/analytics_processing.py
@@ -5,8 +5,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import html
 
-from core.unicode import safe_format_number
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import safe_format_number, sanitize_for_utf8
 from services import get_analytics_service
 
 try:

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -9,8 +9,7 @@ from config.dynamic_config import dynamic_config
 from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode import process_large_csv_content
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import process_large_csv_content, sanitize_for_utf8
 from security.unicode_security_processor import sanitize_dataframe
 from services.data_processing.core.exceptions import (
     FileProcessingError,

--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -17,7 +17,7 @@ from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.unicode import safe_format_number
 from core.performance_file_processor import PerformanceFileProcessor
-from core.unicode_decode import safe_unicode_decode
+from core.unicode import safe_unicode_decode
 from analytics_core.utils.unicode_processor import UnicodeHelper
 from .file_handler import process_file_simple
 

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -17,8 +17,7 @@ from config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode import UnicodeProcessor, sanitize_dataframe
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import UnicodeProcessor, sanitize_dataframe, sanitize_for_utf8, safe_unicode_decode
 from upload_types import ValidationResult
 from .unified_upload_validator import UnifiedUploadValidator
 from .common import process_dataframe
@@ -40,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 def safe_decode_with_unicode_handling(data: bytes, encoding: str) -> str:
     """Decode bytes using ``encoding`` and sanitize output."""
-    from core.unicode_decode import safe_unicode_decode
 
     text = safe_unicode_decode(data, encoding)
 

--- a/services/data_processing/unified_upload_validator.py
+++ b/services/data_processing/unified_upload_validator.py
@@ -17,8 +17,7 @@ from config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode import UnicodeProcessor, sanitize_dataframe
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import UnicodeProcessor, sanitize_dataframe, sanitize_for_utf8
 from upload_types import ValidationResult
 from .dataframe_utils import process_dataframe
 from utils.file_utils import safe_decode_with_unicode_handling

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -219,7 +219,7 @@ class FileProcessorService(BaseService):
                     return text
             except Exception:
                 continue
-        from core.unicode_decode import safe_unicode_decode
+        from core.unicode import safe_unicode_decode
 
         logger.warning("All encodings failed, using replacement characters")
         return safe_unicode_decode(content, "utf-8")

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -16,11 +16,11 @@ from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode_decode import safe_unicode_decode
+from core.unicode import safe_unicode_decode
 from config.constants import DEFAULT_CHUNK_SIZE
 
 # Core processing imports only - NO UI COMPONENTS
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import sanitize_for_utf8
 
 
 def _get_max_display_rows(config: ConfigurationProtocol = dynamic_config) -> int:

--- a/tests/test_unicode_decode.py
+++ b/tests/test_unicode_decode.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode_decode import safe_unicode_decode
+from core.unicode import safe_unicode_decode
 
 
 def test_removes_invalid_surrogates():

--- a/tests/test_unicode_enhanced.py
+++ b/tests/test_unicode_enhanced.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode_enhanced import (
+from core.unicode import (
     EnhancedUnicodeProcessor,
     SurrogateHandlingConfig,
     SurrogateHandlingStrategy,

--- a/tests/test_unicode_unified_regression.py
+++ b/tests/test_unicode_unified_regression.py
@@ -1,0 +1,11 @@
+from core.unicode import safe_unicode_decode, sanitize_for_utf8
+
+
+def test_safe_unicode_decode_handles_surrogates():
+    data = b"A\xed\xa0\x80B"  # contains lone high surrogate
+    assert safe_unicode_decode(data) == "AB"
+
+
+def test_sanitize_for_utf8_normalizes_and_strips():
+    text = "A" + "\ud800" + "B" + "\ufeff" + "Ｃ"
+    assert sanitize_for_utf8(text) == "ABC"

--- a/tests/test_unicode_utils.py
+++ b/tests/test_unicode_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode_utils import (
+from core.unicode import (
     normalize_unicode_safely,
     detect_surrogate_pairs,
     sanitize_for_utf8,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -19,7 +19,7 @@ from core.unicode import (
     utf8_safe_encode,
     utf8_safe_decode,
 )
-from core.unicode_enhanced import (
+from core.unicode import (
     EnhancedUnicodeProcessor,
     SurrogateHandlingConfig,
     SurrogateHandlingStrategy,

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Helper utilities for working with files."""
 
 from security.unicode_security_validator import UnicodeSecurityValidator
-from core.unicode_decode import safe_unicode_decode
+from core.unicode import safe_unicode_decode
 
 _validator = UnicodeSecurityValidator()
 

--- a/utils/preview_utils.py
+++ b/utils/preview_utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
 from core.protocols import ConfigurationProtocol
-from core.unicode_utils import sanitize_for_utf8
+from core.unicode import sanitize_for_utf8
 
 
 def _get_max_display_rows(config: ConfigurationProtocol = dynamic_config) -> int:


### PR DESCRIPTION
## Summary
- fold unicode_decode, unicode_utils, and unicode_enhanced into unicode
- update imports and deprecate old modules
- add regression coverage for surrogate decoding

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: 160 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688129dcda9c8320ab783a9e5a7b7615