### PR TITLE
Auto-apply Linkerd service mesh

### DIFF
--- a/docs/k8s_dev.md
+++ b/docs/k8s_dev.md
@@ -13,6 +13,8 @@ scripts/setup_k8s_dev.sh
 
 The script installs k3s if it is not already present, then deploys Linkerd, the Strimzi operator, and Prometheus/Grafana via Helm.
 
+It also applies the manifests in `k8s/linkerd` so the service mesh is deployed automatically.
+
 ## Deploying the Dashboard
 
 After the cluster is ready apply the base manifests and the production manifests:

--- a/scripts/setup_k8s_dev.sh
+++ b/scripts/setup_k8s_dev.sh
@@ -40,3 +40,6 @@ done
 # Apply base manifests
 kubectl apply -f k8s/base
 
+# Apply Linkerd service mesh configuration
+kubectl apply -f k8s/linkerd
+


### PR DESCRIPTION
## Summary
- ensure the dev setup script applies Linkerd manifests
- mention the automatic service mesh deployment in the k8s dev doc

## Testing
- `pre-commit run --files scripts/setup_k8s_dev.sh docs/k8s_dev.md`

------
https://chatgpt.com/codex/tasks/task_e_68824612b5588320ae7e00ed849feced