### PR TITLE
Update CI clean-arch checks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.lock
-      - name: Dry run migration
-        run: python scripts/migrate_to_clean_arch.py --dry-run
       - name: Validate directory structure
         run: python scripts/validate_structure.py
+      - name: Verify imports
+        run: python scripts/verify_imports.py
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.lock
-      - name: Dry run migration
-        run: python scripts/migrate_to_clean_arch.py --dry-run
       - name: Validate directory structure
         run: python scripts/validate_structure.py
+      - name: Verify imports
+        run: python scripts/verify_imports.py
 
   lint:
     needs: [validate-configs, clean-arch-check]


### PR DESCRIPTION
## Summary
- verify import statements during clean-arch checks
- drop dry-run migration step

## Testing
- `pytest tests/scripts/test_update_imports.py -q` *(fails: ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_688369d32aa8832084c7f1828e71a746