### PR TITLE
Apply env overrides in UnifiedLoader

### DIFF
--- a/config/unified_loader.py
+++ b/config/unified_loader.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Any
 from google.protobuf import json_format
 
 from .base_loader import BaseConfigLoader
+from .environment_processor import EnvironmentProcessor
 from .generated.protobuf.config.schema import config_pb2
 
 
@@ -34,6 +35,8 @@ class UnifiedLoader(BaseConfigLoader):
         cfg_dict = self._read_source(path)
         message = config_pb2.YosaiConfig()
         json_format.ParseDict(cfg_dict, message, ignore_unknown_fields=True)
+        processor = EnvironmentProcessor()
+        processor.apply(message)
         return message
 
 

--- a/docs/unified_config.md
+++ b/docs/unified_config.md
@@ -26,3 +26,9 @@ accessors like `get_app_config()` and `get_database_config()`.  Services obtain
 it from the dependency injection container and operate purely on the typed
 protobuf object.
 
+When loading configuration directly via `UnifiedLoader` the loader applies
+`EnvironmentProcessor` automatically. Any environment variables prefixed with
+`YOSAI_` will override the corresponding fields in the resulting protobuf
+message. This mirrors the behaviour of the traditional dataclass configuration
+pipeline.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ if "services" not in sys.modules:
     sys.modules["services"] = services_stub
 
 # Optional heavy dependencies used by a subset of tests
-_optional_packages = {"hvac", "cryptography"}
+_optional_packages = {"hvac", "cryptography", "boto3", "confluent_kafka"}
 _missing_optional = [
     pkg for pkg in _optional_packages if importlib.util.find_spec(pkg) is None
 ]
@@ -54,6 +54,12 @@ if "cryptography" not in sys.modules and "cryptography" in _missing_optional:
     crypto_stub.fernet = fernet_stub
     sys.modules["cryptography"] = crypto_stub
     sys.modules["cryptography.fernet"] = fernet_stub
+
+if "boto3" not in sys.modules and "boto3" in _missing_optional:
+    sys.modules["boto3"] = types.ModuleType("boto3")
+
+if "confluent_kafka" not in sys.modules and "confluent_kafka" in _missing_optional:
+    sys.modules["confluent_kafka"] = types.ModuleType("confluent_kafka")
 
 
 def pytest_ignore_collect(path, config):

--- a/tests/test_unified_loader.py
+++ b/tests/test_unified_loader.py
@@ -1,0 +1,38 @@
+import types
+import sys
+
+
+def _stub_optional_modules():
+    """Provide minimal stubs for optional heavy dependencies."""
+    sys.modules.setdefault("boto3", types.ModuleType("boto3"))
+    sys.modules.setdefault("hvac", types.ModuleType("hvac"))
+    sys.modules.setdefault("cryptography", types.ModuleType("cryptography"))
+    sys.modules.setdefault("confluent_kafka", types.ModuleType("confluent_kafka"))
+
+
+def test_environment_processor_applied(monkeypatch, tmp_path):
+    cfg_text = """
+app:
+  host: localhost
+  port: 8000
+database:
+  host: db.local
+security:
+  secret_key: default
+"""
+    path = tmp_path / "config.yaml"
+    path.write_text(cfg_text, encoding="utf-8")
+
+    monkeypatch.setenv("YOSAI_DATABASE_HOST", "db.example.com")
+    monkeypatch.setenv("YOSAI_PORT", "9000")
+    monkeypatch.setenv("SECRET_KEY", "envsecret")
+
+    _stub_optional_modules()
+    from config.unified_loader import UnifiedLoader
+
+    loader = UnifiedLoader(str(path))
+    cfg = loader.load()
+
+    assert cfg.database.host == "db.example.com"
+    assert cfg.app.port == 9000
+    assert cfg.app.secret_key == "envsecret"


### PR DESCRIPTION
## Summary
- apply `EnvironmentProcessor` when loading config via `UnifiedLoader`
- document the automatic environment overrides
- stub optional dependencies in tests
- add a unit test for the new behaviour

## Testing
- `pytest tests/test_unified_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68824557cf548320b47154aa70ee82a9