### PR TITLE
Add Avro schema documentation generator

### DIFF
--- a/docs/avro/access_event_v1.html
+++ b/docs/avro/access_event_v1.html
@@ -1,0 +1,14 @@
+<h1>AccessEvent Schema</h1>
+<p>Namespace: <code>com.yosai.access</code></p>
+<p>| Field | Type | Default |
+|-------|------|---------|
+| <code>event_id</code> | <code>string</code> | <code>|
+| `timestamp` | `long (timestamp-millis)` |</code> |
+| <code>person_id</code> | <code>null | string</code> | <code>null</code> |
+| <code>door_id</code> | <code>null | string</code> | <code>null</code> |
+| <code>badge_id</code> | <code>null | string</code> | <code>null</code> |
+| <code>access_result</code> | <code>string</code> | <code>` |
+|</code>badge_status<code>|</code>null | string<code>|</code>null<code>|
+|</code>door_held_open_time<code>|</code>null | double<code>|</code>0.0<code>|
+|</code>entry_without_badge<code>|</code>null | boolean<code>|</code>false<code>|
+|</code>device_status<code>|</code>null | string<code>|</code>"normal"` |</p>

--- a/docs/avro/access_event_v1.md
+++ b/docs/avro/access_event_v1.md
@@ -1,0 +1,16 @@
+# AccessEvent Schema
+
+Namespace: `com.yosai.access`
+
+| Field | Type | Default |
+|-------|------|---------|
+| `event_id` | `string` | `` |
+| `timestamp` | `long (timestamp-millis)` | `` |
+| `person_id` | `null | string` | `null` |
+| `door_id` | `null | string` | `null` |
+| `badge_id` | `null | string` | `null` |
+| `access_result` | `string` | `` |
+| `badge_status` | `null | string` | `null` |
+| `door_held_open_time` | `null | double` | `0.0` |
+| `entry_without_badge` | `null | boolean` | `false` |
+| `device_status` | `null | string` | `"normal"` |

--- a/docs/avro/analytics_event_v1.html
+++ b/docs/avro/analytics_event_v1.html
@@ -1,0 +1,9 @@
+<h1>AnalyticsEvent Schema</h1>
+<p>Namespace: <code>com.yosai.analytics</code></p>
+<p>| Field | Type | Default |
+|-------|------|---------|
+| <code>event_id</code> | <code>string</code> | <code>|
+| `timestamp` | `long (timestamp-millis)` |</code> |
+| <code>analysis_type</code> | <code>string</code> | <code>|
+| `result` | `string` |</code> |
+| <code>success</code> | <code>boolean</code> | `` |</p>

--- a/docs/avro/analytics_event_v1.md
+++ b/docs/avro/analytics_event_v1.md
@@ -1,0 +1,11 @@
+# AnalyticsEvent Schema
+
+Namespace: `com.yosai.analytics`
+
+| Field | Type | Default |
+|-------|------|---------|
+| `event_id` | `string` | `` |
+| `timestamp` | `long (timestamp-millis)` | `` |
+| `analysis_type` | `string` | `` |
+| `result` | `string` | `` |
+| `success` | `boolean` | `` |

--- a/docs/avro/anomaly_event_v1.html
+++ b/docs/avro/anomaly_event_v1.html
@@ -1,0 +1,9 @@
+<h1>AnomalyEvent Schema</h1>
+<p>Namespace: <code>com.yosai.anomaly</code></p>
+<p>| Field | Type | Default |
+|-------|------|---------|
+| <code>event_id</code> | <code>string</code> | <code>|
+| `timestamp` | `long (timestamp-millis)` |</code> |
+| <code>device_id</code> | <code>null | string</code> | <code>null</code> |
+| <code>severity</code> | <code>string</code> | <code>` |
+|</code>description<code>|</code>null | string<code>|</code>null` |</p>

