### PR TITLE
Fix configurable settings file with locking

### DIFF
--- a/api/settings_endpoint.py
+++ b/api/settings_endpoint.py
@@ -1,20 +1,28 @@
 import json
 import os
+from filelock import FileLock
 from flask import Blueprint, jsonify, request
 
-settings_bp = Blueprint('settings', __name__)
+settings_bp = Blueprint("settings", __name__)
 
-SETTINGS_FILE = os.path.join(os.path.dirname(__file__), 'user_settings.json')
+SETTINGS_FILE = os.getenv(
+    "YOSAI_SETTINGS_FILE",
+    os.path.join(os.path.dirname(__file__), "user_settings.json"),
+)
+LOCK_FILE = f"{SETTINGS_FILE}.lock"
 DEFAULT_SETTINGS = {
-    'theme': 'light',
-    'itemsPerPage': 10,
+    "theme": "light",
+    "itemsPerPage": 10,
 }
+
 
 def _load_settings():
     if os.path.exists(SETTINGS_FILE):
+        lock = FileLock(LOCK_FILE)
         try:
-            with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
+            with lock:
+                with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+                    return json.load(f)
         except Exception:
             pass
     return DEFAULT_SETTINGS.copy()
@@ -22,28 +30,29 @@ def _load_settings():
 
 def _save_settings(settings: dict) -> None:
     os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
-    with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
-        json.dump(settings, f)
+    lock = FileLock(LOCK_FILE)
+    with lock:
+        with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
+            json.dump(settings, f)
 
 
-@settings_bp.route('/api/v1/settings', methods=['GET'])
+@settings_bp.route("/api/v1/settings", methods=["GET"])
 def get_settings():
     """Return saved user settings or defaults."""
     settings = _load_settings()
     return jsonify(settings), 200
 
 
-@settings_bp.route('/api/v1/settings', methods=['POST', 'PUT'])
+@settings_bp.route("/api/v1/settings", methods=["POST", "PUT"])
 def update_settings():
     """Update and persist user settings."""
     data = request.get_json(silent=True) or {}
     if not isinstance(data, dict):
-        return jsonify({'error': 'Invalid payload'}), 400
+        return jsonify({"error": "Invalid payload"}), 400
     settings = _load_settings()
     settings.update(data)
     try:
         _save_settings(settings)
     except Exception as exc:
-        return jsonify({'error': str(exc)}), 500
-    return jsonify({'status': 'success', 'settings': settings}), 200
-
+        return jsonify({"error": str(exc)}), 500
+    return jsonify({"status": "success", "settings": settings}), 200


### PR DESCRIPTION
## Summary
- make settings storage path configurable via environment variable
- add file locking when reading/writing settings

## Testing
- `flake8 api/settings_endpoint.py`
- `pytest -q` *(fails: ImportError - 153 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6881c2059a048320aa21e9bfce698a4f