### PR TITLE
Add basic GraphQL server

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,0 +1,19 @@
+# GraphQL Service
+
+This folder contains a lightweight GraphQL layer for the Yosai Intel Dashboard.
+
+`index.js` starts an Apollo Server instance backed by the existing REST API. It
+defines a basic schema for analytics data, resolves queries via `axios` calls to
+the REST endpoints and exposes a subscription example. `DataLoader` is used to
+batch requests when the same analytics data is requested multiple times during a
+single GraphQL operation. Query depth is limited to prevent expensive queries.
+
+Run the server locally with:
+
+```bash
+npm run graphql
+```
+
+The server listens on port `4000` by default and expects the REST API to be
+available at `http://localhost:5001`. Set the `REST_BASE` environment variable to
+change the target API host.

--- a/graphql/index.js
+++ b/graphql/index.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const { ApolloServer, gql } = require('apollo-server-express');
+const { createServer } = require('http');
+const { WebSocketServer } = require('ws');
+const { useServer } = require('graphql-ws/lib/use/ws');
+const axios = require('axios');
+const DataLoader = require('dataloader');
+const { PubSub } = require('graphql-subscriptions');
+const depthLimit = require('graphql-depth-limit');
+
+const REST_BASE = process.env.REST_BASE || 'http://localhost:5001';
+const pubsub = new PubSub();
+const ANALYTICS_UPDATED = 'ANALYTICS_UPDATED';
+
+// Simple schema for analytics summary
+const typeDefs = gql`
+  type AnalyticsSummary {
+    total_records: Int
+    unique_users: Int
+    unique_devices: Int
+  }
+
+  type Query {
+    analyticsSummary(facilityId: String, range: String): AnalyticsSummary
+  }
+
+  type Subscription {
+    analyticsUpdated: AnalyticsSummary
+  }
+`;
+
+const analyticsLoader = new DataLoader(async keys => {
+  return Promise.all(
+    keys.map(async ({ facilityId, range }) => {
+      const resp = await axios.get(`${REST_BASE}/api/v1/analytics/patterns`, {
+        params: { facility_id: facilityId, range }
+      });
+      const data = resp.data;
+      return {
+        total_records: data.data_summary?.total_records,
+        unique_users: data.data_summary?.unique_users,
+        unique_devices: data.data_summary?.unique_devices,
+      };
+    })
+  );
+});
+
+const resolvers = {
+  Query: {
+    analyticsSummary: (_, args) => {
+      const facilityId = args.facilityId || 'default';
+      const range = args.range || '30d';
+      return analyticsLoader.load({ facilityId, range });
+    },
+  },
+  Subscription: {
+    analyticsUpdated: {
+      subscribe: () => pubsub.asyncIterator([ANALYTICS_UPDATED])
+    }
+  }
+};
+
+async function start() {
+  const app = express();
+  const httpServer = createServer(app);
+
+  const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: ({ req }) => ({ token: req.headers.authorization }),
+    validationRules: [depthLimit(5)]
+  });
+  await server.start();
+  server.applyMiddleware({ app, path: '/graphql' });
+
+  const wsServer = new WebSocketServer({ server: httpServer, path: '/graphql' });
+  useServer({ schema: server.schema, context: () => ({}) }, wsServer);
+
+  const PORT = process.env.GRAPHQL_PORT || 4000;
+  httpServer.listen(PORT, () => {
+    console.log(`GraphQL server ready at http://localhost:${PORT}${server.graphqlPath}`);
+  });
+}
+
+start();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,14 @@
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5",
     "zustand": "^5.0.6"
+    ,
+    "apollo-server-express": "^3.12.0",
+    "express": "^4.18.2",
+    "graphql": "^16.8.1",
+    "graphql-subscriptions": "^2.1.0",
+    "graphql-ws": "^5.10.0",
+    "dataloader": "^2.2.2",
+    "graphql-depth-limit": "^1.1.0"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^7.0.2",
@@ -62,7 +70,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:a11y": "pa11y http://localhost:8050",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "graphql": "node graphql/index.js"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- integrate Apollo Server with Express
- fetch analytics data from existing REST endpoints via DataLoader
- expose example subscription for analytics updates
- document GraphQL service
- add GraphQL script and dependencies

## Testing
- `pre-commit run --files package.json graphql/index.js graphql/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68825277390083208bb599a8fb003e0d