### PR TITLE
Refactor suggest_devices

### DIFF
--- a/device_endpoint.py
+++ b/device_endpoint.py
@@ -12,6 +12,63 @@ if not container.has("upload_processor"):
 
 device_bp = Blueprint('device', __name__)
 
+
+def load_stored_data(filename: str, upload_service) -> pd.DataFrame | None:
+    """Return the stored dataframe for *filename* from ``upload_service``."""
+    stored_data = upload_service.store.get_all_data()
+    return stored_data.get(filename)
+
+
+def determine_device_column(column_mappings: dict, df: pd.DataFrame) -> str | None:
+    """Find the source column mapped as the device name."""
+    for source_col, mapped_col in column_mappings.items():
+        if mapped_col in ["device_name", "device", "hostname"] and source_col in df.columns:
+            return source_col
+    return None
+
+
+def build_device_mappings(
+    filename: str,
+    df: pd.DataFrame,
+    device_service,
+    upload_service,
+) -> dict:
+    """Construct the device mapping dictionary for *df* and *filename*."""
+    device_mappings: dict[str, dict] = {}
+
+    user_mappings = device_service.get_user_device_mappings(filename)
+    if user_mappings:
+        for device, mapping in user_mappings.items():
+            device_mappings[device] = {
+                "device_type": mapping.get("device_type", "unknown"),
+                "location": mapping.get("location"),
+                "properties": mapping.get("properties", {}),
+                "confidence": 1.0,
+                "source": "user_confirmed",
+            }
+    else:
+        from services.ai_mapping_store import ai_mapping_store
+
+        ai_mapping_store.clear()
+        learned_applied = upload_service.auto_apply_learned_mappings(df, filename)
+
+        if not learned_applied:
+            from components import simple_device_mapping as sdm
+
+            sdm.generate_ai_device_defaults(df, "auto")
+
+        store_mappings = ai_mapping_store.all()
+        for device, mapping in store_mappings.items():
+            device_mappings[device] = {
+                "device_type": mapping.get("device_type", "unknown"),
+                "location": mapping.get("location"),
+                "properties": mapping.get("properties", {}),
+                "confidence": mapping.get("confidence", 0.8),
+                "source": mapping.get("source", "ai_suggested"),
+            }
+
+    return device_mappings
+
 @device_bp.route('/v1/ai/suggest-devices', methods=['POST'])
 def suggest_devices():
     """Get device suggestions using DeviceLearningService"""
@@ -20,70 +77,22 @@ def suggest_devices():
         filename = data.get('filename')
         column_mappings = data.get('column_mappings', {})
         
-        # Get services from shared container
         device_service = container.get("device_learning_service")
         upload_service = container.get("upload_processor")
-        
-        # Get the dataframe from store
-        stored_data = upload_service.store.get_all_data()
-        df = stored_data.get(filename)
-        
+
+        df = load_stored_data(filename, upload_service)
         if df is None:
             return error_response('not_found', 'File data not found'), 404
