### PR TITLE
Add load testing suite

### DIFF
--- a/performance_report.py
+++ b/performance_report.py
@@ -1,0 +1,55 @@
+"""Utility to generate performance reports from load test results."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def load_locust_stats(csv_path: Path) -> pd.DataFrame:
+    """Load Locust statistics CSV."""
+    return pd.read_csv(csv_path)
+
+
+def load_k6_stats(json_path: Path) -> pd.DataFrame:
+    """Load k6 summary JSON."""
+    with open(json_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    metrics = data.get("metrics", {})
+    rows: List[Tuple[str, float]] = []
+    for name, m in metrics.items():
+        if "p(95)" in m:
+            rows.append((name, m["p(95)"], m.get("p(99)", 0)))
+    return pd.DataFrame(rows, columns=["metric", "p95", "p99"])
+
+
+def plot_latency(df: pd.DataFrame, title: str, output: Path) -> None:
+    df.plot(x="metric", y=["p95", "p99"], kind="bar")
+    plt.title(title)
+    plt.ylabel("ms")
+    plt.tight_layout()
+    plt.savefig(output)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="Path to locust CSV or k6 summary JSON")
+    parser.add_argument("--type", choices=["locust", "k6"], default="locust")
+    parser.add_argument("--output", default="report.png")
+    args = parser.parse_args()
+
+    path = Path(args.input)
+    if args.type == "locust":
+        df = load_locust_stats(path)
+        df = df.rename(columns={"95%": "p95", "99%": "p99"})
+        plot_latency(df, "Locust Latency", Path(args.output))
+    else:
+        df = load_k6_stats(path)
+        plot_latency(df, "k6 Latency", Path(args.output))
+    print(f"Report written to {args.output}")

--- a/tests/performance/k6/events-stress-test.js
+++ b/tests/performance/k6/events-stress-test.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    stress: {
+      executor: 'constant-arrival-rate',
+      rate: 100000,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 10000,
+      maxVUs: 10000,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<500', 'p(99)<1000'],
+  },
+};
+
+export default function () {
+  const payload = JSON.stringify({
+    deviceId: __VU,
+    ts: Date.now(),
+    eventType: 'granted',
+  });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  const res = http.post('http://localhost:8000/events', payload, params);
+  check(res, { accepted: (r) => r.status === 202 });
+}

--- a/tests/performance/k6/soak-test.js
+++ b/tests/performance/k6/soak-test.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    soak: {
+      executor: 'constant-arrival-rate',
+      rate: 1000,
+      timeUnit: '1s',
+      duration: '30m',
+      preAllocatedVUs: 1000,
+      maxVUs: 1000,
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<750', 'p(99)<1500'],
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:8000/health');
+  check(res, { ok: (r) => r.status === 200 });
+  sleep(1);
+}

--- a/tests/performance/k6/spike-test.js
+++ b/tests/performance/k6/spike-test.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+
+export const options = {
+  scenarios: {
+    spike: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1000,
+      timeUnit: '1s',
+      preAllocatedVUs: 1000,
+      stages: [
+        { target: 20000, duration: '10s' },
+        { target: 20000, duration: '20s' },
+        { target: 0, duration: '10s' },
+      ],
+    },
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:8000/health');
+  check(res, { ok: (r) => r.status === 200 });
+  sleep(1);
+}

--- a/tests/performance/locust/analytics_load.py
+++ b/tests/performance/locust/analytics_load.py
@@ -1,0 +1,15 @@
+"""Locust tasks for analytics query load testing."""
+
+from locust import HttpUser, task, between
+from .utils import random_user_id
+
+
+class AnalyticsQueryUser(HttpUser):
+    """Simulate heavy analytics queries from multiple users."""
+
+    wait_time = between(0.1, 0.5)
+
+    @task
+    def query_analytics(self) -> None:
+        user = random_user_id()
+        self.client.get(f"/analytics/query?user_id={user}", name="GET /analytics/query")

--- a/tests/performance/locust/events_load.py
+++ b/tests/performance/locust/events_load.py
@@ -1,0 +1,37 @@
+"""Locust tasks for event ingestion throughput testing."""
+
+import json
+from locust import HttpUser, task, between
+from .utils import generate_event
+
+
+class EventIngestionUser(HttpUser):
+    """Simulate users sending events via REST and Kafka."""
+
+    wait_time = between(0.001, 0.005)
+
+    def on_start(self) -> None:
+        """Initialize optional Kafka producer if available."""
+        try:
+            from confluent_kafka import Producer
+
+            self.producer = Producer({"bootstrap.servers": "localhost:9092"})
+        except Exception:  # pragma: no cover - optional dependency
+            self.producer = None
+
+    @task(2)
+    def rest_event(self) -> None:
+        """Send event to the REST API."""
+        event = generate_event()
+        self.client.post("/events", json=event, name="REST /events")
+
+    @task(1)
+    def kafka_event(self) -> None:
+        """Publish event to Kafka topic if producer available."""
+        if not self.producer:
+            return
+        event = generate_event()
+        self.producer.produce(
+            "events", key=event["user_id"], value=json.dumps(event).encode()
+        )
+        self.producer.poll(0)

--- a/tests/performance/locust/locustfile.py
+++ b/tests/performance/locust/locustfile.py
@@ -1,0 +1,31 @@
+"""Main Locust entrypoint for performance suite."""
+
+from locust import LoadTestShape
+from locust.env import Environment
+
+from .events_load import EventIngestionUser
+from .analytics_load import AnalyticsQueryUser
+
+
+class RampUpShape(LoadTestShape):
+    """Gradually ramp users then hold."""
+
+    stages = [
+        {"duration": 60, "users": 1000, "spawn_rate": 50},
+        {"duration": 120, "users": 5000, "spawn_rate": 100},
+        {"duration": 180, "users": 10000, "spawn_rate": 200},
+    ]
+
+    def tick(self):
+        run_time = self.get_run_time()
+        total = 0
+        for stage in self.stages:
+            total += stage["duration"]
+            if run_time < total:
+                return (stage["users"], stage["spawn_rate"])
+        return None
+
+# Locust uses Environment to register users when launched via CLI
+class UserEnvironment(Environment):
+    user_classes = [EventIngestionUser, AnalyticsQueryUser]
+    shape_class = RampUpShape

--- a/tests/performance/locust/utils.py
+++ b/tests/performance/locust/utils.py
@@ -1,0 +1,22 @@
+import random
+import string
+import time
+from dataclasses import dataclass
+from typing import Dict, List
+
+EVENT_TYPES: List[str] = ["granted", "denied", "tailgating", "forced"]
+
+
+def random_user_id() -> str:
+    """Return a random user identifier."""
+    return "user-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+
+
+def generate_event() -> Dict[str, str]:
+    """Generate a single random event record."""
+    return {
+        "user_id": random_user_id(),
+        "device_id": f"device-{random.randint(1, 100):03d}",
+        "event_type": random.choice(EVENT_TYPES),
+        "timestamp": int(time.time() * 1000),
+    }

--- a/tests/performance/scenarios/data_generator.py
+++ b/tests/performance/scenarios/data_generator.py
@@ -1,0 +1,50 @@
+"""Generate realistic event data based on traffic patterns."""
+
+from __future__ import annotations
+
+import random
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from ..locust.utils import EVENT_TYPES, random_user_id
+
+
+def load_pattern(path: str) -> Dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def generate_events(pattern_file: str, count: int) -> List[Dict]:
+    pattern = load_pattern(pattern_file)
+    mix = pattern.get("mix", {})
+    weights = [mix.get(t, 0.0) for t in EVENT_TYPES]
+    events = []
+    for _ in range(count):
+        events.append(
+            {
+                "user_id": random_user_id(),
+                "device_id": f"device-{random.randint(1, 100):03d}",
+                "event_type": random.choices(EVENT_TYPES, weights=weights, k=1)[0],
+                "timestamp": int(time.time() * 1000),
+            }
+        )
+    return events
+
+
+if __name__ == "__main__":
+    import json
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pattern", help="YAML pattern file")
+    parser.add_argument("count", type=int, default=1000)
+    parser.add_argument("output", type=Path, default=Path("events.json"))
+    args = parser.parse_args()
+
+    data = generate_events(args.pattern, args.count)
+    with args.output.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    print(f"Generated {args.count} events to {args.output}")

--- a/tests/performance/scenarios/realistic_traffic.yaml
+++ b/tests/performance/scenarios/realistic_traffic.yaml
@@ -1,0 +1,13 @@
+# Example traffic pattern definitions
+ramp_up:
+  - duration: 60
+    users: 1000
+  - duration: 120
+    users: 5000
+  - duration: 180
+    users: 10000
+mix:
+  granted: 0.7
+  denied: 0.2
+  tailgating: 0.05
+  forced: 0.05


### PR DESCRIPTION
## Summary
- add Locust load tests for events and analytics
- add k6 scenarios for stress, spike and soak testing
- provide traffic patterns and data generator utilities
- generate performance reports with matplotlib

## Testing
- `pytest -q tests/performance/test_event_processing.py` *(fails: No module named 'monitoring.prometheus')*

------
https://chatgpt.com/codex/tasks/task_e_6883548d57f883208509a12b28314674