### PR TITLE
Add protoc generation targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,16 @@ See [docs/test_architecture.md](docs/test_architecture.md) and
 the testing protocols, container builder and available test doubles.
 
 Please ensure tests and linters pass before opening a pull request.
+
+## Generating Protobuf Code
+
+Protobuf service definitions live under `proto/`. When the `.proto` files
+change, regenerate the language specific sources using the Makefile helpers:
+
+```bash
+make proto-python   # build Python stubs
+make proto-go       # build Go stubs
+make proto-all      # run both
+```
+
+Commit the resulting generated files so CI can verify they are up to date.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ DURATION ?= 60
 CLI ?= python -m tools.ops_cli
 
 .PHONY: load-test validate build test deploy format lint clean \
-build-all test-all deploy-all logs deprecation-docs
+build-all test-all deploy-all logs deprecation-docs \
+proto-python proto-go proto-all
 
 load-test:
 	python tools/load_test.py --brokers $(BROKERS) --prom-url $(PROM_URL) --rate $(RATE) --duration $(DURATION)
@@ -45,5 +46,15 @@ deprecation-docs:
 	python scripts/generate_deprecation_docs.py
 
 clean:
-	$(CLI) clean
+        $(CLI) clean
+
+PROTOS := $(wildcard proto/*.proto)
+
+proto-python:
+	python -m grpc_tools.protoc -I proto --python_out=. --grpc_python_out=. $(PROTOS)
+
+proto-go:
+	protoc -I proto --go_out=. --go-grpc_out=. $(PROTOS)
+
+proto-all: proto-python proto-go
 


### PR DESCRIPTION
## Summary
- add `proto-python` and `proto-go` targets to Makefile
- allow `proto-all` to build all stubs
- document protobuf generation workflow

## Testing
- `pre-commit run --files Makefile CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_688208823d908320a4b0e3f9dd1d57ec