### PR TITLE
Update auth docs and OpenAPI

### DIFF
--- a/api/openapi/yosai-api-v2.yaml
+++ b/api/openapi/yosai-api-v2.yaml
@@ -4,10 +4,11 @@ info:
   version: 2.0.0
   description: |
     Physical security intelligence and access control API.
-    
+
     # Authentication
-    Use Bearer token (JWT) or API key authentication.
-    
+    Use Bearer token (JWT) for inter-service communication and require an
+    `X-CSRF-Token` header on state-changing requests.
+
     # Versioning
     API version is included in the URL path (e.g., /v2/events).
   termsOfService: https://yosai.com/terms
@@ -24,6 +25,10 @@ servers:
     description: Staging
   - url: http://localhost:8080/v2
     description: Development
+
+security:
+  - jwtAuth: []
+  - csrfToken: []
 
 tags:
   - name: Events
@@ -51,14 +56,16 @@ paths:
 
 components:
   securitySchemes:
-    bearerAuth:
+    jwtAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-    apiKey:
+      description: Signed JWT present in the Authorization header
+    csrfToken:
       type: apiKey
       in: header
-      name: X-API-Key
+      name: X-CSRF-Token
+      description: Anti-CSRF token required for mutating operations
   schemas:
     Error:
       type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,13 @@ Commit the updated `docs/openapi.json`, `analytics/clients/event_client`, and
 sync with the codebase. CI will fail if these files differ from the checked in
 versions.
 
+## Authentication
+
+API requests require a signed JWT in the `Authorization` header and a CSRF
+token for state-changing operations. See
+[Service Authentication](service_authentication.md) for details on how tokens
+are issued and verified.
+
 ## API Versioning
 
 All endpoints are prefixed with a version such as `/v1` or `/api/v1`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,108 +1,179 @@
 {
-    "components": {
-        "responses": {
-            "BadRequest": {
-                "content": {
-                    "application/json": {
-                        "schema": {"$ref": "#/components/schemas/Error"}
-                    }
-                },
-                "description": "Bad request",
-            },
-            "NotFound": {
-                "content": {
-                    "application/json": {
-                        "schema": {"$ref": "#/components/schemas/Error"}
-                    }
-                },
-                "description": "Resource not found",
-            },
-        },
-        "schemas": {
-            "AccessEvent": {
-                "properties": {
-                    "door_id": {"type": "string"},
-                    "event_id": {"type": "string"},
-                    "person_id": {"type": "string"},
-                    "result": {
-                        "enum": ["granted", "denied", "tailgating", "forced"],
-                        "type": "string",
-                    },
-                    "timestamp": {"format": "date-time", "type": "string"},
-                },
-                "required": ["person_id", "door_id", "timestamp"],
-                "type": "object",
-            },
-            "Error": {
-                "properties": {
-                    "code": {"type": "string"},
-                    "details": {"additionalProperties": true, "type": "object"},
-                    "message": {"type": "string"},
-                },
-                "required": ["code", "message"],
-                "type": "object",
-            },
-            "EventListResponse": {
-                "properties": {
-                    "events": {
-                        "items": {"$ref": "#/components/schemas/AccessEvent"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-        },
-        "securitySchemes": {
-            "apiKey": {"in": "header", "name": "X-API-Key", "type": "apiKey"},
-            "bearerAuth": {"bearerFormat": "JWT", "scheme": "bearer", "type": "http"},
-        },
-    },
-    "info": {
-        "contact": {"email": "api-support@yosai.com"},
-        "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) or API key authentication.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
-        "license": {
-            "name": "Apache 2.0",
-            "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
-        },
-        "termsOfService": "https://yosai.com/terms",
-        "title": "Yōsai Intel Dashboard API",
-        "version": "2.0.0",
-    },
-    "openapi": "3.0.3",
-    "paths": {
-        "/events": {
-            "get": {
-                "operationId": "listAccessEvents",
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EventListResponse"
-                                }
-                            }
-                        },
-                        "description": "Successful response",
-                    },
-                    "400": {"$ref": "#/components/responses/BadRequest"},
-                    "404": {"$ref": "#/components/responses/NotFound"},
-                },
-                "summary": "List access events",
-                "tags": ["Events"],
+  "components": {
+    "responses": {
+      "BadRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
             }
-        }
+          }
+        },
+        "description": "Bad request"
+      },
+      "NotFound": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        },
+        "description": "Resource not found"
+      }
     },
