### PR TITLE
Add Timescale migration scripts and update policies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Alembic upgrade check
         if: matrix.job == 'migration'
         run: alembic -c database/migrations/alembic.ini upgrade head
+      - name: Timescale upgrade check
+        if: matrix.job == 'migration'
+        run: alembic -c migrations/timescale/alembic.ini upgrade head
       - name: Compile replication script
         if: matrix.job == 'migration'
         run: python -m py_compile scripts/replicate_to_timescale.py

--- a/README.md
+++ b/README.md
@@ -1242,8 +1242,8 @@ Add `--test-mode` to perform a dry run on the first chunk only.
 
 The SQL file creates an `access_events` hypertable with policies:
 
-* **Compression** after one day: `add_compression_policy('access_events', INTERVAL '1 day')`
-* **Retention** after seven days: `add_retention_policy('access_events', INTERVAL '7 days')`
+* **Compression** after thirty days: `add_compression_policy('access_events', INTERVAL '30 days')`
+* **Retention** after one year: `add_retention_policy('access_events', INTERVAL '365 days')`
 
 It also defines indexes used by the migration:
 

--- a/docs/timescale_integration.md
+++ b/docs/timescale_integration.md
@@ -2,14 +2,14 @@
 
 The dashboard can store access events in TimescaleDB for efficient time-series
 analytics. Hypertables are created automatically when the `TimescaleDBManager`
-initialises. Events are compressed after seven days and removed after ninety
-days using retention policies.
+initialises. Events are compressed after thirty days and removed after one year
+using retention policies.
 
 ## Data Retention
 
 ```sql
-SELECT add_compression_policy('access_events', INTERVAL '7 days');
-SELECT add_retention_policy('access_events', INTERVAL '90 days');
+SELECT add_compression_policy('access_events', INTERVAL '30 days');
+SELECT add_retention_policy('access_events', INTERVAL '365 days');
 ```
 
 Continuous aggregates refresh every five minutes to keep summary data up to

--- a/migrations/timescale/001_create_hypertables.sql
+++ b/migrations/timescale/001_create_hypertables.sql
@@ -1,0 +1,20 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE IF NOT EXISTS access_events (
+    time TIMESTAMPTZ NOT NULL,
+    event_id UUID PRIMARY KEY,
+    person_id VARCHAR(50),
+    door_id VARCHAR(50),
+    facility_id VARCHAR(50),
+    access_result VARCHAR(20),
+    badge_status VARCHAR(20),
+    response_time_ms INTEGER,
+    metadata JSONB
+);
+SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
+CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
+CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);

--- a/migrations/timescale/002_create_continuous_aggregates.sql
+++ b/migrations/timescale/002_create_continuous_aggregates.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS access_events_5min
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('5 minutes', time) AS bucket,
+    facility_id,
+    COUNT(*) AS event_count
+FROM access_events
+GROUP BY bucket, facility_id
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('access_events_5min',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '5 minutes');

--- a/migrations/timescale/003_setup_compression.sql
+++ b/migrations/timescale/003_setup_compression.sql
@@ -1,0 +1,8 @@
+ALTER TABLE access_events
+  SET (
+       timescaledb.compress,
+       timescaledb.compress_orderby = 'time DESC',
+       timescaledb.compress_segmentby = 'facility_id'
+  );
+
+SELECT add_compression_policy('access_events', INTERVAL '30 days');

--- a/migrations/timescale/004_retention_policies.sql
+++ b/migrations/timescale/004_retention_policies.sql
@@ -1,0 +1,1 @@
+SELECT add_retention_policy('access_events', INTERVAL '365 days');

--- a/migrations/timescale/versions/0001_initial.py
+++ b/migrations/timescale/versions/0001_initial.py
@@ -1,8 +1,11 @@
 """Timescale initial schema"""
+
 from __future__ import annotations
+
 from pathlib import Path
-from alembic import op
+
 import sqlalchemy as sa  # noqa:F401
+from alembic import op
 
 revision = "0001"
 down_revision = None
