### PR TITLE
Add ErrorBoundary wrappers and shared spinners

### DIFF
--- a/src/components/shared/CenteredSpinner.test.tsx
+++ b/src/components/shared/CenteredSpinner.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import CenteredSpinner from './CenteredSpinner';
+
+test('centers the spinner', () => {
+  const { container } = render(<CenteredSpinner />);
+  expect(container.firstChild).toHaveClass('flex items-center justify-center');
+});

--- a/src/components/shared/CenteredSpinner.tsx
+++ b/src/components/shared/CenteredSpinner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Spinner from './Spinner';
+
+interface Props {
+  sizeClass?: string;
+  className?: string;
+}
+
+export const CenteredSpinner: React.FC<Props> = ({ sizeClass, className = '' }) => (
+  <div className={`flex items-center justify-center ${className}`}>
+    <Spinner sizeClass={sizeClass} />
+  </div>
+);
+
+export default CenteredSpinner;

--- a/src/components/shared/Spinner.test.tsx
+++ b/src/components/shared/Spinner.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import Spinner from './Spinner';
+
+test('renders spinner element', () => {
+  const { container } = render(<Spinner />);
+  expect(container.firstChild).toHaveClass('animate-spin');
+});

--- a/src/components/shared/Spinner.tsx
+++ b/src/components/shared/Spinner.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface SpinnerProps {
+  /** CSS size classes like 'h-6 w-6' */
+  sizeClass?: string;
+  className?: string;
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({ sizeClass = 'h-6 w-6', className = '' }) => (
+  <div
+    className={`animate-spin rounded-full border-2 border-b-transparent border-current ${sizeClass} ${className}`}
+    role="status"
+  />
+);
+
+export default Spinner;

--- a/src/components/upload/DeviceMappingModal.tsx
+++ b/src/components/upload/DeviceMappingModal.tsx
@@ -12,6 +12,7 @@ import { Input } from '../shared/Input';
 import { Select } from '../shared/Select';
 import { Checkbox } from '../shared/Checkbox';
 import { Badge } from '../shared/Badge';
+import Spinner from '../shared/Spinner';
 
 interface DeviceMapping {
   deviceId: string;
@@ -148,7 +149,7 @@ export const DeviceMappingModal: React.FC<Props> = ({
 
             {loading ? (
               <div className="flex items-center justify-center py-12">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+                <Spinner sizeClass="h-12 w-12" className="text-blue-600" />
               </div>
             ) : (
               <div className="overflow-x-auto">

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { useAnalyticsStore } from '../state/store';
 import { BarChart3, Filter, Download, AlertCircle } from 'lucide-react';
 import { api } from '../api/client';
@@ -174,4 +175,10 @@ const Analytics: React.FC = () => {
   );
 };
 
-export default Analytics;
+const AnalyticsPage: React.FC = () => (
+  <ErrorBoundary>
+    <Analytics />
+  </ErrorBoundary>
+);
+
+export default AnalyticsPage;

--- a/src/pages/Export.tsx
+++ b/src/pages/Export.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Download } from 'lucide-react';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const Export: React.FC = () => {
   return (
@@ -10,4 +11,10 @@ const Export: React.FC = () => {
   );
 };
 
-export default Export;
+const ExportPage: React.FC = () => (
+  <ErrorBoundary>
+    <Export />
+  </ErrorBoundary>
+);
+
+export default ExportPage;

--- a/src/pages/Graphs.tsx
+++ b/src/pages/Graphs.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { LineChart as LineChartIcon } from 'lucide-react';
 import {
   LineChart,
@@ -118,4 +119,10 @@ const Graphs: React.FC = () => {
   );
 };
 
-export default Graphs;
+const GraphsPage: React.FC = () => (
+  <ErrorBoundary>
+    <Graphs />
+  </ErrorBoundary>
+);
+
+export default GraphsPage;

--- a/src/pages/RealTimeAnalyticsPage.tsx
+++ b/src/pages/RealTimeAnalyticsPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 import {
   BarChart,
   Bar,
@@ -92,4 +93,10 @@ const RealTimeAnalyticsPage: React.FC = () => {
   );
 };
 
-export default RealTimeAnalyticsPage;
+const RealTimeAnalyticsWrapper: React.FC = () => (
+  <ErrorBoundary>
+    <RealTimeAnalyticsPage />
+  </ErrorBoundary>
+);
+
+export default RealTimeAnalyticsWrapper;

--- a/src/pages/RealTimeMonitoring.tsx
+++ b/src/pages/RealTimeMonitoring.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Activity, Users, DoorOpen, AlertCircle } from 'lucide-react';
 import { useWebSocket } from '../hooks/useWebSocket';
@@ -141,4 +142,10 @@ export const RealTimeMonitoring: React.FC = () => {
   );
 };
 
-export default RealTimeMonitoring;
+const RealTimeMonitoringPage: React.FC = () => (
+  <ErrorBoundary>
+    <RealTimeMonitoring />
+  </ErrorBoundary>
+);
+
+export default RealTimeMonitoringPage;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { api } from '../api/client';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 interface UserSettings {
   theme: string;
@@ -89,5 +90,11 @@ const Settings: React.FC = () => {
   );
 };
 
-export default Settings;
+const SettingsPage: React.FC = () => (
+  <ErrorBoundary>
+    <Settings />
+  </ErrorBoundary>
+);
+
+export default SettingsPage;
 

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { useDropzone } from 'react-dropzone';
 import Papa from 'papaparse';
 import {
@@ -742,16 +743,18 @@ export const Upload: React.FC = () => {
 };
 
 const UploadPage: React.FC = () => (
-  <UploadProvider>
-    <Card>
-      <CardHeader>
-        <h5>Upload Data Files</h5>
-      </CardHeader>
-      <CardBody>
-        <UploadInner />
-      </CardBody>
-    </Card>
-  </UploadProvider>
+  <ErrorBoundary>
+    <UploadProvider>
+      <Card>
+        <CardHeader>
+          <h5>Upload Data Files</h5>
+        </CardHeader>
+        <CardBody>
+          <UploadInner />
+        </CardBody>
+      </Card>
+    </UploadProvider>
+  </ErrorBoundary>
 );
 
 export default UploadPage;


### PR DESCRIPTION
## Summary
- wrap all pages with `ErrorBoundary`
- add new reusable spinner components
- use spinner in `DeviceMappingModal`

## Testing
- `npm test --silent` *(fails: ProgressBar, Navigation, Navbar, Upload.error)*

------
https://chatgpt.com/codex/tasks/task_e_688246353f2083208f0d4087a4b444be