### PR TITLE
Update Unicode migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ The dashboard now centralizes Unicode handling in `core.unicode`.
 Detect legacy usage and validate the migration with the helper tools:
 
 ```bash
-python tools/legacy_unicode_audit.py --path .
+python tools/validate_unicode_cleanup.py
 python tools/validate_unicode_migration.py
 ```
 


### PR DESCRIPTION
## Summary
- fix README instructions to run `validate_unicode_cleanup.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'confluent_kafka')*

------
https://chatgpt.com/codex/tasks/task_e_6881fa265ea88320b5f61a873d53cc58