### PR TITLE
Add secure SQL utilities and migration report

### DIFF
--- a/mappings_endpoint.py
+++ b/mappings_endpoint.py
@@ -138,4 +138,4 @@ def process_enhanced_data():
         }), 200
         
     except Exception as e:
-        return error_response('server_error', str(e)), 500
+        return error_response('server_error', clean_unicode_surrogates(e)), 500

--- a/scripts/sql_migration_report.py
+++ b/scripts/sql_migration_report.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Report and optionally fix SQL string concatenation patterns."""
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from scripts.find_sql_concat import iter_py_files, scan_file, apply_fixes
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan for unsafe SQL concatenation patterns"
+    )
+    parser.add_argument(
+        "paths", nargs="*", default=["."], help="Files or directories to scan"
+    )
+    parser.add_argument(
+        "--auto-fix", action="store_true", help="Automatically rewrite simple cases"
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    findings: list[tuple[Path, int]] = []
+    for file in iter_py_files(args.paths):
+        lines = scan_file(file)
+        if lines:
+            for ln in lines:
+                findings.append((file, ln))
+            if args.auto_fix:
+                apply_fixes(file, lines)
+
+    if findings:
+        print("Possible SQL concatenation found:")
+        for file, ln in findings:
+            print(f"{file}:{ln}")
+        if args.auto_fix:
+            print("Simple patterns were automatically rewritten. Review remaining occurrences manually.")
+        return 1
+
+    print("No SQL concatenation patterns detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -9,6 +9,10 @@ from .attack_detection import AttackDetection
 from .secrets_validator import SecretsValidator, register_health_endpoint
 from .unicode_security_validator import UnicodeSecurityValidator
 from .validation_exceptions import SecurityViolation
+from .secure_query_wrapper import (
+    execute_secure_sql,
+    execute_secure_command,
+)
 
 
 def __getattr__(name: str):
@@ -46,4 +50,6 @@ __all__ = [
     "AttackDetection",
     "SecretsValidator",
     "register_health_endpoint",
+    "execute_secure_sql",
+    "execute_secure_command",
 ]

--- a/security/secure_query_wrapper.py
+++ b/security/secure_query_wrapper.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""High level secure SQL execution helpers."""
+
+import logging
+from typing import Any, Iterable, Optional
+
+from config.unicode_handler import UnicodeQueryHandler
+from database.secure_exec import execute_query, execute_command
+from core.unicode_handler import clean_unicode_surrogates
+
+logger = logging.getLogger(__name__)
+
+
+def execute_secure_sql(
+    conn: Any, query: str, params: Optional[Iterable[Any]] = None
+) -> Any:
+    """Safely execute a read query using parameterization."""
+    if not isinstance(query, str):
+        raise TypeError("query must be a string")
+    sanitized_query = UnicodeQueryHandler.safe_encode_query(query)
+    sanitized_params = UnicodeQueryHandler.safe_encode_params(params)
+    logger.debug("Executing query: %s", sanitized_query)
+    try:
+        return execute_query(conn, sanitized_query, sanitized_params)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Query failed: %s", clean_unicode_surrogates(exc))
+        raise
+
+
+def execute_secure_command(
+    conn: Any, command: str, params: Optional[Iterable[Any]] = None
+) -> Any:
+    """Safely execute an INSERT/UPDATE/DELETE using parameterization."""
+    if not isinstance(command, str):
+        raise TypeError("command must be a string")
+    sanitized_cmd = UnicodeQueryHandler.safe_encode_query(command)
+    sanitized_params = UnicodeQueryHandler.safe_encode_params(params)
+    logger.debug("Executing command: %s", sanitized_cmd)
+    try:
+        return execute_command(conn, sanitized_cmd, sanitized_params)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Command failed: %s", clean_unicode_surrogates(exc))
+        raise
+
+
+__all__ = ["execute_secure_sql", "execute_secure_command"]

--- a/tests/test_secure_query_wrapper.py
+++ b/tests/test_secure_query_wrapper.py
@@ -1,0 +1,47 @@
+import pytest
+
+from security.secure_query_wrapper import (
+    execute_secure_sql,
+    execute_secure_command,
+)
+from config.database_exceptions import UnicodeEncodingError
+
+
+class DummyConn:
+    def __init__(self):
+        self.last = None
+
+    def execute_query(self, query: str, params: tuple | None = None):
+        self.last = (query, params)
+        return [("ok",)]
+
+    def execute_command(self, query: str, params: tuple | None = None):
+        self.last = (query, params)
+        return 1
+
+
+def test_execute_secure_sql_basic():
+    conn = DummyConn()
+    result = execute_secure_sql(conn, "SELECT 1 WHERE a=%s", ("b",))
+    assert result == [("ok",)]
+    assert conn.last == ("SELECT 1 WHERE a=%s", ("b",))
+
+
+def test_injection_through_params():
+    conn = DummyConn()
+    execute_secure_sql(conn, "SELECT 1 WHERE a=%s", ("1 OR 1=1",))
+    assert conn.last == ("SELECT 1 WHERE a=%s", ("1 OR 1=1",))
+
+
+def test_surrogate_query_rejected():
+    conn = DummyConn()
+    bad_query = "SELECT '" + chr(0xD800) + "'"
+    with pytest.raises(UnicodeEncodingError):
+        execute_secure_sql(conn, bad_query)
+
+
+def test_execute_secure_command():
+    conn = DummyConn()
+    result = execute_secure_command(conn, "DELETE FROM t WHERE id=%s", (1,))
+    assert result == 1
+    assert conn.last == ("DELETE FROM t WHERE id=%s", (1,))


### PR DESCRIPTION
## Summary
- add `execute_secure_sql` helpers for safe query execution
- expose helpers via `security.__all__`
- fix unicode sanitization in `mappings_endpoint`
- provide `sql_migration_report` script for locating SQL concatenation
- test secure query wrapper utilities

## Testing
- `python -m py_compile security/secure_query_wrapper.py tests/test_secure_query_wrapper.py scripts/sql_migration_report.py mappings_endpoint.py`
- `pytest -q tests/test_secure_query_wrapper.py::test_execute_secure_sql_basic` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68815b31b8b0832090fb669898c9d9a3