### PR TITLE
Add centralized Flask error handlers

### DIFF
--- a/api/openapi/yosai-api-v2.yaml
+++ b/api/openapi/yosai-api-v2.yaml
@@ -46,6 +46,8 @@ paths:
                 $ref: '#/components/schemas/EventListResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:
@@ -96,6 +98,12 @@ components:
   responses:
     BadRequest:
       description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
       content:
         application/json:
           schema:

--- a/api/risk_scoring.py
+++ b/api/risk_scoring.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from flask import jsonify, request
-
 from api.adapter import api_adapter
-from core.security_validator import SecurityValidator
+from app import app
+from flask import abort, jsonify, request
 
 from analytics.risk_scoring import calculate_risk_score
-from app import app
+from core.security_validator import SecurityValidator
 
 
 @app.route("/api/v1/risk/score", methods=["POST"])
@@ -17,13 +16,15 @@ def calculate_score_endpoint():
     payload = request.get_json(silent=True) or {}
     for key, value in payload.items():
         check = SecurityValidator().validate_input(str(value), key)
-        if not check['valid']:
-            return jsonify({"error": "Invalid parameter", "issues": check['issues']}), 400
+        if not check["valid"]:
+            abort(400, description="Invalid parameter")
 
     anomaly = float(payload.get("anomaly_score", 0))
     patterns = float(payload.get("pattern_score", 0))
     behavior = float(payload.get("behavior_deviation", 0))
 
     result = calculate_risk_score(anomaly, patterns, behavior)
-    safe = api_adapter.unicode_processor.process_dict({"score": result.score, "level": result.level})
+    safe = api_adapter.unicode_processor.process_dict(
+        {"score": result.score, "level": result.level}
+    )
     return jsonify(safe)

--- a/api/settings_endpoint.py
+++ b/api/settings_endpoint.py
@@ -1,7 +1,8 @@
 import json
 import os
+
 from filelock import FileLock
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, abort, jsonify, request
 
 settings_bp = Blueprint("settings", __name__)
 
@@ -48,11 +49,11 @@ def update_settings():
     """Update and persist user settings."""
     data = request.get_json(silent=True) or {}
     if not isinstance(data, dict):
-        return jsonify({"error": "Invalid payload"}), 400
+        abort(400, description="Invalid payload")
     settings = _load_settings()
     settings.update(data)
     try:
         _save_settings(settings)
     except Exception as exc:
-        return jsonify({"error": str(exc)}), 500
+        abort(500, description=str(exc))
     return jsonify({"status": "success", "settings": settings}), 200

--- a/core/app_factory/__init__.py
+++ b/core/app_factory/__init__.py
@@ -2,11 +2,12 @@
 """Fresh, minimal app factory."""
 
 import dash
-from dash import html, dcc
 import dash_bootstrap_components as dbc
+from dash import dcc, html
 
 # Import Path for building robust file paths
 from components.ui.navbar import create_navbar_layout
+from core.error_handlers import register_error_handlers
 
 
 def create_app(mode=None, **kwargs):
@@ -17,6 +18,7 @@ def create_app(mode=None, **kwargs):
         external_stylesheets=[dbc.themes.BOOTSTRAP],
     )
 
