### PR TITLE
Introduce modular service builder framework

### DIFF
--- a/docs/migrating_base_service.md
+++ b/docs/migrating_base_service.md
@@ -1,0 +1,20 @@
+# Migrating from the old BaseService
+
+The legacy `BaseService` bundled logging, metrics and tracing in a single struct.
+New applications should use the `ServiceBuilder` and component interfaces
+introduced in `go/framework`.
+
+1. Import the builder and create a new instance:
+   ```go
+   builder, _ := framework.NewServiceBuilder("service-name", "config.yaml")
+   svc, _ := builder.Build()
+   ```
+2. Start the returned `BaseService` as usual:
+   ```go
+   go svc.Start()
+   defer svc.Stop()
+   ```
+
+The builder configures a zap logger, Prometheus metrics collector and Jaeger
+tracer. Custom implementations can be supplied via the `WithLogger`,
+`WithMetrics` and `WithTracer` methods before calling `Build`.

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -47,15 +47,18 @@ func validateRequiredEnv(vars []string) {
 }
 
 func main() {
-	svc, err := framework.NewBaseService("gateway", "")
+	b, err := framework.NewServiceBuilder("gateway", "")
 	if err != nil {
-		log.Fatalf("failed to init base service: %v", err)
+		log.Fatalf("failed to init service builder: %v", err)
+	}
+	svc, err := b.Build()
+	if err != nil {
+		log.Fatalf("failed to build service: %v", err)
 	}
 	go svc.Start()
 	defer svc.Stop()
 
 	validateRequiredEnv([]string{"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_GATEWAY_NAME"})
-
 
 	shutdown, err := tracing.InitTracing("gateway")
 	if err != nil {

--- a/go/framework/builder.go
+++ b/go/framework/builder.go
@@ -1,0 +1,72 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/WSG23/yosai-framework/health"
+	"github.com/WSG23/yosai-framework/logging"
+	"github.com/WSG23/yosai-framework/metrics"
+	"github.com/WSG23/yosai-framework/tracing"
+)
+
+// ServiceBuilder assembles service components.
+type ServiceBuilder struct {
+	name    string
+	cfg     Config
+	logger  logging.Logger
+	metrics metrics.MetricsCollector
+	tracer  tracing.Tracer
+	health  *health.HealthManager
+}
+
+func NewServiceBuilder(name, cfgPath string) (*ServiceBuilder, error) {
+	var cfg Config
+	var err error
+	if cfgPath != "" {
+		cfg, err = LoadConfig(cfgPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ServiceBuilder{name: name, cfg: cfg}, nil
+}
+
+func (b *ServiceBuilder) WithLogger(l logging.Logger) *ServiceBuilder { b.logger = l; return b }
+func (b *ServiceBuilder) WithMetrics(m metrics.MetricsCollector) *ServiceBuilder {
+	b.metrics = m
+	return b
+}
+func (b *ServiceBuilder) WithTracer(t tracing.Tracer) *ServiceBuilder        { b.tracer = t; return b }
+func (b *ServiceBuilder) WithHealth(h *health.HealthManager) *ServiceBuilder { b.health = h; return b }
+
+// Build assembles the components and returns a BaseService.
+func (b *ServiceBuilder) Build() (*BaseService, error) {
+	if b.health == nil {
+		b.health = health.NewManager()
+	}
+	if b.logger == nil {
+		lg, err := logging.NewZapLogger(b.name, b.cfg.LogLevel)
+		if err != nil {
+			return nil, err
+		}
+		b.logger = lg
+	}
+	if b.metrics == nil && b.cfg.MetricsAddr != "" {
+		b.metrics = metrics.NewPrometheusCollector(b.cfg.MetricsAddr, b.health, b.logger)
+	}
+	if b.tracer == nil {
+		b.tracer = tracing.NewJaegerTracer()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &BaseService{
+		Name:    b.name,
+		Config:  b.cfg,
+		ctx:     ctx,
+		cancel:  cancel,
+		Logger:  b.logger,
+		Metrics: b.metrics,
+		Health:  b.health,
+		tracer:  b.tracer,
+	}, nil
+}

--- a/go/framework/config.go
+++ b/go/framework/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	TracingEndpoint string `yaml:"tracing_endpoint"`
 }
 
-var schemaPath = "../config/service.schema.yaml"
+var schemaPath = "../../config/service.schema.yaml"
 
 func LoadConfig(path string) (Config, error) {
 	var cfg Config

--- a/go/framework/core/service.go
+++ b/go/framework/core/service.go
@@ -1,0 +1,7 @@
+package core
+
+// Service represents a runnable service with start and stop lifecycle methods.
+type Service interface {
+	Start()
+	Stop()
+}

--- a/go/framework/go.mod
+++ b/go/framework/go.mod
@@ -15,10 +15,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors => ../../shared/errors
-
 require (
-	github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors v0.0.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/framework/health/health.go
+++ b/go/framework/health/health.go
@@ -1,0 +1,70 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HealthChecker exposes current service health state.
+type HealthChecker interface {
+	Live() bool
+	Ready() bool
+	StartupComplete() bool
+}
+
+// HealthManager implements HealthChecker and allows state mutation.
+type HealthManager struct {
+	live            bool
+	ready           bool
+	startupComplete bool
+}
+
+// NewManager returns a new HealthManager with all states false.
+func NewManager() *HealthManager { return &HealthManager{} }
+
+func (h *HealthManager) Live() bool            { return h.live }
+func (h *HealthManager) Ready() bool           { return h.ready }
+func (h *HealthManager) StartupComplete() bool { return h.startupComplete }
+
+func (h *HealthManager) SetLive(v bool)            { h.live = v }
+func (h *HealthManager) SetReady(v bool)           { h.ready = v }
+func (h *HealthManager) SetStartupComplete(v bool) { h.startupComplete = v }
+
+func writeJSON(w http.ResponseWriter, status string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
+}
+
+// Handler returns /health status.
+func (h *HealthManager) Handler(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, "ok")
+}
+
+// LiveHandler returns liveness.
+func (h *HealthManager) LiveHandler(w http.ResponseWriter, _ *http.Request) {
+	if h.live {
+		writeJSON(w, "ok")
+		return
+	}
+	writeJSON(w, "shutdown")
+}
+
+// ReadyHandler returns readiness.
+func (h *HealthManager) ReadyHandler(w http.ResponseWriter, _ *http.Request) {
+	if h.ready {
+		writeJSON(w, "ready")
+		return
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	writeJSON(w, "not ready")
+}
+
+// StartupHandler returns startup completion state.
+func (h *HealthManager) StartupHandler(w http.ResponseWriter, _ *http.Request) {
+	if h.startupComplete {
+		writeJSON(w, "complete")
+		return
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	writeJSON(w, "starting")
+}

--- a/go/framework/health/health_test.go
+++ b/go/framework/health/health_test.go
@@ -1,0 +1,42 @@
+package health
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlers(t *testing.T) {
+	h := NewManager()
+	h.SetLive(true)
+	h.SetReady(true)
+	h.SetStartupComplete(true)
+
+	rr := httptest.NewRecorder()
+	h.Handler(rr, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("health status %d", rr.Code)
+	}
+
+	tests := []struct {
+		handler http.HandlerFunc
+		expect  string
+	}{
+		{h.LiveHandler, `{"status":"ok"}`},
+		{h.ReadyHandler, `{"status":"ready"}`},
+		{h.StartupHandler, `{"status":"complete"}`},
+	}
+	for _, tt := range tests {
+		rr := httptest.NewRecorder()
+		tt.handler(rr, nil)
+		body, _ := io.ReadAll(rr.Body)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status %d", rr.Code)
+		}
+		if string(bytes.TrimSpace(body)) != tt.expect {
+			t.Fatalf("unexpected body %s", string(body))
+		}
+	}
+}

--- a/go/framework/logging/logger.go
+++ b/go/framework/logging/logger.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// Logger abstracts logging implementation.
+type Logger interface {
+	Info(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+}
+
+// ZapLogger is a zap based implementation of Logger.
+type ZapLogger struct{ *zap.Logger }
+
+// NewZapLogger creates a named zap logger using the provided level.
+func NewZapLogger(name, level string) (*ZapLogger, error) {
+	cfg := zap.NewProductionConfig()
+	cfg.OutputPaths = []string{"stdout"}
+	lvl := zap.InfoLevel
+	if v := strings.ToUpper(level); v != "" {
+		if parsed, err := zap.ParseAtomicLevel(v); err == nil {
+			lvl = parsed.Level()
+		}
+	}
+	cfg.Level = zap.NewAtomicLevelAt(lvl)
+	lg, err := cfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	return &ZapLogger{lg.Named(name)}, nil
+}
+
+func (l *ZapLogger) Info(msg string, fields ...zap.Field)  { l.Logger.Info(msg, fields...) }
+func (l *ZapLogger) Error(msg string, fields ...zap.Field) { l.Logger.Error(msg, fields...) }

--- a/go/framework/logging/logger_test.go
+++ b/go/framework/logging/logger_test.go
@@ -1,0 +1,35 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestZapLoggerJSON(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	lg, err := NewZapLogger("test", "INFO")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lg.Info("hello")
+	lg.Logger.Sync()
+	w.Close()
+	os.Stdout = orig
+	data, _ := io.ReadAll(r)
+	data = bytes.TrimSpace(data)
+	if !bytes.HasPrefix(data, []byte("{")) {
+		t.Fatalf("expected JSON log, got %s", string(data))
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("invalid JSON log: %v", err)
+	}
+	if m["msg"] != "hello" {
+		t.Fatalf("unexpected message %v", m["msg"])
+	}
+}

--- a/go/framework/metrics/metrics.go
+++ b/go/framework/metrics/metrics.go
@@ -1,0 +1,113 @@
+package metrics
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"go.uber.org/zap"
+
+	"github.com/WSG23/yosai-framework/health"
+	"github.com/WSG23/yosai-framework/logging"
+)
+
+// MetricsCollector represents metrics functionality for a service.
+type MetricsCollector interface {
+	Start() error
+	Stop(ctx context.Context) error
+	ListenerAddr() string
+	Requests() *prometheus.CounterVec
+	Durations() *prometheus.HistogramVec
+	Errors() *prometheus.CounterVec
+}
+
+type PrometheusCollector struct {
+	Addr      string
+	registry  *prometheus.Registry
+	reqCount  *prometheus.CounterVec
+	reqDur    *prometheus.HistogramVec
+	reqErr    *prometheus.CounterVec
+	srv       *http.Server
+	ln        net.Listener
+	healthMgr *health.HealthManager
+	logger    logging.Logger
+}
+
+// NewPrometheusCollector creates a Prometheus metrics collector bound to addr.
+func NewPrometheusCollector(addr string, hm *health.HealthManager, lg logging.Logger) *PrometheusCollector {
+	return &PrometheusCollector{Addr: addr, healthMgr: hm, logger: lg}
+}
+
+func (p *PrometheusCollector) init() error {
+	p.registry = prometheus.NewRegistry()
+	p.reqCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "yosai_request_total",
+		Help: "Total HTTP requests",
+	}, []string{"method", "endpoint", "status"})
+	p.reqDur = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "yosai_request_duration_seconds",
+		Help:    "HTTP request duration in seconds",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method", "endpoint", "status"})
+	p.reqErr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "yosai_error_total",
+		Help: "Total errors encountered",
+	}, []string{"endpoint"})
+	p.registry.MustRegister(p.reqCount, p.reqDur, p.reqErr)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{}))
+	if p.healthMgr != nil {
+		mux.HandleFunc("/health", p.healthMgr.Handler)
+		mux.HandleFunc("/health/live", p.healthMgr.LiveHandler)
+		mux.HandleFunc("/health/ready", p.healthMgr.ReadyHandler)
+		mux.HandleFunc("/health/startup", p.healthMgr.StartupHandler)
+	}
+	p.srv = &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", p.Addr)
+	if err != nil {
+		return err
+	}
+	p.ln = ln
+	return nil
+}
+
+func (p *PrometheusCollector) Start() error {
+	if p.Addr == "" {
+		return nil
+	}
+	if err := p.init(); err != nil {
+		if p.logger != nil {
+			p.logger.Error("metrics listener error", zap.Error(err))
+		}
+		return err
+	}
+	go func() {
+		if err := p.srv.Serve(p.ln); err != nil && err != http.ErrServerClosed {
+			if p.logger != nil {
+				p.logger.Error("metrics server error", zap.Error(err))
+			}
+		}
+	}()
+	return nil
+}
+
+func (p *PrometheusCollector) Stop(ctx context.Context) error {
+	if p.srv != nil {
+		return p.srv.Shutdown(ctx)
+	}
+	return nil
+}
+
+func (p *PrometheusCollector) ListenerAddr() string {
+	if p.ln != nil {
+		return p.ln.Addr().String()
+	}
+	return ""
+}
+
+func (p *PrometheusCollector) Requests() *prometheus.CounterVec    { return p.reqCount }
+func (p *PrometheusCollector) Durations() *prometheus.HistogramVec { return p.reqDur }
+func (p *PrometheusCollector) Errors() *prometheus.CounterVec      { return p.reqErr }

