### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,11 @@ jobs:
       - name: PyTest
         run: |
           set -xe
-          LIGHTWEIGHT_SERVICES=1 pytest --maxfail=1 --disable-warnings -q --cov=.
+          LIGHTWEIGHT_SERVICES=1 pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - name: Go Coverage
         run: |
           set -xe

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci.yml/badge.svg)](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci.yml)
 [![CI/CD](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/WSG23/yosai_intel_dashboard_fresh/actions/workflows/ci-cd.yml)
+[![codecov](https://codecov.io/gh/WSG23/yosai_intel_dashboard_fresh/branch/main/graph/badge.svg)](https://codecov.io/gh/WSG23/yosai_intel_dashboard_fresh)
 
 An AI-powered modular security intelligence dashboard for physical access control monitoring.
 


### PR DESCRIPTION
## Summary
- run pytest with coverage XML in ci workflow
- upload coverage to Codecov
- show coverage badge in README

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=xml` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6881cff085b8832088c9a6baa3e21ca3