### PR TITLE
Add Timescale backup scripts

### DIFF
--- a/docs/timescale_integration.md
+++ b/docs/timescale_integration.md
@@ -62,3 +62,22 @@ spec:
 ```
 
 The job also inherits the standard configuration from `yosai-config` and `yosai-secrets` via `envFrom` like the other microservices.
+
+## Backup and Restore
+
+Use `scripts/backup_timescale.sh` to create pg_dump archives of the Timescale database. Set `TIMESCALE_DSN` to the connection string and optionally `OUTPUT_DIR` and `RETENTION_DAYS`.
+
+```bash
+TIMESCALE_DSN=postgres://user:pass@db/timescale ./scripts/backup_timescale.sh
+```
+
+The script verifies the dump with `pg_restore --list` and removes backups older than `RETENTION_DAYS` (default 7 days).
+
+Restore a dump with `scripts/restore_timescale.sh`:
+
+```bash
+TIMESCALE_DSN=postgres://user:pass@db/timescale ./scripts/restore_timescale.sh backups/timescale_20240101_120000.dump
+```
+
+Always check that the restore completed successfully and that the expected tables are present.
+

--- a/scripts/backup_timescale.sh
+++ b/scripts/backup_timescale.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: TIMESCALE_DSN=<connection_string> [OUTPUT_DIR=backups] [RETENTION_DAYS=7] ./scripts/backup_timescale.sh
+# Creates a pg_dump archive and prunes old backups based on retention.
+
+SRC_DSN="${TIMESCALE_DSN:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+
+if [[ -z "$SRC_DSN" ]]; then
+  echo "TIMESCALE_DSN environment variable not set" >&2
+  exit 1
+fi
+
+if [[ $# -ge 1 ]]; then
+  OUTPUT_DIR="$1"
+fi
+
+TIMESTAMP="$(date +"%Y%m%d_%H%M%S")"
+mkdir -p "$OUTPUT_DIR"
+BACKUP_FILE="$OUTPUT_DIR/timescale_${TIMESTAMP}.dump"
+
+echo "Creating backup $BACKUP_FILE"
+pg_dump --format=custom --file "$BACKUP_FILE" "$SRC_DSN"
+
+echo "Verifying backup"
+pg_restore --list "$BACKUP_FILE" >/dev/null
+
+echo "Pruning backups older than $RETENTION_DAYS days"
+find "$OUTPUT_DIR" -type f -name 'timescale_*.dump' -mtime "+$RETENTION_DAYS" -delete
+
+echo "Backup complete: $BACKUP_FILE"
+

--- a/scripts/restore_timescale.sh
+++ b/scripts/restore_timescale.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: TIMESCALE_DSN=<connection_string> ./scripts/restore_timescale.sh <backup_file>
+# Restores a pg_dump archive created by backup_timescale.sh.
+
+TGT_DSN="${TIMESCALE_DSN:-}"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: TIMESCALE_DSN=<connection_string> $0 <backup_file>" >&2
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+
+if [[ -z "$TGT_DSN" ]]; then
+  echo "TIMESCALE_DSN environment variable not set" >&2
+  exit 1
+fi
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "Backup file $BACKUP_FILE not found" >&2
+  exit 1
+fi
+
+echo "Restoring $BACKUP_FILE to $TGT_DSN"
+pg_restore --clean --if-exists --no-owner --dbname "$TGT_DSN" "$BACKUP_FILE"
+
+echo "Restore completed"
+


### PR DESCRIPTION
## Summary
- add `backup_timescale.sh` to dump TimescaleDB
- add `restore_timescale.sh` to load a dump
- explain backup/restore workflow in the Timescale integration docs

## Testing
- `pre-commit run --files scripts/backup_timescale.sh scripts/restore_timescale.sh docs/timescale_integration.md`

------
https://chatgpt.com/codex/tasks/task_e_6883588093c88320a68ba51e17cf5238