### PR TITLE
Add async DB migration framework

### DIFF
--- a/migration_tests/test_migration_cli.py
+++ b/migration_tests/test_migration_cli.py
@@ -1,0 +1,38 @@
+import importlib.util
+import pathlib
+import types
+import sys
+
+import pytest
+
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[1] / "services"
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(SERVICES_PATH)]
+sys.modules.setdefault("services", services_pkg)
+cli_spec = importlib.util.spec_from_file_location(
+    "services.migration.cli",
+    SERVICES_PATH / "migration" / "cli.py",
+)
+migration_cli = importlib.util.module_from_spec(cli_spec)
+cli_spec.loader.exec_module(migration_cli)
+
+
+class DummyManager:
+    def __init__(self) -> None:
+        self.called = []
+
+    async def migrate(self) -> None:
+        self.called.append("run")
+
+    async def rollback(self) -> None:
+        self.called.append("rollback")
+
+    async def status(self):
+        self.called.append("status")
+        return {"progress": {}, "failures": []}
+
+
+def test_cli_status(monkeypatch):
+    monkeypatch.setattr(migration_cli, "_build_manager", lambda args: DummyManager())
+    rc = migration_cli.main(["status"])
+    assert rc == 0

--- a/migration_tests/test_migration_framework.py
+++ b/migration_tests/test_migration_framework.py
@@ -1,0 +1,102 @@
+import asyncio
+import importlib.util
+import pathlib
+import types
+import sys
+
+import pytest
+
+SERVICES_PATH = pathlib.Path(__file__).resolve().parents[1] / "services"
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(SERVICES_PATH)]
+sys.modules.setdefault("services", services_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "services.migration.framework",
+    SERVICES_PATH / "migration" / "framework.py",
+)
+framework = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(framework)
+
+spec = importlib.util.spec_from_file_location(
+    "services.migration.strategies.gateway_migration",
+    SERVICES_PATH / "migration" / "strategies" / "gateway_migration.py",
+)
+gateway_migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gateway_migration)
+
+spec = importlib.util.spec_from_file_location(
+    "services.migration.strategies.events_migration",
+    SERVICES_PATH / "migration" / "strategies" / "events_migration.py",
+)
+events_migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(events_migration)
+
+spec = importlib.util.spec_from_file_location(
+    "services.migration.strategies.analytics_migration",
+    SERVICES_PATH / "migration" / "strategies" / "analytics_migration.py",
+)
+analytics_migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(analytics_migration)
+
+
+class DummyPool:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.inserted = []
+        self._fetch_count = 0
+
+    async def fetch(self, *a, **k):
+        self._fetch_count += 1
+        if self._fetch_count > 1:
+            return []
+        return list(self.rows)
+
+    async def fetchval(self, *a, **k):
+        return len(self.inserted)
+
+    async def executemany(self, _query, values):
+        self.inserted.extend(list(values))
+
+    def acquire(self):
+        return self
+
+    def release(self, _c=None):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def execute(self, query):
+        if query.startswith("TRUNCATE"):
+            self.inserted.clear()
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_progress(monkeypatch):
+    src_pool = DummyPool(rows=[{"id": 1}])
+    gw_pool = DummyPool()
+    ev_pool = DummyPool()
+    an_pool = DummyPool()
+
+    pools = iter([src_pool, gw_pool, ev_pool, an_pool])
+
+    async def fake_create_pool(*_, **__):
+        return next(pools)
+
+    monkeypatch.setattr(framework.asyncpg, "create_pool", fake_create_pool)
+
+    mgr = framework.MigrationManager(
+        "postgresql://source",
+        [
+            gateway_migration.GatewayMigration("postgresql://gw"),
+            events_migration.EventsMigration("postgresql://ev"),
+            analytics_migration.AnalyticsMigration("postgresql://an"),
+        ],
+    )
+    await mgr.migrate()
+    status = await mgr.status()
+    assert status["progress"]["gateway_logs"] == 1

--- a/services/migration/__init__.py
+++ b/services/migration/__init__.py
@@ -1,0 +1,3 @@
+from .framework import MigrationManager, MigrationStrategy
+
+__all__ = ["MigrationManager", "MigrationStrategy"]

