### PR TITLE
Fix event-ingestion build contexts

### DIFF
--- a/.github/workflows/microservices-ci-cd.yml
+++ b/.github/workflows/microservices-ci-cd.yml
@@ -83,7 +83,7 @@ jobs:
             context: .
             dockerfile: Dockerfile
           - name: event-ingestion
-            context: ./services/event-ingestion
+            context: ./services/event-ingestion/
             dockerfile: Dockerfile
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -163,7 +163,7 @@ jobs:
             context: .
             dockerfile: Dockerfile
           - name: event-ingestion
-            context: ./services/event-ingestion
+            context: ./services/event-ingestion/
             dockerfile: Dockerfile
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile.ingestion
+++ b/Dockerfile.ingestion
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install only required dependency for EventStreamingService
 RUN pip install --no-cache-dir kafka-python
 
-COPY services services
+COPY services/event-ingestion services/event-ingestion
 COPY config config
 COPY tools tools
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -77,7 +77,7 @@ services:
 
   event-ingestion:
     build:
-      context: ./services/event-ingestion
+      context: ./services/event-ingestion/
       dockerfile: Dockerfile
     environment:
       KAFKA_BROKERS: kafka1:9092,kafka2:9093,kafka3:9094

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -153,7 +153,7 @@ services:
 
   event-ingestion:
     build:
-      context: ./services/event-ingestion
+      context: ./services/event-ingestion/
       dockerfile: Dockerfile
     environment:
       KAFKA_BROKERS: kafka1:29092,kafka2:29093,kafka3:29094

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -31,7 +31,7 @@ services:
 
   event-ingestion:
     build:
-      context: ./services/event-ingestion
+      context: ./services/event-ingestion/
       dockerfile: Dockerfile
     environment:
       <<: *yosai-env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
 
   event-ingestion:
     build:
-      context: ./services/event-ingestion
+      context: ./services/event-ingestion/
       dockerfile: Dockerfile
     environment:
       <<: *shared-env


### PR DESCRIPTION
## Summary
- narrow Dockerfile.ingestion COPY to the service folder
- normalize build contexts for event-ingestion service across compose files and workflows

## Testing
- `pytest -q` *(fails: 167 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68824f271c9883209da1a3a45145f596