### PR TITLE
Add unified error handling package

### DIFF
--- a/error_handling/__init__.py
+++ b/error_handling/__init__.py
@@ -1,0 +1,13 @@
+"""Unified error handling utilities."""
+
+from .core import ErrorContext, ErrorHandler
+from .decorators import handle_errors
+from .exceptions import ErrorCategory, YosaiException
+
+__all__ = [
+    "ErrorHandler",
+    "ErrorContext",
+    "handle_errors",
+    "YosaiException",
+    "ErrorCategory",
+]

--- a/error_handling/core.py
+++ b/error_handling/core.py
@@ -1,0 +1,39 @@
+"""Core error handling primitives."""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .exceptions import ErrorCategory, YosaiException
+
+
+@dataclass
+class ErrorContext:
+    """Runtime context captured when handling an exception."""
+
+    exception: Exception
+    category: ErrorCategory
+    message: str
+    details: Optional[Any] = None
+
+
+class ErrorHandler:
+    """Convert exceptions to :class:`YosaiException` objects."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self.log = logger or logging.getLogger(__name__)
+
+    def handle(
+        self,
+        exc: Exception,
+        category: ErrorCategory = ErrorCategory.INTERNAL,
+        details: Optional[Any] = None,
+    ) -> YosaiException:
+        """Create a :class:`YosaiException` for *exc* and log it."""
+
+        self.log.exception("unhandled error", exc_info=exc)
+        context = ErrorContext(exc, category, str(exc), details)
+        return YosaiException(context.category, context.message, context.details)
+
+
+__all__ = ["ErrorHandler", "ErrorContext"]

--- a/error_handling/decorators.py
+++ b/error_handling/decorators.py
@@ -1,0 +1,51 @@
+"""Convenience decorators for error handling."""
+
+import asyncio
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+from .core import ErrorHandler
+from .exceptions import ErrorCategory
+
+T = TypeVar("T")
+
+
+def handle_errors(
+    category: ErrorCategory = ErrorCategory.INTERNAL,
+    reraise: bool = False,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Wrap *func* and convert exceptions into :class:`YosaiException`."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        handler = ErrorHandler()
+
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> T:
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    err = handler.handle(exc, category)
+                    if reraise:
+                        raise err
+                    return err  # type: ignore[return-value]
+
+            return async_wrapper
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                err = handler.handle(exc, category)
+                if reraise:
+                    raise err
+                return err  # type: ignore[return-value]
+
+        return sync_wrapper
+
+    return decorator
+
+
+__all__ = ["handle_errors"]

--- a/error_handling/exceptions.py
+++ b/error_handling/exceptions.py
@@ -1,0 +1,40 @@
+"""Application specific exceptions using the standard error contract."""
+
+from enum import Enum
+from typing import Any, Optional
+
+from shared.errors.types import ErrorCode
+
+
+class ErrorCategory(str, Enum):
+    """Standard error categories matching :class:`~shared.errors.types.ErrorCode`."""
+
+    INVALID_INPUT = ErrorCode.INVALID_INPUT.value
+    UNAUTHORIZED = ErrorCode.UNAUTHORIZED.value
+    NOT_FOUND = ErrorCode.NOT_FOUND.value
+    INTERNAL = ErrorCode.INTERNAL.value
+    UNAVAILABLE = ErrorCode.UNAVAILABLE.value
+
+
+class YosaiException(Exception):
+    """Base application exception conforming to the error contract."""
+
+    def __init__(
+        self,
+        category: ErrorCategory,
+        message: str,
+        details: Optional[Any] = None,
+    ) -> None:
+        self.category = category
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+    def to_dict(self) -> dict[str, Any]:
+        body = {"code": self.category.value, "message": self.message}
+        if self.details is not None:
+            body["details"] = self.details
+        return body
+
+
+__all__ = ["ErrorCategory", "YosaiException"]

--- a/error_handling/middleware.py
+++ b/error_handling/middleware.py
@@ -1,0 +1,30 @@
+"""FastAPI middleware for unified error responses."""
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from shared.errors.types import ErrorCode
+from yosai_framework.errors import CODE_TO_STATUS
+
+from .core import ErrorHandler
+from .exceptions import ErrorCategory
+
+
+class ErrorHandlingMiddleware(BaseHTTPMiddleware):
+    """Transform uncaught exceptions into standard error responses."""
+
+    def __init__(self, app, handler: ErrorHandler | None = None) -> None:
+        super().__init__(app)
+        self.handler = handler or ErrorHandler()
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        try:
+            return await call_next(request)
+        except Exception as exc:  # noqa: BLE001
+            err = self.handler.handle(exc, ErrorCategory.INTERNAL)
+            status = CODE_TO_STATUS.get(ErrorCode(err.category.value), 500)
+            return JSONResponse(content=err.to_dict(), status_code=status)
+
+
+__all__ = ["ErrorHandlingMiddleware"]


### PR DESCRIPTION
## Summary
- implement `error_handling` package with reusable error helpers
- include new exceptions, handler, decorator and middleware
- expose utilities via package `__init__`

## Testing
- `pre-commit run --files error_handling/__init__.py error_handling/exceptions.py error_handling/core.py error_handling/decorators.py error_handling/middleware.py` *(fails: mypy, bandit)*

------
https://chatgpt.com/codex/tasks/task_e_6882086d3c248320a2cb452ffab995c2