### PR TITLE
Implement env overrides in Go config loader

### DIFF
--- a/go/config/go.mod
+++ b/go/config/go.mod
@@ -5,8 +5,6 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
-    gopkg.in/yaml.v3 v3.0.1
-    github.com/yosai-intel/dashboard/go/config/generated v0.0.0
+	google.golang.org/protobuf v1.36.6
+	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/yosai-intel/dashboard/go/config/generated => ./generated

--- a/go/config/go.sum
+++ b/go/config/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/config/loader.go
+++ b/go/config/loader.go
@@ -1,46 +1,138 @@
 package config
 
 import (
-    "encoding/json"
-    "io/ioutil"
-    "os"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
 
-    pb "github.com/yosai-intel/dashboard/go/config/generated"
-    "gopkg.in/yaml.v3"
+	pb "github.com/yosai-intel/dashboard/go/config/generated/github.com/yosai-intel/dashboard/go/config/generated"
+	"gopkg.in/yaml.v3"
 )
 
 // Load reads a configuration file in JSON or YAML format and returns a YosaiConfig struct.
 func Load(path string) (*pb.YosaiConfig, error) {
-    var data []byte
-    var err error
+	var data []byte
+	var err error
 
-    if path != "" {
-        data, err = ioutil.ReadFile(path)
-        if err != nil {
-            return nil, err
-        }
-    } else if env := os.Getenv("YOSAI_CONFIG_JSON"); env != "" {
-        data = []byte(env)
-    }
+	if path != "" {
+		data, err = ioutil.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+	} else if env := os.Getenv("YOSAI_CONFIG_JSON"); env != "" {
+		data = []byte(env)
+	}
 
-    if len(data) == 0 {
-        return &pb.YosaiConfig{}, nil
-    }
+	if len(data) == 0 {
+		return &pb.YosaiConfig{}, nil
+	}
 
-    if data[0] != '{' && data[0] != '[' {
-        var obj interface{}
-        if err := yaml.Unmarshal(data, &obj); err != nil {
-            return nil, err
-        }
-        data, err = json.Marshal(obj)
-        if err != nil {
-            return nil, err
-        }
-    }
+	if data[0] != '{' && data[0] != '[' {
+		var obj interface{}
+		if err := yaml.Unmarshal(data, &obj); err != nil {
+			return nil, err
+		}
+		data, err = json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-    cfg := &pb.YosaiConfig{}
-    if err := json.Unmarshal(data, cfg); err != nil {
-        return nil, err
-    }
-    return cfg, nil
+	cfg := &pb.YosaiConfig{}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	applyEnvOverrides(cfg)
+	if err := validate(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// applyEnvOverrides updates cfg fields from YOSAI_* environment variables.
+func applyEnvOverrides(cfg *pb.YosaiConfig) {
+	prefix := "YOSAI_"
+	for _, e := range os.Environ() {
+		kv := strings.SplitN(e, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		name, val := kv[0], kv[1]
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		key := strings.TrimPrefix(name, prefix)
+		parts := strings.SplitN(strings.ToLower(key), "_", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		section, field := parts[0], parts[1]
+		var target interface{}
+		switch section {
+		case "app":
+			if cfg.App == nil {
+				cfg.App = &pb.AppConfig{}
+			}
+			target = cfg.App
+		case "database":
+			if cfg.Database == nil {
+				cfg.Database = &pb.DatabaseConfig{}
+			}
+			target = cfg.Database
+		case "security":
+			if cfg.Security == nil {
+				cfg.Security = &pb.SecurityConfig{}
+			}
+			target = cfg.Security
+		default:
+			continue
+		}
+		setField(target, field, val)
+	}
+}
+
+func setField(obj interface{}, name, value string) {
+	v := reflect.ValueOf(obj).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if strings.EqualFold(tag, name) || strings.EqualFold(f.Name, name) {
+			switch f.Type.Kind() {
+			case reflect.Int32, reflect.Int, reflect.Int64:
+				if iv, err := strconv.Atoi(value); err == nil {
+					v.Field(i).SetInt(int64(iv))
+				}
+			case reflect.Bool:
+				v.Field(i).SetBool(strings.ToLower(value) == "true" || value == "1" || strings.ToLower(value) == "yes")
+			case reflect.String:
+				v.Field(i).SetString(value)
+			}
+			return
+		}
+	}
+}
+
+func validate(cfg *pb.YosaiConfig) error {
+	missing := []string{}
+	if cfg.App == nil {
+		missing = append(missing, "app")
+	}
+	if cfg.Database == nil {
+		missing = append(missing, "database")
+	}
+	if cfg.Security == nil {
+		missing = append(missing, "security")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing configuration sections: %s", strings.Join(missing, ", "))
+	}
+	if strings.ToLower(cfg.Environment) == "production" && cfg.Security != nil && cfg.Security.SecretKey == "" {
+		return fmt.Errorf("SECRET_KEY must be set for production")
+	}
+	return nil
 }

--- a/go/config/loader_test.go
+++ b/go/config/loader_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvOverrides(t *testing.T) {
+	os.Setenv("YOSAI_CONFIG_JSON", `{"app":{"title":"t"},"database":{"name":"db"},"security":{"secret_key":"x"}}`)
+	os.Setenv("YOSAI_APP_TITLE", "override")
+	os.Setenv("YOSAI_DATABASE_HOST", "db.example")
+	defer os.Clearenv()
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.GetApp().GetTitle() != "override" {
+		t.Fatalf("expected override got %s", cfg.GetApp().GetTitle())
+	}
+	if cfg.GetDatabase().GetHost() != "db.example" {
+		t.Fatalf("expected db.example got %s", cfg.GetDatabase().GetHost())
+	}
+}
+
+func TestValidation(t *testing.T) {
+	os.Setenv("YOSAI_CONFIG_JSON", `{}`)
+	defer os.Clearenv()
+
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- update go config module dependencies
- add environment overrides and validation to the loader
- cover new functionality with unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688245599ad483209d80808e30f4b283