### PR TITLE
Enforce SECRET_KEY requirement

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -102,7 +102,9 @@ class DatabaseConfig:
 class SecurityConfig:
     """Security configuration."""
 
-    secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
+    secret_key: str = field(
+        default_factory=lambda: require_env_var("SECRET_KEY")
+    )
     session_timeout: int = 3600
     session_timeout_by_role: Dict[str, int] = field(default_factory=dict)
     cors_origins: List[str] = field(default_factory=list)

--- a/config/config_validator.py
+++ b/config/config_validator.py
@@ -91,9 +91,12 @@ class ConfigValidator(ConfigValidatorProtocol):
         """Run built-in and custom validation rules."""
         result = ValidationResult()
 
+        if not getattr(config.app, "secret_key", None) or not getattr(
+            config.security, "secret_key", None
+        ):
+            result.errors.append("SECRET_KEY must be set")
+
         if config.environment == "production":
-            if not config.app.secret_key:
-                result.errors.append("SECRET_KEY must be set for production")
             if not config.database.password and config.database.type != "sqlite":
                 result.warnings.append("Production database requires password")
             if config.app.host == "127.0.0.1":

--- a/config/pydantic_models.py
+++ b/config/pydantic_models.py
@@ -41,7 +41,10 @@ class DatabaseModel(BaseModel):
 
 
 class SecurityModel(BaseModel):
-    secret_key: str = Field(default="", json_schema_extra={"env": "SECRET_KEY"})
+    secret_key: str = Field(
+        ...,
+        json_schema_extra={"env": "SECRET_KEY"},
+    )
     session_timeout: int = 3600
     session_timeout_by_role: Dict[str, int] = Field(default_factory=dict)
     cors_origins: List[str] = Field(default_factory=list)

--- a/config/schema.py
+++ b/config/schema.py
@@ -88,7 +88,9 @@ class DatabaseSettings(BaseModel):
 class SecuritySettings(BaseModel):
     """Security related settings."""
 
-    secret_key: str = Field(default_factory=lambda: os.getenv("SECRET_KEY", ""))
+    secret_key: str = Field(
+        default_factory=lambda: require_env_var("SECRET_KEY")
+    )
     session_timeout: int = 3600
     session_timeout_by_role: Dict[str, int] = Field(default_factory=dict)
     cors_origins: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- require SECRET_KEY in security config dataclasses
- tighten config validator to always enforce SECRET_KEY
- make SecurityModel SECRET_KEY mandatory

## Testing
- `pytest tests/test_config_validator.py::test_valid_config tests/test_config_validator.py::test_upload_limit_error tests/test_config_validator.py::test_upload_limit_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_688242ae08d8832092e359fb58a18a33