@@ -11,8 +14,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    sql_path = Path(__file__).resolve().parents[3] / "scripts" / "init_timescaledb.sql"
-    op.execute(sql_path.read_text())
+    base = Path(__file__).resolve().parents[1]
+    for fname in [
+        "001_create_hypertables.sql",
+        "002_create_continuous_aggregates.sql",
+        "003_setup_compression.sql",
+        "004_retention_policies.sql",
+    ]:
+        op.execute((base / fname).read_text())
 
 
 def downgrade() -> None:

--- a/scripts/init_timescaledb.sql
+++ b/scripts/init_timescaledb.sql
@@ -36,5 +36,5 @@ SELECT add_continuous_aggregate_policy('access_events_5min',
     end_offset => INTERVAL '1 minute',
     schedule_interval => INTERVAL '5 minutes');
 
-SELECT add_compression_policy('access_events', INTERVAL '7 days');
-SELECT add_retention_policy('access_events', INTERVAL '90 days');
+SELECT add_compression_policy('access_events', INTERVAL '30 days');
+SELECT add_retention_policy('access_events', INTERVAL '365 days');

--- a/scripts/migrate_to_timescale.py
+++ b/scripts/migrate_to_timescale.py
@@ -27,8 +27,9 @@ from typing import Any, Iterable, List, Mapping, Sequence, cast
 import psycopg2
 from psycopg2.extensions import connection, cursor
 from psycopg2.extras import DictCursor, execute_batch
-from database.secure_exec import execute_query, execute_command
 from tqdm import tqdm
+
+from database.secure_exec import execute_command, execute_query
 
 CHUNK_SIZE = 10_000
 CHECKPOINT_TABLE = "migration_checkpoint"
@@ -230,7 +231,7 @@ def setup_timescale(conn: connection) -> None:
             """
             SELECT add_compression_policy(
                 'access_events',
-                INTERVAL '7 days',
+                INTERVAL '30 days',
                 if_not_exists => TRUE
             )
             """
@@ -239,7 +240,7 @@ def setup_timescale(conn: connection) -> None:
             """
             SELECT add_retention_policy(
                 'access_events',
-                INTERVAL '90 days',
+                INTERVAL '365 days',
                 if_not_exists => TRUE
             )
             """
@@ -380,7 +381,9 @@ def run_verification(target_conn: connection) -> None:
         )
         tables = [r[0] for r in cur.fetchall()]
         LOG.info("Tables: %s", ", ".join(tables))
-        execute_query(cur, "SELECT * FROM timescaledb_information.compressed_hypertables")
+        execute_query(
+            cur, "SELECT * FROM timescaledb_information.compressed_hypertables"
+        )
         LOG.info("Compressed hypertables:")
         for row in cur.fetchall():
             LOG.info(str(row))

--- a/services/timescale/manager.py
+++ b/services/timescale/manager.py
@@ -96,11 +96,11 @@ class TimescaleDBManager:
         )
         await conn.execute(
             "SELECT add_compression_policy('access_events',"
-            " INTERVAL '7 days', if_not_exists => TRUE)"
+            " INTERVAL '30 days', if_not_exists => TRUE)"
         )
         await conn.execute(
             "SELECT add_retention_policy('access_events',"
-            " INTERVAL '90 days', if_not_exists => TRUE)"
+            " INTERVAL '365 days', if_not_exists => TRUE)"
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add TimescaleSQL migrations and call them from Alembic upgrade
- configure compression at 30 days and retention at 1 year
- run Timescale migrations in CI
- adjust manager defaults and documentation

## Testing
- `pre-commit run --files .github/workflows/ci-cd.yml README.md docs/timescale_integration.md migrations/timescale/versions/0001_initial.py scripts/init_timescaledb.sql scripts/migrate_to_timescale.py services/timescale/manager.py migrations/timescale/001_create_hypertables.sql migrations/timescale/002_create_continuous_aggregates.sql migrations/timescale/003_setup_compression.sql migrations/timescale/004_retention_policies.sql` *(fails: black, isort, flake8, mypy, bandit)*

------
https://chatgpt.com/codex/tasks/task_e_68835876995883209cc9b515adbf81b8