### PR TITLE
Add initial Avro schemas

### DIFF
--- a/schemas/avro/audit_event_v1.avsc
+++ b/schemas/avro/audit_event_v1.avsc
@@ -1,0 +1,13 @@
+{
+  "namespace": "com.yosai.audit",
+  "type": "record",
+  "name": "AuditEvent",
+  "fields": [
+    {"name": "event_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "user_id", "type": ["null", "string"], "default": null},
+    {"name": "action", "type": "string"},
+    {"name": "resource", "type": ["null", "string"], "default": null},
+    {"name": "status", "type": "string"}
+  ]
+}

--- a/schemas/avro/system_event_v1.avsc
+++ b/schemas/avro/system_event_v1.avsc
@@ -1,0 +1,12 @@
+{
+  "namespace": "com.yosai.system",
+  "type": "record",
+  "name": "SystemEvent",
+  "fields": [
+    {"name": "event_id", "type": "string"},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "component", "type": ["null", "string"], "default": null},
+    {"name": "level", "type": "string"},
+    {"name": "message", "type": ["null", "string"], "default": null}
+  ]
+}


### PR DESCRIPTION
## Summary
- add audit_event_v1 and system_event_v1 schemas under `schemas/avro`
- ensure schemas comply with documented evolution rules

## Testing
- `python scripts/check_schema_compatibility.py`

------
https://chatgpt.com/codex/tasks/task_e_68835d9551148320af51e93ee2f14ce4