### PR TITLE
Add SSE fallback for websockets

### DIFF
--- a/src/hooks/__tests__/websocket_fallback.test.tsx
+++ b/src/hooks/__tests__/websocket_fallback.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWebSocket } from '../useWebSocket';
+import { useEventStream } from '../useEventStream';
+
+const useWithFallback = (
+  wsFactory: (url: string) => WebSocket,
+  esFactory: (url: string) => EventSource,
+) => {
+  const { data: wsData, isConnected } = useWebSocket('ws://test', wsFactory);
+  const { data: esData } = useEventStream('/events', esFactory, !isConnected);
+  return { data: isConnected ? wsData : esData };
+};
+
+class MockWS {
+  public onopen: (() => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public close = jest.fn();
+  constructor(public url: string) {
+    MockWS.instance = this;
+  }
+  static instance: MockWS | null = null;
+}
+
+class MockES {
+  public onopen: (() => void) | null = null;
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public onerror: (() => void) | null = null;
+  public close = jest.fn();
+  constructor(public url: string) {
+    MockES.instance = this;
+  }
+  static instance: MockES | null = null;
+}
+
+describe('websocket fallback', () => {
+  it('uses SSE when websocket fails to connect', () => {
+    const { result, unmount } = renderHook(() =>
+      useWithFallback(
+        url => new MockWS(url) as unknown as WebSocket,
+        url => new MockES(url) as unknown as EventSource,
+      ),
+    );
+
+    act(() => {
+      MockES.instance?.onmessage?.({ data: 'sse' });
+    });
+
+    expect(result.current.data).toBe('sse');
+
+    unmount();
+    expect(MockES.instance?.close).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEventStream.ts
+++ b/src/hooks/useEventStream.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useEventStream = (
+  path: string,
+  eventSourceFactory?: (url: string) => EventSource,
+  enabled: boolean = true,
+) => {
+  const [data, setData] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const fullUrl = path.startsWith('http')
+      ? path
+      : `${window.location.origin}${path}`;
+    const es = eventSourceFactory ? eventSourceFactory(fullUrl) : new EventSource(fullUrl);
+    esRef.current = es;
+
+    es.onopen = () => setIsConnected(true);
+    es.onmessage = (ev: MessageEvent) => setData(ev.data as string);
+    es.onerror = () => setIsConnected(false);
+
+    return () => {
+      es.close();
+    };
+  }, [path, eventSourceFactory, enabled]);
+
+  return { data, isConnected };
+};
+
+export default useEventStream;

--- a/src/pages/RealTimeMonitoring.tsx
+++ b/src/pages/RealTimeMonitoring.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Activity, Users, DoorOpen, AlertCircle } from 'lucide-react';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { useEventStream } from '../hooks/useEventStream';
 import {
   LineChart,
   Line,
@@ -79,15 +80,18 @@ export const RealTimeMonitoring: React.FC = () => {
     anomaliesDetected: 0,
   });
 
-  const { data, isConnected } = useWebSocket('/ws/events');
+  const { data: wsData, isConnected } = useWebSocket('/ws/events');
+  const { data: sseData } = useEventStream('/events/stream', undefined, !isConnected);
+
+  const activeData = isConnected ? wsData : sseData;
 
   useEffect(() => {
-    if (data) {
-      const event = JSON.parse(data) as AccessEvent;
+    if (activeData) {
+      const event = JSON.parse(activeData) as AccessEvent;
       setEvents((prev) => [event, ...prev].slice(0, 100));
       updateMetrics(event);
     }
-  }, [data]);
+  }, [activeData]);
 
   const updateMetrics = (event: AccessEvent) => {
     setMetrics((prev) => ({


### PR DESCRIPTION
## Summary
- add `useEventStream` hook for Server-Sent Events
- use SSE as fallback in `RealTimeMonitoring`
- test WebSocket fallback behaviour

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688242b39cbc8320b38cece4966a166f