### PR TITLE
Add throughput load test job

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -34,3 +34,24 @@ jobs:
       - name: Check thresholds
         run: |
           load-tests/check_thresholds.sh api.json ingest.json analytics.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps
+        run: pip install requests kafka-python
+
+      - name: Run Python load test
+        run: |
+          python tools/load_test.py \
+            --brokers localhost:9092 \
+            --prom-url http://localhost:9090 \
+            --rate 50 --duration 60 | tee load_test_results.json
+
+      - name: Upload throughput results
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results
+          path: load_test_results.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,3 +50,24 @@ python tests/performance/test_event_processing.py
 ```
 
 The script targets the gateway at `http://localhost:8081`.
+
+## Kafka Load Test
+
+Another script, `tools/load_test.py`, publishes synthetic events to Kafka and
+calculates throughput from Prometheus metrics. The Makefile exposes a helper
+target so the stack can be exercised easily:
+
+```bash
+make load-test
+```
+
+Optional variables allow adjusting brokers, Prometheus URL, event rate and test
+duration:
+
+```bash
+make load-test RATE=100 DURATION=30
+```
+
+Ensure the Docker Compose stack is running so Kafka and Prometheus are
+available. The command prints a JSON summary which is also saved by the CI
+performance job as an artifact.


### PR DESCRIPTION
## Summary
- extend performance tests workflow with a Python load test step
- store the JSON results as artifacts
- document the load-test Makefile target

## Testing
- `python -m py_compile tools/load_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688242b0d6488320acef9de0fc2fe633