### PR TITLE
Add migration CLI current command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ control:
 
 ```bash
 python scripts/db_migration_cli.py upgrade  # create RBAC tables
+python scripts/db_migration_cli.py current  # verify current revision
 ```
 
 Set the permission service URL in your environment if it differs from

--- a/scripts/db_migration_cli.py
+++ b/scripts/db_migration_cli.py
@@ -30,6 +30,7 @@ def main(argv: List[str] | None = None) -> int:
     down.add_argument("revision")
 
     sub.add_parser("rollback", help="Rollback the last applied migration")
+    sub.add_parser("current", help="Show current revision")
 
     args = parser.parse_args(argv)
     mgr = MigrationManager(args.config)
@@ -40,6 +41,8 @@ def main(argv: List[str] | None = None) -> int:
         mgr.downgrade(args.revision)
     elif args.command == "rollback":
         mgr.rollback()
+    elif args.command == "current":
+        mgr.current()
     else:
         parser.print_help()
         return 1

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -33,3 +33,16 @@ def test_migration_upgrade_and_rollback(monkeypatched_commands):
     mgr.rollback()
     # rollback triggers downgrade
     assert ("downgrade", "base") in monkeypatched_commands.called
+
+
+def test_cli_current(monkeypatched_commands):
+    from scripts import db_migration_cli
+
+    exit_code = db_migration_cli.main([
+        "--config",
+        "migrations/alembic.ini",
+        "current",
+    ])
+
+    assert exit_code == 0
+    assert ("current", None) in monkeypatched_commands.called


### PR DESCRIPTION
## Summary
- add `current` subcommand in the migration CLI
- show how to inspect the current Alembic revision in the README
- test that CLI `current` calls alembic's `current` command

## Testing
- `pytest tests/test_migrations.py -q` *(with stub modules for heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_688245f53ce88320a67bfb4cb42ee350