### PR TITLE
Add deprecation usage metrics

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -21,6 +21,7 @@ from .intelligent_multilevel_cache import (
 from .memory_manager import MemoryManager
 from .truly_unified_callbacks import TrulyUnifiedCallbacks
 from .base_database_service import BaseDatabaseService
+from .deprecation import deprecated
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .truly_unified_callbacks import (
@@ -47,4 +48,5 @@ __all__ = [
     "CallbackModuleRegistry",
     "BaseModel",
     "BaseDatabaseService",
+    "deprecated",
 ]

--- a/core/deprecation.py
+++ b/core/deprecation.py
@@ -1,0 +1,34 @@
+import functools
+import warnings
+from typing import Callable
+
+from .performance import MetricType, get_performance_monitor
+from monitoring.prometheus.deprecation import record_deprecated_call
+
+
+def deprecated(reason: str | None = None) -> Callable[[Callable], Callable]:
+    """Decorator to mark functions as deprecated and record usage metrics."""
+
+    def decorator(func: Callable) -> Callable:
+        message = (
+            f"{func.__module__}.{func.__name__} is deprecated"
+            + (f": {reason}" if reason else "")
+        )
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            get_performance_monitor().record_metric(
+                message,
+                1,
+                MetricType.DEPRECATED_USAGE,
+                metadata={"function": f"{func.__module__}.{func.__name__}"},
+            )
+            record_deprecated_call(func.__name__)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+__all__ = ["deprecated"]

--- a/core/performance.py
+++ b/core/performance.py
@@ -41,6 +41,7 @@ class MetricType(Enum):
     FILE_PROCESSING = "file_processing"
     API_CALL = "api_call"
     USER_INTERACTION = "user_interaction"
+    DEPRECATED_USAGE = "deprecated_usage"
 
 
 @dataclass
@@ -256,6 +257,15 @@ class PerformanceMonitor:
                 )
 
         return sorted(slow_ops, key=lambda x: x["duration"], reverse=True)
+
+    def get_deprecation_counts(self, hours: int = 24) -> Dict[str, int]:
+        """Return how often deprecated functions were called in the last ``hours``."""
+        cutoff = datetime.now() - timedelta(hours=hours)
+        counts: Dict[str, int] = defaultdict(int)
+        for metric in self.metrics:
+            if metric.timestamp >= cutoff and metric.metric_type == MetricType.DEPRECATED_USAGE:
+                counts[metric.name] += 1
+        return dict(counts)
 
     def _percentile(self, values: List[float], percentile: int) -> float:
         """Calculate percentile of values"""

--- a/dashboards/grafana/deprecation-usage.json
+++ b/dashboards/grafana/deprecation-usage.json
@@ -1,0 +1,19 @@
+{
+  "uid": "deprecation-usage",
+  "title": "Deprecated Usage",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Deprecated Function Calls",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(rate(deprecated_function_calls_total[1m])) by (function)",
+          "legendFormat": "{{function}}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 36,
+  "version": 1
+}

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -49,6 +49,27 @@ HTTP port (defaults to `8004`).
 All services expose their runtime metrics at `/metrics` so Prometheus can scrape
 them without additional configuration.
 
+### Deprecated Function Usage
+
+Decorate legacy helpers with `@deprecated` from `core` to automatically record
+how often they are still invoked.  The decorator emits a Prometheus counter
+`deprecated_function_calls_total` with a `function` label and also stores
+entries in the global `PerformanceMonitor`.  Example:
+
+```python
+from core import deprecated
+
+@deprecated("use new_service.process() instead")
+def old_process(*args):
+    ...
+```
+
+Aggregated counts are returned via `get_performance_monitor().get_deprecation_counts()`.
+Prioritise migrations by addressing functions with the highest counts first.
+Example alerting rules live in `monitoring/prometheus/rules/deprecation_alerts.yml`
+and a companion Grafana dashboard in
+`monitoring/grafana/dashboards/deprecation-usage.json`.
+
 ### Logstash
 
 `logging/logstash.conf` reads the application, Postgres and Redis logs and can

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -14,6 +14,11 @@ from .model_performance_monitor import (
     get_model_performance_monitor,
 )
 from .ui_monitor import RealTimeUIMonitor, get_ui_monitor
+from .prometheus.deprecation import (
+    deprecated_calls,
+    record_deprecated_call,
+    start_deprecation_metrics_server,
+)
 
 __all__ = [
     "PerformanceMonitor",
@@ -26,4 +31,7 @@ __all__ = [
     "RealTimeUIMonitor",
     "get_ui_monitor",
     "check_cluster_health",
+    "deprecated_calls",
+    "record_deprecated_call",
+    "start_deprecation_metrics_server",
 ]

--- a/monitoring/prometheus/deprecation.py
+++ b/monitoring/prometheus/deprecation.py
@@ -1,0 +1,35 @@
+"""Prometheus metrics for deprecated function usage."""
+from prometheus_client import Counter, REGISTRY, start_http_server
+from prometheus_client.core import CollectorRegistry
+
+if "deprecated_function_calls_total" not in REGISTRY._names_to_collectors:
+    deprecated_calls = Counter(
+        "deprecated_function_calls_total",
+        "Count of deprecated function calls",
+        ["function"],
+    )
+else:  # pragma: no cover - defensive
+    deprecated_calls = Counter(
+        "deprecated_function_calls_total",
+        "Count of deprecated function calls",
+        ["function"],
+        registry=CollectorRegistry(),
+    )
+
+_metrics_started = False
+
+
+def start_deprecation_metrics_server(port: int = 8006) -> None:
+    """Expose deprecation metrics on ``port`` if not already started."""
+    global _metrics_started
+    if not _metrics_started:
+        start_http_server(port)
+        _metrics_started = True
+
+
+def record_deprecated_call(function: str) -> None:
+    """Increment Prometheus counter for ``function``."""
+    deprecated_calls.labels(function=function).inc()
+
+
+__all__ = ["deprecated_calls", "start_deprecation_metrics_server", "record_deprecated_call"]

--- a/monitoring/prometheus/rules/deprecation_alerts.yml
+++ b/monitoring/prometheus/rules/deprecation_alerts.yml
@@ -1,0 +1,10 @@
+groups:
+- name: deprecations
+  rules:
+  - alert: DeprecatedFunctionCalled
+    expr: rate(deprecated_function_calls_total[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: Deprecated function invoked recently


### PR DESCRIPTION
## Summary
- track deprecated function calls via a new decorator
- expose `deprecated_function_calls_total` Prometheus counter
- aggregate deprecated usage in `PerformanceMonitor`
- add alerting rule and Grafana dashboard examples
- document interpreting deprecation metrics

## Testing
- `python -m py_compile core/deprecation.py core/performance.py monitoring/prometheus/deprecation.py`
- `pytest -k deprecated -q` *(fails: ImportError: No module named 'analytics.utils')*

------
https://chatgpt.com/codex/tasks/task_e_6881fa29086c83208248185d127a2cf1