### PR TITLE
Fix Unicode handling in utility scripts

### DIFF
--- a/mde.py
+++ b/mde.py
@@ -1,15 +1,26 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
 MVP Data Enhancement Tool - Thin Shell Around Existing Base Code
 Tests the complete upload flow using existing project architecture
 """
+
+def safe_str(obj):
+    """Handle unicode and encoding issues."""
+    try:
+        if isinstance(obj, bytes):
+            return obj.decode('utf-8', errors='replace')
+        return str(obj).encode('utf-8', errors='ignore').decode('utf-8', errors='replace')
+    except:
+        return repr(obj)
+
 import asyncio
 import sys
 from pathlib import Path
 
-# Add project root to path  
+# Add project root to path
 PROJECT_ROOT = Path(__file__).parent
-sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, safe_str(PROJECT_ROOT))
 
 import dash
 from dash import dcc, html, callback_context
@@ -261,7 +272,7 @@ class MVPTestApp(BaseDatabaseService):
                 
             except Exception as e:
                 logger.error(f"💥 Upload processing failed: {e}")
-                error_display = dbc.Alert(f"Processing failed: {str(e)}", color="danger")
+                error_display = dbc.Alert(f"Processing failed: {safe_str(e)}", color="danger")
                 return error_display, "", "", "", session_data
         
         @self.app.callback(
@@ -388,7 +399,7 @@ class MVPTestApp(BaseDatabaseService):
             ])
                     
         except Exception as e:
-            return dbc.Alert(f"Device mapping error: {str(e)}", color="warning")
+            return dbc.Alert(f"Device mapping error: {safe_str(e)}", color="warning")
 
     def _create_data_display(self, df):
         """Create data configuration UI with preview and action buttons."""

--- a/test_base_services.py
+++ b/test_base_services.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """Test base code service loading"""
+
+def safe_str(obj):
+    """Handle unicode and encoding issues."""
+    try:
+        if isinstance(obj, bytes):
+            return obj.decode('utf-8', errors='replace')
+        return str(obj).encode('utf-8', errors='ignore').decode('utf-8', errors='replace')
+    except:
+        return repr(obj)
+
 import sys
 from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent
-sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, safe_str(PROJECT_ROOT))
 
 try:
     print("🔍 Testing base code imports...")

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 
 from flask import Blueprint, abort, jsonify, request
@@ -37,7 +38,7 @@ def upload_files():
                 if not file.filename:
                     continue
                 file_bytes = file.read()
-                b64 = base64.b64encode(file_bytes).decode()
+                b64 = base64.b64encode(file_bytes).decode('utf-8', errors='replace')
                 mime = file.mimetype or "application/octet-stream"
                 contents.append(f"data:{mime};base64,{b64}")
                 filenames.append(file.filename)


### PR DESCRIPTION
## Summary
- add `safe_str` helper for robust UTF-8 conversion
- ensure UTF-8 coding declaration in affected modules
- sanitize project root and error strings when logging
- decode base64 bytes with explicit fallback

## Testing
- `pytest -k upload_endpoint -q` *(fails: ImportError: No module named 'analytics.anomaly_detection.types')*

------
https://chatgpt.com/codex/tasks/task_e_6881f00d8414832090729c605fa760f2