### PR TITLE
Add deprecation docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DURATION ?= 60
 CLI ?= python -m tools.ops_cli
 
 .PHONY: load-test validate build test deploy format lint clean \
-build-all test-all deploy-all logs
+build-all test-all deploy-all logs deprecation-docs
 
 load-test:
 	python tools/load_test.py --brokers $(BROKERS) --prom-url $(PROM_URL) --rate $(RATE) --duration $(DURATION)
@@ -40,6 +40,9 @@ format:
 
 lint:
 	$(CLI) lint
+
+deprecation-docs:
+	python scripts/generate_deprecation_docs.py
 
 clean:
 	$(CLI) clean

--- a/README.md
+++ b/README.md
@@ -295,9 +295,15 @@ make test
 make lint
 make format
 
+# regenerate deprecation documentation
+make deprecation-docs
+
 # tear everything down and clean caches
 make clean
 ```
+
+Updates to component lifecycle should be recorded in `deprecation.yml`. Run
+`make deprecation-docs` whenever this file changes.
 
 ### Kafka Event Processor
 

--- a/deprecation.yml
+++ b/deprecation.yml
@@ -1,0 +1,8 @@
+- component: legacy-auth
+  deprecated_since: 1.2.0
+  removal_version: 2.0.0
+  migration_path: docs/migration/legacy-auth.md
+- component: old-dashboard
+  deprecated_since: 1.5.0
+  removal_version: 2.1.0
+  migration_path: docs/migration/new-dashboard.md

--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -1,0 +1,16 @@
+# Deprecation Timeline
+
+This file is auto-generated from `deprecation.yml`.
+
+| Component | Deprecated Since | Removal Version |
+|-----------|-----------------|-----------------|
+| legacy-auth | 1.2.0 | 2.0.0 |
+| old-dashboard | 1.5.0 | 2.1.0 |
+
+## Migration Guides
+
+Migration instructions for deprecated components will appear here.
+
+## Impact Analysis
+
+This section will detail user impact and remediation steps.

--- a/scripts/generate_deprecation_docs.py
+++ b/scripts/generate_deprecation_docs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generate documentation about deprecated components."""
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+YAML_FILE = Path('deprecation.yml')
+OUTPUT_FILE = Path('docs/deprecation_timeline.md')
+
+
+def generate_docs(yaml_path: Path = YAML_FILE, output_path: Path = OUTPUT_FILE) -> None:
+    """Read deprecation data and write the markdown summary."""
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"{yaml_path} not found")
+
+    entries = yaml.safe_load(yaml_path.read_text()) or []
+
+    lines = [
+        "# Deprecation Timeline",
+        "",
+        "This file is auto-generated from `deprecation.yml`.",
+        "",
+        "| Component | Deprecated Since | Removal Version |",
+        "|-----------|-----------------|-----------------|",
+    ]
+
+    for item in entries:
+        comp = item.get("component", "-")
+        since = item.get("deprecated_since", "-")
+        removal = item.get("removal_version", "-")
+        lines.append(f"| {comp} | {since} | {removal} |")
+
+    lines.extend([
+        "",
+        "## Migration Guides",
+        "",
+        "Migration instructions for deprecated components will appear here.",
+        "",
+        "## Impact Analysis",
+        "",
+        "This section will detail user impact and remediation steps.",
+        "",
+    ])
+
+    output_path.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    generate_docs()


### PR DESCRIPTION
## Summary
- track deprecated components in `deprecation.yml`
- script to build `docs/deprecation_timeline.md`
- new `deprecation-docs` target in `Makefile`
- document usage of doc generation in README

## Testing
- `make deprecation-docs`
- `make test` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_6881fa23d8fc83208cec1e5bd4b28fa9