### PR TITLE
Initialize analytics cache manager on blueprint registration

### DIFF
--- a/api/analytics_endpoints.py
+++ b/api/analytics_endpoints.py
@@ -17,7 +17,13 @@ export_bp = Blueprint("export", __name__, url_prefix="/api/v1/export")
 
 # Cached analytics helper
 _cache_manager = AdvancedCacheManager(CacheConfig(timeout_seconds=300))
-asyncio.run(_cache_manager.start())
+
+
+async def init_cache_manager() -> None:
+    """Initialize the cache manager asynchronously."""
+    await _cache_manager.start()
+
+
 _cached_service = CachedAnalyticsService(_cache_manager)
 
 MOCK_DATA = {
@@ -104,6 +110,7 @@ def register_analytics_blueprints(app):
     app.register_blueprint(analytics_bp)
     app.register_blueprint(graphs_bp)
     app.register_blueprint(export_bp)
+    asyncio.run(init_cache_manager())
     logger.info("Analytics blueprints registered")
 
 


### PR DESCRIPTION
## Summary
- avoid side effects on import by removing module-level cache start
- add `init_cache_manager()` helper to start cache asynchronously
- start cache manager when registering analytics blueprints

## Testing
- `python -m py_compile api/analytics_endpoints.py`
- `pytest tests/integration/test_api_csrf.py::test_csrf_token_and_protected_endpoint -q` *(fails: ModuleNotFoundError: No module named 'flask_wtf')*

------
https://chatgpt.com/codex/tasks/task_e_68816528d6a88320ad40c28506c62dc0