### PR TITLE
Update documentation and tests to use src imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,8 +629,8 @@ caches during start-up. This avoids expensive database queries on the first
 request.
 
 ```python
-from core.cache_warmer import IntelligentCacheWarmer
-from core.hierarchical_cache_manager import HierarchicalCacheManager
+from yosai_intel_dashboard.src.core.cache_warmer import IntelligentCacheWarmer
+from yosai_intel_dashboard.src.core.hierarchical_cache_manager import HierarchicalCacheManager
 
 cache = HierarchicalCacheManager()
 warmer = IntelligentCacheWarmer(cache, loader=load_from_db)
@@ -699,7 +699,7 @@ resolved from anywhere:
 
 
 ```python
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 from config import create_config_manager
 
 container = Container()
@@ -852,7 +852,7 @@ previous `config_manager.py` have been removed. Create a container and access
 the new unified configuration through it instead:
 
 ```python
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 from config import create_config_manager
 
 container = Container()
@@ -895,7 +895,7 @@ Use `EnhancedThreadSafePluginManager` to track plugin load times and
 resource usage:
 
 ```python
-from core.plugins.performance_manager import EnhancedThreadSafePluginManager
+from yosai_intel_dashboard.src.core.plugins.performance_manager import EnhancedThreadSafePluginManager
 manager = EnhancedThreadSafePluginManager(container, config)
 data = manager.get_plugin_performance_metrics()
 ```
@@ -932,8 +932,8 @@ manager.execute_query_with_retry("SELECT 1")
   Register an instance with the container to access analytics operations:
 
   ```python
-  from core.container import Container
-  from services.analytics_service import create_analytics_service
+  from yosai_intel_dashboard.src.core.container import Container
+  from yosai_intel_dashboard.src.services.analytics_service import create_analytics_service
 
   container = Container()
   container.register("analytics", create_analytics_service())
@@ -1137,7 +1137,7 @@ safe_query = SQLProcessor.encode_query(query)
 ### Firing events
 ```python
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 
 manager = CallbackManager()
 manager.trigger(CallbackEvent.ANALYSIS_COMPLETE, "analytics", {"rows": 42})
@@ -1145,7 +1145,7 @@ manager.trigger(CallbackEvent.ANALYSIS_COMPLETE, "analytics", {"rows": 42})
 
 Performance metrics can be retrieved via:
 ```python
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 summary = get_performance_monitor().get_metrics_summary()
 ```
 ### Standardizing column names

--- a/docs/ab_testing.md
+++ b/docs/ab_testing.md
@@ -21,7 +21,7 @@ Create a tester instance and call `predict` with your input data:
 
 ```python
 from models.ml import ModelRegistry
-from services.ab_testing import ModelABTester
+from yosai_intel_dashboard.src.services.ab_testing import ModelABTester
 
 registry = ModelRegistry("sqlite:///registry.db", "ml-bucket")
 tester = ModelABTester("my-model", registry)

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,7 +109,7 @@ dependency injection mechanism. It resolves services by name and caches
 instances created by registered factories.
 
 ```python
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 container = ServiceContainer()
 container.register_factory("db", DatabaseManager)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,8 @@ needed:
 
 ```python
 from config import create_config_manager
-from core.container import Container
-from services.analytics_service import create_analytics_service
+from yosai_intel_dashboard.src.core.container import Container
+from yosai_intel_dashboard.src.services.analytics_service import create_analytics_service
 
 container = Container()
 container.register("config", create_config_manager())

--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -9,8 +9,8 @@ namespace.
 ## Registering Callbacks
 
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 
 callbacks = TrulyUnifiedCallbacks(app)
 
@@ -45,7 +45,7 @@ def submit_query(n):
 
 ```python
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 
 events = CallbackManager()
 
@@ -63,7 +63,7 @@ useful when a Dash callback needs to orchestrate multiple steps.
 
 
 ```python
-from core.callbacks import UnifiedCallbackManager
+from yosai_intel_dashboard.src.core.callbacks import UnifiedCallbackManager
 
 ops = UnifiedCallbackManager()
 ops.register_operation("refresh", load_data)

--- a/docs/column_verification.md
+++ b/docs/column_verification.md
@@ -13,7 +13,7 @@ features. The function expects a `TrulyUnifiedCallbacks` or
 
 ```python
 from components.column_verification import register_callbacks
-from core.master_callback_system import MasterCallbackSystem
+from yosai_intel_dashboard.src.core.master_callback_system import MasterCallbackSystem
 
 callbacks = MasterCallbackSystem(app)
 register_callbacks(callbacks)

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -36,7 +36,7 @@ This separation makes the pipeline extensible and easier to test as new data sou
 Example event:
 ```python
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 
 manager = CallbackManager()
 manager.trigger(CallbackEvent.FILE_UPLOAD_COMPLETE, "uploader", {"rows": len(df)})

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -15,7 +15,7 @@ Flask applications can expose unified JSON errors by calling
 
 ```python
 from flask import Flask
-from core.error_handlers import register_error_handlers
+from yosai_intel_dashboard.src.core.error_handlers import register_error_handlers
 
 app = Flask(__name__)
 register_error_handlers(app)
@@ -32,7 +32,7 @@ logs the exception, stores it in the global `ErrorHandler` history and returns
 `None` (or re-raises if `reraise=True`):
 
 ```python
