### PR TITLE
Add error handling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This project follows a fully modular design built around a dependency injection 
 - [React Component Architecture](docs/react_component_architecture.md)
 - [Validation Overview](docs/validation_overview.md)
 - [Error Response Contract](docs/error_contract.md)
+- [Error Handling](docs/error_handling.md)
 - [Model Cards](docs/model_cards.md)
 - [Data Versioning](docs/data_versioning.md)
 - [Data Processing](docs/data_processing.md)
@@ -500,6 +501,7 @@ critical vulnerabilities are detected. Download the artifact from the
 - **Metrics & Monitoring**: `PerformanceMonitor` tracks system performance
   using `psutil`.
 - **Dependabot Updates**: Python dependencies automatically kept up-to-date.
+- **Unified Error Handling**: Use `core.error_handling` decorators and middleware for consistent logging
 
 **Note:** The file upload and column mapping functionality relies on `pandas`.
 If `pandas` is missing these pages will be disabled. Ensure you run

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -1,0 +1,78 @@
+# Error Handling Overview
+
+The `core.error_handling` module provides a flexible framework for capturing
+and summarising exceptions across the platform.  It replaces ad-hoc
+`try/except` blocks and the minimal JSON handlers defined in
+`core.error_handlers`.  All services should migrate to this module for
+consistent metrics and logging.
+
+## Usage Patterns
+
+### Registering the middleware
+
+Flask applications can expose unified JSON errors by calling
+`register_error_handlers` during initialisation:
+
+```python
+from flask import Flask
+from core.error_handlers import register_error_handlers
+
+app = Flask(__name__)
+register_error_handlers(app)
+```
+
+This middleware converts custom `YosaiBaseException` instances and generic
+`HTTPException` objects into the standard error response format.  Unknown
+exceptions are logged and returned as a 500 response.
+
+### Decorator for functions
+
+Use `with_error_handling` to wrap synchronous code.  The decorator automatically
+logs the exception, stores it in the global `ErrorHandler` history and returns
+`None` (or re-raises if `reraise=True`):
+
+```python
+from core.error_handling import (
+    ErrorCategory,
+    ErrorSeverity,
+    with_error_handling,
+)
+
+@with_error_handling(category=ErrorCategory.DATABASE, severity=ErrorSeverity.HIGH)
+def load_records(db):
+    return db.query('SELECT * FROM records')
+```
+
+Async functions can use `with_async_error_handling` in the same way.
+
+### Circuit breaker and retries
+
+External API calls should use the `CircuitBreaker` utility combined with
+`with_retry` to avoid repeated failures:
+
+```python
+from core.error_handling import CircuitBreaker, with_retry
+
+breaker = CircuitBreaker(name='external_api')
+
+@with_retry(max_attempts=5, delay=2.0)
+def fetch_data(client):
+    return breaker.call(client.get_data)
+```
+
+Metrics for breaker state transitions are exported via Prometheus.
+
+## Migration Guide
+
+1. Import `register_error_handlers` in your app factory and remove any old
+   `@app.errorhandler` declarations.
+2. Replace manual `try/except` blocks with `with_error_handling` or
+   `with_async_error_handling`.  The decorator automatically records context and
+   severity.
+3. Wrap fragile external service calls with `CircuitBreaker.call` and optionally
+   decorate them with `with_retry` for transient failures.
+4. Review the recorded history using `error_handler.get_error_summary()` to gain
+   insight into error trends.
+
+Moving to this module centralises logging and ensures that Prometheus metrics are
+available for all critical exceptions.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -13,6 +13,7 @@ into your existing Yōsai Intel application
 from flask import Flask
 from flask_login import login_required
 from config import create_config_manager
+from core.error_handlers import register_error_handlers
 from core.container import Container
 from database.connection import create_database_connection
 
@@ -37,6 +38,7 @@ def create_app(config_name: str = None) -> Flask:
     Enhanced app factory with full compliance integration
     """
     app = Flask(__name__)
+    register_error_handlers(app)
     
     # Load configuration
     config_manager = create_config_manager()

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -51,3 +51,6 @@ REQUIREMENTS:
 - Performance comparison data
 - Security improvement documentation
 
+
+### Error Handling Migration
+Use `core.error_handling` for unified decorators and circuit breakers. Replace custom @app.errorhandler code with `register_error_handlers` and wrap functions with `with_error_handling`.


### PR DESCRIPTION
## Summary
- document unified error handling patterns
- reference new module in README
- show middleware usage in integration guide
- note migration in migration guide

## Testing
- `pytest tests/api/test_error_handlers.py -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_68820872696c832080333a7f77dc9738