### PR TITLE
Add backup & rollback docs

### DIFF
--- a/docs/developer_guide_clean_arch.md
+++ b/docs/developer_guide_clean_arch.md
@@ -39,3 +39,23 @@ python scripts/validate_structure.py
 
 Add this command to your pre-commit hooks to avoid accidentally adding modules in
 the wrong location.
+## Backups and Rollback
+
+The migration script can create an archive of the directories it moves. Use `--backup` with the target path:
+
+```bash
+python scripts/migrate_to_clean_arch.py --backup /tmp/clean_arch_backup.tar.gz
+```
+
+To revert a failed migration provide the same file to `--rollback`:
+
+```bash
+python scripts/migrate_to_clean_arch.py --rollback /tmp/clean_arch_backup.tar.gz
+```
+
+### Zero-downtime tips
+
+- Run the migration on a staging instance first using `--dry-run` and verify that the archive contains all expected directories.
+- Ensure sufficient disk space is available for the backup archive.
+- Apply the migration incrementally across servers: migrate one instance, restart it, confirm health checks, then proceed with the next.
+- If an error occurs or the service does not start, roll back immediately using the archive and restart the node.


### PR DESCRIPTION
## Summary
- document backup and rollback options in the clean architecture guide

## Testing
- `pre-commit run --files docs/developer_guide_clean_arch.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_688245019894832088f88cee2b163cd6