### PR TITLE
Fix logging initialization on import

### DIFF
--- a/data_enhancer.py
+++ b/data_enhancer.py
@@ -31,8 +31,7 @@ from dash import Input, Output, State, callback_context, dash_table, dcc, html
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from config.constants import DEFAULT_CHUNK_SIZE
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Logger for this module. Configuration happens in __main__.
 logger = logging.getLogger(__name__)
 
 # Try to import existing services with fallbacks
@@ -1708,6 +1707,7 @@ DATA OVERVIEW:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     print("=" * 70)
     print("🚀 Starting MVP Data Enhancement Tool - Multi-Building Analysis")
     print("=" * 70)

--- a/debug_mde.py
+++ b/debug_mde.py
@@ -14,7 +14,6 @@ from dash import Input, Output, State, dcc, html
 
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 # Test basic Dash upload first
@@ -57,4 +56,5 @@ def debug_upload(contents, filename):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     app.run_server(debug=True, port=5003)

--- a/examples/debug_chunked_analysis.py
+++ b/examples/debug_chunked_analysis.py
@@ -10,10 +10,6 @@ import pandas as pd
 
 from services.analytics_service import AnalyticsService
 
-# Setup logging to see all debug info
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
@@ -73,5 +69,9 @@ def test_chunked_analysis():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     success = test_chunked_analysis()
     exit(0 if success else 1)

--- a/examples/debug_deep_analytics.py
+++ b/examples/debug_deep_analytics.py
@@ -11,12 +11,6 @@ from pathlib import Path
 
 import pandas as pd
 
-# Setup comprehensive logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    stream=sys.stdout,
-)
 logger = logging.getLogger(__name__)
 
 
@@ -246,4 +240,9 @@ def test_complete_pipeline():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
     test_complete_pipeline()

--- a/examples/debug_live_upload.py
+++ b/examples/debug_live_upload.py
@@ -10,8 +10,6 @@ import sys
 
 sys.path.append(".")
 
-# Enhanced logging
-logging.basicConfig(level=logging.INFO, format="🔍 %(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -108,6 +106,7 @@ def add_debug_hooks():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="🔍 %(levelname)s: %(message)s")
     add_debug_hooks()
     logger.info(
         "🚀 Upload debugging hooks installed. Upload a file and check the logs!"

--- a/examples/diagnostic_script.py
+++ b/examples/diagnostic_script.py
@@ -11,12 +11,6 @@ from pathlib import Path
 
 import pandas as pd
 
-# Setup comprehensive logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    stream=sys.stdout,
-)
 logger = logging.getLogger(__name__)
 
 
@@ -246,4 +240,9 @@ def test_complete_pipeline():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
     test_complete_pipeline()

--- a/examples/performance_unique_patterns.py
+++ b/examples/performance_unique_patterns.py
@@ -77,7 +77,6 @@ def generate_sample_access_data(num_records: int = 1000):
     df = pd.DataFrame(data).sort_values("timestamp").reset_index(drop=True)
     return df
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -95,4 +94,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
     main()

--- a/examples/unique_patterns_debug.py
+++ b/examples/unique_patterns_debug.py
@@ -9,10 +9,6 @@ import sys
 
 import pandas as pd
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
@@ -237,4 +233,8 @@ def test_unique_patterns_specific():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     test_unique_patterns_specific()

--- a/mde.py
+++ b/mde.py
@@ -38,8 +38,7 @@ from services.data_enhancer import get_ai_column_suggestions
 from services.device_learning_service import DeviceLearningService
 from analytics.db_interface import AnalyticsDataAccessor
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Module logger configured in __main__
 logger = logging.getLogger(__name__)
 
 class MVPTestApp:
@@ -435,6 +434,7 @@ class MVPTestApp:
                 style_table={"overflowX": "auto"},
             )
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     # Create and run the minimal test app
     app = MVPTestApp()
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -15,7 +15,6 @@ sys.path.insert(0, str(ROOT))
 
 from database.migrations import MigrationManager
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 LOG = logging.getLogger(__name__)
 
 
@@ -53,4 +52,5 @@ def main(argv: List[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     raise SystemExit(main())

--- a/scripts/migrate_to_timescale.py
+++ b/scripts/migrate_to_timescale.py
@@ -33,10 +33,6 @@ from tqdm import tqdm
 CHUNK_SIZE = 10_000
 CHECKPOINT_TABLE = "migration_checkpoint"
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-)
 LOG = logging.getLogger(__name__)
 
 
@@ -459,4 +455,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
     main()

--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -14,7 +14,6 @@ from psycopg2.extras import DictCursor, execute_values
 from database.secure_exec import execute_query, execute_command
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 SRC_DSN = os.getenv("SOURCE_DSN", "dbname=yosai_intel")
 TGT_DSN = os.getenv("TARGET_DSN", "dbname=yosai_timescale")
@@ -130,4 +129,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
     main()

--- a/yosai-assessment/production-readiness-review.py
+++ b/yosai-assessment/production-readiness-review.py
@@ -15,12 +15,7 @@ from pathlib import Path
 from collections import defaultdict
 
 
-# Configure logging with UTF-8 safe encoding
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
+# Logger configuration happens in __main__
 logger = logging.getLogger(__name__)
 
 
@@ -921,4 +916,9 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[logging.StreamHandler()],
+    )
     main()


### PR DESCRIPTION
## Summary
- avoid configuring logging when modules are imported
- move `logging.basicConfig` calls into `__main__` blocks for scripts and examples

## Testing
- `pytest tests/test_investor_demo_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d887027483208c9f9e9d9dbd78d8