### PR TITLE
Add test for Flask error handlers

### DIFF
--- a/tests/api/test_error_handlers.py
+++ b/tests/api/test_error_handlers.py
@@ -1,0 +1,30 @@
+import types
+from flask import Flask, Blueprint
+
+from core.error_handlers import register_error_handlers
+from core.exceptions import ValidationError
+
+
+def _create_app():
+    app = Flask(__name__)
+    register_error_handlers(app)
+
+    bp = Blueprint('fail', __name__)
+
+    @bp.route('/fail')
+    def fail_route():
+        raise ValidationError('bad')
+
+    app.register_blueprint(bp)
+    return app
+
+
+def test_yosai_base_exception_handled():
+    app = _create_app()
+    client = app.test_client()
+
+    resp = client.get('/fail')
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["code"] == "invalid_input"
+    assert body["message"] == "bad"


### PR DESCRIPTION
## Summary
- add regression test for Yōsai Flask error handlers

## Testing
- `python - <<'PY'
import sys, types, pytest
pandas = types.ModuleType('pandas'); pandas.DataFrame = object
sys.modules['pandas'] = pandas
pytest.main(['tests/api/test_error_handlers.py', '-q'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6881db6038188320855131828181ded9