### PR TITLE
Add mandatory Trivy security scanning

### DIFF
--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -1,0 +1,21 @@
+name: Daily Container Scan
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  daily-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.3
+        with:
+          version: v0.64.1
+          cache: true
+      - name: Scan latest images
+        run: |
+          trivy image --severity HIGH,CRITICAL --exit-code 1 ghcr.io/${{ github.repository }}-gateway:latest
+          trivy image --severity HIGH,CRITICAL --exit-code 1 ghcr.io/${{ github.repository }}-analytics:latest
+          trivy image --severity HIGH,CRITICAL --exit-code 1 ghcr.io/${{ github.repository }}-event-ingestion:latest

--- a/.github/workflows/microservices-ci-cd.yml
+++ b/.github/workflows/microservices-ci-cd.yml
@@ -57,14 +57,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run Trivy scan
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.3
+        with:
+          version: v0.64.1
+          cache: true
+      - name: Update vulnerability database
+        run: trivy --download-db-only
+      - name: Dependency and license scan
         uses: aquasecurity/trivy-action@v0.12.0
         with:
-          scan-type: filesystem
-          format: table
-          ignore-unfixed: true
-          exit-code: 0
+          scan-type: fs
           path: .
+          scanners: vuln,license
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+          trivyignores: .trivyignore
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          scan-type: fs
+          format: spdx-json
+          output: sbom.json
+          path: .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json
 
   build-image:
     needs: security-scan

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# List of vulnerabilities to ignore
+# Example: CVE-2020-1234


### PR DESCRIPTION
## Summary
- enforce Trivy vulnerability scanning in microservices CI/CD
- add daily scheduled container scans
- allow ignoring false positives with `.trivyignore`

## Testing
- `pre-commit run --files .github/workflows/microservices-ci-cd.yml .github/workflows/daily-security-scan.yml .trivyignore`

------
https://chatgpt.com/codex/tasks/task_e_688252b603b08320a1064688629d8a0c