### PR TITLE
Implement secret invalidation step

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,6 +10,14 @@ Manual rotation can be performed with:
 ```bash
 python scripts/vault_rotate.py
 ```
-Pods will read the new values on the next request because the Vault
-client caches secrets in memory. In emergency situations follow the
-[break glass procedure](break_glass.md).
+Set `SECRET_INVALIDATE_URLS` to a comma-separated list of service
+addresses before running the script. Each address should expose a
+`/invalidate-secret` endpoint that triggers `invalidate_secret()` so new
+credentials are reloaded immediately:
+
+```bash
+export SECRET_INVALIDATE_URLS="http://dashboard:8050,http://analytics:8001"
+python scripts/vault_rotate.py
+```
+
+In emergency situations follow the [break glass procedure](break_glass.md).


### PR DESCRIPTION
## Summary
- notify services via `/invalidate-secret` after rotating Vault secrets
- document `SECRET_INVALIDATE_URLS` usage in operations guide

## Testing
- `python -m tools.ops_cli test` *(fails: ModuleNotFoundError: No module named 'monitoring.prometheus')*

------
https://chatgpt.com/codex/tasks/task_e_68833f8d970083209db4afa417ff36bf