--- a/services/migration/cli.py
+++ b/services/migration/cli.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import List
+
+from .framework import MigrationManager
+from .strategies import AnalyticsMigration, EventsMigration, GatewayMigration
+
+
+def _build_manager(args: argparse.Namespace) -> MigrationManager:
+    strategies = [
+        GatewayMigration(args.gateway_dsn),
+        EventsMigration(args.events_dsn),
+        AnalyticsMigration(args.analytics_dsn),
+    ]
+    return MigrationManager(args.source_dsn, strategies)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Database migration manager")
+    parser.add_argument("--source-dsn", default="postgresql:///yosai_db")
+    parser.add_argument("--gateway-dsn", default="postgresql:///yosai_gateway_db")
+    parser.add_argument("--events-dsn", default="postgresql:///yosai_events_db")
+    parser.add_argument("--analytics-dsn", default="postgresql:///yosai_analytics_db")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("run")
+    sub.add_parser("rollback")
+    sub.add_parser("status")
+
+    args = parser.parse_args(argv)
+    mgr = _build_manager(args)
+
+    if args.cmd == "run":
+        asyncio.run(mgr.migrate())
+        return 0
+    if args.cmd == "rollback":
+        asyncio.run(mgr.rollback())
+        return 0
+    if args.cmd == "status":
+        status = asyncio.run(mgr.status())
+        print(json.dumps(status, indent=2))
+        return 0
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/migration/framework.py
+++ b/services/migration/framework.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, AsyncIterator, Dict, List, Sequence
+
+import asyncpg
+
+from .validators.integrity_checker import IntegrityChecker
+
+LOG = logging.getLogger(__name__)
+
+
+class MigrationStrategy(ABC):
+    """Abstract base for service specific migration strategies."""
+
+    def __init__(self, name: str, target_dsn: str) -> None:
+        self.name = name
+        self.target_dsn = target_dsn
+        self.target_pool: asyncpg.Pool | None = None
+        self.checker = IntegrityChecker()
+
+    async def setup(self) -> None:
+        self.target_pool = await asyncpg.create_pool(dsn=self.target_dsn)
+
+    @abstractmethod
+    async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
+        """Yield migrated row counts."""
+
+    async def rollback(self) -> None:
+        if self.target_pool is None:
+            return
+        async with self.target_pool.acquire() as conn:
+            await conn.execute(f"TRUNCATE TABLE {self.name} CASCADE")
+
+
+class MigrationManager:
+    """Coordinate database migration across multiple strategies."""
+
+    def __init__(self, source_dsn: str, strategies: Sequence[MigrationStrategy]):
+        self.source_dsn = source_dsn
+        self.strategies = list(strategies)
+        self.source_pool: asyncpg.Pool | None = None
+        self.tasks: List[asyncio.Task[Any]] = []
+        self.progress: Dict[str, int] = {}
+        self.failures: List[str] = []
+
+    async def setup(self) -> None:
+        self.source_pool = await asyncpg.create_pool(dsn=self.source_dsn)
+        for strat in self.strategies:
+            await strat.setup()
+
+    async def migrate(self) -> None:
+        await self.setup()
+        assert self.source_pool is not None
+        for strat in self.strategies:
+            task = asyncio.create_task(self._run_strategy(strat))
+            self.tasks.append(task)
+        await asyncio.gather(*self.tasks)
+
+    async def _run_strategy(self, strat: MigrationStrategy) -> None:
+        assert self.source_pool is not None
+        try:
+            async for count in strat.run(self.source_pool):
+                self.progress[strat.name] = self.progress.get(strat.name, 0) + count
+        except Exception as exc:  # pragma: no cover - runtime failures
+            LOG.exception("Migration %s failed: %s", strat.name, exc)
+            self.failures.append(strat.name)
+            await strat.rollback()
+
+    async def rollback(self) -> None:
+        for strat in self.strategies:
+            await strat.rollback()
+
+    async def status(self) -> Dict[str, Any]:
+        return {"progress": self.progress, "failures": self.failures}
+
+
+__all__ = ["MigrationManager", "MigrationStrategy"]

