### PR TITLE
Remove dev secret fallback

### DIFF
--- a/config/config_validator.py
+++ b/config/config_validator.py
@@ -92,11 +92,7 @@ class ConfigValidator(ConfigValidatorProtocol):
         result = ValidationResult()
 
         if config.environment == "production":
-            if config.app.secret_key in {
-                "dev-key-change-in-production",
-                "change-me",
-                "",
-            }:
+            if config.app.secret_key in {"change-me", ""}:
                 result.errors.append("SECRET_KEY must be set for production")
             if not config.database.password and config.database.type != "sqlite":
                 result.warnings.append("Production database requires password")


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY requirement during configuration transformation
- drop references to deprecated secret fallback

## Testing
- `pytest tests/test_config_transformer.py tests/test_config_validator.py -q`
- `pytest -q` *(fails: 160 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688134130ca483208332c5286fb80e31