+    register_error_handlers(app.server)
     # Simple working layout
     app.layout = html.Div(
         [

--- a/core/error_handlers.py
+++ b/core/error_handlers.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from flask import Flask, jsonify
+from werkzeug.exceptions import HTTPException
+
+from core.exceptions import YosaiBaseException
+from shared.errors.types import ErrorCode
+
+_CODE_TO_STATUS: dict[ErrorCode, int] = {
+    ErrorCode.INVALID_INPUT: 400,
+    ErrorCode.UNAUTHORIZED: 401,
+    ErrorCode.NOT_FOUND: 404,
+    ErrorCode.INTERNAL: 500,
+    ErrorCode.UNAVAILABLE: 503,
+}
+
+
+def _json_body(code: ErrorCode | str, message: str, details: Optional[Any] = None):
+    if isinstance(code, ErrorCode):
+        code = code.value
+    body = {"code": code, "message": message}
+    if details is not None:
+        body["details"] = details
+    return jsonify(body)
+
+
+def register_error_handlers(app: Flask) -> None:
+    """Register global JSON error handlers on *app*."""
+
+    @app.errorhandler(YosaiBaseException)
+    def _handle_yosai_error(error: YosaiBaseException):  # type: ignore[missing-return-type]
+        status = _CODE_TO_STATUS.get(error.error_code, 500)
+        return _json_body(error.error_code, error.message, error.details), status
+
+    @app.errorhandler(HTTPException)
+    def _handle_http_exception(error: HTTPException):  # type: ignore[missing-return-type]
+        code = error.code or 500
+        mapping = {
+            400: ErrorCode.INVALID_INPUT,
+            401: ErrorCode.UNAUTHORIZED,
+            404: ErrorCode.NOT_FOUND,
+            503: ErrorCode.UNAVAILABLE,
+        }
+        err_code = mapping.get(code, ErrorCode.INTERNAL)
+        return _json_body(err_code, error.description), code
+
+    @app.errorhandler(Exception)
+    def _handle_generic(error: Exception):  # type: ignore[missing-return-type]
+        return _json_body(ErrorCode.INTERNAL, str(error)), 500

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,156 +1,104 @@
 {
-  "components": {
-    "responses": {
-      "BadRequest": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        },
-        "description": "Bad request"
-      }
-    },
-    "schemas": {
-      "AccessEvent": {
-        "properties": {
-          "door_id": {
-            "type": "string"
-          },
-          "event_id": {
-            "type": "string"
-          },
-          "person_id": {
-            "type": "string"
-          },
-          "result": {
-            "enum": [
-              "granted",
-              "denied",
-              "tailgating",
-              "forced"
-            ],
-            "type": "string"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "person_id",
-          "door_id",
-          "timestamp"
-        ],
-        "type": "object"
-      },
-      "Error": {
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "details": {
-            "additionalProperties": true,
-            "type": "object"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "type": "object"
-      },
-      "EventListResponse": {
-        "properties": {
-          "events": {
-            "items": {
-              "$ref": "#/components/schemas/AccessEvent"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "in": "header",
-        "name": "X-API-Key",
-        "type": "apiKey"
-      },
-      "bearerAuth": {
-        "bearerFormat": "JWT",
-        "scheme": "bearer",
-        "type": "http"
-      }
-    }
-  },
-  "info": {
-    "contact": {
-      "email": "api-support@yosai.com"
-    },
-    "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) or API key authentication.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
-    "license": {
-      "name": "Apache 2.0",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
-    },
-    "termsOfService": "https://yosai.com/terms",
-    "title": "Yōsai Intel Dashboard API",
-    "version": "2.0.0"
-  },
-  "openapi": "3.0.3",
-  "paths": {
-    "/events": {
-      "get": {
-        "operationId": "listAccessEvents",
+    "components": {
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventListResponse"
-                }
-              }
+            "BadRequest": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Error"}
+                    }
+                },
+                "description": "Bad request",
             },
-            "description": "Successful response"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          }
+            "NotFound": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Error"}
+                    }
+                },
+                "description": "Resource not found",
+            },
         },
-        "summary": "List access events",
-        "tags": [
-          "Events"
-        ]
-      }
-    }
-  },
-  "servers": [
-    {
-      "description": "Production",
-      "url": "https://api.yosai.com/v2"
+        "schemas": {
+            "AccessEvent": {
+                "properties": {
+                    "door_id": {"type": "string"},
+                    "event_id": {"type": "string"},
+                    "person_id": {"type": "string"},
+                    "result": {
+                        "enum": ["granted", "denied", "tailgating", "forced"],
+                        "type": "string",
+                    },
+                    "timestamp": {"format": "date-time", "type": "string"},
+                },
+                "required": ["person_id", "door_id", "timestamp"],
+                "type": "object",
+            },
+            "Error": {
+                "properties": {
+                    "code": {"type": "string"},
+                    "details": {"additionalProperties": true, "type": "object"},
+                    "message": {"type": "string"},
+                },
+                "required": ["code", "message"],
+                "type": "object",
+            },
+            "EventListResponse": {
+                "properties": {
+                    "events": {
+                        "items": {"$ref": "#/components/schemas/AccessEvent"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+        },
+        "securitySchemes": {
+            "apiKey": {"in": "header", "name": "X-API-Key", "type": "apiKey"},
+            "bearerAuth": {"bearerFormat": "JWT", "scheme": "bearer", "type": "http"},
+        },
     },
-    {
-      "description": "Staging",
-      "url": "https://staging-api.yosai.com/v2"
+    "info": {
+        "contact": {"email": "api-support@yosai.com"},
+        "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) or API key authentication.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+        },
+        "termsOfService": "https://yosai.com/terms",
+        "title": "Yōsai Intel Dashboard API",
+        "version": "2.0.0",
     },
-    {
-      "description": "Development",
-      "url": "http://localhost:8080/v2"
-    }
-  ],
-  "tags": [
-    {
-      "description": "Access control events",
-      "name": "Events"
+    "openapi": "3.0.3",
+    "paths": {
+        "/events": {
+            "get": {
+                "operationId": "listAccessEvents",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventListResponse"
+                                }
+                            }
+                        },
+                        "description": "Successful response",
+                    },
+                    "400": {"$ref": "#/components/responses/BadRequest"},
+                    "404": {"$ref": "#/components/responses/NotFound"},
+                },
+                "summary": "List access events",
+                "tags": ["Events"],
+            }
+        }
     },
-    {
-      "description": "Analytics and reporting",
-      "name": "Analytics"
-    }
-  ]
+    "servers": [
+        {"description": "Production", "url": "https://api.yosai.com/v2"},
+        {"description": "Staging", "url": "https://staging-api.yosai.com/v2"},
+        {"description": "Development", "url": "http://localhost:8080/v2"},
+    ],
+    "tags": [
+        {"description": "Access control events", "name": "Events"},
+        {"description": "Analytics and reporting", "name": "Analytics"},
+    ],
 }

