### PR TITLE
Refactor input sanitization

### DIFF
--- a/core/security_validator.py
+++ b/core/security_validator.py
@@ -10,6 +10,7 @@ import secrets
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
+import html
 
 import requests
 import sqlparse
@@ -135,20 +136,8 @@ class SecurityValidator(BaseModel, SecurityServiceProtocol):
         validator = UnicodeSurrogateValidator()
         value = validator.sanitize(value)
         value = sanitize_unicode_input(value)
-        # HTML entity encoding
-        replacements = {
-            "&": "&amp;",
-            "<": "&lt;",
-            ">": "&gt;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            "/": "&#x2F;",
-        }
 
-        sanitized = value
-        for char, entity in replacements.items():
-            sanitized = sanitized.replace(char, entity)
-
+        sanitized = html.escape(value, quote=True)
         return sanitized
 
     def _validate_sql_injection(

--- a/tests/test_security_validator.py
+++ b/tests/test_security_validator.py
@@ -1,4 +1,5 @@
 import types
+import html
 import pytest
 
 from core.security_validator import (
@@ -28,14 +29,15 @@ def test_main_validation_orchestration():
     )
 
     validator = SecurityValidator()
-    result = validator.validate_input("<script>alert('xss')</script>", "comment")
+    value = "<script>alert('xss')</script>"
+    result = validator.validate_input(value, "comment")
     assert not result["valid"]
     assert result["issues"]
-    assert "sanitized" in result
+    assert result["sanitized"] == html.escape(value, quote=True)
 
 
 def test_check_permissions_allows(monkeypatch):
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, headers=None, timeout=None):
         class Resp:
             def raise_for_status(self):
                 pass
@@ -51,7 +53,7 @@ def test_check_permissions_allows(monkeypatch):
 
 
 def test_check_permissions_denied(monkeypatch):
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, headers=None, timeout=None):
         class Resp:
             def raise_for_status(self):
                 pass


### PR DESCRIPTION
## Summary
- escape unsafe characters with html.escape
- adjust unit tests for SecurityValidator

## Testing
- `pytest tests/test_security_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68816529cc6083208056d4fcbc13ba41