### PR TITLE
Remove star import from compliance models

### DIFF
--- a/models/compliance.py
+++ b/models/compliance.py
@@ -1,1 +1,25 @@
-from plugins.compliance_plugin.models.compliance import *
+"""Expose compliance models used across the application."""
+
+from plugins.compliance_plugin.models.compliance import (
+    ConsentLog,
+    ConsentType,
+    DataSensitivityLevel,
+    DSARRequest,
+    DSARRequestType,
+    DSARStatus,
+    ComplianceAuditLog,
+    DataRetentionPolicy,
+    CREATE_COMPLIANCE_TABLES_SQL,
+)
+
+__all__ = [
+    "ConsentLog",
+    "ConsentType",
+    "DataSensitivityLevel",
+    "DSARRequest",
+    "DSARRequestType",
+    "DSARStatus",
+    "ComplianceAuditLog",
+    "DataRetentionPolicy",
+    "CREATE_COMPLIANCE_TABLES_SQL",
+]


### PR DESCRIPTION
## Summary
- import explicit names from `compliance_plugin.models`
- define `__all__` for exported compliance models

## Testing
- `python -m py_compile models/compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_6881db5d44d883208a9cce899643b2b6