### PR TITLE
Remove openapi go generator step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
           set -xe
           pip install -r requirements.lock
           pip install -r requirements-test.txt
-      - name: Generate OpenAPI spec
-        working-directory: ./api/openapi
-        run: go run .
       - name: Generate client SDKs
         run: ./scripts/generate_clients.sh
       - name: Check generated clients up to date


### PR DESCRIPTION
## Summary
- stop running the OpenAPI Go generator in CI

## Testing
- `pytest -q tests/test_mapping_models.py tests/conftest.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68824f28c5f88320b741776c6e794129