### PR TITLE
Implement secure query helper

### DIFF
--- a/database/secure_exec.py
+++ b/database/secure_exec.py
@@ -33,6 +33,15 @@ def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
     raise AttributeError("Object has no execute or execute_query method")
 
 
+def execute_secure_query(
+    conn: Any, sql: str, params: Iterable[Any]
+) -> Any:
+    """Execute a parameterized SELECT query enforcing provided params."""
+    if params is None:
+        raise ValueError("params must be provided for execute_secure_query")
+    return execute_query(conn, sql, params)
+
+
 def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
     """Validate and execute a modification command on the given connection."""
     if not isinstance(sql, str):
@@ -48,4 +57,4 @@ def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None)
     raise AttributeError("Object has no execute or execute_command method")
 
 
-__all__ = ["execute_query", "execute_command"]
+__all__ = ["execute_query", "execute_command", "execute_secure_query"]


### PR DESCRIPTION
## Summary
- add `execute_secure_query` wrapper for parameterized SQL
- use `execute_secure_query` in `OptimizedQueryService`

## Testing
- `pytest tests/services/test_optimized_queries.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688153e9230883208f42987e7b03ba7b