### PR TITLE
Fix test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ with this Python release and newer.
    ```bash
    ./scripts/setup.sh
    ```
-   The script installs both `requirements.txt` and `requirements-dev.txt` from
-   PyPI (or a local `packages/` directory if present) and runs `npm install` to
+   The script installs `requirements.txt`, `requirements-dev.txt`, and
+   `requirements-test.txt` from PyPI (or a local `packages/` directory if
+   present) and runs `npm install` to
    fetch Node dependencies. The Python requirements now include the Kafka
    clients `confluent-kafka` and `fastavro`. Ensure dependencies are installed
    **before** running Pyright or using the Pylance extension. Missing packages
@@ -345,6 +346,7 @@ following steps:
    ```bash
    pip install -r requirements.txt
    pip install -r requirements-dev.txt
+   pip install -r requirements-test.txt
    # or simply run ./scripts/setup.sh
    ```
 5. If Dash packages behave unexpectedly, reinstall them with pinned versions:
@@ -427,7 +429,7 @@ schema in `schemas/access-event.avsc` with your schema registry (set
 
 Install dependencies before running the tests:
 ```bash
-# Option 1: use the helper script
+# Option 1: use the helper script (installs test requirements as well)
 ./scripts/setup.sh
 # Option 2: install packages manually
 pip install -r requirements.txt -r requirements-test.txt
@@ -503,7 +505,8 @@ critical vulnerabilities are detected. Download the artifact from the
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run
-`pip install -r requirements.txt` and `pip install -r requirements-dev.txt` to
+`pip install -r requirements.txt`, `pip install -r requirements-dev.txt` and
+`pip install -r requirements-test.txt` to
 install all dependencies (or execute `./scripts/setup.sh`).
 `PerformanceMonitor` requires `psutil` for CPU and memory metrics, and the
 file processing utilities depend on `chardet` to detect text encoding.

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -26,9 +26,9 @@ This guide walks new contributors through setting up a local development environ
    ```bash
    ./scripts/setup.sh
    ```
-   This installs both `requirements.txt` and `requirements-dev.txt`. The
-   development requirements include additional packages such as **PyYAML** that
-   are necessary when running the test suite.
+   This installs `requirements.txt`, `requirements-dev.txt` and
+   `requirements-test.txt`. The development requirements include additional
+   packages such as **PyYAML** that are necessary when running the test suite.
 
 4. **Install Node dependencies:**
    ```bash

--- a/docs/developer_setup_checklist.md
+++ b/docs/developer_setup_checklist.md
@@ -16,7 +16,7 @@ This checklist summarizes the basic steps required to prepare a development envi
 3. Install the **Black** plugin (or add it as an external tool) and enable it as the formatter.
 
 ## Pre‑commit Hooks
-1. Install the dependencies and `pre-commit`:
+1. Install the dependencies (including test packages) and `pre-commit`:
    ```bash
    ./scripts/setup.sh
    pip install pre-commit

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -17,8 +17,9 @@ pip install -r requirements.txt
 pip install -r requirements-test.txt
 ```
 Alternatively you can run `./scripts/setup.sh` to install the standard
-dependencies. `requirements-test.txt` includes additional packages such as
-**PyYAML** that are required by the tests but not needed in production.
+dependencies **and** all test requirements. `requirements-test.txt` includes
+additional packages such as **PyYAML** that are required by the tests but not
+needed in production.
 
 ### Required Python Packages
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,10 +7,14 @@ if [ -d "$ROOT_DIR/packages" ]; then
     # Install from local package directory when available
     pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements.txt"
     pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements-dev.txt"
+    # Install packages needed exclusively for running the tests
+    pip install --no-index --find-links "$ROOT_DIR/packages" -r "$ROOT_DIR/requirements-test.txt"
 else
     # Fallback to PyPI
     pip install -r "$ROOT_DIR/requirements.txt"
     pip install -r "$ROOT_DIR/requirements-dev.txt"
+    # Install packages needed exclusively for running the tests
+    pip install -r "$ROOT_DIR/requirements-test.txt"
 fi
 
 # Install Node dependencies for the CSS build step


### PR DESCRIPTION
## Summary
- install test requirements via `setup.sh`
- clarify docs around running the test suite

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt --upgrade`
- `pytest tests/components/test_nav_icon.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882085210708320a60240db0053cc97