--- a/mappings_endpoint.py
+++ b/mappings_endpoint.py
@@ -1,80 +1,82 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, abort, jsonify, request
 
-from utils.api_error import error_response
-from core.unicode_handler import clean_unicode_surrogates
+from config.service_registration import register_upload_services
 
 # Shared container ensures services are available across blueprints
 from core.container import container
-from config.service_registration import register_upload_services
+from core.unicode_handler import clean_unicode_surrogates
 
 if not container.has("upload_processor"):
     register_upload_services(container)
 
-mappings_bp = Blueprint('mappings', __name__)
+mappings_bp = Blueprint("mappings", __name__)
 
-@mappings_bp.route('/v1/mappings/columns', methods=['POST'])
+
+@mappings_bp.route("/v1/mappings/columns", methods=["POST"])
 def save_column_mappings_route():
     """Persist column mappings for a processed file."""
     try:
         payload = request.get_json(force=True)
-        file_id = payload.get('file_id')
-        mappings = payload.get('mappings', {})
+        file_id = payload.get("file_id")
+        mappings = payload.get("mappings", {})
 
         if not file_id:
-            return error_response('missing_file_id', 'file_id is required'), 400
+            abort(400, description="file_id is required")
 
-        service = container.get('consolidated_learning_service')
+        service = container.get("consolidated_learning_service")
         service.save_column_mappings(file_id, mappings)
 
-        return jsonify({'status': 'success'}), 200
+        return jsonify({"status": "success"}), 200
     except KeyError as exc:
-        return error_response('server_error', clean_unicode_surrogates(exc)), 500
+        abort(500, description=clean_unicode_surrogates(exc))
     except Exception as exc:
-        return error_response('server_error', clean_unicode_surrogates(exc)), 500
+        abort(500, description=clean_unicode_surrogates(exc))
 
-@mappings_bp.route('/v1/mappings/devices', methods=['POST'])
+
+@mappings_bp.route("/v1/mappings/devices", methods=["POST"])
 def save_device_mappings_route():
     """Persist device mappings for a processed file."""
     try:
         payload = request.get_json(force=True)
-        file_id = payload.get('file_id')
-        mappings = payload.get('mappings', {})
+        file_id = payload.get("file_id")
+        mappings = payload.get("mappings", {})
 
         if not file_id:
-            return error_response('missing_file_id', 'file_id is required'), 400
+            abort(400, description="file_id is required")
 
-        service = container.get('device_learning_service')
+        service = container.get("device_learning_service")
         service.save_device_mappings(file_id, mappings)
 
-        return jsonify({'status': 'success'}), 200
+        return jsonify({"status": "success"}), 200
     except KeyError as exc:
-        return error_response('server_error', clean_unicode_surrogates(exc)), 500
+        abort(500, description=clean_unicode_surrogates(exc))
     except Exception as exc:
-        return error_response('server_error', clean_unicode_surrogates(exc)), 500
+        abort(500, description=clean_unicode_surrogates(exc))
 
-@mappings_bp.route('/v1/mappings/save', methods=['POST'])
+
+@mappings_bp.route("/v1/mappings/save", methods=["POST"])
 def save_mappings():
     """Save column or device mappings"""
     try:
         data = request.json
-        filename = data.get('filename')
-        mapping_type = data.get('mapping_type')
-        
+        filename = data.get("filename")
+        mapping_type = data.get("mapping_type")
+
         # Get services
 
-        if mapping_type == 'column':
+        if mapping_type == "column":
             # Save column mappings