-        
-        # Get unique devices from data
-        devices = []
-        device_column = None
-        
-        # Find device column from mappings
-        for source_col, mapped_col in column_mappings.items():
-            if mapped_col in ['device_name', 'device', 'hostname']:
-                device_column = source_col
-                break
-        
-        if device_column and device_column in df.columns:
-            devices = df[device_column].dropna().unique().tolist()
-        
-        # Get AI/learned mappings
-        device_mappings = {}
-        
-        # First check for user-saved mappings
-        user_mappings = device_service.get_user_device_mappings(filename)
-        
-        if user_mappings:
-            # Use saved mappings
-            for device, mapping in user_mappings.items():
-                device_mappings[device] = {
-                    'device_type': mapping.get('device_type', 'unknown'),
-                    'location': mapping.get('location'),
-                    'properties': mapping.get('properties', {}),
-                    'confidence': 1.0,
-                    'source': 'user_confirmed'
-                }
-        else:
-            # Try learned mappings
-            from services.ai_mapping_store import ai_mapping_store
-            ai_mapping_store.clear()
-            
-            # Apply learned mappings
-            learned_applied = upload_service.auto_apply_learned_mappings(df, filename)
-            
-            if not learned_applied:
-                # Generate AI suggestions for new devices
-                from components import simple_device_mapping as sdm
-                sdm.generate_ai_device_defaults(df, "auto")
-            
-            # Get mappings from store
-            store_mappings = ai_mapping_store.all()
-            for device, mapping in store_mappings.items():
-                device_mappings[device] = {
-                    'device_type': mapping.get('device_type', 'unknown'),
-                    'location': mapping.get('location'),
-                    'properties': mapping.get('properties', {}),
-                    'confidence': mapping.get('confidence', 0.8),
-                    'source': mapping.get('source', 'ai_suggested')
-                }
-        
+
+        device_column = determine_device_column(column_mappings, df)
+        devices = (
+            df[device_column].dropna().unique().tolist() if device_column else []
+        )
+
+        device_mappings = build_device_mappings(
+            filename, df, device_service, upload_service
+        )
+
         return jsonify({
             'devices': devices,
             'device_mappings': device_mappings

--- a/tests/test_device_endpoint_utils.py
+++ b/tests/test_device_endpoint_utils.py
@@ -1,0 +1,89 @@
+import sys
+import types
+import pandas as pd
+
+# Provide lightweight stubs required for importing device_endpoint
+core_container_stub = types.ModuleType("core.container")
+core_container_stub.container = types.SimpleNamespace(
+    has=lambda name: True,
+    get=lambda name: None,
+)
+service_reg_stub = types.ModuleType("config.service_registration")
+service_reg_stub.register_upload_services = lambda c: None
+sys.modules.setdefault("core.container", core_container_stub)
+sys.modules.setdefault("config.service_registration", service_reg_stub)
+
+# Allow importing submodules from the real "services" package
+services_mod = sys.modules.setdefault("services", types.ModuleType("services"))
+services_mod.__path__ = [str((__file__)).rsplit("/tests/", 1)[0] + "/services"]
+
+from device_endpoint import (
+    load_stored_data,
+    determine_device_column,
+    build_device_mappings,
+)
+
+class DummyUploadService:
+    def __init__(self, df_map):
+        self.store = types.SimpleNamespace(get_all_data=lambda: df_map)
+    def auto_apply_learned_mappings(self, df, filename):
+        return False
+
+class DummyDeviceService:
+    def __init__(self, user_map=None):
+        self.user_map = user_map or {}
+    def get_user_device_mappings(self, filename):
+        return self.user_map
+
+
+def test_load_stored_data_found():
+    df = pd.DataFrame({"a": [1]})
+    svc = DummyUploadService({"file.csv": df})
+    out = load_stored_data("file.csv", svc)
+    assert out is df
+
+
+def test_load_stored_data_missing():
+    svc = DummyUploadService({})
+    out = load_stored_data("missing.csv", svc)
+    assert out is None
+
+
+def test_determine_device_column():
+    df = pd.DataFrame({"host": ["a"], "val": [1]})
+    col = determine_device_column({"host": "device"}, df)
+    assert col == "host"
+
+
+def test_determine_device_column_none():
+    df = pd.DataFrame({"host": ["a"]})
+    col = determine_device_column({"other": "device"}, df)
+    assert col is None
+
+
+def test_build_device_mappings_user():
+    df = pd.DataFrame({})
+    dsvc = DummyDeviceService({"dev": {"device_type": "door"}})
+    usvc = DummyUploadService({})
+    mapping = build_device_mappings("f.csv", df, dsvc, usvc)
+    assert mapping["dev"]["device_type"] == "door"
+    assert mapping["dev"]["source"] == "user_confirmed"
+
+
+def test_build_device_mappings_ai(monkeypatch):
+    df = pd.DataFrame({})
+    dsvc = DummyDeviceService()
+    ai_map = {"dev": {"device_type": "door", "confidence": 0.7}}
+    from services.ai_mapping_store import ai_mapping_store
+    monkeypatch.setattr(ai_mapping_store, "clear", lambda: None)
+    monkeypatch.setattr(ai_mapping_store, "all", lambda: ai_map)
+    usvc = DummyUploadService({})
+    monkeypatch.setattr(usvc, "auto_apply_learned_mappings", lambda df, fn: False)
+    sdm_stub = types.ModuleType("components.simple_device_mapping")
+    sdm_stub.generate_ai_device_defaults = lambda df, profile="auto": None
+    components_pkg = types.ModuleType("components")
+    components_pkg.simple_device_mapping = sdm_stub
+    sys.modules["components"] = components_pkg
+    sys.modules["components.simple_device_mapping"] = sdm_stub
+    mapping = build_device_mappings("f.csv", df, dsvc, usvc)
+    assert mapping["dev"]["source"] == "ai_suggested"


### PR DESCRIPTION
## Summary
- break up `suggest_devices` logic into helper functions
- add device endpoint unit tests

## Testing
- `pytest tests/test_device_endpoint_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881341729dc832099cbd1849102ce7c