--- a/go/framework/metrics/metrics_test.go
+++ b/go/framework/metrics/metrics_test.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/WSG23/yosai-framework/health"
+	"github.com/WSG23/yosai-framework/logging"
+)
+
+func TestPrometheusCollector(t *testing.T) {
+	hm := health.NewManager()
+	logger := &logging.ZapLogger{Logger: zap.NewNop()}
+	c := NewPrometheusCollector("127.0.0.1:0", hm, logger)
+	if err := c.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Stop(context.Background())
+	c.Requests().WithLabelValues("GET", "/", "200").Inc()
+	resp, err := http.Get("http://" + c.ListenerAddr() + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "yosai_request_total") {
+		t.Fatalf("counter not exposed: %s", string(body))
+	}
+}

--- a/go/framework/service.go
+++ b/go/framework/service.go
@@ -2,176 +2,80 @@ package framework
 
 import (
 	"context"
-	"log"
-	"net"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/jaeger"
-	"go.opentelemetry.io/otel/propagation"
-	sdkresource "go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"github.com/WSG23/yosai-framework/health"
+	"github.com/WSG23/yosai-framework/logging"
+	"github.com/WSG23/yosai-framework/metrics"
+	"github.com/WSG23/yosai-framework/tracing"
 	"go.uber.org/zap"
 )
 
