### PR TITLE
Expose Dash callbacks via Flask

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,2 +1,3 @@
 """API module"""
 # Temporarily disabled imports to avoid circular dependencies
+from .callbacks_endpoint import callbacks_bp

--- a/api/adapter.py
+++ b/api/adapter.py
@@ -22,6 +22,7 @@ from config.constants import API_PORT
 from device_endpoint import device_bp
 from mappings_endpoint import mappings_bp
 from upload_endpoint import upload_bp
+from .callbacks_endpoint import callbacks_bp
 
 
 def create_api_app() -> "FastAPI":
@@ -60,6 +61,7 @@ def create_api_app() -> "FastAPI":
     app.register_blueprint(device_bp)
     app.register_blueprint(mappings_bp)
     app.register_blueprint(settings_bp)
+    app.register_blueprint(callbacks_bp)
 
     @app.route("/", defaults={"path": ""})
     @app.route("/<path:path>")

--- a/api/callbacks_endpoint.py
+++ b/api/callbacks_endpoint.py
@@ -1,0 +1,107 @@
+from flask import Blueprint, jsonify, request
+
+"""Expose legacy Dash callback logic as Flask endpoints."""
+
+
+callbacks_bp = Blueprint("callbacks", __name__, url_prefix="/api/v1/callbacks")
+
+
+@callbacks_bp.post("/toggle-custom-field")
+def api_toggle_custom_field():
+    from components.column_verification import toggle_custom_field
+    data = request.get_json(force=True)
+    selected_value = data.get("selected_value")
+    result = toggle_custom_field(selected_value)
+    return jsonify(result)
+
+
+@callbacks_bp.post("/save-column-mappings")
+def api_save_column_mappings():
+    from components.column_verification import save_column_mappings_callback
+    payload = request.get_json(force=True)
+    n_clicks = payload.get("n_clicks")
+    column_values = payload.get("column_values", [])
+    custom_values = payload.get("custom_values", [])
+    uploaded_files = payload.get("uploaded_files", {})
+    message, color = save_column_mappings_callback(
+        n_clicks, column_values, custom_values, uploaded_files
+    )
+    return jsonify({"message": message, "color": color})
+
+
+@callbacks_bp.post("/toggle-device-verification")
+def api_toggle_device_verification():
+    from components.device_verification import toggle_device_verification_modal
+    data = request.get_json(force=True)
+    confirm = data.get("confirm_clicks")
+    cancel = data.get("cancel_clicks")
+    is_open = data.get("is_open", False)
+    result = toggle_device_verification_modal(confirm, cancel, is_open)
+    return jsonify({"is_open": result})
+
+
+@callbacks_bp.post("/mark-device-edited")
+def api_mark_device_edited():
+    from components.device_verification import mark_device_as_edited
+    data = request.get_json(force=True)
+    floor = data.get("floor")
+    access = data.get("access")
+    special = data.get("special")
+    security = data.get("security")
+    result = mark_device_as_edited(floor, access, special, security)
+    return jsonify({"edited": result})
+
+
+@callbacks_bp.post("/toggle-simple-device-modal")
+def api_toggle_simple_device_modal():
+    from components.simple_device_mapping import toggle_simple_device_modal
+    data = request.get_json(force=True)
+    open_clicks = data.get("open_clicks")
+    cancel_clicks = data.get("cancel_clicks")
+    save_clicks = data.get("save_clicks")
+    is_open = data.get("is_open", False)
+    result = toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open)
+    return jsonify({"is_open": result})
+
+
+@callbacks_bp.post("/save-user-inputs")
+def api_save_user_inputs():
+    from components.simple_device_mapping import save_user_inputs
+    data = request.get_json(force=True)
+    floors = data.get("floors", [])
+    security = data.get("security", [])
+    access = data.get("access", [])
+    special = data.get("special", [])
+    devices = data.get("devices", [])
+    status = save_user_inputs(floors, security, access, special, devices)
+    return jsonify({"status": status})
+
+
+@callbacks_bp.post("/apply-ai-device-suggestions")
+def api_apply_ai_device_suggestions():
+    from components.simple_device_mapping import apply_ai_device_suggestions
+    data = request.get_json(force=True)
+    suggestions = data.get("suggestions", {})
+    devices = data.get("devices", [])
+    floors, access, special, security = apply_ai_device_suggestions(suggestions, devices)
+    return jsonify({
+        "floors": floors,
+        "access": access,
+        "special": special,
+        "security": security,
+    })
+
+
+@callbacks_bp.post("/populate-simple-device-modal")
+def api_populate_simple_device_modal():
+    from components.simple_device_mapping import populate_simple_device_modal
+    data = request.get_json(force=True)
+    is_open = data.get("is_open", False)
+    result = populate_simple_device_modal(is_open)
+    if isinstance(result, tuple) or hasattr(result, "to_plotly_json"):
+        return jsonify({"error": "unsupported return type"}), 400
+    if isinstance(result, dict) and "props" in result:
+        return jsonify({"error": "dash component returned"}), 400
+    # When using the service directly, the function returns a Modal or dash.no_update.
+    # For the API we simplify: True if modal should open otherwise False.
+    return jsonify({"open": result is not None})

