### PR TITLE
Add import validation and rollback improvements

### DIFF
--- a/scripts/verify_imports.py
+++ b/scripts/verify_imports.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Validate absence of legacy import paths."""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from scripts.update_imports import PATTERNS, ROOT
+
+
+def _check_file(path: Path, compiled: list[re.Pattern[str]]) -> list[str]:
+    results = []
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        for pattern in compiled:
+            if pattern.search(line):
+                results.append(f"{path}:{lineno}:{line}")
+                break
+    return results
+
+
+def verify_paths(paths: list[Path]) -> int:
+    compiled = [re.compile(p) for p in PATTERNS]
+    issues: list[str] = []
+    for root in paths:
+        for py_file in root.rglob("*.py"):
+            issues.extend(_check_file(py_file, compiled))
+    if issues:
+        for issue in issues:
+            print(issue)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check for legacy imports")
+    parser.add_argument("paths", nargs="*", type=Path, default=[ROOT])
+    args = parser.parse_args(argv)
+    return verify_paths(args.paths)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    raise SystemExit(main())

--- a/tests/scripts/test_update_imports.py
+++ b/tests/scripts/test_update_imports.py
@@ -45,3 +45,20 @@ def test_update_imports_cli(tmp_path: Path) -> None:
     main([str(tmp_path)])
     expected = "from yosai_intel_dashboard.src.infrastructure.config import x\n"
     assert file_path.read_text() == expected
+
+
+def test_update_imports_report_and_verify(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text("from config import y\n")
+    report = tmp_path / "changes.txt"
+    exit_code = main([
+        str(tmp_path),
+        "--verify",
+        "--report",
+        str(report),
+    ])
+    expected = "from yosai_intel_dashboard.src.infrastructure.config import y\n"
+    assert bad.read_text() == expected
+    assert report.read_text().strip() == str(bad)
+    assert exit_code == 0
+

--- a/tests/scripts/test_verify_imports.py
+++ b/tests/scripts/test_verify_imports.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from scripts.verify_imports import verify_paths, main
+
+
+def test_verify_paths_detects_legacy(tmp_path: Path) -> None:
+    file = tmp_path / "bad.py"
+    file.write_text("from config import x\n")
+    result = verify_paths([tmp_path])
+    assert result == 1
+
+
+def test_verify_cli_passes_when_clean(tmp_path: Path) -> None:
+    file = tmp_path / "good.py"
+    file.write_text(
+        "from yosai_intel_dashboard.src.infrastructure.config import x\n"
+    )
+    exit_code = main([str(tmp_path)])
+    assert exit_code == 0
+


### PR DESCRIPTION
## Summary
- add `scripts/verify_imports.py` for checking legacy imports
- extend `scripts/update_imports.py` with reporting and optional verification
- support archive based rollback in `scripts/migrate_to_clean_arch.py`
- add unit tests for new scripts and options

## Testing
- `pytest -q tests/scripts/test_update_imports.py tests/scripts/test_verify_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_688369d0f4d483209e48df2fe54c1b26