### PR TITLE
Refactor mapping persistence into shared service

### DIFF
--- a/services/mappings.py
+++ b/services/mappings.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from core.container import container
+
+
+def _ensure_services() -> None:
+    """Ensure upload-related services are registered."""
+    if container.has("upload_processor"):
+        return
+    try:  # pragma: no cover - optional registration
+        from config.service_registration import register_upload_services
+    except Exception:
+        return
+
+    register_upload_services(container)
+
+
+def save_column_mappings(file_id: str, mappings: Dict[str, str]) -> None:
+    """Persist column mappings for *file_id* using the configured service."""
+    _ensure_services()
+    service = container.get("consolidated_learning_service")
+    service.save_column_mappings(file_id, mappings)
+
+
+def save_device_mappings(file_id: str, mappings: Dict[str, Any]) -> None:
+    """Persist device mappings for *file_id* using the configured service."""
+    _ensure_services()
+    service = container.get("device_learning_service")
+    if hasattr(service, "save_device_mappings"):
+        try:
+            service.save_device_mappings(file_id, mappings)
+            return
+        except TypeError:
+            pass
+    if hasattr(service, "save_user_device_mapping"):
+        for device_name, mapping in mappings.items():
+            service.save_user_device_mapping(
+                filename=file_id,
+                device_name=device_name,
+                device_type=mapping.get("device_type", "unknown"),
+                location=mapping.get("location"),
+                properties=mapping.get("properties", {}),
+            )
+    else:
+        raise AttributeError("Device learning service missing save method")

--- a/tests/services/test_mappings.py
+++ b/tests/services/test_mappings.py
@@ -1,0 +1,64 @@
+from core.service_container import ServiceContainer
+import types
+import sys
+import os
+from pathlib import Path
+
+os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
+services_mod = sys.modules.setdefault("services", types.ModuleType("services"))
+services_mod.__path__ = [str(Path(__file__).resolve().parents[2] / "services")]
+import services.mappings as mappings
+
+
+def _setup(monkeypatch):
+    container = ServiceContainer()
+    monkeypatch.setattr(mappings, "container", container)
+    config_pkg = types.ModuleType("config")
+    sr_stub = types.ModuleType("config.service_registration")
+    sr_stub.register_upload_services = lambda c: None
+    config_pkg.service_registration = sr_stub
+    monkeypatch.setitem(sys.modules, "config", config_pkg)
+    monkeypatch.setitem(sys.modules, "config.service_registration", sr_stub)
+    return container
+
+
+class DummyColumnService:
+    def __init__(self):
+        self.calls = []
+
+    def save_column_mappings(self, file_id: str, mapping: dict[str, str]) -> None:
+        self.calls.append((file_id, mapping))
+
+
+class DummyDeviceService:
+    def __init__(self):
+        self.calls = []
+
+    def save_user_device_mapping(self, *, filename: str, device_name: str, device_type: str, location=None, properties=None):
+        self.calls.append((filename, device_name, device_type, location, properties or {}))
+
+
+def test_save_column_mappings(monkeypatch):
+    container = _setup(monkeypatch)
+    svc = DummyColumnService()
+    container.register_singleton("consolidated_learning_service", svc)
+
+    mappings.save_column_mappings("file.csv", {"a": "b"})
+
+    assert svc.calls == [("file.csv", {"a": "b"})]
+
+
+def test_save_device_mappings(monkeypatch):
+    container = _setup(monkeypatch)
+    svc = DummyDeviceService()
+    container.register_singleton("device_learning_service", svc)
+
+    mappings.save_device_mappings(
+        "file.csv",
+        {"door1": {"device_type": "door", "location": "L1"}},
+    )
+
+    assert svc.calls == [
+        ("file.csv", "door1", "door", "L1", {}),
+    ]
+


### PR DESCRIPTION
## Summary
- centralize mapping save helpers under `services.mappings`
- use the helpers from `mappings_endpoint` and the legacy backend
- add unit tests for new helpers
- adjust existing tests for new import behaviour

## Testing
- `pytest -q tests/services/test_mappings.py tests/test_mappings_endpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_6881cfeb6c808320bf9c450fd33f7eaa