### PR TITLE
Use Vault for Timescale credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,12 +1256,11 @@ It also defines indexes used by the migration:
 
 A continuous aggregate `access_event_hourly` summarises hourly counts per facility and refreshes automatically once the migration is complete.
 
-Set the connection strings via the environment variables `SOURCE_DSN` and `TARGET_DSN`.  In Kubernetes deployments the following variables control the Timescale connection:
-
-```text
-TIMESCALE_HOST, TIMESCALE_PORT, TIMESCALE_DB_NAME,
-TIMESCALE_DB_USER, TIMESCALE_DB_PASSWORD
-```
+Set the connection strings via the environment variables `SOURCE_DSN` and
+`TARGET_DSN`. If unset, they are loaded from Vault at
+`secret/data/timescale#source` and `secret/data/timescale#target`. The
+`TimescaleDBManager` also retrieves its host, port, database, user and password
+fields from the same Vault path.
 
 The default `docker-compose.dev.yml` exposes TimescaleDB on port `5433`.
 

--- a/docs/timescale_integration.md
+++ b/docs/timescale_integration.md
@@ -36,7 +36,10 @@ exported with a gauge `hypertable_bytes_total`.
 
 ## Replication CronJob
 
-Add the `timescale-replication` CronJob to periodically copy new events from the primary database. The job simply executes `scripts/replicate_to_timescale.py` inside the standard dashboard image. Connection strings are supplied via the `timescale-dsns` secret using the `SOURCE_DSN` and `TARGET_DSN` variables.
+Add the `timescale-replication` CronJob to periodically copy new events from the
+primary database. The job simply executes `scripts/replicate_to_timescale.py`
+inside the standard dashboard image. Connection strings are fetched from Vault
+using the `secret/data/timescale` path.
 
 Example schedule running every five minutes:
 
@@ -56,17 +59,6 @@ spec:
             - name: replicate-to-timescale
               image: yosai-intel-dashboard:latest
               command: ["python", "scripts/replicate_to_timescale.py"]
-              env:
-                - name: SOURCE_DSN
-                  valueFrom:
-                    secretKeyRef:
-                      name: timescale-dsns
-                      key: SOURCE_DSN
-                - name: TARGET_DSN
-                  valueFrom:
-                    secretKeyRef:
-                      name: timescale-dsns
-                      key: TARGET_DSN
 ```
 
 The job also inherits the standard configuration from `yosai-config` and `yosai-secrets` via `envFrom` like the other microservices.

--- a/k8s/microservices/timescale-dsns-secret.yaml
+++ b/k8s/microservices/timescale-dsns-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: timescale-dsns
   namespace: yosai-dev
 stringData:
-  SOURCE_DSN: postgresql://yosai_user:change-me@postgres:5432/yosai_intel
-  TARGET_DSN: postgresql://postgres:change-me@timescaledb:5432/yosai_timescale
+  SOURCE_DSN: vault:secret/data/timescale#source
+  TARGET_DSN: vault:secret/data/timescale#target
 

--- a/k8s/microservices/timescale-replication-cronjob.yaml
+++ b/k8s/microservices/timescale-replication-cronjob.yaml
@@ -20,15 +20,4 @@ spec:
                     name: vault-config
                 - secretRef:
                     name: vault-secret
-              env:
-                - name: SOURCE_DSN
-                  valueFrom:
-                    secretKeyRef:
-                      name: timescale-dsns
-                      key: SOURCE_DSN
-                - name: TARGET_DSN
-                  valueFrom:
-                    secretKeyRef:
-                      name: timescale-dsns
-                      key: TARGET_DSN
 


### PR DESCRIPTION
## Summary
- look up Timescale credentials via `services.common.secrets.get_secret`
- document Vault usage for Timescale in README and integration guide
- remove DSN env vars from replication cronjob and fetch credentials from Vault
- update Timescale DSN secret with Vault paths
- allow `replicate_to_timescale.py` to resolve Vault references

## Testing
- `pre-commit run --files services/timescale/manager.py README.md docs/timescale_integration.md k8s/microservices/timescale-replication-cronjob.yaml k8s/microservices/timescale-dsns-secret.yaml scripts/replicate_to_timescale.py` *(fails: ModuleNotFoundError: No module named 'monitoring.prometheus')*

------
https://chatgpt.com/codex/tasks/task_e_68833f8a311c8320a05b0c2e4460b341