--- a/src/components/upload/CustomFieldToggle.tsx
+++ b/src/components/upload/CustomFieldToggle.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useCallbackApi } from './useCallbackApi';
+
+const CustomFieldToggle: React.FC = () => {
+  const { toggleCustomField } = useCallbackApi();
+  const [value, setValue] = useState('');
+  const [style, setStyle] = useState<Record<string, string>>({});
+
+  const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    setValue(val);
+    const res = await toggleCustomField(val);
+    setStyle(res);
+  };
+
+  return (
+    <div>
+      <select value={value} onChange={handleChange} aria-label="Select field">
+        <option value="">Choose</option>
+        <option value="other">Other</option>
+        <option value="ignore">Ignore</option>
+      </select>
+      <input type="text" style={style} aria-label="Custom field" />
+    </div>
+  );
+};
+
+export default CustomFieldToggle;

--- a/src/components/upload/index.ts
+++ b/src/components/upload/index.ts
@@ -4,3 +4,5 @@ export { default as ColumnMappingModal } from './ColumnMappingModal';
 export { default as DeviceMappingModal } from './DeviceMappingModal';
 export { default as ProgressIndicator } from './ProgressIndicator';
 export { default as AIColumnSuggestions } from './AIColumnSuggestions';
+export { default as CustomFieldToggle } from './CustomFieldToggle';
+export { useCallbackApi } from './useCallbackApi';

--- a/src/components/upload/useCallbackApi.ts
+++ b/src/components/upload/useCallbackApi.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const API_URL = process.env.REACT_APP_API_URL || '/api';
+
+export const useCallbackApi = () => {
+  const toggleCustomField = async (selected: string) => {
+    const res = await axios.post(`${API_URL}/v1/callbacks/toggle-custom-field`, { selected_value: selected });
+    return res.data;
+  };
+
+  return {
+    toggleCustomField,
+  };
+};

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,12 +2,14 @@ import { createStore } from 'zustand';
 import { useStore } from 'zustand';
 import { createSessionSlice, SessionSlice } from './sessionSlice';
 import { createAnalyticsSlice, AnalyticsSlice } from './analyticsSlice';
+import { createUploadSlice, UploadSlice } from './uploadSlice';
 
-export type BoundState = SessionSlice & AnalyticsSlice;
+export type BoundState = SessionSlice & AnalyticsSlice & UploadSlice;
 
 export const boundStore = createStore<BoundState>()((...a) => ({
   ...createSessionSlice(...a),
   ...createAnalyticsSlice(...a),
+  ...createUploadSlice(...a),
 }));
 
 export const useBoundStore = <T,>(selector: (state: BoundState) => T) =>
@@ -22,3 +24,9 @@ export const useAnalyticsStore = () => useBoundStore((state) => ({
   analyticsCache: state.analyticsCache,
   setAnalytics: state.setAnalytics,
 }));
+
+export const useUploadStore = () =>
+  useBoundStore((state) => ({
+    uploadedFiles: state.uploadedFiles,
+    setUploadedFiles: state.setUploadedFiles,
+  }));

--- a/src/state/uploadSlice.ts
+++ b/src/state/uploadSlice.ts
@@ -1,0 +1,12 @@
+import { StateCreator } from 'zustand';
+import { UploadedFile } from '../components/upload/types';
+
+export interface UploadSlice {
+  uploadedFiles: UploadedFile[];
+  setUploadedFiles: (files: UploadedFile[]) => void;
+}
+
+export const createUploadSlice: StateCreator<UploadSlice, [], [], UploadSlice> = (set) => ({
+  uploadedFiles: [],
+  setUploadedFiles: (files: UploadedFile[]) => set({ uploadedFiles: files }),
+});


### PR DESCRIPTION
## Summary
- add callback endpoints for Python component logic
- register callbacks blueprint in API adapter
- add Zustand upload slice and API hook
- add CustomFieldToggle React component

## Testing
- `pip install -r requirements-test.txt`
- `pip install httpx flask_cors`
- `pytest tests/api/test_cors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68824c90fdcc8320b86167982b24c59e