--- a/services/migration/strategies/__init__.py
+++ b/services/migration/strategies/__init__.py
@@ -1,0 +1,9 @@
+from .gateway_migration import GatewayMigration
+from .events_migration import EventsMigration
+from .analytics_migration import AnalyticsMigration
+
+__all__ = [
+    "GatewayMigration",
+    "EventsMigration",
+    "AnalyticsMigration",
+]

--- a/services/migration/strategies/analytics_migration.py
+++ b/services/migration/strategies/analytics_migration.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, List
+
+import asyncpg
+
+from ..framework import MigrationStrategy
+
+
+class AnalyticsMigration(MigrationStrategy):
+    """Migrate analytics related tables."""
+
+    TABLE = "analytics_results"
+    CHUNK_SIZE = 1000
+
+    def __init__(self, target_dsn: str) -> None:
+        super().__init__(self.TABLE, target_dsn)
+
+    async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
+        start = 0
+        assert self.target_pool is not None
+        while True:
+            rows: List[asyncpg.Record] = await source_pool.fetch(
+                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+            )
+            if not rows:
+                break
+            await self.target_pool.executemany(
+                f"INSERT INTO {self.TABLE} VALUES($1:record)", rows
+            )
+            start += len(rows)
+            yield len(rows)

--- a/services/migration/strategies/events_migration.py
+++ b/services/migration/strategies/events_migration.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, List
+
+import asyncpg
+
+from ..framework import MigrationStrategy
+
+
+class EventsMigration(MigrationStrategy):
+    """Migrate access events table. Supports TimescaleDB targets."""
+
+    TABLE = "access_events"
+    CHUNK_SIZE = 10000
+
+    def __init__(self, target_dsn: str) -> None:
+        super().__init__(self.TABLE, target_dsn)
+
+    async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
+        start = 0
+        assert self.target_pool is not None
+        while True:
+            rows: List[asyncpg.Record] = await source_pool.fetch(
+                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+            )
+            if not rows:
+                break
+            await self.target_pool.executemany(
+                f"INSERT INTO {self.TABLE} VALUES($1:record)", rows
+            )
+            start += len(rows)
+            yield len(rows)

--- a/services/migration/strategies/gateway_migration.py
+++ b/services/migration/strategies/gateway_migration.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, List
+
+import asyncpg
+
+from ..framework import MigrationStrategy
+
+
+class GatewayMigration(MigrationStrategy):
+    """Migrate gateway related tables."""
+
+    TABLE = "gateway_logs"
+    CHUNK_SIZE = 1000
+
+    def __init__(self, target_dsn: str) -> None:
+        super().__init__(self.TABLE, target_dsn)
+
+    async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
+        start = 0
+        assert self.target_pool is not None
+        while True:
+            rows: List[asyncpg.Record] = await source_pool.fetch(
+                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+            )
+            if not rows:
+                break
+            await self.target_pool.executemany(
+                f"INSERT INTO {self.TABLE} VALUES($1:record)", rows
+            )
+            start += len(rows)
+            yield len(rows)

--- a/services/migration/validators/integrity_checker.py
+++ b/services/migration/validators/integrity_checker.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import asyncpg
+
+
+class IntegrityChecker:
+    """Validate table row counts between source and target."""
+
+    async def rowcount_equal(
+        self, source: asyncpg.Pool, target: asyncpg.Pool, table: str
+    ) -> bool:
+        src = await source.fetchval(f"SELECT COUNT(*) FROM {table}")
+        tgt = await target.fetchval(f"SELECT COUNT(*) FROM {table}")
+        return src == tgt
+
+
+__all__ = ["IntegrityChecker"]


### PR DESCRIPTION
## Summary
- implement asynchronous migration framework
- add service-specific strategies and CLI
- provide integrity checker utility
- include basic migration tests

## Testing
- `pytest migration_tests -q --confcutdir=migration_tests`

------
https://chatgpt.com/codex/tasks/task_e_68835465d3e883208543e3c1b60735c3