### PR TITLE
Switch some print calls to logging

### DIFF
--- a/archive/mvp/mvp_cli_engine.py
+++ b/archive/mvp/mvp_cli_engine.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 import argparse
 import json
 from pathlib import Path
@@ -73,12 +78,12 @@ def process_file(
     filepath: Path, output: Path, validate_only: bool, debug: bool
 ) -> None:
     if debug:
-        print(f"Processing {filepath} -> {output}")
+        logger.info(f"Processing {filepath} -> {output}")
     df = load_dataframe(filepath, debug=debug)
     verifier = DataVerificationComponent()
     df, mapping = verifier.verify_dataframe(df)
     if validate_only:
-        print("Validation complete. Exiting due to --validate-only flag.")
+        logger.info("Validation complete. Exiting due to --validate-only flag.")
         return
     if Processor:
         try:
@@ -90,7 +95,7 @@ def process_file(
     out_file = output / f"{filepath.stem}_analytics.json"
     safe_file_write(out_file, json.dumps(analytics, indent=2))
     verifier.save_verification(mapping, output / f"{filepath.stem}_verification.json")
-    print(f"✅ Results saved to {output}")
+    logger.info(f"✅ Results saved to {output}")
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -112,7 +117,7 @@ def main(argv: list[str] | None = None) -> None:
             import traceback
 
             traceback.print_exc()
-        print(f"❌ Processing failed: {clean_text(str(exc))}")
+        logger.error(f"❌ Processing failed: {clean_text(str(exc))}")
 
 
 if __name__ == "__main__":

--- a/scripts/register_schemas.py
+++ b/scripts/register_schemas.py
@@ -1,5 +1,10 @@
 """Register Avro schemas with the Confluent Schema Registry."""
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 from __future__ import annotations
 
 import json
@@ -33,7 +38,9 @@ def register_schema(file_path: Path) -> bool:
     url = f"{SCHEMA_REGISTRY_URL}/subjects/{subject}/versions"
     response = requests.post(url, headers=HEADERS, data=payload, timeout=10)
     if response.status_code >= 300:
-        print(f"Failed to register {subject}: {response.status_code} {response.text}", file=sys.stderr)
+        logger.error(
+            f"Failed to register {subject}: {response.status_code} {response.text}"
+        )
         return False
 
     # Try to read version from response, otherwise fetch it
@@ -41,14 +48,13 @@ def register_schema(file_path: Path) -> bool:
     if version is None:
         vers_resp = requests.get(url.rsplit("/", 1)[0] + "/versions", timeout=10)
         if vers_resp.status_code >= 300:
-            print(
-                f"Failed retrieving version for {subject}: {vers_resp.status_code} {vers_resp.text}",
-                file=sys.stderr,
+            logger.error(
+                f"Failed retrieving version for {subject}: {vers_resp.status_code} {vers_resp.text}"
             )
             return False
         version = max(vers_resp.json())
 
-    print(f"Registered {subject} version {version}")
+    logger.info(f"Registered {subject} version {version}")
     return True
 
 


### PR DESCRIPTION
## Summary
- use logger in MVP CLI engine
- use logger when registering schemas

## Testing
- `pip install -r requirements-test.txt --quiet`
- `pytest -k 'mvp_cli_engine or register_schemas' -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6881cffda2ac8320adb53f76afca3f8a