### PR TITLE
Improve Timescale manager resilience

### DIFF
--- a/services/common/async_db.py
+++ b/services/common/async_db.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import asyncio
+import logging
 from typing import Optional
 
 import asyncpg
@@ -11,17 +15,34 @@ async def create_pool(
     min_size: int = 1,
     max_size: int = 10,
     timeout: float = 30.0,
+    max_retries: int = 3,
+    backoff: float = 0.5,
 ) -> asyncpg.pool.Pool:
-    """Create a global asyncpg pool if not already created."""
+    """Create a global asyncpg pool if not already created with retries."""
+
     global _pool
-    if _pool is None:
-        _pool = await asyncpg.create_pool(
-            dsn=dsn,
-            min_size=min_size,
-            max_size=max_size,
-            timeout=timeout,
-        )
-    return _pool
+    if _pool is not None:
+        return _pool
+
+    attempt = 0
+    delay = backoff
+    log = logging.getLogger(__name__)
+    while True:
+        try:
+            _pool = await asyncpg.create_pool(
+                dsn=dsn,
+                min_size=min_size,
+                max_size=max_size,
+                timeout=timeout,
+            )
+            return _pool
+        except Exception as exc:  # pragma: no cover - network failures
+            attempt += 1
+            log.error("Async pool connection failed (attempt %s): %s", attempt, exc)
+            if attempt >= max_retries:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
 
 
 async def get_pool() -> asyncpg.pool.Pool:


### PR DESCRIPTION
## Summary
- add connection retries in async DB adapter
- implement Timescale health monitor and query metrics
- track metrics for analytics microservice queries

## Testing
- `pre-commit run --files services/common/async_db.py services/timescale/manager.py services/analytics_microservice/async_queries.py`
- `pytest tests/integration/test_analytics_microservice_metrics.py::test_metrics_increment -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6883587ea4b083209fe82ff97c3e1c80