-            column_mappings = data.get('column_mappings', {})
-            
+            column_mappings = data.get("column_mappings", {})
+
             # Use consolidated learning service if available
             learning_service = container.get("consolidated_learning_service")
             if learning_service:
                 learning_service.save_column_mappings(filename, column_mappings)
-            
-        elif mapping_type == 'device':
+
+        elif mapping_type == "device":
             # Save device mappings
-            device_mappings = data.get('device_mappings', {})
-            
+            device_mappings = data.get("device_mappings", {})
+
             device_service = container.get("device_learning_service")
             if device_service:
                 # Save each device mapping
@@ -82,60 +84,66 @@ def save_mappings():
                     device_service.save_user_device_mapping(
                         filename=filename,
                         device_name=device_name,
-                        device_type=mapping.get('device_type', 'unknown'),
-                        location=mapping.get('location'),
-                        properties=mapping.get('properties', {})
+                        device_type=mapping.get("device_type", "unknown"),
+                        location=mapping.get("location"),
+                        properties=mapping.get("properties", {}),
                     )
-        
-        return jsonify({'status': 'success'}), 200
+
+        return jsonify({"status": "success"}), 200
 
     except Exception as e:
-        return error_response('server_error', clean_unicode_surrogates(e)), 500
+        abort(500, description=clean_unicode_surrogates(e))
 
-@mappings_bp.route('/v1/process-enhanced', methods=['POST'])
+
+@mappings_bp.route("/v1/process-enhanced", methods=["POST"])
 def process_enhanced_data():
     """Process data with applied mappings"""
     try:
         data = request.json
-        filename = data.get('filename')
-        column_mappings = data.get('column_mappings', {})
-        device_mappings = data.get('device_mappings', {})
-        
+        filename = data.get("filename")
+        column_mappings = data.get("column_mappings", {})
+        device_mappings = data.get("device_mappings", {})
+
         # Get services
         upload_service = container.get("upload_processor")
-        
+
         # Get the dataframe
         stored_data = upload_service.store.get_all_data()
         df = stored_data.get(filename)
-        
+
         if df is None:
-            return error_response('not_found', 'File data not found'), 404
-        
+            abort(404, description="File data not found")
+
         # Apply column mappings (rename columns)
         if column_mappings:
             df = df.rename(columns=column_mappings)
-        
+
         # Apply device mappings (add device metadata)
         if device_mappings:
             # Add device type column if device_name exists
-            if 'device_name' in df.columns:
-                df['device_type'] = df['device_name'].map(
-                    lambda x: device_mappings.get(x, {}).get('device_type', 'unknown')
+            if "device_name" in df.columns:
+                df["device_type"] = df["device_name"].map(
+                    lambda x: device_mappings.get(x, {}).get("device_type", "unknown")
                 )
-                df['location'] = df['device_name'].map(
-                    lambda x: device_mappings.get(x, {}).get('location', '')
+                df["location"] = df["device_name"].map(
+                    lambda x: device_mappings.get(x, {}).get("location", "")
                 )
-        
+
         # Store enhanced data
         enhanced_filename = f"enhanced_{filename}"
         upload_service.store.store_data(enhanced_filename, df)
-        
-        return jsonify({
-            'status': 'success',
-            'enhanced_filename': enhanced_filename,
-            'rows': len(df),
-            'columns': len(df.columns)
-        }), 200
-        
+
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "enhanced_filename": enhanced_filename,
+                    "rows": len(df),
+                    "columns": len(df.columns),
+                }
+            ),
+            200,
+        )
+
     except Exception as e:
-        return error_response('server_error', clean_unicode_surrogates(e)), 500
+        abort(500, description=clean_unicode_surrogates(e))


### PR DESCRIPTION
## Summary
- add `core/error_handlers.py` and register in app factory
- rely on the new handlers in API endpoints
- update OpenAPI spec and regenerate `docs/openapi.json`

## Testing
- `pre-commit run --files api/analytics_endpoints.py api/openapi/yosai-api-v2.yaml api/plugin_performance.py api/risk_scoring.py api/settings_endpoint.py core/app_factory/__init__.py device_endpoint.py docs/openapi.json mappings_endpoint.py upload_endpoint.py core/error_handlers.py`
- `mypy api/analytics_endpoints.py api/plugin_performance.py api/risk_scoring.py api/settings_endpoint.py core/app_factory/__init__.py device_endpoint.py mappings_endpoint.py upload_endpoint.py core/error_handlers.py` *(fails: missing imports)*
- `pytest tests/test_upload_endpoint.py tests/test_mappings_endpoint.py` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881cfecc65c83208bfe0040217d54f7