### PR TITLE
Add clean architecture validation job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
 
 jobs:
+  clean-arch-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.lock
+      - name: Dry run migration
+        run: python scripts/migrate_to_clean_arch.py --dry-run
+      - name: Validate directory structure
+        run: python scripts/validate_structure.py
+
   tests:
     runs-on: ubuntu-latest
     strategy:
@@ -71,7 +84,7 @@ jobs:
         run: python scripts/verify_timescale_migration.py
   container-build:
     runs-on: ubuntu-latest
-    needs: tests
+    needs: [tests, clean-arch-check]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -16,8 +16,22 @@ jobs:
           kubectl apply --dry-run=client -f k8s/production
           kubectl apply --dry-run=client -f k8s/canary
 
-  lint:
+  clean-arch-check:
     needs: validate-configs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.lock
+      - name: Dry run migration
+        run: python scripts/migrate_to_clean_arch.py --dry-run
+      - name: Validate directory structure
+        run: python scripts/validate_structure.py
+
+  lint:
+    needs: [validate-configs, clean-arch-check]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/developer_guide_clean_arch.md
+++ b/docs/developer_guide_clean_arch.md
@@ -39,3 +39,11 @@ python scripts/validate_structure.py
 
 Add this command to your pre-commit hooks to avoid accidentally adding modules in
 the wrong location.
+
+## CI Check
+
+The GitHub Actions workflows include a job that verifies the repository can be
+migrated to the clean layout. It executes
+`scripts/migrate_to_clean_arch.py --dry-run` followed by
+`scripts/validate_structure.py`. If the validation step prints
+"Missing required directory" the job fails and the workflow stops.


### PR DESCRIPTION
## Summary
- validate clean architecture layout in CI
- ensure container build waits for validation
- document the CI check

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/ci-cd.yml .github/workflows/unified-ci.yml`
- `python scripts/validate_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_688244fee898832099b1ac214f718e48