### PR TITLE
Enable UnifiedLoader in config manager

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -56,7 +56,7 @@ def create_config_manager(
     else:
         loader = validator = transformer = None
 
-    loader = loader or HierarchicalLoader()
+    loader = loader or UnifiedLoader()
     validator = validator or ConfigValidator()
     transformer = transformer or ConfigTransformer()
 

--- a/config/protocols.py
+++ b/config/protocols.py
@@ -20,7 +20,7 @@ class ConnectionRetryManagerProtocol(Protocol):
 class ConfigLoaderProtocol(Protocol):
     """Load configuration data from a path."""
 
-    def load(self, config_path: Optional[str] = None) -> Dict[str, Any]:
+    def load(self, config_path: Optional[str] = None) -> Any:
         """Return configuration data from ``config_path``."""
         ...
 

--- a/docs/unified_config.md
+++ b/docs/unified_config.md
@@ -21,8 +21,8 @@ services can use the new fields.
 
 ## Using `YosaiConfig`
 
-`create_config_manager()` returns an instance of `YosaiConfig` which exposes
-accessors like `get_app_config()` and `get_database_config()`.  Services obtain
-it from the dependency injection container and operate purely on the typed
-protobuf object.
+`create_config_manager()` now uses `UnifiedLoader` under the hood. The loader
+parses the YAML/JSON files into a `YosaiConfig` protobuf message which is then
+converted back into the existing dataclass structure. Services continue to work
+with the familiar dataclasses returned by the various `get_*_config()` helpers.
 


### PR DESCRIPTION
## Summary
- load config via UnifiedLoader and convert protobuf to dataclasses
- relax ConfigLoaderProtocol return type
- set UnifiedLoader as default in factory
- document dataclass conversion

## Testing
- `pytest tests/test_plugin_manager_core.py::test_load_plugin_success -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6882455b9ef88320822579040d59be79