-        ,"/models/register": {"post": {"operationId": "registerModel", "summary": "Register a model", "tags": ["Models"], "responses": {"200": {"description": "Registered"}}}}
-        ,"/models/{name}": {"get": {"operationId": "listModelVersions", "summary": "List model versions", "tags": ["Models"], "responses": {"200": {"description": "Versions"}}}}
-        ,"/models/{name}/rollback": {"post": {"operationId": "rollbackModel", "summary": "Rollback active model version", "tags": ["Models"], "responses": {"200": {"description": "Rolled back"}}}}
-    "servers": [
-        {"description": "Production", "url": "https://api.yosai.com/v2"},
-        {"description": "Staging", "url": "https://staging-api.yosai.com/v2"},
-        {"description": "Development", "url": "http://localhost:8080/v2"},
-    ],
-    "tags": [
-        {"description": "Access control events", "name": "Events"},
-        {"description": "Analytics and reporting", "name": "Analytics"},
-        {"description": "Model registry", "name": "Models"},
-    ],
+    "schemas": {
+      "AccessEvent": {
+        "properties": {
+          "door_id": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "person_id": {
+            "type": "string"
+          },
+          "result": {
+            "enum": [
+              "granted",
+              "denied",
+              "tailgating",
+              "forced"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "person_id",
+          "door_id",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "Error": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "EventListResponse": {
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/AccessEvent"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "csrfToken": {
+        "description": "Anti-CSRF token required for mutating operations",
+        "in": "header",
+        "name": "X-CSRF-Token",
+        "type": "apiKey"
+      },
+      "jwtAuth": {
+        "bearerFormat": "JWT",
+        "description": "Signed JWT present in the Authorization header",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "api-support@yosai.com"
+    },
+    "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) for inter-service communication and require an\n`X-CSRF-Token` header on state-changing requests.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "termsOfService": "https://yosai.com/terms",
+    "title": "Yōsai Intel Dashboard API",
+    "version": "2.0.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/events": {
+      "get": {
+        "operationId": "listAccessEvents",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventListResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List access events",
+        "tags": [
+          "Events"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "jwtAuth": []
+    },
+    {
+      "csrfToken": []
+    }
+  ],
+  "servers": [
+    {
+      "description": "Production",
+      "url": "https://api.yosai.com/v2"
+    },
+    {
+      "description": "Staging",
+      "url": "https://staging-api.yosai.com/v2"
+    },
+    {
+      "description": "Development",
+      "url": "http://localhost:8080/v2"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Access control events",
+      "name": "Events"
+    },
+    {
+      "description": "Analytics and reporting",
+      "name": "Analytics"
+    }
+  ]
 }

--- a/docs/service_authentication.md
+++ b/docs/service_authentication.md
@@ -13,3 +13,26 @@ rejected with HTTP 401.
 
 Use the helper functions in `services.security.jwt_service` to generate and
 verify these tokens when communicating between services.
+
+## Login Sequence
+
+![Login flow](auth_flow.png)
+
+1. The user submits credentials to the gateway.
+2. A signed JWT is created when authentication succeeds.
+3. The response returns the token and a CSRF cookie.
+
+## Token Issuance
+
+![Token issuance](auth_flow.png)
+
+1. Services request new tokens from the gateway using their own credentials.
+2. Tokens include an issuer claim so downstream services can identify callers.
+
+## Service-to-Service Authentication
+
+![Service authentication](auth_flow.png)
+
+1. Service A calls Service B with the JWT in the `Authorization` header.
+2. Service B verifies the signature and expiration time.
+3. Requests lacking the JWT or CSRF header are rejected with `401`.


### PR DESCRIPTION
## Summary
- document login/token flows with diagrams
- crosslink auth docs from API guide
- add JWT and CSRF security schemes to OpenAPI

## Testing
- `go run .` in `api/openapi` to regenerate `openapi.json`
- `pytest -q` *(fails: Missing pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_6882465877508320839afe01f991472c