### PR TITLE
Guard Timescale setup for non‑Postgres

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -51,7 +51,8 @@ def run_migrations_online() -> None:
             poolclass=pool.NullPool,
         )
         with connectable.connect() as connection:
-            _ensure_timescale(connection)
+            if connection.dialect.name.startswith("postgres"):
+                _ensure_timescale(connection)
             context.configure(connection=connection)
             with context.begin_transaction():
                 context.run_migrations()

--- a/tests/migration/test_env_sqlite.py
+++ b/tests/migration/test_env_sqlite.py
@@ -1,0 +1,61 @@
+import configparser
+import importlib
+from types import SimpleNamespace
+
+import alembic.context
+
+
+class DummyConnection:
+    def __init__(self, dialect_name="sqlite"):
+        self.dialect = type("dialect", (), {"name": dialect_name})()
+    def connect(self):
+        return self
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def execute(self, *a, **k):
+        pass
+
+class DummyEngine(DummyConnection):
+    pass
+
+
+def test_skip_timescale_for_sqlite(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "alembic.ini"
+    cfg_file.write_text("[foo_db]\nsqlalchemy.url = sqlite://\n")
+    alembic.context.config = SimpleNamespace(config_file_name=str(cfg_file))
+    alembic.context.is_offline_mode = lambda: True
+    alembic.context.configure = lambda **kw: None
+    class DummyTxn:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    alembic.context.begin_transaction = lambda: DummyTxn()
+    alembic.context.run_migrations = lambda: None
+    monkeypatch.setattr("logging.config.fileConfig", lambda *a, **k: None)
+    env = importlib.import_module("migrations.env")
+    calls = []
+    monkeypatch.setattr(env, "_ensure_timescale", lambda conn: calls.append(True))
+
+    def fake_engine_from_config(opts, prefix="sqlalchemy.", poolclass=None):
+        return DummyEngine()
+
+    monkeypatch.setattr(env, "engine_from_config", fake_engine_from_config)
+    monkeypatch.setattr(env.context, "configure", lambda **kw: None)
+    monkeypatch.setattr(env.context, "run_migrations", lambda: None)
+
+    class DummyTxn:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    monkeypatch.setattr(env.context, "begin_transaction", lambda: DummyTxn())
+
+    parser = configparser.ConfigParser()
+    parser.read_dict({"foo_db": {"sqlalchemy.url": "sqlite://"}})
+    env.parser = parser
+
+    env.run_migrations_online()
+    assert not calls


### PR DESCRIPTION
## Summary
- ensure migrations only create TimescaleDB objects when using Postgres
- test that SQLite migrations skip Timescale setup

## Testing
- `pytest tests/migration/test_env_sqlite.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688245efefb08320b2a9a29ffcfa1ca3