### PR TITLE
Document unified config

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,11 @@ applies environment variable overrides.
 The underlying loading logic lives in `config/base_loader.py` as `BaseConfigLoader`.
 It handles YAML `!include` expansion, JSON files and environment variable substitution. Earlier versions used separate modules
 such as `app_config.py` and `simple_config.py`; these have been replaced by this
-unified loader. Register the configuration with the DI container so it can be
+unified loader. The configuration schema is also defined using a protobuf file
+(`config/yosai_config.proto`). Loaders compile this schema to the Python module
+`yosai_config_pb2.py` and a convenience wrapper called `YosaiConfig`. All
+services read YAML/JSON and convert it to this protobuf representation before
+use. Register the configuration with the DI container so it can be
 resolved from anywhere:
 
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -1,5 +1,8 @@
 # Configuration Reference
 
+See [unified_config.md](unified_config.md) for details on regenerating the
+protobuf schema and the `YosaiConfig` loader.
+
 ## App
 
 | Field | Default | Env Var |

--- a/docs/unified_config.md
+++ b/docs/unified_config.md
@@ -1,0 +1,28 @@
+# Unified Configuration
+
+The configuration schema for all services is now defined in the protobuf file
+`config/yosai_config.proto`.  When building the project the file is compiled to
+`yosai_config_pb2.py` together with a thin `YosaiConfig` wrapper.  Services load
+YAML or JSON configuration and convert it into this protobuf representation so
+that Python and Go components share the same structure.
+
+## Regenerating the schema
+
+After editing `yosai_config.proto` run the code generation script to rebuild the
+Python modules:
+
+```bash
+scripts/generate_protos.sh
+```
+
+This command invokes `protoc` with the correct include paths and updates the
+`config` package.  Commit the resulting `yosai_config_pb2.py` file so other
+services can use the new fields.
+
+## Using `YosaiConfig`
+
+`create_config_manager()` returns an instance of `YosaiConfig` which exposes
+accessors like `get_app_config()` and `get_database_config()`.  Services obtain
+it from the dependency injection container and operate purely on the typed
+protobuf object.
+


### PR DESCRIPTION
## Summary
- document protobuf-based configuration loader
- explain how to regenerate protobuf and how YosaiConfig is used
- link new docs from configuration reference

## Testing
- `make test` *(fails: ModuleNotFoundError and other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_6882088015248320aa68c332a8af14c9