### PR TITLE
Add infrastructure config modules and wrappers

### DIFF
--- a/config/database_exceptions.py
+++ b/config/database_exceptions.py
@@ -1,35 +1,11 @@
 """Database-related exception classes."""
 
-from typing import Any, Optional
-
-
-class DatabaseError(Exception):
-    """Base exception for database operations."""
-
-    pass
-
-
-class ConnectionRetryExhausted(DatabaseError):
-    """Exception raised when connection retry attempts are exhausted."""
-
-    def __init__(self, message: str, retry_count: int = 0) -> None:
-        super().__init__(message)
-        self.retry_count = retry_count
-
-
-class ConnectionValidationFailed(DatabaseError):
-    """Exception raised when database connection validation fails."""
-
-    pass
-
-
-class UnicodeEncodingError(DatabaseError):
-    """Exception raised when Unicode encoding fails in database operations."""
-
-    def __init__(self, message: str, original_value: Optional[Any] = None) -> None:
-        super().__init__(message)
-        self.original_value = original_value
-
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import (
+    DatabaseError,
+    ConnectionRetryExhausted,
+    ConnectionValidationFailed,
+    UnicodeEncodingError,
+)
 
 __all__ = [
     "DatabaseError",

--- a/config/secure_db.py
+++ b/config/secure_db.py
@@ -1,18 +1,6 @@
+"""Helpers for executing sanitized database queries."""
 from __future__ import annotations
 
-"""Helpers for executing sanitized database queries."""
-
-from typing import Any, Optional
-
-from unicode_toolkit import UnicodeQueryHandler
-from database.secure_exec import execute_query as _execute_query
-
-
-def execute_secure_query(conn: Any, query: str, params: Optional[tuple] = None):
-    """Encode query and parameters then execute via :mod:`database.secure_exec`."""
-    sanitized_query = UnicodeQueryHandler.safe_encode_query(query)
-    sanitized_params = UnicodeQueryHandler.safe_encode_params(params)
-    return _execute_query(conn, sanitized_query, sanitized_params)
-
+from yosai_intel_dashboard.src.infrastructure.config.secure_db import execute_secure_query
 
 __all__ = ["execute_secure_query"]

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -1,0 +1,24 @@
+"""Infrastructure configuration utilities."""
+
+# Intentionally avoid eager imports to prevent circular dependencies during
+# package initialization. Attributes are imported on first access.
+
+__all__ = [
+    "DatabaseError",
+    "ConnectionRetryExhausted",
+    "ConnectionValidationFailed",
+    "UnicodeEncodingError",
+    "execute_secure_query",
+]
+
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    if name in {"DatabaseError", "ConnectionRetryExhausted", "ConnectionValidationFailed", "UnicodeEncodingError"}:
+        module = import_module(f"{__name__}.database_exceptions")
+        return getattr(module, name)
+    if name == "execute_secure_query":
+        module = import_module(f"{__name__}.secure_db")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py
@@ -1,0 +1,39 @@
+"""Database-related exception classes."""
+
+from typing import Any, Optional
+
+
+class DatabaseError(Exception):
+    """Base exception for database operations."""
+
+    pass
+
+
+class ConnectionRetryExhausted(DatabaseError):
+    """Exception raised when connection retry attempts are exhausted."""
+
+    def __init__(self, message: str, retry_count: int = 0) -> None:
+        super().__init__(message)
+        self.retry_count = retry_count
+
+
+class ConnectionValidationFailed(DatabaseError):
+    """Exception raised when database connection validation fails."""
+
+    pass
+
+
+class UnicodeEncodingError(DatabaseError):
+    """Exception raised when Unicode encoding fails in database operations."""
+
+    def __init__(self, message: str, original_value: Optional[Any] = None) -> None:
+        super().__init__(message)
+        self.original_value = original_value
+
+
+__all__ = [
+    "DatabaseError",
+    "ConnectionRetryExhausted",
+    "ConnectionValidationFailed",
+    "UnicodeEncodingError",
+]

--- a/yosai_intel_dashboard/src/infrastructure/config/secure_db.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secure_db.py
@@ -1,0 +1,17 @@
+"""Helpers for executing sanitized database queries."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from unicode_toolkit import UnicodeQueryHandler
+from database.secure_exec import execute_query as _execute_query
+
+
+def execute_secure_query(conn: Any, query: str, params: Optional[tuple] = None):
+    """Encode query and parameters then execute via :mod:`database.secure_exec`."""
+    sanitized_query = UnicodeQueryHandler.safe_encode_query(query)
+    sanitized_params = UnicodeQueryHandler.safe_encode_params(params)
+    return _execute_query(conn, sanitized_query, sanitized_params)
+
+
+__all__ = ["execute_secure_query"]


### PR DESCRIPTION
## Summary
- add `database_exceptions` and `secure_db` under `yosai_intel_dashboard/src/infrastructure/config`
- expose these modules via lazy-loaded `__init__`
- re-export the new implementations from the legacy `config` package

## Testing
- `pytest tests/test_secure_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68824f25eee883208730f33e93d00d67