### PR TITLE
Add model performance monitoring

### DIFF
--- a/analytics/anomaly_detection/ml_inference.py
+++ b/analytics/anomaly_detection/ml_inference.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+
+from monitoring.model_performance_monitor import (
+    ModelMetrics,
+    get_model_performance_monitor,
+)
 from utils.sklearn_compat import optional_import
 
 IsolationForest = optional_import("sklearn.ensemble.IsolationForest")
@@ -127,4 +132,15 @@ def detect_ml_anomalies(
             )
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("ML anomaly detection failed: %s", exc)
+    finally:
+        if len(df) > 0:
+            metrics = ModelMetrics(
+                accuracy=1.0 - len(anomalies) / len(df),
+                precision=0.0,
+                recall=0.0,
+            )
+            monitor = get_model_performance_monitor()
+            monitor.log_metrics(metrics)
+            if monitor.detect_drift(metrics):
+                logger.warning("Model drift detected")
     return anomalies

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+
+from monitoring.model_performance_monitor import (
+    ModelMetrics,
+    get_model_performance_monitor,
+)
 from utils.sklearn_compat import optional_import
 
 KMeans = optional_import("sklearn.cluster.KMeans")
@@ -125,6 +130,16 @@ class UserBehaviorAnalyzer:
             recommendations = self._generate_behavioral_recommendations(
                 high_risk_count, global_patterns
             )
