### PR TITLE
Add risk scoring model training

### DIFF
--- a/analytics/risk_scoring_model.py
+++ b/analytics/risk_scoring_model.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+"""Machine learning risk scoring utilities."""
+
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+import hashlib
+import tempfile
+from pathlib import Path
+
+import joblib
+import pandas as pd
+
+
+def optional_import(name: str, fallback: type | None = None) -> Any:
+    """Attempt to import ``name`` returning ``fallback`` if unavailable."""
+    try:
+        if name.startswith("sklearn."):
+            parts = name.split(".")
+            if len(parts) > 2:
+                module_path = ".".join(parts[:-1])
+                class_name = parts[-1]
+                module = __import__(module_path, fromlist=[class_name])
+                return getattr(module, class_name)
+            module = __import__(name, fromlist=["*"])
+        else:
+            module = __import__(name, fromlist=["*"])
+        return module
+    except Exception as exc:  # pragma: no cover - optional dependency
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Optional dependency '%s' unavailable: %s", name, exc
+        )
+        return fallback
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from models.ml import ModelRegistry
+else:  # pragma: no cover - runtime fallback
+    ModelRegistry = Any  # type: ignore
+
+LogisticRegression = optional_import("sklearn.linear_model.LogisticRegression")
+GradientBoostingClassifier = optional_import(
+    "sklearn.ensemble.GradientBoostingClassifier"
+)
+StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+if LogisticRegression is None:  # pragma: no cover - fallback definitions
+
+    class LogisticRegression:  # type: ignore
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError("scikit-learn is required for LogisticRegression")
+
+if GradientBoostingClassifier is None:  # pragma: no cover - fallback definitions
+
+    class GradientBoostingClassifier:  # type: ignore
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "scikit-learn is required for GradientBoostingClassifier"
+            )
+
+if StandardScaler is None:  # pragma: no cover - fallback definitions
+
+    class StandardScaler:  # type: ignore
+        def fit_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+            return X
+
+        def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+            return X
+
+__all__ = ["train_risk_model", "predict_risk_score"]
+
+
+_TARGET_COLUMNS = ["risk_label", "label", "target"]
+
+
+def _select_target_column(df: pd.DataFrame) -> str:
+    for col in _TARGET_COLUMNS:
+        if col in df.columns:
+            return col
+    raise ValueError("DataFrame must contain a target column")
+
+
+def train_risk_model(
+    df: pd.DataFrame,
+    *,
+    model_registry: Optional[ModelRegistry] = None,
+    model_name: str = "risk-model",
+) -> Tuple[Any, Any]:
+    """Train a simple risk classification model.
+
+    Parameters
+    ----------
+    df:
+        Training data including a binary target column.
+    model_registry:
+        Optional model registry used to version the trained model.
+    model_name:
+        Name under which the model should be registered.
+
+    Returns
+    -------
+    tuple
+        ``(model, scaler)`` pair.
+    """
+
+    target_col = _select_target_column(df)
+    feature_df = df.drop(columns=[target_col])
+    numeric = feature_df.select_dtypes(include=["number", "bool"]).fillna(0)
+
+    scaler = StandardScaler()
+    data = scaler.fit_transform(numeric)
+
+    # Use gradient boosting if available, otherwise logistic regression
+    if GradientBoostingClassifier is not None:
+        model = GradientBoostingClassifier(random_state=42)
+    else:
+        model = LogisticRegression(max_iter=200)
+
+    model.fit(data, df[target_col])
+
+    if model_registry is not None:
+        metrics = {"accuracy": float(model.score(data, df[target_col]))}
+        dataset_hash = hashlib.sha256(
+            pd.util.hash_pandas_object(df, index=True).values.tobytes()
+        ).hexdigest()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "model.joblib"
+            joblib.dump({"model": model, "scaler": scaler}, path)
+            record = model_registry.register_model(
+                model_name,
+                str(path),
+                metrics,
+                dataset_hash,
+            )
+            model_registry.set_active_version(model_name, record.version)
+
+    return model, scaler
+
+
+def predict_risk_score(
+    model: Any, features: pd.DataFrame | list | tuple | Any, scaler: Any | None = None
+) -> Any:
+    """Predict risk score or probability for the given features."""
+
+    df = pd.DataFrame(features)
+    data = df if scaler is None else scaler.transform(df)
+
+    if hasattr(model, "predict_proba"):
+        proba = model.predict_proba(data)
+        if proba.ndim == 2:
+            return proba[:, -1]
+        return proba
+    return model.predict(data)

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -1,0 +1,19 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root on path for imports
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Prevent importing the real analytics package during collection
+ANALYTICS_DIR = Path(__file__).resolve().parents[1]
+if "analytics" not in sys.modules:
+    analytics_stub = types.ModuleType("analytics")
+    analytics_stub.__path__ = [str(ANALYTICS_DIR)]
+    sys.modules["analytics"] = analytics_stub
+
+# Minimal stubs for optional dependencies
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))

--- a/analytics/tests/test_risk_scoring_model.py
+++ b/analytics/tests/test_risk_scoring_model.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+# Ensure project root is on sys.path when running tests directly
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import importlib.util
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "analytics.risk_scoring_model", MODULE_DIR / "risk_scoring_model.py"
+)
+risk_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(risk_module)
+train_risk_model = risk_module.train_risk_model
+predict_risk_score = risk_module.predict_risk_score
+
+
+class DummyRegistry:
+    def __init__(self) -> None:
+        self.registered = False
+        self.active_version = None
+
+    def register_model(self, name, model_path, metrics, dataset_hash, **kwargs):
+        self.registered = True
+        class Rec:
+            def __init__(self) -> None:
+                self.version = "0.1.0"
+        return Rec()
+
+    def set_active_version(self, name, version):
+        self.active_version = version
+
+
+def test_train_and_predict():
+    df = pd.DataFrame(
+        {
+            "f1": [0, 1, 0, 1],
+            "f2": [1, 1, 0, 0],
+            "label": [0, 1, 0, 1],
+        }
+    )
+    registry = DummyRegistry()
+    model, scaler = train_risk_model(df, model_registry=registry)
+
+    assert registry.registered
+    assert registry.active_version == "0.1.0"
+
+    preds = predict_risk_score(model, df[["f1", "f2"]], scaler)
+    assert len(preds) == len(df)
+    assert ((preds >= 0) & (preds <= 1)).all()


### PR DESCRIPTION
## Summary
- add ML-based risk scoring model with optional gradient boosting
- version trained models via `ModelRegistry`
- provide inference helper
- test risk scoring model training and prediction

## Testing
- `pytest analytics/tests/test_risk_scoring_model.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882469d91c48320ae3325a87cb52307