### PR TITLE
Add generic deprecation decorator

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -21,6 +21,7 @@ from .intelligent_multilevel_cache import (
 from .memory_manager import MemoryManager
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
 from .base_database_service import BaseDatabaseService
+from .deprecation import deprecated
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .truly_unified_callbacks import (
@@ -47,4 +48,5 @@ __all__ = [
     "CallbackModuleRegistry",
     "BaseModel",
     "BaseDatabaseService",
+    "deprecated",
 ]

--- a/core/deprecation.py
+++ b/core/deprecation.py
@@ -1,0 +1,53 @@
+"""Utilities for deprecating functions and tracking usage."""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import Callable, Any
+
+from .performance import get_performance_monitor
+
+
+def deprecated(
+    since: str,
+    removal: str | None = None,
+    migration: str | None = None,
+    track_usage: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Mark a function as deprecated.
+
+    Parameters
+    ----------
+    since:
+        Version when the function was deprecated.
+    removal:
+        Planned version for removal. If provided, included in the warning
+        message.
+    migration:
+        Optional hint for migrating off the deprecated functionality.
+    track_usage:
+        If ``True``, each call records a ``deprecated.<func>`` metric via the
+        :mod:`core.performance` monitor.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        parts = [f"{func.__module__}.{func.__name__} is deprecated since {since}"]
+        if removal:
+            parts.append(f"and will be removed in {removal}")
+        if migration:
+            parts.append(migration)
+        message = " ".join(parts)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            if track_usage:
+                get_performance_monitor().record_metric(
+                    f"deprecated.{func.__name__}", 1
+                )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,39 @@
+import warnings
+
+from core import performance
+from core.deprecation import deprecated
+
+
+class Dummy:
+    @deprecated("1.0", removal="2.0", migration="use new_func()", track_usage=True)
+    def old(self, x):
+        return x * 2
+
+
+def test_deprecated_warns_and_records(monkeypatch):
+    monitor = performance.PerformanceMonitor(max_metrics=10)
+    monkeypatch.setattr(performance, "_performance_monitor", monitor)
+
+    dummy = Dummy()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        assert dummy.old(3) == 6
+
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert any(m.name == "deprecated.old" for m in monitor.metrics)
+
+
+def test_deprecated_no_tracking(monkeypatch):
+    monitor = performance.PerformanceMonitor(max_metrics=10)
+    monkeypatch.setattr(performance, "_performance_monitor", monitor)
+
+    @deprecated("1.0", track_usage=False)
+    def func():
+        return "ok"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        assert func() == "ok"
+
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert not any(m.name == "deprecated.func" for m in monitor.metrics)


### PR DESCRIPTION
## Summary
- implement `core.deprecation` with a decorator to warn and optionally track usage
- expose `deprecated` in `core.__init__`
- test warning emission and metric recording

## Testing
- `pytest tests/test_deprecation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fa2039dc83208bf2507e2852c7d7