### PR TITLE
Add model AB testing service

### DIFF
--- a/docs/ab_testing.md
+++ b/docs/ab_testing.md
@@ -1,0 +1,32 @@
+# A/B Testing Models
+
+`ModelABTester` allows routing a portion of prediction traffic to different model versions.
+Candidate models are loaded from the `ModelRegistry` and selected according to
+user defined weights.
+
+## Configuring Weights
+
+Use the CLI tool to update the traffic split for a model:
+
+```bash
+python tools/cli_ab_testing.py my-model "1.0.0=80,1.1.0=20" --db sqlite:///registry.db --bucket ml-bucket
+```
+
+Weights are stored in `ab_weights.json` by default. The tester reloads the
+models when weights change.
+
+## Making Predictions
+
+Create a tester instance and call `predict` with your input data:
+
+```python
+from models.ml import ModelRegistry
+from services.ab_testing import ModelABTester
+
+registry = ModelRegistry("sqlite:///registry.db", "ml-bucket")
+tester = ModelABTester("my-model", registry)
+result = tester.predict(data)
+```
+
+Each call randomly chooses a model version based on the configured weights and
+logs which version produced the prediction.

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -16,6 +16,7 @@ else:
     from .analytics.publisher import Publisher
     from .analytics.upload_analytics import UploadAnalyticsProcessor
     from .analytics_generator import AnalyticsGenerator
+    from .ab_testing import ModelABTester
     from .analytics_processor import AnalyticsProcessor
     from .async_file_processor import AsyncFileProcessor
     from .chunked_analysis import analyze_with_chunking
@@ -94,4 +95,5 @@ else:
         "AnalyticsProcessor",
         "MicroservicesArchitect",
         "ServiceBoundary",
+        "ModelABTester",
     ]

--- a/services/ab_testing.py
+++ b/services/ab_testing.py
@@ -1,0 +1,109 @@
+"""Simple A/B testing wrapper for ML models."""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import joblib
+
+from models.ml import ModelRegistry
+
+
+class ModelABTester:
+    """Route predictions across model versions based on configured weights."""
+
+    def __init__(
+        self,
+        model_name: str,
+        registry: ModelRegistry,
+        *,
+        weights: Optional[Dict[str, float]] = None,
+        weights_file: str = "ab_weights.json",
+        model_dir: str = "ab_models",
+    ) -> None:
+        self.model_name = model_name
+        self.registry = registry
+        self.weights_file = Path(weights_file)
+        self.model_dir = Path(model_dir)
+        self.logger = logging.getLogger(__name__)
+        self.weights: Dict[str, float] = weights or self._load_weights()
+        self.models: Dict[str, Any] = {}
+        if self.weights:
+            self._load_models()
+
+    # ------------------------------------------------------------------
+    def _load_weights(self) -> Dict[str, float]:
+        if self.weights_file.exists():
+            try:
+                with self.weights_file.open() as fh:
+                    data = json.load(fh)
+                if isinstance(data, dict):
+                    return {str(k): float(v) for k, v in data.items()}
+            except Exception as exc:  # pragma: no cover - best effort
+                self.logger.warning("Failed to load weights: %s", exc)
+        return {}
+
+    def _save_weights(self) -> None:
+        try:
+            with self.weights_file.open("w") as fh:
+                json.dump(self.weights, fh)
+        except Exception as exc:  # pragma: no cover - best effort
+            self.logger.error("Failed to save weights: %s", exc)
+
+    def _load_models(self) -> None:
+        self.models.clear()
+        for version in self.weights:
+            record = self.registry.get_model(self.model_name, version=version)
+            if record is None:
+                self.logger.warning(
+                    "Model %s version %s not found in registry", self.model_name, version
+                )
+                continue
+            self.model_dir.mkdir(parents=True, exist_ok=True)
+            local_path = self.model_dir / f"{self.model_name}_{version}.bin"
+            if not local_path.exists():
+                try:
+                    self.registry.download_artifact(record.storage_uri, str(local_path))
+                except Exception as exc:  # pragma: no cover - network failures
+                    self.logger.error("Failed to download model %s:%s - %s", self.model_name, version, exc)
+                    continue
+            try:
+                model = joblib.load(local_path)
+                self.models[version] = model
+            except Exception as exc:  # pragma: no cover - invalid files
+                self.logger.error("Failed to load model artifact %s - %s", local_path, exc)
+
+    # ------------------------------------------------------------------
+    def set_weights(self, weights: Dict[str, float]) -> None:
+        """Update traffic weights and reload models."""
+        self.weights = {str(k): float(v) for k, v in weights.items()}
+        self._save_weights()
+        self._load_models()
+
+    # ------------------------------------------------------------------
+    def _choose_version(self) -> str:
+        versions = list(self.weights.keys())
+        probs = [self.weights[v] for v in versions]
+        total = sum(probs)
+        if total <= 0:
+            raise RuntimeError("Invalid weights: sum must be > 0")
+        return random.choices(versions, weights=probs, k=1)[0]
+
+    def predict(self, data: Iterable[Any]) -> Any:
+        """Predict using one of the loaded model versions."""
+        if not self.weights:
+            raise RuntimeError("No traffic weights configured")
+        version = self._choose_version()
+        model = self.models.get(version)
+        if model is None:
+            raise RuntimeError(f"Model version {version} not loaded")
+        result = model.predict(data)
+        self.logger.info("ab_test_prediction", extra={"version": version})
+        return result
+
+
+__all__ = ["ModelABTester"]

--- a/tools/cli_ab_testing.py
+++ b/tools/cli_ab_testing.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Command line tool to configure A/B testing weights."""
+
+import argparse
+from typing import Dict
+
+from models.ml import ModelRegistry
+from services.ab_testing import ModelABTester
+
+
+def parse_weights(value: str) -> Dict[str, float]:
+    weights: Dict[str, float] = {}
+    for item in value.split(","):
+        if not item:
+            continue
+        version, weight = item.split("=")
+        weights[version] = float(weight)
+    return weights
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Set traffic weights for model A/B testing")
+    parser.add_argument("model", help="Model name")
+    parser.add_argument("weights", help="Comma separated version=weight pairs")
+    parser.add_argument("--db", dest="db", default="sqlite:///models.db", help="Model registry database URL")
+    parser.add_argument("--bucket", dest="bucket", default="models", help="S3 bucket for artifacts")
+    parser.add_argument("--weights-file", dest="weights_file", default="ab_weights.json", help="Weights JSON file")
+    args = parser.parse_args()
+
+    registry = ModelRegistry(args.db, args.bucket)
+    tester = ModelABTester(args.model, registry, weights_file=args.weights_file)
+    tester.set_weights(parse_weights(args.weights))
+    print(f"Updated weights for {args.model}: {tester.weights}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `ModelABTester` service
- expose the service via `services.__init__`
- add CLI tool to configure weights
- document A/B testing usage

## Testing
- `pytest -q` *(fails: 109 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688246a0d230832094410b2ac1e7c18e