### PR TITLE
Add webhook and websocket documentation

### DIFF
--- a/api/openapi/yosai-api-v2.yaml
+++ b/api/openapi/yosai-api-v2.yaml
@@ -94,6 +94,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AccessEvent'
+      
+    WebhookAlertPayload:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+
+    AnalyticsUpdate:
+      type: object
+      description: Generic analytics update broadcast over WebSocket.
+      additionalProperties: true
 
   responses:
     BadRequest:

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,26 @@
+# Webhook Alerts
+
+The monitoring utilities send alert messages via a generic webhook when
+`AlertConfig.webhook_url` is configured. The payload structure is
+simple and mirrors the implementation in
+`core/monitoring/user_experience_metrics.py`.
+
+## Payload Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "message": {"type": "string"}
+  },
+  "required": ["message"]
+}
+```
+
+Example payload:
+
+```json
+{
+  "message": "High error rate detected"
+}
+```

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -1,0 +1,30 @@
+# WebSocket Events
+
+`services/websocket_server.py` exposes `AnalyticsWebSocketServer`, a
+broadcast-only server that sends analytics updates to all connected
+clients. It listens for `analytics_update` events on the internal
+`EventBus` and forwards the payload as a JSON message.
+
+Clients connect to `ws://<host>:<port>` (default `0.0.0.0:6789`). The
+message format is an arbitrary JSON object describing the analytics
+update. A common example is the dashboard summary emitted by
+`AnalyticsService.get_dashboard_summary`.
+
+## Message Schema
+
+```json
+{
+  "type": "object",
+  "description": "Analytics update data",
+  "additionalProperties": true
+}
+```
+
+Example message:
+
+```json
+{
+  "status": "ok",
+  "data_summary": {"total_records": 120}
+}
+```


### PR DESCRIPTION
## Summary
- document webhook alert schema based on AlertDispatcher
- describe websocket events from AnalyticsWebSocketServer
- extend OpenAPI spec with new schemas

## Testing
- `pytest tests/test_fastapi_error_handler.py::test_fastapi_error_format -q`

------
https://chatgpt.com/codex/tasks/task_e_6882465437808320af5271ac62f32af6