-from core.error_handling import (
+from yosai_intel_dashboard.src.core.error_handling import (
     ErrorCategory,
     ErrorSeverity,
     with_error_handling,
@@ -51,7 +51,7 @@ External API calls should use the `CircuitBreaker` utility combined with
 `with_retry` to avoid repeated failures:
 
 ```python
-from core.error_handling import CircuitBreaker, with_retry
+from yosai_intel_dashboard.src.core.error_handling import CircuitBreaker, with_retry
 
 breaker = CircuitBreaker(name='external_api')
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -38,7 +38,7 @@ Use `services.feature_flags.feature_flags.is_enabled(name)` to check a
 flag:
 
 ```python
-from services.feature_flags import feature_flags
+from yosai_intel_dashboard.src.services.feature_flags import feature_flags
 
 if feature_flags.is_enabled("use_timescaledb"):
     ...

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -13,8 +13,8 @@ into your existing Yōsai Intel application
 from flask import Flask
 from flask_login import login_required
 from config import create_config_manager
-from core.error_handlers import register_error_handlers
-from core.container import Container
+from yosai_intel_dashboard.src.core.error_handlers import register_error_handlers
+from yosai_intel_dashboard.src.core.container import Container
 from database.connection import create_database_connection
 
 # Import all compliance components
@@ -27,11 +27,11 @@ from config.compliance_setup import (
     setup_data_retention_scheduler
 )
 from controllers.compliance_controller import register_compliance_routes
-from services.compliance.breach_notification_service import create_breach_notification_service
-from services.compliance.cross_border_transfer_service import create_cross_border_transfer_service
-from services.compliance.compliance_dashboard import create_compliance_dashboard
-from services.compliance.data_retention_service import create_data_retention_service
-from services.compliance.dpia_service import create_dpia_service
+from yosai_intel_dashboard.src.services.compliance.breach_notification_service import create_breach_notification_service
+from yosai_intel_dashboard.src.services.compliance.cross_border_transfer_service import create_cross_border_transfer_service
+from yosai_intel_dashboard.src.services.compliance.compliance_dashboard import create_compliance_dashboard
+from yosai_intel_dashboard.src.services.compliance.data_retention_service import create_data_retention_service
+from yosai_intel_dashboard.src.services.compliance.dpia_service import create_dpia_service
 
 def create_app(config_name: str = None) -> Flask:
     """
@@ -178,7 +178,7 @@ def upgrade_existing_people_table():
 # Update your existing services to include compliance:
 
 from flask_login import current_user
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 
 class EnhancedAnalyticsService:
     """
@@ -498,7 +498,7 @@ def run_compliance_tests():
     }
     
     try:
-        from core.container import Container
+        from yosai_intel_dashboard.src.core.container import Container
         container = Container()
         
         # Test 1: Database schema

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -10,7 +10,7 @@ sanitization helpers and SQL encoding functions.
 
 ### Text Processing Migration
 ```python
-from core.unicode import UnicodeProcessor, UnicodeSecurityProcessor
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor, UnicodeSecurityProcessor
 
 result = UnicodeProcessor.clean_text(text)
 

--- a/docs/performance_file_processor.md
+++ b/docs/performance_file_processor.md
@@ -5,7 +5,7 @@ while keeping memory usage under control. Data is streamed in chunks and
 the current memory footprint can be observed after each chunk.
 
 ```python
-from core import PerformanceFileProcessor
+from yosai_intel_dashboard.src.core import PerformanceFileProcessor
 
 processor = PerformanceFileProcessor(chunk_size=50_000)
 

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -5,7 +5,7 @@ The dashboard collects runtime metrics through the `core.performance` module. A 
 Use `get_performance_monitor()` to access it and view summaries.
 
 ```python
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 summary = get_performance_monitor().get_metrics_summary()
 ```
 
@@ -57,7 +57,7 @@ how often they are still invoked.  The decorator emits a Prometheus counter
 entries in the global `PerformanceMonitor`.  Example:
 
 ```python
-from core import deprecated
+from yosai_intel_dashboard.src.core import deprecated
 
 @deprecated("use new_service.process() instead")
 def old_process(*args):
@@ -204,7 +204,7 @@ files asynchronously and yields `DataFrame` chunks. Configure chunk size and
 memory limits with `ANALYTICS_CHUNK_SIZE` and `ANALYTICS_MAX_MEMORY_MB`.
 
 ```python
-from services.data_processing.async_file_processor import AsyncFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
 
 processor = AsyncFileProcessor()
 async for chunk in processor.read_csv_chunks("large.csv"):

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -13,7 +13,7 @@ plugin exposes a `create_plugin()` factory that returns an object implementing
 ```python
 # plugins/my_plugin.py
 from dataclasses import dataclass
-from services.data_processing.core.protocols import (
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import (
     PluginProtocol,
     CallbackPluginProtocol,
     PluginMetadata,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,7 +26,7 @@ a `create_plugin()` function so the `PluginManager` can instantiate it.
 ```python
 # plugins/hello_world.py
 from dash import Input, Output
-from services.data_processing.core.protocols import CallbackPluginProtocol, PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import CallbackPluginProtocol, PluginMetadata
 
 
 class HelloWorldPlugin(CallbackPluginProtocol):

--- a/docs/service_container.md
+++ b/docs/service_container.md
@@ -10,9 +10,9 @@ explicit instance is not supplied.
 Create a container and register implementations with the desired lifetime:
 
 ```python
-from core.service_container import ServiceContainer
-from services.analytics_service import AnalyticsService
-from services.interfaces import AnalyticsServiceProtocol
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.interfaces import AnalyticsServiceProtocol
 
 container = ServiceContainer()
 container.register_singleton(

--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -19,8 +19,8 @@ These interfaces can be found under `services/interfaces.py` and `services/secur
 `ServiceContainer` in `core.service_container` manages service lifetimes and resolves dependencies based on the protocols. Services register themselves as singletons or transients. Test suites create a fresh container and register stubs or mocks as needed:
 
 ```python
-from core.service_container import ServiceContainer
-from services.interfaces import UploadValidatorProtocol
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.interfaces import UploadValidatorProtocol
 
 class DummyValidator(UploadValidatorProtocol):
     def validate(self, filename: str, content: str) -> tuple[bool, str]:
@@ -60,7 +60,7 @@ Each protocol can be satisfied by lightweight fakes during testing.
 function is executed on first resolution and the instance is cached:
 
 ```python
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 container = ServiceContainer()
 container.register_singleton("logger", DummyLogger())
@@ -86,7 +86,7 @@ These builders keep test setup short and expressive.
 Tests typically create a fresh container with fakes registered:
 
 ```python
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 from tests.fakes import FakeUploadStore, FakeDeviceLearningService
 
 @pytest.fixture
@@ -122,7 +122,7 @@ sys.modules["services.analytics_service"] = analytics_stub
 Using the container removes the need for module manipulation:
 
 ```python
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 container = ServiceContainer()
 container.register_singleton("analytics_service", DummyAnalytics())

--- a/docs/type_import_pattern.md
+++ b/docs/type_import_pattern.md
@@ -6,7 +6,7 @@ Use this template when you need the `TrulyUnifiedCallbacksType` for type hints w
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
+    from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
 else:  # pragma: no cover - fallback runtime alias
     TrulyUnifiedCallbacksType = Any
 ```

--- a/tests/api/test_error_handlers.py
+++ b/tests/api/test_error_handlers.py
@@ -1,8 +1,8 @@
 import types
 from flask import Flask, Blueprint
 
-from core.error_handlers import register_error_handlers
-from core.exceptions import ValidationError, ServiceUnavailableError
+from yosai_intel_dashboard.src.core.error_handlers import register_error_handlers
+from yosai_intel_dashboard.src.core.exceptions import ValidationError, ServiceUnavailableError
 
 
 def _create_app():

--- a/tests/builders.py
+++ b/tests/builders.py
@@ -7,12 +7,12 @@ from typing import Any, Dict
 import pandas as pd
 
 from config.complete_service_registration import register_all_services
-from core.service_container import ServiceContainer
-from core.protocols import (
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.protocols import (
     UnicodeProcessorProtocol,
     ConfigurationProtocol,
 )
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadStorageProtocol,
     FileProcessorProtocol,
 )

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -3,7 +3,7 @@ import pytest
 
 from dash import no_update
 from upload_core import UploadCore
-from services.upload.core.processor import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload.core.processor import UploadProcessingService
 from tests.fakes import (
     FakeUploadStore,
     FakeDeviceLearningService,

--- a/tests/cli_file_processor.py
+++ b/tests/cli_file_processor.py
@@ -16,9 +16,9 @@ from typing import Any, Dict
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 from config.service_registration import register_upload_services
-from services.file_processor_service import FileProcessorService
+from yosai_intel_dashboard.src.services.file_processor_service import FileProcessorService
 from config import create_config_manager
 
 

--- a/tests/components/test_plugin_adapter.py
+++ b/tests/components/test_plugin_adapter.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 import components.plugin_adapter as plugin_adapter
 from components.plugin_adapter import ComponentPluginAdapter
-from core.unicode import clean_unicode_text, sanitize_dataframe
+from yosai_intel_dashboard.src.core.unicode import clean_unicode_text, sanitize_dataframe
 
 
 def test_get_ai_column_suggestions_with_plugin(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ import pytest
 from tests.fake_unicode_processor import FakeUnicodeProcessor
 
 try:
-    from services.upload.protocols import UploadStorageProtocol
+    from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 except Exception:  # pragma: no cover - optional dep fallback
     from typing import Protocol
 
@@ -144,7 +144,7 @@ except Exception:  # pragma: no cover - optional dep fallback
 
 
 try:
-    from core.protocols import ConfigurationProtocol
+    from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 except Exception:  # pragma: no cover - optional dep fallback
 
     class ConfigurationProtocol(Protocol):
@@ -156,7 +156,7 @@ except Exception:  # pragma: no cover - optional dep fallback
         def validate_config(self) -> dict[str, Any]: ...
 
 
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 
 try:  # Optional real models may not be available in minimal environments
     from models.entities import AccessEvent, Door, Person
@@ -206,7 +206,7 @@ def fake_unicode_processor() -> FakeUnicodeProcessor:
 def upload_data_service(tmp_path: Path):
     """Provide a fresh ``UploadDataService`` backed by a temp store."""
 
-    from services.upload_data_service import UploadDataService
+    from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService
     from utils.upload_store import UploadedDataStore
 
     store = UploadedDataStore(storage_dir=tmp_path)

--- a/tests/custom/test_upload_queue_manager.py
+++ b/tests/custom/test_upload_queue_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-from services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
 
 
 async def _handler(item: str) -> str:

--- a/tests/di/test_container_core.py
+++ b/tests/di/test_container_core.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock
 
 import pytest
-from core.container import Container
-from core.service_container import DependencyInjectionError
+from yosai_intel_dashboard.src.core.container import Container
+from yosai_intel_dashboard.src.core.service_container import DependencyInjectionError
 
 
 def test_container_initialization():

--- a/tests/di/test_dependency_discovery.py
+++ b/tests/di/test_dependency_discovery.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 
 class Foo:

--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,7 +1,7 @@
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 
 from config import create_config_manager
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 
 
 def test_container_initializes_without_circular_dependencies():

--- a/tests/di/test_performance_monitor.py
+++ b/tests/di/test_performance_monitor.py
@@ -1,6 +1,6 @@
 import time
-from core.service_container import ServiceContainer
-from core.performance_monitor import DIPerformanceMonitor
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.performance_monitor import DIPerformanceMonitor
 
 
 def test_container_records_resolution_time():

--- a/tests/di/test_service_container.py
+++ b/tests/di/test_service_container.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.service_container import (
+from yosai_intel_dashboard.src.core.service_container import (
     ServiceContainer,
     ServiceLifetime,
     DependencyInjectionError,

--- a/tests/docs/test_documentation_examples.py
+++ b/tests/docs/test_documentation_examples.py
@@ -1,5 +1,5 @@
 from analytics_core import create_manager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 
 class DatabaseManager:

--- a/tests/doubles/test_configuration.py
+++ b/tests/doubles/test_configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 
 
 class TestConfiguration(ConfigurationProtocol):

--- a/tests/doubles/test_file_processor_service.py
+++ b/tests/doubles/test_file_processor_service.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Tuple
 
 import pandas as pd
 
-from services.upload.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import FileProcessorProtocol
 
 
 class FileProcessorServiceStub(FileProcessorProtocol):

--- a/tests/doubles/test_unicode_processor.py
+++ b/tests/doubles/test_unicode_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
 
 
 class TestUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 try:
-    from services.configuration_service import ConfigurationServiceProtocol
+    from yosai_intel_dashboard.src.services.configuration_service import ConfigurationServiceProtocol
 except Exception:  # pragma: no cover - optional deps
     from typing import Protocol
 
@@ -70,19 +70,19 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        from core.config import get_upload_chunk_size
+        from yosai_intel_dashboard.src.core.config import get_upload_chunk_size
         return get_upload_chunk_size()
 
     def get_max_parallel_uploads(self) -> int:
-        from core.config import get_max_parallel_uploads
+        from yosai_intel_dashboard.src.core.config import get_max_parallel_uploads
         return get_max_parallel_uploads()
 
     def get_validator_rules(self) -> dict:
-        from core.config import get_validator_rules
+        from yosai_intel_dashboard.src.core.config import get_validator_rules
         return get_validator_rules()
 
     def get_ai_confidence_threshold(self) -> int:
-        from core.config import get_ai_confidence_threshold
+        from yosai_intel_dashboard.src.core.config import get_ai_confidence_threshold
         return get_ai_confidence_threshold()
 
     def get_db_pool_size(self) -> int:

--- a/tests/fake_unicode_processor.py
+++ b/tests/fake_unicode_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional, Union
 
 import pandas as pd
 
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
 
 
 class FakeUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Callable
 import pandas as pd
 
 try:
-    from services.upload.protocols import UploadStorageProtocol, FileProcessorProtocol
+    from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol, FileProcessorProtocol
 except Exception:  # pragma: no cover - fallback stubs for optional deps
     from typing import Protocol
 
@@ -31,7 +31,7 @@ except Exception:  # pragma: no cover - fallback stubs for optional deps
         ) -> tuple[pd.DataFrame, str]: ...
 
 try:
-    from services.interfaces import (
+    from yosai_intel_dashboard.src.services.interfaces import (
         DeviceLearningServiceProtocol,
         UploadDataServiceProtocol,
     )
@@ -61,7 +61,7 @@ except Exception:  # pragma: no cover - fallback stubs
         def load_dataframe(self, filename: str) -> pd.DataFrame: ...
 
 try:
-    from services.configuration_service import ConfigurationServiceProtocol
+    from yosai_intel_dashboard.src.services.configuration_service import ConfigurationServiceProtocol
 except Exception:  # pragma: no cover - fallback stub
     from typing import Protocol
 
@@ -70,7 +70,7 @@ except Exception:  # pragma: no cover - fallback stub
         def get_max_upload_size_bytes(self) -> int: ...
 
 try:
-    from core.protocols import UnicodeProcessorProtocol
+    from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
 except Exception:  # pragma: no cover - fallback stub
     from typing import Protocol
 

--- a/tests/file_processing/test_column_mapper.py
+++ b/tests/file_processing/test_column_mapper.py
@@ -2,7 +2,7 @@ import pandas as pd
 from pathlib import Path
 
 from file_processing.column_mapper import map_columns
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/file_processing/test_common_dataframe.py
+++ b/tests/file_processing/test_common_dataframe.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.data_processing.common import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.common import process_dataframe
 
 
 def test_process_dataframe_csv(tmp_path):

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -18,7 +18,7 @@ app_spec = importlib.util.spec_from_file_location(
 app_module = importlib.util.module_from_spec(app_spec)
 app_spec.loader.exec_module(app_module)
 
-from services.migration import adapter as migration_adapter
+from yosai_intel_dashboard.src.services.migration import adapter as migration_adapter
 
 
 class DummyAnalytics:

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -4,8 +4,8 @@ import pytest
 from dash import Dash, html
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.auto_config import setup_plugins
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.auto_config import setup_plugins
 from tests.test_auto_configuration import _set_env
 from tests.utils.plugin_package_builder import PluginPackageBuilder
 

--- a/tests/integration/test_plugin_health_endpoint.py
+++ b/tests/integration/test_plugin_health_endpoint.py
@@ -31,10 +31,10 @@ sys.modules["services.data_processing.core.protocols"] = protocols_mod
 
 import pytest
 from flask import Flask
-from core.service_container import ServiceContainer
-from core.plugins.manager import PluginManager
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import PluginManager
 from config import create_config_manager
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 
 class EnumJSONProvider(DefaultJSONProvider):

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -27,10 +27,10 @@ if "scipy" not in sys.modules:
 sys.modules.setdefault("scipy.stats", types.ModuleType("scipy.stats"))
 sys.modules["scipy"].stats = sys.modules["scipy.stats"]
 
-from core.events import EventBus
-from core.plugins.auto_config import setup_plugins
-from core.service_container import ServiceContainer
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.events import EventBus
+from yosai_intel_dashboard.src.core.plugins.auto_config import setup_plugins
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from config import create_config_manager
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
@@ -50,8 +50,8 @@ def _build_plugin(tmp_path):
     plugin_code = """
 from dash import Output, Input
 from dash.exceptions import PreventUpdate
-from services.data_processing.core.protocols import PluginMetadata
-from core.plugins.callback_unifier import CallbackUnifier
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.plugins.callback_unifier import CallbackUnifier
 
 class SamplePlugin:
     metadata = PluginMetadata(
@@ -129,7 +129,7 @@ def test_plugin_upload_event_sse_ws(
     cfg = create_config_manager()
     cfg.config.plugin_settings["sample_plugin"] = {"enabled": True}
 
-    from services.websocket_server import AnalyticsWebSocketServer
+    from yosai_intel_dashboard.src.services.websocket_server import AnalyticsWebSocketServer
 
     ws_server = AnalyticsWebSocketServer(
         event_bus=event_bus, host="127.0.0.1", port=8765

--- a/tests/integration/test_unicode_handling_integration.py
+++ b/tests/integration/test_unicode_handling_integration.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-import core.unicode as handler
-from core.unicode import UnicodeProcessor, sanitize_dataframe
+import yosai_intel_dashboard.src.core.unicode as handler
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor, sanitize_dataframe
 
 
 def test_unicode_handler_centralization():

--- a/tests/integration/test_unicode_upload_endpoint.py
+++ b/tests/integration/test_unicode_upload_endpoint.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from core.unicode import safe_unicode_encode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_encode
 from security.unicode_security_handler import UnicodeSecurityHandler
 
 

--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -7,8 +7,8 @@ import pytest
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.upload.upload_queue_manager import UploadQueueManager
-from services.upload.chunked_upload_manager import ChunkedUploadManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.chunked_upload_manager import ChunkedUploadManager
 
 from config.connection_retry import ConnectionRetryManager, RetryConfig
 

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -6,7 +6,7 @@ from dash import dcc, html
 import shutil
 import pytest
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")

--- a/tests/plugins/test_ai_classification_plugin.py
+++ b/tests/plugins/test_ai_classification_plugin.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from plugins.ai_classification.plugin import AIClassificationPlugin
+from yosai_intel_dashboard.src.plugins.ai_classification.plugin import AIClassificationPlugin
 
 
 def test_start_initializes_services(monkeypatch):

--- a/tests/plugins/test_performance_monitoring.py
+++ b/tests/plugins/test_performance_monitoring.py
@@ -1,5 +1,5 @@
 import time
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 import types
 from tests.plugins.test_plugin_manager import _install_protocol_stubs
 
@@ -14,7 +14,7 @@ class FakeProc:
 
 def test_monitoring_alerts(monkeypatch):
     _install_protocol_stubs(monkeypatch)
-    from core.plugins.performance_manager import EnhancedThreadSafePluginManager
+    from yosai_intel_dashboard.src.core.plugins.performance_manager import EnhancedThreadSafePluginManager
 
     class DummyConfig:
         def __init__(self):

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Protocol
 import pytest
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 
 def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:
@@ -79,7 +79,7 @@ def test_thread_stops_after_atexit(monkeypatch):
 
     monkeypatch.setattr(atexit, "register", fake_register)
 
-    from core.plugins.manager import ThreadSafePluginManager as PluginManager
+    from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
 
     mgr = PluginManager(
         ServiceContainer(), create_config_manager(), health_check_interval=1

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -1,8 +1,8 @@
 import sys
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
 
 
 class MyPlugin:

--- a/tests/scripts/test_update_imports.py
+++ b/tests/scripts/test_update_imports.py
@@ -20,8 +20,8 @@ def test_update_imports_patterns(tmp_path: Path) -> None:
     import security.helpers
     from api.client import d
     import api.client
-    from plugins.extra import e
-    import plugins.extra
+    from yosai_intel_dashboard.src.plugins.extra import e
+    import yosai_intel_dashboard.src.plugins.extra
     """
     after = """
     from yosai_intel_dashboard.src.infrastructure.config.utils import a

--- a/tests/security/test_secrets_validator.py
+++ b/tests/security/test_secrets_validator.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from flask import Flask
 
-from core.secret_manager import SecretsManager
+from yosai_intel_dashboard.src.core.secret_manager import SecretsManager
 from security.secrets_validator import SecretsValidator, register_health_endpoint
 
 

--- a/tests/security/test_unicode_security_processor.py
+++ b/tests/security/test_unicode_security_processor.py
@@ -1,4 +1,4 @@
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 
 def test_sanitize_unicode_removes_surrogates_and_normalizes():

--- a/tests/security/test_unicode_utils.py
+++ b/tests/security/test_unicode_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 
 def test_sanitize_unicode_removes_surrogates():

--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
 from validation.security_validator import SecurityValidator
 from security.xss_validator import XSSPrevention
 

--- a/tests/session_tests/test_session_lifetime.py
+++ b/tests/session_tests/test_session_lifetime.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Dict
 from flask import Flask, session
 
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -41,7 +41,7 @@ class FakeConfiguration(ConfigurationProtocol):
         return {"valid": True}
 
 
-from core.auth import User, _determine_session_timeout, _apply_session_timeout
+from yosai_intel_dashboard.src.core.auth import User, _determine_session_timeout, _apply_session_timeout
 
 
 def test_determine_session_timeout(monkeypatch):

--- a/tests/stubs/config/complete_service_registration.py
+++ b/tests/stubs/config/complete_service_registration.py
@@ -1,4 +1,4 @@
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 
 def register_all_application_services(container: ServiceContainer) -> None:

--- a/tests/stubs/config/dynamic_config.py
+++ b/tests/stubs/config/dynamic_config.py
@@ -8,7 +8,7 @@ class Analytics:
     max_memory_mb = 1024
 
 
-from core.config import (
+from yosai_intel_dashboard.src.core.config import (
     get_upload_chunk_size,
     get_max_parallel_uploads,
     get_validator_rules,

--- a/tests/stubs/services/task_queue.py
+++ b/tests/stubs/services/task_queue.py
@@ -1,6 +1,6 @@
 from typing import Any, Awaitable, Callable, Dict
 
-from services.task_queue_protocol import TaskQueueProtocol
+from yosai_intel_dashboard.src.services.task_queue_protocol import TaskQueueProtocol
 
 
 class StubTaskQueue(TaskQueueProtocol):

--- a/tests/stubs/utils/file_validator.py
+++ b/tests/stubs/utils/file_validator.py
@@ -1,4 +1,4 @@
-from core.unicode import safe_decode_bytes
+from yosai_intel_dashboard.src.core.unicode import safe_decode_bytes
 
 
 def safe_decode_with_unicode_handling(data: bytes, enc: str):

--- a/tests/test_advanced_cache.py
+++ b/tests/test_advanced_cache.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.cache_manager import InMemoryCacheManager, cache_with_lock, CacheConfig
+from yosai_intel_dashboard.src.core.cache_manager import InMemoryCacheManager, cache_with_lock, CacheConfig
 
 
 @pytest.mark.asyncio

--- a/tests/test_ai_device_generator.py
+++ b/tests/test_ai_device_generator.py
@@ -4,7 +4,7 @@ Test suite for AI device generator module.
 
 import pytest
 
-from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
 
 
 class TestAIDeviceGenerator:

--- a/tests/test_ai_processor_model_integration.py
+++ b/tests/test_ai_processor_model_integration.py
@@ -3,7 +3,7 @@ import pandas as pd
 import importlib.util
 import importlib.machinery
 import sys
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 from mapping.models import RuleBasedModel
 
 # Insert stub before importing the adapter

--- a/tests/test_ai_suggestions.py
+++ b/tests/test_ai_suggestions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from services.data_enhancer import get_ai_column_suggestions
+from yosai_intel_dashboard.src.services.data_enhancer import get_ai_column_suggestions
 
 
 def test_basic_suggestions():

--- a/tests/test_analysis_extract_utils.py
+++ b/tests/test_analysis_extract_utils.py
@@ -1,4 +1,4 @@
-from services.analytics_processing import (
+from yosai_intel_dashboard.src.services.analytics_processing import (
     _extract_counts,
     _extract_security_metrics,
 )

--- a/tests/test_analytics_controller.py
+++ b/tests/test_analytics_controller.py
@@ -3,7 +3,7 @@ import pandas as pd
 from analytics.business_service import AnalyticsBusinessService
 from analytics.data_repository import AnalyticsDataRepository
 from analytics.ui_controller import AnalyticsUIController
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from models import ModelFactory
-from services import create_analytics_service, get_analytics_service
+from yosai_intel_dashboard.src.services import create_analytics_service, get_analytics_service
 
 
 def test_analytics_service_creation():
@@ -45,7 +45,7 @@ def test_model_factory_absent(monkeypatch):
     """ModelFactory gracefully handles missing registry entry"""
     from importlib import reload
 
-    import services.registry as reg
+    import yosai_intel_dashboard.src.services.registry as reg
 
     original = reg.get_service
 

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -21,7 +21,7 @@ if "chardet" not in sys.modules:
     sys.modules["chardet"] = types.ModuleType("chardet")
 import pandas as pd
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 from tests.fake_configuration import FakeConfiguration
 
 
@@ -95,7 +95,7 @@ def test_get_real_uploaded_data_no_files(monkeypatch):
 def test_service_receives_config(monkeypatch):
     """Provided config should be stored on the service instance."""
 
-    import services.analytics_service as mod
+    import yosai_intel_dashboard.src.services.analytics_service as mod
 
     # ensure a fresh global instance
     mod._analytics_service = None

--- a/tests/test_analytics_service_patterns.py
+++ b/tests/test_analytics_service_patterns.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
 
 
 def _make_df():

--- a/tests/test_analytics_service_threadsafe.py
+++ b/tests/test_analytics_service_threadsafe.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 
-from services import analytics_service
+from yosai_intel_dashboard.src.services import analytics_service
 
 
 def test_get_analytics_service_threadsafe(monkeypatch):

--- a/tests/test_analytics_summary.py
+++ b/tests/test_analytics_summary.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.analytics_summary import (
+from yosai_intel_dashboard.src.services.analytics_summary import (
     generate_basic_analytics,
     generate_sample_analytics,
 )

--- a/tests/test_analyze_with_chunking.py
+++ b/tests/test_analyze_with_chunking.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 
 
 def test_analyze_with_chunking_large_df():

--- a/tests/test_async_upload_processor.py
+++ b/tests/test_async_upload_processor.py
@@ -2,7 +2,7 @@ import asyncio
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.upload.async_processor import AsyncUploadProcessor
+from yosai_intel_dashboard.src.services.upload.async_processor import AsyncUploadProcessor
 
 
 def test_async_upload_processor_csv_parquet(tmp_path, async_runner):

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,7 +1,7 @@
 import pytest
 
-from core.exceptions import ValidationError
-from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_validator_methods_basic():

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -5,12 +5,12 @@ import pytest
 from dash import Dash, Input, Output
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.json_serialization_plugin import JsonSerializationPlugin
-from core.plugins.auto_config import setup_plugins
-from core.plugins.callback_unifier import CallbackUnifier
-from core.plugins.decorators import safe_callback
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.json_serialization_plugin import JsonSerializationPlugin
+from yosai_intel_dashboard.src.core.plugins.auto_config import setup_plugins
+from yosai_intel_dashboard.src.core.plugins.callback_unifier import CallbackUnifier
+from yosai_intel_dashboard.src.core.plugins.decorators import safe_callback
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 
@@ -35,8 +35,8 @@ def _create_package(tmp_path):
     (pkg / "__init__.py").write_text("")
     plugin_code = """
 from dash import Output, Input
-from services.data_processing.core.protocols import PluginMetadata
-from core.plugins.callback_unifier import CallbackUnifier
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.plugins.callback_unifier import CallbackUnifier
 
 class AutoPlugin:
     metadata = PluginMetadata(

--- a/tests/test_base_database_service.py
+++ b/tests/test_base_database_service.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from config import DatabaseSettings
-from core.base_database_service import BaseDatabaseService
+from yosai_intel_dashboard.src.core.base_database_service import BaseDatabaseService
 
 
 def _install_fake_module(monkeypatch, name, factory_attr):

--- a/tests/test_cache_env_ttl.py
+++ b/tests/test_cache_env_ttl.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from core.cache_manager import InMemoryCacheManager, cache_with_lock, CacheConfig
+from yosai_intel_dashboard.src.core.cache_manager import InMemoryCacheManager, cache_with_lock, CacheConfig
 
 manager = InMemoryCacheManager(CacheConfig())
 

--- a/tests/test_cache_json.py
+++ b/tests/test_cache_json.py
@@ -1,4 +1,4 @@
-from core.cache_manager import InMemoryCacheManager, CacheConfig
+from yosai_intel_dashboard.src.core.cache_manager import InMemoryCacheManager, CacheConfig
 import asyncio
 
 manager = InMemoryCacheManager(CacheConfig())

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -1,6 +1,6 @@
 import asyncio
-from core.cache_warmer import IntelligentCacheWarmer, UsagePatternAnalyzer
-from core.hierarchical_cache_manager import HierarchicalCacheManager
+from yosai_intel_dashboard.src.core.cache_warmer import IntelligentCacheWarmer, UsagePatternAnalyzer
+from yosai_intel_dashboard.src.core.hierarchical_cache_manager import HierarchicalCacheManager
 
 
 def _loader(key: str) -> str:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.calculator import Calculator  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.calculator import Calculator  # noqa: E402
 
 
 def _make_df():

--- a/tests/test_callback_controller.py
+++ b/tests/test_callback_controller.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import pytest
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/test_callback_fix.py
+++ b/tests/test_callback_fix.py
@@ -1,7 +1,7 @@
 import pytest
-from core.app_factory import create_app
-from core.callback_registry import _callback_registry
-from core.unicode import safe_encode_text, safe_decode_bytes
+from yosai_intel_dashboard.src.core.app_factory import create_app
+from yosai_intel_dashboard.src.core.callback_registry import _callback_registry
+from yosai_intel_dashboard.src.core.unicode import safe_encode_text, safe_decode_bytes
 
 
 def test_create_app_registers_callbacks(monkeypatch):

--- a/tests/test_callback_manager.py
+++ b/tests/test_callback_manager.py
@@ -1,6 +1,6 @@
 import threading
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/test_callback_manager_events.py
+++ b/tests/test_callback_manager_events.py
@@ -1,4 +1,4 @@
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -2,9 +2,9 @@ import dash
 import pytest
 from dash import Input, Output
 
-from core.callback_registry import CallbackRegistry
-from core.plugins.decorators import unified_callback
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.callback_registry import CallbackRegistry
+from yosai_intel_dashboard.src.core.plugins.decorators import unified_callback
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_callbacks_alias.py
+++ b/tests/test_callbacks_alias.py
@@ -4,8 +4,8 @@ import dash
 if not hasattr(dash, "no_update"):
     dash.no_update = None
 
-from core.callbacks import UnifiedCallbackManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.callbacks import UnifiedCallbackManager
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 
 def test_unified_callback_manager_alias():

--- a/tests/test_centralized_state_manager.py
+++ b/tests/test_centralized_state_manager.py
@@ -1,4 +1,4 @@
-from core.state import CentralizedStateManager
+from yosai_intel_dashboard.src.core.state import CentralizedStateManager
 
 
 def test_state_updates_and_subscribe():

--- a/tests/test_chunked_upload_manager.py
+++ b/tests/test_chunked_upload_manager.py
@@ -3,7 +3,7 @@ import pytest
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.upload.chunked_upload_manager import ChunkedUploadManager
+from yosai_intel_dashboard.src.services.upload.chunked_upload_manager import ChunkedUploadManager
 from utils.upload_store import UploadedDataStore
 
 

--- a/tests/test_chunked_upload_manager_async.py
+++ b/tests/test_chunked_upload_manager_async.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.upload.chunked_upload_manager_async import ChunkedUploadManager
+from yosai_intel_dashboard.src.services.upload.chunked_upload_manager_async import ChunkedUploadManager
 from utils.upload_store import UploadedDataStore
 
 

--- a/tests/test_complete_dataset_analysis.py
+++ b/tests/test_complete_dataset_analysis.py
@@ -7,7 +7,7 @@ import tempfile
 import pandas as pd
 import pytest
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 
 
 def test_complete_dataset_analysis():

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -17,7 +17,7 @@ sys.modules["config.config_manager"] = _cfg_module
 spec.loader.exec_module(_cfg_module)  # type: ignore
 create_config_manager = _cfg_module.create_config_manager
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 from config.config_validator import ConfigValidator
 
 

--- a/tests/test_consolidated_learning_service.py
+++ b/tests/test_consolidated_learning_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from services.learning.src.api.consolidated_service import ConsolidatedLearningService
+from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import ConsolidatedLearningService
 
 
 class TestConsolidatedLearningService:
@@ -85,7 +85,7 @@ class TestConsolidatedLearningService:
 
     def test_apply_to_global_store(self):
         """Applying learned mappings should update the global store."""
-        from services.ai_mapping_store import ai_mapping_store
+        from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
         df = pd.DataFrame({"door_id": ["door_1"]})
         mappings = {"door_1": {"floor": 2}}

--- a/tests/test_contains_surrogates.py
+++ b/tests/test_contains_surrogates.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import contains_surrogates
+from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 
 
 def test_contains_surrogates_detects_unpaired_high():

--- a/tests/test_csrf_plugin.py
+++ b/tests/test_csrf_plugin.py
@@ -1,7 +1,7 @@
 import os
 
 from config import reload_config
-from core import app_factory
+from yosai_intel_dashboard.src.core import app_factory
 
 
 def test_csrf_plugin_enabled_in_production(monkeypatch):
@@ -14,7 +14,7 @@ def test_csrf_plugin_enabled_in_production(monkeypatch):
     monkeypatch.setenv("AUTH0_AUDIENCE", "dummy")
     reload_config()
 
-    from core.plugins import PluginManager
+    from yosai_intel_dashboard.src.core.plugins import PluginManager
 
     monkeypatch.setattr(PluginManager, "load_all_plugins", lambda self: None)
 

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -3,7 +3,7 @@ import base64
 import pandas as pd
 import pytest
 
-from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 @pytest.mark.parametrize("sep", [";", "\t"])

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.data_loader import DataLoader  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.data_loader import DataLoader  # noqa: E402
 
 
 class DummyUploadProc:

--- a/tests/test_data_quality_monitor.py
+++ b/tests/test_data_quality_monitor.py
@@ -53,7 +53,7 @@ def test_processor_evaluates_quality(monkeypatch):
         module.Processor = Processor
         sys.modules["services.data_processing.processor"] = module
 
-    from services.data_processing.processor import Processor
+    from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 
     proc = Processor()
     df = pd.DataFrame(

--- a/tests/test_database_analytics_service.py
+++ b/tests/test_database_analytics_service.py
@@ -1,4 +1,4 @@
-from services.database_analytics_service import DatabaseAnalyticsService
+from yosai_intel_dashboard.src.services.database_analytics_service import DatabaseAnalyticsService
 
 
 class FakeConnection:

--- a/tests/test_datetime_fix.py
+++ b/tests/test_datetime_fix.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from analytics.utils import ensure_datetime_columns
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 
 
 def create_test_data(rows=100):

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,11 +1,11 @@
 import pytest
 import sys
 
-from core.plugins.dependency_resolver import PluginDependencyResolver
-from core.plugins.manager import PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.dependency_resolver import PluginDependencyResolver
+from yosai_intel_dashboard.src.core.plugins.manager import PluginManager
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 from config import create_config_manager
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 
 class DummyPlugin:
@@ -69,7 +69,7 @@ def test_manager_cycle_logging(tmp_path, caplog, mock_auth_env):
     pkg = _create_pkg(tmp_path, "cyclepkg")
     (pkg / "plug_a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class PlugA:
     metadata = PluginMetadata(
@@ -96,7 +96,7 @@ def create_plugin():
     )
     (pkg / "plug_b.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class PlugB:
     metadata = PluginMetadata(
@@ -144,7 +144,7 @@ def test_manager_unknown_dependency_logging(tmp_path, caplog, mock_auth_env):
     pkg = _create_pkg(tmp_path, "unkpkg")
     (pkg / "plug_a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class PlugA:
     metadata = PluginMetadata(

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,7 +1,7 @@
 import warnings
 
-from core import performance
-from core.deprecation import deprecated
+from yosai_intel_dashboard.src.core import performance
+from yosai_intel_dashboard.src.core.deprecation import deprecated
 
 
 class Dummy:

--- a/tests/test_device_endpoint_utils.py
+++ b/tests/test_device_endpoint_utils.py
@@ -76,7 +76,7 @@ def test_build_device_mappings_ai(monkeypatch):
     df = pd.DataFrame({})
     dsvc = DummyDeviceService()
     ai_map = {"dev": {"device_type": "door", "confidence": 0.7}}
-    from services.ai_mapping_store import ai_mapping_store
+    from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
     monkeypatch.setattr(ai_mapping_store, "clear", lambda: None)
     monkeypatch.setattr(ai_mapping_store, "all", lambda: ai_map)
     usvc = DummyUploadService({})
@@ -102,7 +102,7 @@ def test_build_user_device_mappings_helper():
 def test_build_ai_device_mappings_helper(monkeypatch):
     df = pd.DataFrame({})
     ai_map = {"dev": {"device_type": "door", "confidence": 0.7}}
-    from services.ai_mapping_store import ai_mapping_store
+    from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
     monkeypatch.setattr(ai_mapping_store, "clear", lambda: None)
     monkeypatch.setattr(ai_mapping_store, "all", lambda: ai_map)
     usvc = DummyUploadService({})

--- a/tests/test_device_learning_service.py
+++ b/tests/test_device_learning_service.py
@@ -2,7 +2,7 @@ import json
 
 import pandas as pd
 
-from services.device_learning_service import DeviceLearningService
+from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
 
 
 def _init_service(tmp_path):

--- a/tests/test_display_rows_limit.py
+++ b/tests/test_display_rows_limit.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from config import get_config
-from services.data_processing.file_processor import create_file_preview
+from yosai_intel_dashboard.src.services.data_processing.file_processor import create_file_preview
 
 
 def test_create_file_preview_respects_limit(monkeypatch):

--- a/tests/test_door_mapping_service.py
+++ b/tests/test_door_mapping_service.py
@@ -24,9 +24,9 @@ sys.modules.setdefault(
 sys.modules["services.ai_device_generator"].AIDeviceGenerator = _DummyAIGen
 sys.modules["services.ai_device_generator"].DeviceAttributes = _DummyAttrs
 
-from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
-from services.configuration_service import DynamicConfigurationService
-from services.door_mapping_service import DoorMappingService
+from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+from yosai_intel_dashboard.src.services.configuration_service import DynamicConfigurationService
+from yosai_intel_dashboard.src.services.door_mapping_service import DoorMappingService
 
 
 def test_standardized_output(monkeypatch):

--- a/tests/test_doubles.py
+++ b/tests/test_doubles.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from core.protocols import UnicodeProcessorProtocol
-from services.upload.protocols import UploadStorageProtocol
+from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 
 
 class SimpleUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/test_enhanced_security_details.py
+++ b/tests/test_enhanced_security_details.py
@@ -1,4 +1,4 @@
-from services.analytics_processing import _extract_enhanced_security_details
+from yosai_intel_dashboard.src.services.analytics_processing import _extract_enhanced_security_details
 
 
 def test_extract_enhanced_security_details_basic():

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from core.error_handling import (
+from yosai_intel_dashboard.src.core.error_handling import (
     ErrorHandler,
     ErrorCategory,
     ErrorSeverity,

--- a/tests/test_event_publisher.py
+++ b/tests/test_event_publisher.py
@@ -25,7 +25,7 @@ services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
 sys.modules.setdefault("services", services_stub)
 publish_event = importlib.import_module("services.event_publisher").publish_event
 
-from services.event_publisher import publish_event
+from yosai_intel_dashboard.src.services.event_publisher import publish_event
 
 
 class DummyBus:

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 
 
 def test_process_csv(tmp_path):

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -5,7 +5,7 @@ import io
 import pandas as pd
 import pytest
 
-from services.data_processing.file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     UnicodeFileProcessor,
     create_file_preview,
     process_uploaded_file,

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -6,12 +6,12 @@ from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
-from services.data_enhancer import (
+from yosai_intel_dashboard.src.services.data_enhancer import (
     apply_fuzzy_column_matching,
     get_mapping_suggestions,
 )
-from services.data_processing.file_processor import process_uploaded_file
-from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from yosai_intel_dashboard.src.services.data_processing.file_processor import process_uploaded_file
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from validation.security_validator import SecurityValidator
 
 

--- a/tests/test_file_processor_service_surrogates.py
+++ b/tests/test_file_processor_service_surrogates.py
@@ -12,7 +12,7 @@ spec = importlib.util.spec_from_file_location(
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 FileProcessorService = module.FileProcessorService
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 
 def test_decode_with_surrogate_pairs():

--- a/tests/test_file_validator_errors.py
+++ b/tests/test_file_validator_errors.py
@@ -1,4 +1,4 @@
-from services.data_processing.unified_upload_validator import (
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import (
     process_dataframe,
     safe_decode_file,
 )

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,10 +1,10 @@
 import pandas as pd
 import pytest
 
-from core.performance_file_processor import (
+from yosai_intel_dashboard.src.core.performance_file_processor import (
     PerformanceFileProcessor as UnlimitedFileProcessor,
 )
-from core.unicode import safe_format_number, sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import safe_format_number, sanitize_unicode_input
 
 
 @pytest.mark.performance

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_none_upload_rejected():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,8 @@
 
 import pandas as pd
 
-from services.ai_device_generator import AIDeviceGenerator
-from services.learning.src.api.consolidated_service import get_learning_service
+from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator
+from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import get_learning_service
 
 
 def test_end_to_end_device_mapping():

--- a/tests/test_intelligent_multilevel_cache.py
+++ b/tests/test_intelligent_multilevel_cache.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
+from yosai_intel_dashboard.src.core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 from config.base import CacheConfig
 
 

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -12,14 +12,14 @@ import pytest
 from flask import Flask
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.json_serialization_plugin import (
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.json_serialization_plugin import (
     JsonCallbackService,
     JsonSerializationConfig,
     JsonSerializationPlugin,
     JsonSerializationService,
 )
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
 
 # Legacy DI tests were skipped previously. Run them now.
 # pytest.skip("legacy DI tests skipped", allow_module_level=True)

--- a/tests/test_lazystring_fix.py
+++ b/tests/test_lazystring_fix.py
@@ -1,7 +1,7 @@
 import pytest
 
 from config.constants import SecurityLimits
-from core.serialization import SafeJSONSerializer
+from yosai_intel_dashboard.src.core.serialization import SafeJSONSerializer
 
 serializer = SafeJSONSerializer()
 

--- a/tests/test_learning_priority.py
+++ b/tests/test_learning_priority.py
@@ -1,8 +1,8 @@
 import pytest
 
-from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
-from services.ai_mapping_store import ai_mapping_store
-from services.upload import analyze_device_name_with_ai
+from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
+from yosai_intel_dashboard.src.services.upload import analyze_device_name_with_ai
 
 
 class DummyAttrs:

--- a/tests/test_legacy_code_detector.py
+++ b/tests/test_legacy_code_detector.py
@@ -13,7 +13,7 @@ def test_detect_deprecated_imports(tmp_path):
     rules = tmp_path / "rules.yaml"
     rules.write_text("deprecated_imports:\n  - old.module\n", encoding="utf-8")
 
-    create_temp_file(tmp_path / "a.py", "import services.analytics.data_loader\n")
+    create_temp_file(tmp_path / "a.py", "import yosai_intel_dashboard.src.services.analytics.data_loader\n")
     create_temp_file(tmp_path / "b.py", "from old.module import foo\n")
 
     detector = LegacyCodeDetector(rules)

--- a/tests/test_mapping_metrics.py
+++ b/tests/test_mapping_metrics.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from core import performance
+from yosai_intel_dashboard.src.core import performance
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_mapping_models.py
+++ b/tests/test_mapping_models.py
@@ -4,7 +4,7 @@ import yaml
 
 from mapping.models import load_model, RuleBasedModel
 from mapping.models.base import MappingModel
-from core.performance import PerformanceMonitor
+from yosai_intel_dashboard.src.core.performance import PerformanceMonitor
 
 
 def test_load_model_from_yaml(tmp_path):
@@ -25,7 +25,7 @@ def test_load_model_from_yaml(tmp_path):
 
 def test_model_caching_and_metrics(monkeypatch):
     monitor = PerformanceMonitor(max_metrics=10)
-    from core import performance as perf_module
+    from yosai_intel_dashboard.src.core import performance as perf_module
 
     monkeypatch.setattr(perf_module, "_performance_monitor", monitor)
     model = RuleBasedModel({"A": "timestamp"})

--- a/tests/test_mapping_modular.py
+++ b/tests/test_mapping_modular.py
@@ -5,7 +5,7 @@ from mapping.processors.column_processor import ColumnProcessor
 from mapping.processors.device_processor import DeviceProcessor
 from mapping.processors.ai_processor import AIColumnMapperAdapter
 from mapping.models import MappingModel
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 
 class DummyAdapter:

--- a/tests/test_mappings_endpoint.py
+++ b/tests/test_mappings_endpoint.py
@@ -2,7 +2,7 @@ import pandas as pd
 from flask import Flask
 
 import mappings_endpoint
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 import importlib
 from pathlib import Path
 import sys
@@ -89,7 +89,7 @@ def _create_app(monkeypatch):
     container.register_singleton("device_learning_service", device_service)
     container.register_singleton("consolidated_learning_service", column_service)
 
-    import core.service_container as sc
+    import yosai_intel_dashboard.src.core.service_container as sc
     monkeypatch.setattr(sc, "ServiceContainer", lambda: container)
 
     return app, store, device_service, column_service

--- a/tests/test_master_callback_system.py
+++ b/tests/test_master_callback_system.py
@@ -2,8 +2,8 @@ import pytest
 from dash import Dash
 from dash.dependencies import Input, Output
 
-from core.master_callback_system import MasterCallbackSystem
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.master_callback_system import MasterCallbackSystem
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -5,7 +5,7 @@ from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
 from config.constants import MAX_DISPLAY_ROWS
-from services.data_processing.file_processor import create_file_preview
+from yosai_intel_dashboard.src.services.data_processing.file_processor import create_file_preview
 
 
 def test_dynamic_config_default_display_rows():

--- a/tests/test_memory_abort.py
+++ b/tests/test_memory_abort.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from core.performance_file_processor import PerformanceFileProcessor
+from yosai_intel_dashboard.src.core.performance_file_processor import PerformanceFileProcessor
 
 
 class FakeProcess:

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -4,9 +4,9 @@ import pytest
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
-from core.performance import get_performance_monitor
-from services.data_processing.file_handler import process_file_simple
-from services.data_processing.unified_upload_validator import process_dataframe
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.services.data_processing.file_handler import process_file_simple
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import process_dataframe
 
 
 def test_memory_limit_abort_csv(monkeypatch, tmp_path):

--- a/tests/test_migration_and_plugin_performance.py
+++ b/tests/test_migration_and_plugin_performance.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.plugins.performance_manager import PluginPerformanceManager
+from yosai_intel_dashboard.src.core.plugins.performance_manager import PluginPerformanceManager
 from tools.migration_validator import (
     MigrationValidator,
     test_migration_equivalence,

--- a/tests/test_modular_callbacks.py
+++ b/tests/test_modular_callbacks.py
@@ -1,4 +1,4 @@
-from core.callback_modules import CallbackModuleRegistry
+from yosai_intel_dashboard.src.core.callback_modules import CallbackModuleRegistry
 
 
 class DummyModule:

--- a/tests/test_navigation_manager.py
+++ b/tests/test_navigation_manager.py
@@ -1,4 +1,4 @@
-from core.navigation.enterprise_navigation_manager import (
+from yosai_intel_dashboard.src.core.navigation.enterprise_navigation_manager import (
     EnterpriseNavigationManager,
     NavigationLoopError,
 )

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -3,9 +3,9 @@ import time
 from pathlib import Path
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 
 class SimplePlugin:
@@ -57,7 +57,7 @@ def test_load_all_plugins(tmp_path):
     plugin_file = pkg_dir / "plug.py"
     plugin_file.write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class Plug:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -4,9 +4,9 @@ import types
 from pathlib import Path
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginMetadata, PluginStatus
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata, PluginStatus
 
 
 class DummyPlugin:
@@ -111,7 +111,7 @@ def test_load_all_plugins(tmp_path, monkeypatch):
     plugin_module = pkg_dir / "plugin_a.py"
     plugin_module.write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class Plugin:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager_cycle_logging.py
+++ b/tests/test_plugin_manager_cycle_logging.py
@@ -1,6 +1,6 @@
 import sys
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 import types
 
 
@@ -18,7 +18,7 @@ def _create_cycle_pkg(tmp_path):
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / "a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class APlugin:
     metadata = PluginMetadata(
@@ -45,7 +45,7 @@ def create_plugin():
     )
     (pkg_dir / "b.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class BPlugin:
     metadata = PluginMetadata(
@@ -79,7 +79,7 @@ def _create_missing_dep_pkg(tmp_path):
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / "plug.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 class P:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -1,8 +1,8 @@
 import time
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
 
 
 def test_health_thread_stops_on_exit():

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -1,9 +1,9 @@
 import sys
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginPriority
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager as PluginManager
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginPriority
 
 
 def test_priority_order(tmp_path):
@@ -14,7 +14,7 @@ def test_priority_order(tmp_path):
     plugin_a = pkg_dir / "plugin_a.py"
     plugin_a.write_text(
         """
-from services.data_processing.core.protocols import PluginPriority
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginPriority
 class PluginA:
     class metadata:
         name = 'a'
@@ -33,7 +33,7 @@ def create_plugin():
     plugin_b = pkg_dir / "plugin_b.py"
     plugin_b.write_text(
         """
-from services.data_processing.core.protocols import PluginPriority
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginPriority
 class PluginB:
     class metadata:
         name = 'b'

--- a/tests/test_process_and_analyze.py
+++ b/tests/test_process_and_analyze.py
@@ -1,14 +1,14 @@
 from validation.security_validator import SecurityValidator
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.file_processor import FileProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from tests.builders import TestDataBuilder
 
 
 def _create_components():
     from flask import Flask
 
-    from core.cache import cache
+    from yosai_intel_dashboard.src.core.cache import cache
 
     cache.init_app(Flask(__name__))
 

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -2,10 +2,10 @@ import asyncio
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.upload import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload import UploadProcessingService
 from upload_core import UploadCore
 from utils.upload_store import UploadedDataStore
-from services.device_learning_service import DeviceLearningService
+from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
 from tests.fakes import FakeUploadDataService
 
 

--- a/tests/test_progress_events.py
+++ b/tests/test_progress_events.py
@@ -1,7 +1,7 @@
 import asyncio
 
-from services.progress_events import ProgressEventManager
-from services.task_queue import clear_task, create_task
+from yosai_intel_dashboard.src.services.progress_events import ProgressEventManager
+from yosai_intel_dashboard.src.services.task_queue import clear_task, create_task
 
 
 def test_progress_event_generator():

--- a/tests/test_progress_sse_endpoint.py
+++ b/tests/test_progress_sse_endpoint.py
@@ -1,6 +1,6 @@
 from flask import Flask, Response, stream_with_context
 
-from core.app_factory.health import register_health_endpoints
+from yosai_intel_dashboard.src.core.app_factory.health import register_health_endpoints
 
 
 class DummyProgress:

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Callable, Protocol, runtime_checkable, asser
 import pandas as pd
 import pytest
 
-from core.service_container import ServiceContainer
-from services.analytics_service import AnalyticsService
-from core.protocols import (
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.core.protocols import (
     AnalyticsServiceProtocol,
     ConfigurationProtocol,
     SecurityServiceProtocol,
@@ -173,7 +173,7 @@ class TestProtocolCompliance:
         assert_type(cfg, ConfigurationProtocol)
 
     def test_analytics_service_compliance(self):
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics_service import AnalyticsService
 
         class ConcreteAnalyticsService(AnalyticsService):
             def analyze_access_patterns(self, days: int) -> Dict[str, Any]:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -34,7 +34,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.publisher import Publisher  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.publisher import Publisher  # noqa: E402
 
 
 class DummyBus:

--- a/tests/test_read_uploaded_file.py
+++ b/tests/test_read_uploaded_file.py
@@ -1,6 +1,6 @@
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 
 
 def test_read_uploaded_file_basic():

--- a/tests/test_regular_analysis_helpers.py
+++ b/tests/test_regular_analysis_helpers.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.result_formatting import (
+from yosai_intel_dashboard.src.services.result_formatting import (
     apply_regular_analysis,
     prepare_regular_result,
 )

--- a/tests/test_sample_paths.py
+++ b/tests/test_sample_paths.py
@@ -1,7 +1,7 @@
 import os
 
 from config import get_config, reload_config
-from services import AnalyticsService
+from yosai_intel_dashboard.src.services import AnalyticsService
 
 
 def test_fixed_processor_paths_from_env(monkeypatch):

--- a/tests/test_sanitize_dataframe_memory.py
+++ b/tests/test_sanitize_dataframe_memory.py
@@ -2,7 +2,7 @@ import pandas as pd
 import psutil
 import pytest
 
-from services.data_processing.file_processor import UnicodeFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import UnicodeFileProcessor
 
 
 @pytest.mark.slow

--- a/tests/test_secret_health.py
+++ b/tests/test_secret_health.py
@@ -1,6 +1,6 @@
 import os
 
-from core.app_factory import create_app
+from yosai_intel_dashboard.src.core.app_factory import create_app
 
 
 def test_secrets_health_endpoint(monkeypatch):

--- a/tests/test_secret_manager.py
+++ b/tests/test_secret_manager.py
@@ -4,7 +4,7 @@ import types
 
 import pytest
 
-from core.secret_manager import SecretManager, validate_secrets
+from yosai_intel_dashboard.src.core.secret_manager import SecretManager, validate_secrets
 
 
 def test_get_env_secret(monkeypatch):

--- a/tests/test_secrets_integration.py
+++ b/tests/test_secrets_integration.py
@@ -1,4 +1,4 @@
-from core.secret_manager import SecretsManager
+from yosai_intel_dashboard.src.core.secret_manager import SecretsManager
 
 
 def test_env_overrides_docker(tmp_path, monkeypatch):

--- a/tests/test_secure_config_manager.py
+++ b/tests/test_secure_config_manager.py
@@ -3,7 +3,7 @@ import pytest
 from cryptography.fernet import Fernet
 
 from config.secure_config_manager import SecureConfigManager
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 
 def test_vault_secret_resolution(monkeypatch, tmp_path):

--- a/tests/test_security_comprehensive.py
+++ b/tests/test_security_comprehensive.py
@@ -5,7 +5,7 @@ class TestSecurityVulnerabilities:
         """Test SQL injection attack patterns."""
         import pytest
 
-        from core.exceptions import ValidationError
+        from yosai_intel_dashboard.src.core.exceptions import ValidationError
         from validation.security_validator import SecurityValidator
 
         malicious_inputs = [
@@ -21,7 +21,7 @@ class TestSecurityVulnerabilities:
 
     def test_unicode_surrogate_handling(self):
         """Test Unicode surrogate character handling."""
-        from core.unicode import sanitize_unicode_input
+        from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
         # Test lone surrogates
         lone_surrogate = "\ud800\ud801"  # Invalid surrogate pair
@@ -32,7 +32,7 @@ class TestSecurityVulnerabilities:
 
     def test_sanitize_unicode_input_ascii_fallback(self):
         """Ensure ASCII-safe text is returned on failure."""
-        from core.unicode import sanitize_unicode_input
+        from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
         class BadStr:
             def __str__(self) -> str:

--- a/tests/test_security_display_fix.py
+++ b/tests/test_security_display_fix.py
@@ -1,7 +1,7 @@
 import pytest
 import dash_bootstrap_components as dbc
 
-from services.analytics_processing import create_analysis_results_display
+from yosai_intel_dashboard.src.services.analytics_processing import create_analysis_results_display
 
 pytestmark = pytest.mark.usefixtures("fake_dbc")
 

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -3,7 +3,7 @@ import pytest
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
-from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import UnifiedUploadValidator
 
 
 def test_malicious_filename_is_invalid():

--- a/tests/test_service_locator.py
+++ b/tests/test_service_locator.py
@@ -1,6 +1,6 @@
 import types
 
-from core.plugins import service_locator
+from yosai_intel_dashboard.src.core.plugins import service_locator
 
 
 def test_service_locator_returns_set_plugin():

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 

--- a/tests/test_summary_reporting_module.py
+++ b/tests/test_summary_reporting_module.py
@@ -1,4 +1,4 @@
-from services.summary_reporter import SummaryReporter
+from yosai_intel_dashboard.src.services.summary_reporter import SummaryReporter
 
 
 class FakeDB:

--- a/tests/test_surrogate_handling.py
+++ b/tests/test_surrogate_handling.py
@@ -2,7 +2,7 @@ import json
 
 import pandas as pd
 
-from services.data_processing.unified_upload_validator import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import process_dataframe
 
 
 def test_process_dataframe_csv_with_surrogate(tmp_path):

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from services.task_queue import TaskQueue
+from yosai_intel_dashboard.src.services.task_queue import TaskQueue
 
 queue = TaskQueue()
 import pytest

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -3,7 +3,7 @@ import dash
 import dash_bootstrap_components as dbc
 from dash import html, dcc, Output, Input
 
-from core.theme_manager import apply_theme_settings, sanitize_theme, DEFAULT_THEME
+from yosai_intel_dashboard.src.core.theme_manager import apply_theme_settings, sanitize_theme, DEFAULT_THEME
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
 
@@ -12,7 +12,7 @@ def create_theme_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 
     # Import and create unified callback coordinator
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
     coordinator = TrulyUnifiedCallbacks(app)
 

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -2,9 +2,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.manager import ThreadSafePluginManager
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 
 class ConcurrencyPlugin:

--- a/tests/test_ui_monitor.py
+++ b/tests/test_ui_monitor.py
@@ -1,8 +1,8 @@
 import importlib.util
 import sys
 
-from core import performance
-from core.performance import PerformanceMonitor
+from yosai_intel_dashboard.src.core import performance
+from yosai_intel_dashboard.src.core.performance import PerformanceMonitor
 
 spec = importlib.util.spec_from_file_location(
     "monitoring.ui_monitor", "monitoring/ui_monitor.py"

--- a/tests/test_unicode_cleaner.py
+++ b/tests/test_unicode_cleaner.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     UnicodeProcessor,
     safe_encode_text,
     sanitize_dataframe,

--- a/tests/test_unicode_decode.py
+++ b/tests/test_unicode_decode.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import safe_unicode_decode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode
 
 
 def test_removes_invalid_surrogates():

--- a/tests/test_unicode_enhanced.py
+++ b/tests/test_unicode_enhanced.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     EnhancedUnicodeProcessor,
     SurrogateHandlingConfig,
     SurrogateHandlingStrategy,

--- a/tests/test_unicode_file_handling.py
+++ b/tests/test_unicode_file_handling.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 import pandas as pd
 
-import services.upload.helpers as upload_helpers
+import yosai_intel_dashboard.src.services.upload.helpers as upload_helpers
 from analytics.db_interface import AnalyticsDataAccessor
-from services.learning.src.api.consolidated_service import ConsolidatedLearningService
-from services.upload import save_ai_training_data
+from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import ConsolidatedLearningService
+from yosai_intel_dashboard.src.services.upload import save_ai_training_data
 
 
 def test_consolidated_learning_unicode(tmp_path):

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     ChunkedUnicodeProcessor,
     UnicodeProcessor,
     clean_unicode_text,
@@ -46,8 +46,8 @@ def callback_handler(event: CallbackEvent):
 
 _GLOBAL = CallbackController()
 fire_event = _GLOBAL.fire_event
-from services.data_processing.file_processor import FileProcessor as RobustFileProcessor
-from services.data_processing.file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor as RobustFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     process_file_simple,
 )
 

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pandas as pd
 import pytest
 
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     contains_surrogates,
     safe_decode_bytes,
     safe_encode_text,

--- a/tests/test_unicode_regression.py
+++ b/tests/test_unicode_regression.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from core.unicode import UnicodeProcessor, sanitize_unicode_input, sanitize_dataframe
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor, sanitize_unicode_input, sanitize_dataframe
 
 
 def test_sanitize_unicode_input_normalizes_and_replaces():

--- a/tests/test_unicode_text_processor.py
+++ b/tests/test_unicode_text_processor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import object_count
+from yosai_intel_dashboard.src.core.unicode import object_count
 
 
 def test_object_count_basic():

--- a/tests/test_unicode_unified_regression.py
+++ b/tests/test_unicode_unified_regression.py
@@ -1,4 +1,4 @@
-from core.unicode import safe_unicode_decode, sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode, sanitize_for_utf8
 
 
 def test_safe_unicode_decode_handles_surrogates():

--- a/tests/test_unicode_utils.py
+++ b/tests/test_unicode_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     normalize_unicode_safely,
     detect_surrogate_pairs,
     sanitize_for_utf8,

--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -5,8 +5,8 @@ import pytest
 
 from config.database_exceptions import UnicodeEncodingError
 from unicode_toolkit import UnicodeSQLProcessor
-from core.unicode import UnicodeProcessor as UtilsProcessor  # Alias check
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor as UtilsProcessor  # Alias check
+from yosai_intel_dashboard.src.core.unicode import (
     clean_unicode_surrogates,
     clean_unicode_text,
     contains_surrogates,

--- a/tests/test_unified_callback_coordinator.py
+++ b/tests/test_unified_callback_coordinator.py
@@ -1,8 +1,8 @@
 import pytest
 from dash import Dash, Input, Output
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_unified_callback_manager.py
+++ b/tests/test_unified_callback_manager.py
@@ -1,8 +1,8 @@
 import pytest
 from dash import Dash
 
-from core import TrulyUnifiedCallbacks
-from core.error_handling import error_handler
+from yosai_intel_dashboard.src.core import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.error_handling import error_handler
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_unified_file_system_integration.py
+++ b/tests/test_unified_file_system_integration.py
@@ -4,7 +4,7 @@ import pandas as pd
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 import pytest
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.core.callback_events import CallbackEvent
 from analytics_core.callbacks.unified_callback_manager import CallbackManager
 
 
@@ -23,11 +23,11 @@ class TemporaryCallback:
 
 
 from file_conversion.storage_manager import StorageManager
-from services.unified_file_controller import (
+from yosai_intel_dashboard.src.services.unified_file_controller import (
     batch_migrate_legacy_files,
 )
-from services.unified_file_controller import callback_manager as _GLOBAL_MANAGER
-from services.unified_file_controller import (
+from yosai_intel_dashboard.src.services.unified_file_controller import callback_manager as _GLOBAL_MANAGER
+from yosai_intel_dashboard.src.services.unified_file_controller import (
     get_processing_metrics,
     process_file_upload,
 )

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -15,12 +15,12 @@ class EnumJSONProvider(DefaultJSONProvider):
 import sys
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
-from core.plugins.auto_config import PluginAutoConfiguration
-from core.plugins.unified_registry import UnifiedPluginRegistry
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.plugins.auto_config import PluginAutoConfiguration
+from yosai_intel_dashboard.src.core.plugins.unified_registry import UnifiedPluginRegistry
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
-from services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
 
 
 class DummyPlugin:

--- a/tests/test_upload_csrf.py
+++ b/tests/test_upload_csrf.py
@@ -16,7 +16,7 @@ if "services" not in sys.modules:
 from tests.stubs.flask_wtf import CSRFProtect, generate_csrf
 from flask import Flask, jsonify
 import werkzeug
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 
 class DummyUploadService:
     async def process_uploaded_files(self, contents, filenames):

--- a/tests/test_upload_data_service.py
+++ b/tests/test_upload_data_service.py
@@ -21,7 +21,7 @@ if "chardet" not in sys.modules:
     sys.modules["chardet"] = types.ModuleType("chardet")
 import pandas as pd
 from unittest.mock import MagicMock
-from services.upload_data_service import UploadDataService
+from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService
 from utils.upload_store import UploadedDataStore
 
 

--- a/tests/test_upload_data_service_interface.py
+++ b/tests/test_upload_data_service_interface.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.upload_data_service import (
+from yosai_intel_dashboard.src.services.upload_data_service import (
     get_uploaded_data,
     get_uploaded_filenames,
     clear_uploaded_data,

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -5,7 +5,7 @@ import types
 import pandas as pd
 from flask import Flask
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.service_container import ServiceContainer
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 

--- a/tests/test_upload_processing_helpers.py
+++ b/tests/test_upload_processing_helpers.py
@@ -1,13 +1,13 @@
 import pandas as pd
 from tests.utils.builders import DataFrameBuilder
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from validation.security_validator import SecurityValidator
 
 
 def _make_processor():
     from flask import Flask
-    from core.cache import cache
+    from yosai_intel_dashboard.src.core.cache import cache
 
     cache.init_app(Flask(__name__))
     vs = SecurityValidator()

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -1,14 +1,14 @@
 from tests.utils.builders import DataFrameBuilder
 
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from validation.security_validator import SecurityValidator
 
 
 def _make_processor():
     from flask import Flask
 
-    from core.cache import cache
+    from yosai_intel_dashboard.src.core.cache import cache
 
     cache.init_app(Flask(__name__))
 

--- a/tests/test_upload_protocols.py
+++ b/tests/test_upload_protocols.py
@@ -1,10 +1,10 @@
 import inspect
 
-from services.upload.core.processor import UploadProcessingService
-from services.upload.core.validator import ClientSideValidator
-from services.data_processing.async_file_processor import AsyncFileProcessor
+from yosai_intel_dashboard.src.services.upload.core.processor import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload.core.validator import ClientSideValidator
+from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
 from utils.upload_store import UploadedDataStore
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadProcessingServiceProtocol,
     UploadValidatorProtocol,
     FileProcessorProtocol,

--- a/tests/test_upload_queue_manager.py
+++ b/tests/test_upload_queue_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-from services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
 
 
 async def _dummy_handler(item):

--- a/tests/test_upload_service_env.py
+++ b/tests/test_upload_service_env.py
@@ -2,7 +2,7 @@ import base64
 import importlib
 
 from tests.fake_configuration import FakeConfiguration
-from services.data_processing import file_processor as upload_module
+from yosai_intel_dashboard.src.services.data_processing import file_processor as upload_module
 
 
 def test_env_max_upload_limit(monkeypatch):

--- a/tests/test_upload_validator.py
+++ b/tests/test_upload_validator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services.data_processing.unified_upload_validator import (
+from yosai_intel_dashboard.src.services.data_processing.unified_upload_validator import (
     UnifiedUploadValidator as UploadValidator,
 )
 

--- a/tests/test_uploaded_chunk_processing.py
+++ b/tests/test_uploaded_chunk_processing.py
@@ -1,6 +1,6 @@
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from services import AnalyticsService
+from yosai_intel_dashboard.src.services import AnalyticsService
 
 
 def test_process_uploaded_data_directly_chunked(tmp_path):

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -7,7 +7,7 @@ from analytics.file_processing_utils import (
     update_counts,
     update_timestamp_range,
 )
-from services import AnalyticsService
+from yosai_intel_dashboard.src.services import AnalyticsService
 from tests.fakes import FakeUploadDataService, FakeUploadStore
 
 

--- a/tests/threading/test_unicode_threading.py
+++ b/tests/threading/test_unicode_threading.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from core.unicode import ChunkedUnicodeProcessor, UnicodeProcessor
+from yosai_intel_dashboard.src.core.unicode import ChunkedUnicodeProcessor, UnicodeProcessor
 
 
 def test_clean_surrogate_chars_threaded():

--- a/tests/utils/plugin_package_builder.py
+++ b/tests/utils/plugin_package_builder.py
@@ -50,8 +50,8 @@ class PluginPackageBuilder(AbstractContextManager):
         (self._pkg_path / "__init__.py").write_text("")
         plugin_code = f"""
 from dash import Output, Input
-from services.data_processing.core.protocols import PluginMetadata
-from core.plugins.callback_unifier import CallbackUnifier
+from yosai_intel_dashboard.src.services.data_processing.core.protocols import PluginMetadata
+from yosai_intel_dashboard.src.core.plugins.callback_unifier import CallbackUnifier
 
 class AutoPlugin:
     metadata = PluginMetadata(

--- a/tests/utils/test_asset_serving.py
+++ b/tests/utils/test_asset_serving.py
@@ -1,6 +1,6 @@
 import os
 
-from core.app_factory import create_app
+from yosai_intel_dashboard.src.core.app_factory import create_app
 from utils import debug_dash_asset_serving
 
 

--- a/tests/utils/test_assets_debug.py
+++ b/tests/utils/test_assets_debug.py
@@ -1,4 +1,4 @@
-from core.app_factory import create_app
+from yosai_intel_dashboard.src.core.app_factory import create_app
 from utils.assets_debug import check_navbar_assets
 
 


### PR DESCRIPTION
## Summary
- replace `from core`, `from services` and similar imports in docs and tests
- update README examples to use `yosai_intel_dashboard.src`
- update integration guide to show new import paths

## Testing
- `pip install PyYAML psutil`
- `pip install pandas`
- `pytest -k documentation_examples -q` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.core.protocols')*

------
https://chatgpt.com/codex/tasks/task_e_688369cfe950832093f7f6f52157a609