### PR TITLE
Add model monitoring scheduler

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -169,6 +169,7 @@ class MonitoringConfig:
     error_reporting_enabled: bool = True
     sentry_dsn: Optional[str] = None
     log_retention_days: int = 30
+    model_evaluation_interval: int = 60
 
 
 @dataclass

--- a/config/monitoring.yaml
+++ b/config/monitoring.yaml
@@ -12,3 +12,6 @@ data_quality:
   max_missing_ratio: 0.1
   max_outlier_ratio: 0.01
   max_schema_violations: 0
+
+model_monitor:
+  evaluation_interval_minutes: 60

--- a/config/schema.py
+++ b/config/schema.py
@@ -149,6 +149,7 @@ class MonitoringSettings(BaseModel):
     error_reporting_enabled: bool = True
     sentry_dsn: Optional[str] = None
     log_retention_days: int = 30
+    model_evaluation_interval: int = 60
 
 
 class DataQualityThresholds(BaseModel):

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -26,3 +26,20 @@ start_model_metrics_server(port=9104)
 
 `model_accuracy`, `model_precision` and `model_recall` gauges will then be
 available on `/metrics`.
+
+## Automated Model Monitoring
+
+`ModelMonitor` evaluates active models at a fixed interval and updates Prometheus metrics.
+The interval can be configured in `config/monitoring.yaml` under `model_monitor.evaluation_interval_minutes`.
+
+During each run metrics are checked for drift using `ModelPerformanceMonitor.detect_drift`.
+When drift is detected a warning is emitted and the baseline metrics are updated.
+
+```python
+from monitoring.model_monitor import ModelMonitor
+from models.ml.model_registry import ModelRegistry
+
+registry = ModelRegistry(database_url="sqlite:///models.db", bucket="models")
+monitor = ModelMonitor(registry)
+monitor.start()
+```

--- a/monitoring/model_monitor.py
+++ b/monitoring/model_monitor.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Scheduled monitoring of active ML models."""
+
+import threading
+import time
+import warnings
+from typing import Optional
+
+from config import get_monitoring_config
+from models.ml.model_registry import ModelRegistry
+from monitoring.model_performance_monitor import (
+    ModelMetrics,
+    get_model_performance_monitor,
+)
+from monitoring.prometheus.model_metrics import update_model_metrics
+
+
+class ModelMonitor:
+    """Periodically evaluate active models and check for drift."""
+
+    def __init__(
+        self,
+        registry: ModelRegistry,
+        *,
+        interval_minutes: Optional[int] = None,
+    ) -> None:
+        cfg = get_monitoring_config()
+        mm_cfg = getattr(cfg, "model_monitor", {})
+        if isinstance(mm_cfg, dict):
+            default_interval = mm_cfg.get("evaluation_interval_minutes", 60)
+        else:
+            default_interval = getattr(mm_cfg, "evaluation_interval_minutes", 60)
+        self.interval_minutes = interval_minutes or default_interval
+        self.registry = registry
+        self.monitor = get_model_performance_monitor()
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start the background evaluation loop."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Stop the evaluation loop."""
+        if self._thread:
+            self._stop.set()
+            self._thread.join()
+
+    # ------------------------------------------------------------------
+    def _run(self) -> None:
+        interval = self.interval_minutes * 60
+        while not self._stop.is_set():
+            self.evaluate_active_models()
+            self._stop.wait(interval)
+
+    # ------------------------------------------------------------------
+    def evaluate_active_models(self) -> None:
+        """Evaluate all active models and record metrics."""
+        records = self.registry.list_models()
+        for rec in records:
+            if not getattr(rec, "is_active", False):
+                continue
+            metrics_dict = rec.metrics or {}
+            metrics = ModelMetrics(
+                accuracy=metrics_dict.get("accuracy", 0.0),
+                precision=metrics_dict.get("precision", 0.0),
+                recall=metrics_dict.get("recall", 0.0),
+            )
+            update_model_metrics(metrics)
+            if self.monitor.detect_drift(metrics):
+                warnings.warn(
+                    f"Model drift detected for {rec.name} {rec.version}",
+                    RuntimeWarning,
+                )
+                self.monitor.baseline = metrics
+
+
+__all__ = ["ModelMonitor"]
+


### PR DESCRIPTION
## Summary
- monitor active models on a schedule
- record drift metrics in Prometheus
- configure model monitor interval
- document model monitor usage

## Testing
- `pytest -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688246a1ce788320801ea1a3e865a90f