### PR TITLE
Add database schema docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)
 - [Data Processing](docs/data_processing.md)
+- [Database Schema](docs/database_schema.md)
 - [Column Verification](docs/column_verification.md)
 - [Service Container](docs/service_container.md)
 - [Distributed State Management](docs/distributed_state.md)

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,0 +1,83 @@
+# Database Schema
+
+This reference summarises the main tables used by the dashboard. Full DDL files can be found under `deployment/` and `migrations/`.
+
+## access_events
+
+Stores every access control event from the facility devices. The table is configured as a hypertable when TimescaleDB is enabled.
+
+```sql
+CREATE TABLE IF NOT EXISTS access_events (
+    event_id VARCHAR(50) PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    person_id VARCHAR(50),
+    door_id VARCHAR(50) REFERENCES doors(door_id),
+    access_result VARCHAR(20) NOT NULL
+    -- additional columns omitted
+);
+```
+
+## anomaly_detections
+
+Links AI-detected anomalies to the originating event.
+
+```sql
+CREATE TABLE IF NOT EXISTS anomaly_detections (
+    anomaly_id VARCHAR(50) PRIMARY KEY,
+    event_id VARCHAR(50) REFERENCES access_events(event_id),
+    anomaly_type VARCHAR(50) NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## incident_tickets
+
+Tracks incident tickets that require human follow-up.
+
+```sql
+CREATE TABLE IF NOT EXISTS incident_tickets (
+    ticket_id VARCHAR(50) PRIMARY KEY,
+    event_id VARCHAR(50) REFERENCES access_events(event_id),
+    status VARCHAR(30) DEFAULT 'new',
+    threat_score INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## behavior_baselines
+
+Used by analytics modules to persist typical behaviour metrics for people, doors and facilities.
+
+```sql
+CREATE TABLE IF NOT EXISTS behavior_baselines (
+    entity_type VARCHAR(10) NOT NULL,
+    entity_id VARCHAR(50) NOT NULL,
+    metric VARCHAR(50) NOT NULL,
+    value FLOAT NOT NULL,
+    PRIMARY KEY (entity_type, entity_id, metric)
+);
+```
+
+## RBAC tables
+
+Role-based access control relies on four tables to map roles and permissions to users.
+
+```sql
+CREATE TABLE IF NOT EXISTS roles (...);
+CREATE TABLE IF NOT EXISTS permissions (...);
+CREATE TABLE IF NOT EXISTS role_permissions (...);
+CREATE TABLE IF NOT EXISTS user_roles (...);
+```
+
+## Index Optimizer
+
+`database.index_optimizer.IndexOptimizer` inspects existing indexes and can suggest new ones. Use the CLI helper to analyse usage or create recommendations:
+
+```bash
+python -m services.index_optimizer_cli analyze
+python -m services.index_optimizer_cli create <table> <column> [column...]
+```
+
+The `analyze_index_usage()` method returns current statistics while `recommend_new_indexes()` emits `CREATE INDEX` statements if columns are not indexed.
+

--- a/docs/pre-deployment-checklist.md
+++ b/docs/pre-deployment-checklist.md
@@ -8,11 +8,14 @@ Follow this checklist before rolling out a new release to ensure the database sc
 2. **Preview the migrations**
    - Run `python scripts/migrate.py --dry-run` to output the SQL statements without executing them.
    - Review the output for unexpected changes.
-3. **Apply migrations**
+3. **Review expected schema**
+   - Compare the planned changes with the reference in [docs/database_schema.md](database_schema.md).
+4. **Apply migrations**
    - Execute `python scripts/migrate.py` from a clean git working tree.
    - The script aborts if uncommitted changes are detected and automatically rolls back on failure.
-4. **Verify results**
+5. **Verify results**
    - Check that all Alembic versions tables show the latest revision for each database.
    - For TimescaleDB tables, ensure hypertables exist using `\dx` and `\dt+` in `psql`.
-5. **Backup**
+   - Run `python -m services.index_optimizer_cli analyze` to identify any missing indexes.
+6. **Backup**
    - Take a fresh database backup after successful migration as part of the release procedure.


### PR DESCRIPTION
## Summary
- document major database tables and index optimizer usage in `docs/database_schema.md`
- link to the new docs from the README
- update pre-deployment checklist to reference schema docs and index optimizer

## Testing
- `pytest tests/database/test_index_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cff368948320b686eca00c929d3d