### PR TITLE
Enable JWT secret rotation at runtime

### DIFF
--- a/services/security/jwt_service.py
+++ b/services/security/jwt_service.py
@@ -3,20 +3,25 @@ from jose import jwt
 
 from services.common.secrets import get_secret
 
-SERVICE_JWT_SECRET = get_secret("secret/data/jwt#secret")
+_SECRET_PATH = "secret/data/jwt#secret"
+
+
+def _jwt_secret() -> str:
+    """Return the current JWT secret from Vault."""
+    return get_secret(_SECRET_PATH)
 
 
 def generate_service_jwt(service_name: str, expires_in: int = 300) -> str:
     """Return a signed JWT token identifying ``service_name``."""
     now = int(time.time())
     payload = {"iss": service_name, "iat": now, "exp": now + expires_in}
-    return jwt.encode(payload, SERVICE_JWT_SECRET, algorithm="HS256")
+    return jwt.encode(payload, _jwt_secret(), algorithm="HS256")
 
 
 def verify_service_jwt(token: str) -> dict | None:
     """Verify a service JWT and return claims or ``None`` if invalid."""
     try:
-        claims = jwt.decode(token, SERVICE_JWT_SECRET, algorithms=["HS256"])
+        claims = jwt.decode(token, _jwt_secret(), algorithms=["HS256"])
     except Exception:
         return None
     exp = claims.get("exp")


### PR DESCRIPTION
## Summary
- fetch JWT secret on-demand for each service token
- retrieve secret on startup rather than cache
- update tests for dynamic secret retrieval

## Testing
- `pytest -q` *(fails: ImportError: No module named 'monitoring.prometheus')*

------
https://chatgpt.com/codex/tasks/task_e_68833f8434848320827e959c967fa90c