### PR TITLE
Centralize navbar callbacks with TrulyUnifiedCallbacks

### DIFF
--- a/components/streamlined_callback_manager.py
+++ b/components/streamlined_callback_manager.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from .streamlined_component import StreamlinedComponent
+
+
+class StreamlinedCallbackManager:
+    """Helper to register callbacks for StreamlinedComponents."""
+
+    def __init__(self, manager: TrulyUnifiedCallbacks) -> None:
+        self.manager = manager
+
+    def register_component(
+        self, component: StreamlinedComponent, controller: Any | None = None
+    ) -> None:
+        component.register_callbacks(self.manager, controller)

--- a/components/streamlined_component.py
+++ b/components/streamlined_component.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from .ui_component import UIComponent
+
+
+class StreamlinedComponent(UIComponent):
+    """Base class for UI components using TrulyUnifiedCallbacks."""
+
+    def register_callbacks(
+        self, manager: TrulyUnifiedCallbacks, controller: Any | None = None
+    ) -> None:
+        """Register Dash callbacks for the component."""
+        return None

--- a/components/ui/__init__.py
+++ b/components/ui/__init__.py
@@ -1,5 +1,9 @@
 """Shared UI components."""
 
-from .navbar import create_navbar_layout, register_navbar_callbacks
+from .navbar import (
+    create_navbar_layout,
+    register_navbar_callbacks,
+    NavbarComponent,
+)
 
-__all__ = ["create_navbar_layout", "register_navbar_callbacks"]
+__all__ = ["create_navbar_layout", "register_navbar_callbacks", "NavbarComponent"]


### PR DESCRIPTION
## Summary
- add `StreamlinedComponent` and `StreamlinedCallbackManager`
- refactor navbar callbacks to use `TrulyUnifiedCallbacks`

## Testing
- `pytest -q tests/components/test_navbar_config.py::test_register_navbar_callbacks_connects_toggle -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c226d6c883209c351a4d99871715