### PR TITLE
Add microservice k8s manifests and deployment docs

### DIFF
--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -164,3 +164,27 @@ scripts/rollback.sh
 
 Then scale down or delete the faulty pods once the service is stable.
 
+
+## Enabling Microservice Manifests
+
+YAML manifests for each microservice reside in `k8s/services`. Apply them to
+create the Deployment, standard `Service`, and headless `Service` objects:
+
+```bash
+kubectl apply -f k8s/services/analytics-service.yaml
+kubectl apply -f k8s/services/api-gateway.yaml
+kubectl apply -f k8s/services/event-ingestion.yaml
+```
+
+The directory also contains example templates for blue/green and canary
+strategies using Istio `VirtualService` weight rules. Adjust the weights and
+apply the files when performing controlled rollouts:
+
+```bash
+kubectl apply -f k8s/services/bluegreen-template.yaml
+kubectl apply -f k8s/services/canary-template.yaml
+```
+
+To enable mTLS between services, adapt the `k8s/services/mtls-snippet.yaml`
+configuration. It mirrors the `ISTIO_MUTUAL` settings from
+`k8s/istio/destination-rules.yaml`.

--- a/k8s/services/analytics-service.yaml
+++ b/k8s/services/analytics-service.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: analytics-service
+spec:
+  selector:
+    app: analytics-service
+  ports:
+    - port: 80
+      targetPort: 8001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: analytics-service-headless
+spec:
+  clusterIP: None
+  selector:
+    app: analytics-service
+  ports:
+    - port: 8001
+      targetPort: 8001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analytics-service
+  labels:
+    app: analytics-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: analytics-service
+  template:
+    metadata:
+      labels:
+        app: analytics-service
+    spec:
+      containers:
+        - name: analytics-service
+          image: yosai-intel-dashboard:latest
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+          command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
+          ports:
+            - containerPort: 8001
+          envFrom:
+            - configMapRef:
+                name: yosai-config
+            - configMapRef:
+                name: vault-config
+            - secretRef:
+                name: vault-secret
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"

--- a/k8s/services/api-gateway.yaml
+++ b/k8s/services/api-gateway.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway-headless
+spec:
+  clusterIP: None
+  selector:
+    app: api-gateway
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+        - name: api-gateway
+          image: yosai-gateway:latest
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"

--- a/k8s/services/bluegreen-template.yaml
+++ b/k8s/services/bluegreen-template.yaml
@@ -1,0 +1,97 @@
+# Template for blue/green deployment using Istio routing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-service-blue
+  labels:
+    app: example-service
+    color: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example-service
+      color: blue
+  template:
+    metadata:
+      labels:
+        app: example-service
+        color: blue
+    spec:
+      containers:
+        - name: example-service
+          image: example:latest
+          ports:
+            - containerPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-service-green
+  labels:
+    app: example-service
+    color: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example-service
+      color: green
+  template:
+    metadata:
+      labels:
+        app: example-service
+        color: green
+    spec:
+      containers:
+        - name: example-service
+          image: example:latest
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+spec:
+  selector:
+    app: example-service
+    color: blue
+  ports:
+    - port: 80
+      targetPort: 8000
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: example-service
+spec:
+  host: example-service
+  subsets:
+    - name: blue
+      labels:
+        color: blue
+    - name: green
+      labels:
+        color: green
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: example-service
+spec:
+  hosts:
+    - example-service
+  http:
+    - route:
+        - destination:
+            host: example-service
+            subset: blue
+          weight: 100
+        - destination:
+            host: example-service
+            subset: green
+          weight: 0

--- a/k8s/services/canary-template.yaml
+++ b/k8s/services/canary-template.yaml
@@ -1,0 +1,85 @@
+# Template for canary deployment using Istio weight-based routing
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-service-stable
+  labels:
+    app: example-service
+    track: stable
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example-service
+      track: stable
+  template:
+    metadata:
+      labels:
+        app: example-service
+        track: stable
+    spec:
+      containers:
+        - name: example-service
+          image: example:latest
+          ports:
+            - containerPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-service-canary
+  labels:
+    app: example-service
+    track: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-service
+      track: canary
+  template:
+    metadata:
+      labels:
+        app: example-service
+        track: canary
+    spec:
+      containers:
+        - name: example-service
+          image: example:new
+          ports:
+            - containerPort: 8000
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: example-service
+spec:
+  host: example-service
+  subsets:
+    - name: stable
+      labels:
+        track: stable
+    - name: canary
+      labels:
+        track: canary
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: example-service
+spec:
+  hosts:
+    - example-service
+  http:
+    - route:
+        - destination:
+            host: example-service
+            subset: stable
+          weight: 90
+        - destination:
+            host: example-service
+            subset: canary
+          weight: 10

--- a/k8s/services/event-ingestion.yaml
+++ b/k8s/services/event-ingestion.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: event-ingestion
+spec:
+  selector:
+    app: event-ingestion
+  ports:
+    - port: 80
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: event-ingestion-headless
+spec:
+  clusterIP: None
+  selector:
+    app: event-ingestion
+  ports:
+    - port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: event-ingestion
+  labels:
+    app: event-ingestion
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: event-ingestion
+  template:
+    metadata:
+      labels:
+        app: event-ingestion
+    spec:
+      containers:
+        - name: event-ingestion
+          image: event-ingestion:latest
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+          command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: yosai-config
+            - configMapRef:
+                name: vault-config
+            - secretRef:
+                name: vault-secret
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"

--- a/k8s/services/mtls-snippet.yaml
+++ b/k8s/services/mtls-snippet.yaml
@@ -1,0 +1,11 @@
+# DestinationRule example enabling mTLS between services
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: example-service
+  namespace: yosai-dev
+spec:
+  host: example-service.yosai-dev.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
## Summary
- add Deployment/Service manifests for each microservice under `k8s/services`
- include headless Service definitions
- provide mTLS DestinationRule snippet
- add blue/green and canary deployment templates with Istio routing
- document how to apply these manifests in `operations_guide.md`

## Testing
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'botocore')*

------
https://chatgpt.com/codex/tasks/task_e_68836547d1ec83208d248f50ea198bec