-// BaseService provides logging, metrics, tracing and signal handling.
+// BaseService composes common service components.
 type BaseService struct {
-	Name            string
-	Config          Config
-	ctx             context.Context
-	cancel          context.CancelFunc
-	logger          *zap.Logger
-	registry        *prometheus.Registry
-	metricsSrv      *http.Server
-	metricsLn       net.Listener
-	reqCount        *prometheus.CounterVec
-	reqDuration     *prometheus.HistogramVec
-	reqErrors       *prometheus.CounterVec
-	traceShutdown   func(context.Context) error
-	ready           bool
-	live            bool
-	startupComplete bool
+	Name   string
+	Config Config
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	Logger  logging.Logger
+	Metrics metrics.MetricsCollector
+	Health  *health.HealthManager
+	tracer  tracing.Tracer
+
+	traceShutdown func(context.Context) error
 }
 
 func NewBaseService(name, cfgPath string) (*BaseService, error) {
-	cfg, err := LoadConfig(cfgPath)
+	b, err := NewServiceBuilder(name, cfgPath)
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	return &BaseService{
-		Name:   name,
-		Config: cfg,
-		ctx:    ctx,
-		cancel: cancel,
-		live:   true,
-	}, nil
+	return b.Build()
 }
 
+// Start runs the configured components and waits for termination signals.
 func (s *BaseService) Start() {
-	s.setupLogging()
-	s.setupMetrics()
-	s.setupTracing()
+	if s.Metrics != nil {
+		_ = s.Metrics.Start()
+	}
+	if s.tracer != nil {
+		shutdown, err := s.tracer.Start(s.Config.ServiceName, s.Config.TracingEndpoint)
+		if err == nil {
+			s.traceShutdown = shutdown
+		} else if s.Logger != nil {
+			s.Logger.Error("init tracing", zap.Error(err))
+		}
+	}
+	s.Health.SetStartupComplete(true)
+	s.Health.SetReady(true)
+	s.Health.SetLive(true)
 	s.handleSignals()
-	s.startupComplete = true
-	s.ready = true
-	s.live = true
-	if s.logger != nil {
-		s.logger.Info("service started")
+	if s.Logger != nil {
+		s.Logger.Info("service started")
 	}
 	<-s.ctx.Done()
-	if s.logger != nil {
-		s.logger.Info("service stopped")
+	if s.Logger != nil {
+		s.Logger.Info("service stopped")
 	}
 }
 
+// Stop shuts down service components.
 func (s *BaseService) Stop() {
-	if s.metricsSrv != nil {
+	if s.Metrics != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		_ = s.metricsSrv.Shutdown(ctx)
+		_ = s.Metrics.Stop(ctx)
 		cancel()
 	}
 	if s.traceShutdown != nil {
 		_ = s.traceShutdown(context.Background())
 	}
-	s.ready = false
-	s.live = false
+	s.Health.SetReady(false)
+	s.Health.SetLive(false)
 	s.cancel()
-}
-
-func (s *BaseService) setupLogging() {
-	cfg := zap.NewProductionConfig()
-	cfg.OutputPaths = []string{"stdout"}
-	level := zap.InfoLevel
-	if lvl := strings.ToUpper(s.Config.LogLevel); lvl != "" {
-		if parsed, err := zap.ParseAtomicLevel(lvl); err == nil {
-			level = parsed.Level()
-		}
-	}
-	cfg.Level = zap.NewAtomicLevelAt(level)
-	logger, err := cfg.Build()
-	if err != nil {
-		log.Printf("failed to init logger: %v", err)
-		return
-	}
-	s.logger = logger.Named(s.Name)
-	zap.ReplaceGlobals(s.logger)
-}
-
-func (s *BaseService) setupMetrics() {
-	if s.Config.MetricsAddr == "" {
-		return
-	}
-	s.registry = prometheus.NewRegistry()
-	s.reqCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "yosai_request_total",
-		Help: "Total HTTP requests",
-	}, []string{"method", "endpoint", "status"})
-	s.reqDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "yosai_request_duration_seconds",
-		Help:    "HTTP request duration in seconds",
-		Buckets: prometheus.DefBuckets,
-	}, []string{"method", "endpoint", "status"})
-	s.reqErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "yosai_error_total",
-		Help: "Total errors encountered",
-	}, []string{"endpoint"})
-	s.registry.MustRegister(s.reqCount, s.reqDuration, s.reqErrors)
-
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{}))
-	mux.HandleFunc("/health", s.handleHealth)
-	mux.HandleFunc("/health/live", s.handleHealthLive)
-	mux.HandleFunc("/health/ready", s.handleHealthReady)
-	mux.HandleFunc("/health/startup", s.handleHealthStartup)
-	s.metricsSrv = &http.Server{Handler: mux}
-	ln, err := net.Listen("tcp", s.Config.MetricsAddr)
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("metrics listener error", zap.Error(err))
-		}
-		return
-	}
-	s.metricsLn = ln
-	go func() {
-		if err := s.metricsSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
-			if s.logger != nil {
-				s.logger.Error("metrics server error", zap.Error(err))
-			}
-		}
-	}()
-}
-
-func (s *BaseService) setupTracing() {
-	endpoint := s.Config.TracingEndpoint
-	if endpoint == "" {
-		endpoint = "http://localhost:14268/api/traces"
-	}
-	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
-	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("init tracing", zap.Error(err))
-		}
-		return
-	}
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exp),
-		sdktrace.WithResource(sdkresource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(s.Config.ServiceName),
-		)),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-	s.traceShutdown = tp.Shutdown
 }
 
 func (s *BaseService) handleSignals() {
@@ -184,38 +88,4 @@ func (s *BaseService) handleSignals() {
 		}
 		s.Stop()
 	}()