+
+            metrics = ModelMetrics(
+                accuracy=1.0 - high_risk_count / len(user_features),
+                precision=0.0,
+                recall=0.0,
+            )
+            monitor = get_model_performance_monitor()
+            monitor.log_metrics(metrics)
+            if monitor.detect_drift(metrics):
+                self.logger.warning("Behavior model drift detected")
 
             return BehaviorAnalysis(
                 total_users_analyzed=len(user_features),

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,28 @@
+# Model Performance Monitoring
+
+`ModelPerformanceMonitor` tracks accuracy, precision and recall for ML models.
+Metrics are forwarded to the global `PerformanceMonitor` and exposed via
+Prometheus gauges.
+
+```python
+from monitoring.model_performance_monitor import (
+    ModelMetrics,
+    get_model_performance_monitor,
+)
+
+monitor = get_model_performance_monitor()
+metrics = ModelMetrics(accuracy=0.95, precision=0.92, recall=0.90)
+monitor.log_metrics(metrics)
+if monitor.detect_drift(metrics):
+    print("Model drift detected")
+```
+
+To expose the metrics for Prometheus scraping start the server:
+
+```python
+from monitoring.prometheus.model_metrics import start_model_metrics_server
+start_model_metrics_server(port=9104)
+```
+
+`model_accuracy`, `model_precision` and `model_recall` gauges will then be
+available on `/metrics`.

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -8,6 +8,11 @@ from .data_quality_monitor import (
     get_data_quality_monitor,
 )
 from .kafka_health import check_cluster_health
+from .model_performance_monitor import (
+    ModelMetrics,
+    ModelPerformanceMonitor,
+    get_model_performance_monitor,
+)
 from .ui_monitor import RealTimeUIMonitor, get_ui_monitor
 
 __all__ = [
@@ -15,6 +20,9 @@ __all__ = [
     "DataQualityMonitor",
     "DataQualityMetrics",
     "get_data_quality_monitor",
+    "ModelPerformanceMonitor",
+    "ModelMetrics",
+    "get_model_performance_monitor",
     "RealTimeUIMonitor",
     "get_ui_monitor",
     "check_cluster_health",

--- a/monitoring/model_performance_monitor.py
+++ b/monitoring/model_performance_monitor.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Utilities for tracking ML model performance."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from core.performance import MetricType, get_performance_monitor
+from monitoring.prometheus.model_metrics import update_model_metrics
+
+
+@dataclass
+class ModelMetrics:
+    """Container for common model evaluation metrics."""
+
+    accuracy: float
+    precision: float
+    recall: float
+
+
+class ModelPerformanceMonitor:
+    """Log model metrics and detect simple performance drift."""
+
+    def __init__(
+        self, baseline: Optional[ModelMetrics] = None, drift_threshold: float = 0.05
+    ) -> None:
+        self.baseline = baseline
+        self.drift_threshold = drift_threshold
+
+    # ------------------------------------------------------------------
+    def log_metrics(self, metrics: ModelMetrics) -> None:
+        """Record metrics using :class:`PerformanceMonitor`."""
+        monitor = get_performance_monitor()
+        monitor.record_metric(
+            "model.accuracy", metrics.accuracy, MetricType.FILE_PROCESSING
+        )
+        monitor.record_metric(
+            "model.precision", metrics.precision, MetricType.FILE_PROCESSING
+        )
+        monitor.record_metric(
+            "model.recall", metrics.recall, MetricType.FILE_PROCESSING
+        )
+        update_model_metrics(metrics)
+
+    # ------------------------------------------------------------------
+    def detect_drift(self, metrics: ModelMetrics) -> bool:
+        """Return ``True`` if metrics deviate from the baseline by ``drift_threshold``."""
+        if not self.baseline:
+            return False
+        return any(
+            abs(getattr(metrics, field) - getattr(self.baseline, field))
+            > self.drift_threshold
+            for field in ("accuracy", "precision", "recall")
+        )
+
+
+_model_performance_monitor: Optional[ModelPerformanceMonitor] = None
+
+
+def get_model_performance_monitor() -> ModelPerformanceMonitor:
+    """Return the global :class:`ModelPerformanceMonitor` instance."""
+    global _model_performance_monitor
+    if _model_performance_monitor is None:
+        _model_performance_monitor = ModelPerformanceMonitor()
+    return _model_performance_monitor
+
+
+__all__ = [
+    "ModelMetrics",
+    "ModelPerformanceMonitor",
+    "get_model_performance_monitor",
+]

--- a/monitoring/prometheus/model_metrics.py
+++ b/monitoring/prometheus/model_metrics.py
@@ -1,0 +1,45 @@
+"""Prometheus metrics for ML model performance."""
+
+from prometheus_client import REGISTRY, Gauge, start_http_server
+from prometheus_client.core import CollectorRegistry
+
+if "model_accuracy" not in REGISTRY._names_to_collectors:
+    model_accuracy = Gauge("model_accuracy", "Latest model accuracy")
+    model_precision = Gauge("model_precision", "Latest model precision")
+    model_recall = Gauge("model_recall", "Latest model recall")
+else:  # pragma: no cover - defensive in tests
+    model_accuracy = Gauge(
+        "model_accuracy", "Latest model accuracy", registry=CollectorRegistry()
+    )
+    model_precision = Gauge(
+        "model_precision", "Latest model precision", registry=CollectorRegistry()
+    )
+    model_recall = Gauge(
+        "model_recall", "Latest model recall", registry=CollectorRegistry()
+    )
+
+_metrics_started = False
+
+
+def start_model_metrics_server(port: int = 8005) -> None:
+    """Expose model metrics on ``port`` if not already started."""
+    global _metrics_started
+    if not _metrics_started:
+        start_http_server(port)
+        _metrics_started = True
+
+
+def update_model_metrics(metrics) -> None:
+    """Update Prometheus gauges using ``metrics``."""
+    model_accuracy.set(metrics.accuracy)
+    model_precision.set(metrics.precision)
+    model_recall.set(metrics.recall)
+
+
+__all__ = [
+    "model_accuracy",
+    "model_precision",
+    "model_recall",
+    "start_model_metrics_server",
+    "update_model_metrics",
+]


### PR DESCRIPTION
## Summary
- implement `ModelPerformanceMonitor` for logging model metrics and drift detection
- expose Prometheus gauges in `monitoring/prometheus/model_metrics.py`
- integrate monitoring into ML analysis flows
- document usage of the new monitor

## Testing
- `make test` *(fails: 162 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6881cff0ff048320b245e989c436fa7f