--- a/docs/avro/anomaly_event_v1.md
+++ b/docs/avro/anomaly_event_v1.md
@@ -1,0 +1,11 @@
+# AnomalyEvent Schema
+
+Namespace: `com.yosai.anomaly`
+
+| Field | Type | Default |
+|-------|------|---------|
+| `event_id` | `string` | `` |
+| `timestamp` | `long (timestamp-millis)` | `` |
+| `device_id` | `null | string` | `null` |
+| `severity` | `string` | `` |
+| `description` | `null | string` | `null` |

--- a/docs/avro/index.html
+++ b/docs/avro/index.html
@@ -1,0 +1,6 @@
+<h1>Avro Schemas</h1>
+<ul>
+<li><a href="access_event_v1.md">access_event_v1</a></li>
+<li><a href="analytics_event_v1.md">analytics_event_v1</a></li>
+<li><a href="anomaly_event_v1.md">anomaly_event_v1</a></li>
+</ul>

--- a/docs/avro/index.md
+++ b/docs/avro/index.md
@@ -1,0 +1,5 @@
+# Avro Schemas
+
+- [access_event_v1](access_event_v1.md)
+- [analytics_event_v1](analytics_event_v1.md)
+- [anomaly_event_v1](anomaly_event_v1.md)

--- a/docs/schema_evolution.md
+++ b/docs/schema_evolution.md
@@ -11,3 +11,6 @@ backward compatible changes. The following rules apply:
 Compatibility of new schemas is validated in CI using the
 `scripts/check_schema_compatibility.py` tool which parses
 all schema files and fails if any are invalid.
+
+Generated reference documentation for each schema is available under
+[`docs/avro/`](avro/).

--- a/tools/gen_schema_docs.py
+++ b/tools/gen_schema_docs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate Markdown and HTML docs for Avro schemas."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+from markdown import markdown
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = REPO_ROOT / "schemas" / "avro"
+DOCS_DIR = REPO_ROOT / "docs" / "avro"
+
+
+def type_repr(t: Any) -> str:
+    """Return a human readable type representation."""
+    if isinstance(t, str):
+        return t
+    if isinstance(t, list):
+        return " | ".join(type_repr(x) for x in t)
+    if isinstance(t, dict):
+        base = t.get("type")
+        logical = t.get("logicalType")
+        if logical:
+            return f"{base} ({logical})"
+        return base or json.dumps(t)
+    return json.dumps(t)
+
+
+def make_markdown(schema: dict[str, Any]) -> str:
+    lines: List[str] = [f"# {schema['name']} Schema", ""]
+    if 'namespace' in schema:
+        lines.append(f"Namespace: `{schema['namespace']}`\n")
+    lines.append("| Field | Type | Default |")
+    lines.append("|-------|------|---------|")
+    for field in schema.get('fields', []):
+        name = field['name']
+        t = type_repr(field['type'])
+        default = field.get('default')
+        if default is None and 'default' not in field:
+            default_repr = ""
+        else:
+            default_repr = json.dumps(default)
+        lines.append(f"| `{name}` | `{t}` | `{default_repr}` |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    schemas = sorted(SCHEMA_DIR.glob("*.avsc"))
+    index_lines = ["# Avro Schemas", ""]
+    for path in schemas:
+        data = json.loads(path.read_text())
+        md = make_markdown(data)
+        base = path.stem
+        md_path = DOCS_DIR / f"{base}.md"
+        html_path = DOCS_DIR / f"{base}.html"
+        md_path.write_text(md)
+        html_path.write_text(markdown(md))
+        index_lines.append(f"- [{base}]({base}.md)")
+        print(f"Wrote {md_path} and {html_path}")
+    (DOCS_DIR / "index.md").write_text("\n".join(index_lines) + "\n")
+    (DOCS_DIR / "index.html").write_text(markdown("\n".join(index_lines)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate docs for `schemas/avro/*.avsc`
- publish generated markdown & html under `docs/avro`
- link new docs directory from schema evolution guide

## Testing
- `python tools/gen_schema_docs.py`
- `pytest -k 'not slow' -q` *(fails: 172 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68835da106488320ba0ea4574b39016d