-}
-
-func (s *BaseService) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{"status":"ok"}`))
-}
-
-func (s *BaseService) handleHealthLive(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	status := "shutdown"
-	if s.live {
-		status = "ok"
-	}
-	_, _ = w.Write([]byte(`{"status":"` + status + `"}`))
-}
-
-func (s *BaseService) handleHealthReady(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if s.ready {
-		_, _ = w.Write([]byte(`{"status":"ready"}`))
-		return
-	}
-	w.WriteHeader(http.StatusServiceUnavailable)
-	_, _ = w.Write([]byte(`{"status":"not ready"}`))
-}
-
-func (s *BaseService) handleHealthStartup(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if s.startupComplete {
-		_, _ = w.Write([]byte(`{"status":"complete"}`))
-		return
-	}
-	w.WriteHeader(http.StatusServiceUnavailable)
-	_, _ = w.Write([]byte(`{"status":"starting"}`))
 }

--- a/go/framework/service_test.go
+++ b/go/framework/service_test.go
@@ -1,159 +1,55 @@
 package framework
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/WSG23/yosai-framework/health"
+	"github.com/WSG23/yosai-framework/logging"
+	"github.com/WSG23/yosai-framework/metrics"
 )
 
 func writeConfig(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "cfg.yaml")
+	path := dir + "/cfg.yaml"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return path
 }
 
-func TestSetupLoggingJSON(t *testing.T) {
-	svc := &BaseService{Name: "test", Config: Config{LogLevel: "INFO"}}
-	svc.ctx, svc.cancel = context.WithCancel(context.Background())
-	r, w, _ := os.Pipe()
-	orig := os.Stdout
-	os.Stdout = w
-	svc.setupLogging()
-	svc.logger.Info("hello")
-	w.Close()
-	os.Stdout = orig
-	data, _ := io.ReadAll(r)
-	data = bytes.TrimSpace(data)
-	if !bytes.HasPrefix(data, []byte("{")) {
-		t.Fatalf("expected JSON log, got %s", string(data))
-	}
-	var m map[string]any
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("invalid JSON log: %v", err)
-	}
-	if m["msg"] != "hello" {
-		t.Fatalf("unexpected message %v", m["msg"])
-	}
-}
-
-func TestMetricsInitialization(t *testing.T) {
-	svc := &BaseService{Name: "test", Config: Config{MetricsAddr: "127.0.0.1:0"}}
-	svc.ctx, svc.cancel = context.WithCancel(context.Background())
-	svc.logger = zap.NewNop()
-	svc.setupMetrics()
-	svc.reqCount.WithLabelValues("GET", "/", "200").Inc()
-	svc.reqDuration.WithLabelValues("GET", "/", "200").Observe(0.1)
-	svc.reqErrors.WithLabelValues("/").Inc()
-	defer svc.Stop()
-	addr := svc.metricsLn.Addr().String()
-	resp, err := http.Get("http://" + addr + "/metrics")
+func TestServiceBuilder(t *testing.T) {
+	b, err := NewServiceBuilder("test", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "yosai_request_total") {
-		t.Fatalf("counter not exposed: %s", string(body))
+	hm := health.NewManager()
+	b.WithHealth(hm)
+	b.WithMetrics(metrics.NewPrometheusCollector("127.0.0.1:0", hm, &logging.ZapLogger{Logger: zap.NewNop()}))
+	svc, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(string(body), "yosai_request_duration_seconds") {
-		t.Fatalf("histogram not exposed: %s", string(body))
-	}
-	if !strings.Contains(string(body), "yosai_error_total") {
-		t.Fatalf("error counter not exposed: %s", string(body))
-	}
-}
-
-func TestHealthEndpoints(t *testing.T) {
-	svc := &BaseService{Name: "test", Config: Config{MetricsAddr: "127.0.0.1:0"}}
-	svc.ctx, svc.cancel = context.WithCancel(context.Background())
-	svc.logger = zap.NewNop()
-	svc.live = true
-	svc.ready = true
-	svc.startupComplete = true
-	svc.setupMetrics()
+	go svc.Start()
 	defer svc.Stop()
-
-	addr := svc.metricsLn.Addr().String()
-	tests := map[string]string{
-		"/health":         `{"status":"ok"}`,
-		"/health/live":    `{"status":"ok"}`,
-		"/health/ready":   `{"status":"ready"}`,
-		"/health/startup": `{"status":"complete"}`,
-	}
-	for path, exp := range tests {
-		resp, err := http.Get("http://" + addr + path)
-		if err != nil {
-			t.Fatalf("request %s failed: %v", path, err)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("%s returned %d", path, resp.StatusCode)
-		}
-		if strings.TrimSpace(string(body)) != exp {
-			t.Fatalf("%s unexpected body %s", path, string(body))
-		}
-	}
-}
-
-func TestHealthNotReady(t *testing.T) {
-	svc := &BaseService{Name: "test", Config: Config{MetricsAddr: "127.0.0.1:0"}}
-	svc.ctx, svc.cancel = context.WithCancel(context.Background())
-	svc.logger = zap.NewNop()
-	svc.live = true
-	svc.ready = false
-	svc.startupComplete = true
-	svc.setupMetrics()
-	defer svc.Stop()
-
-	addr := svc.metricsLn.Addr().String()
-	resp, err := http.Get("http://" + addr + "/health/ready")
+	time.Sleep(100 * time.Millisecond)
+	addr := svc.Metrics.ListenerAddr()
+	resp, err := http.Get("http://" + addr + "/health")
 	if err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
 	}
-	if strings.TrimSpace(string(body)) != `{"status":"not ready"}` {
-		t.Fatalf("unexpected body %s", string(body))
-	}
-}
-
-func TestHealthStartupIncomplete(t *testing.T) {
-	svc := &BaseService{Name: "test", Config: Config{MetricsAddr: "127.0.0.1:0"}}
-	svc.ctx, svc.cancel = context.WithCancel(context.Background())
-	svc.logger = zap.NewNop()
-	svc.live = true
-	svc.ready = true
-	svc.startupComplete = false
-	svc.setupMetrics()
-	defer svc.Stop()
-
-	addr := svc.metricsLn.Addr().String()
-	resp, err := http.Get("http://" + addr + "/health/startup")
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", resp.StatusCode)
-	}
-	if strings.TrimSpace(string(body)) != `{"status":"starting"}` {
+	if string(body) != "{\"status\":\"ok\"}\n" && string(body) != "{\"status\":\"ok\"}" {
 		t.Fatalf("unexpected body %s", string(body))
 	}
 }

--- a/go/framework/tracing/tracer.go
+++ b/go/framework/tracing/tracer.go
@@ -1,0 +1,39 @@
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+// Tracer configures application tracing and returns a shutdown function.
+type Tracer interface {
+	Start(serviceName, endpoint string) (func(context.Context) error, error)
+}
+
+type JaegerTracer struct{}
+
+func NewJaegerTracer() *JaegerTracer { return &JaegerTracer{} }
+
+func (JaegerTracer) Start(serviceName, endpoint string) (func(context.Context) error, error) {
+	if endpoint == "" {
+		endpoint = "http://localhost:14268/api/traces"
+	}
+	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
+	if err != nil {
+		return nil, err
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(sdkresource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName),
+		)),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Shutdown, nil
+}

--- a/go/framework/tracing/tracer_test.go
+++ b/go/framework/tracing/tracer_test.go
@@ -1,0 +1,14 @@
+package tracing
+
+import "testing"
+
+func TestJaegerTracer(t *testing.T) {
+	jt := NewJaegerTracer()
+	shutdown, err := jt.Start("test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shutdown == nil {
+		t.Fatalf("expected shutdown function")
+	}
+}

--- a/services/event_processing/cmd/processor/main.go
+++ b/services/event_processing/cmd/processor/main.go
@@ -13,9 +13,13 @@ import (
 )
 
 func main() {
-	svc, err := framework.NewBaseService("event-processing", "config/service.yaml")
+	b, err := framework.NewServiceBuilder("event-processing", "config/service.yaml")
 	if err != nil {
-		log.Fatalf("failed to init base service: %v", err)
+		log.Fatalf("failed to init service builder: %v", err)
+	}
+	svc, err := b.Build()
+	if err != nil {
+		log.Fatalf("failed to build service: %v", err)
 	}
 
 	cfg, err := config.Load("")


### PR DESCRIPTION
## Summary
- implement new framework component packages for service building
- create `ServiceBuilder` and refactor `BaseService`
- update gateway and event processing services to use the builder
- add unit tests for logging, health, metrics, tracing and the builder
- document migration steps

## Testing
- `go test ./...` in `go/framework`
- `pytest -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688208428f6483208df186eb266eb926