### PR TITLE
Update navbar docs paths

### DIFF
--- a/assets/css/COMPONENT_DOCS.md
+++ b/assets/css/COMPONENT_DOCS.md
@@ -139,25 +139,23 @@ When customizing colors, ensure a minimum contrast ratio of 4.5:1 for text withi
 
 ### Navbar Component
 
-**File:** `components/ui/navbar.py`
+**File:** `components/ui/navbar.py` *(deprecated – use* `src/components/shared/Navbar.tsx` *instead)*
 
 The navigation bar consolidates common links and the theme toggle into a shared
-component. Below is a minimal Dash example using the `create_navbar_layout`
-factory. In development you can preview components interactively using a
-Storybook-style setup with `dash`:
+component. While the legacy Python helper is still available, new development
+should rely on the React component:
 
-```python
-from dash import Dash, html
-from components.ui.navbar import create_navbar_layout
+```tsx
+import Navbar from "@/components/shared/Navbar";
 
-app = Dash(__name__)
-app.layout = html.Div([
-    create_navbar_layout(),
-    html.Div("Preview Area", className="p-4")
-])
-
-if __name__ == "__main__":
-    app.run_server(debug=True)
+export default function App() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-4">Preview Area</div>
+    </>
+  );
+}
 ```
 
 The navbar respects the design tokens defined in `_variables.css` for spacing,

--- a/docs/react_component_architecture.md
+++ b/docs/react_component_architecture.md
@@ -16,15 +16,14 @@ hooks.
 - **Settings** – application preferences (`src/pages/Settings.tsx`).
 
 Navigation between pages is handled by the **Navbar** component
-(`src/components/layout/Navbar.tsx`) which uses `react-router-dom`.
+(`src/components/shared/Navbar.tsx`) which uses `react-router-dom`.
 
 ## Shared Components
 
 Reusable widgets such as `Button`, `Card`, `Input` and `ProgressBar` are defined
 in `src/components/shared`. Complex upload functionality is split into smaller
 components under `src/components/upload` (for example
-`FilePreview` and `ColumnMappingModal`). Layout helpers like `Navbar` and the
-optional `Sidebar` live under `src/components/layout`.
+`FilePreview` and `ColumnMappingModal`).
 
 ## Hooks
 


### PR DESCRIPTION
## Summary
- update Navbar path in React component docs
- clean up Shared Components section
- mark python navbar helper as deprecated and show React example

## Testing
- `pytest tests/components/test_navbar_config.py::test_default_nav_links_have_labels -q` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.core.protocols')*

------
https://chatgpt.com/codex/tasks/task_e_6883722568348320a8a70a3bafdc7bf3