### PR TITLE
Fix import rewriting logic

### DIFF
--- a/scripts/update_imports.py
+++ b/scripts/update_imports.py
@@ -8,23 +8,14 @@ from pathlib import Path
 from typing import IO
 
 ROOT = Path(__file__).resolve().parents[1]
+# Rewrite patterns for imports.  Only modules that have been fully
+# migrated to the new ``yosai_intel_dashboard.src`` layout are included
+# here.  Packages such as ``config`` or ``services`` still live at the
+# repository root, so rewriting them would break imports.  As new
+# packages are migrated they can be added back to this mapping.
 PATTERNS = {
-    r"\bfrom\s+core(\.|\s)": "from yosai_intel_dashboard.src.core\\1",
-    r"\bimport\s+core(\.|$)": "import yosai_intel_dashboard.src.core\\1",
-    r"\bfrom\s+services(\.|\s)": "from yosai_intel_dashboard.src.services\\1",
-    r"\bimport\s+services(\.|$)": "import yosai_intel_dashboard.src.services\\1",
     r"\bfrom\s+models(\.|\s)": "from yosai_intel_dashboard.src.core.domain\\1",
     r"\bimport\s+models(\.|$)": "import yosai_intel_dashboard.src.core.domain\\1",
-    r"\bfrom\s+config(\.|\s)": "from yosai_intel_dashboard.src.infrastructure.config\\1",
-    r"\bimport\s+config(\.|$)": "import yosai_intel_dashboard.src.infrastructure.config\\1",
-    r"\bfrom\s+monitoring(\.|\s)": "from yosai_intel_dashboard.src.infrastructure.monitoring\\1",
-    r"\bimport\s+monitoring(\.|$)": "import yosai_intel_dashboard.src.infrastructure.monitoring\\1",
-    r"\bfrom\s+security(\.|\s)": "from yosai_intel_dashboard.src.infrastructure.security\\1",
-    r"\bimport\s+security(\.|$)": "import yosai_intel_dashboard.src.infrastructure.security\\1",
-    r"\bfrom\s+api(\.|\s)": "from yosai_intel_dashboard.src.adapters.api\\1",
-    r"\bimport\s+api(\.|$)": "import yosai_intel_dashboard.src.adapters.api\\1",
-    r"\bfrom\s+plugins(\.|\s)": "from yosai_intel_dashboard.src.adapters.api.plugins\\1",
-    r"\bimport\s+plugins(\.|$)": "import yosai_intel_dashboard.src.adapters.api.plugins\\1",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,11 @@ if "monitoring.prometheus" not in sys.modules:
     dep_mod.deprecated_calls = []
     dep_mod.record_deprecated_call = lambda name: dep_mod.deprecated_calls.append(name)
     dep_mod.start_deprecation_metrics_server = lambda *a, **k: None
+    metrics_mod = types.ModuleType("monitoring.prometheus.model_metrics")
+    metrics_mod.update_model_metrics = lambda *a, **k: None
     sys.modules["monitoring.prometheus"] = prom_pkg
     sys.modules["monitoring.prometheus.deprecation"] = dep_mod
+    sys.modules["monitoring.prometheus.model_metrics"] = metrics_mod
 
 
 def pytest_ignore_collect(path, config):

--- a/tests/scripts/test_update_imports.py
+++ b/tests/scripts/test_update_imports.py
@@ -12,28 +12,12 @@ def _run_update(tmp_path: Path, content: str) -> str:
 
 def test_update_imports_patterns(tmp_path: Path) -> None:
     before = """
-    from config.utils import a
-    import config.utils
-    from monitoring.metrics import b
-    import monitoring.metrics
-    from security.auth import c
-    import security.helpers
-    from api.client import d
-    import api.client
-    from yosai_intel_dashboard.src.plugins.extra import e
-    import yosai_intel_dashboard.src.plugins.extra
+    from models.user import a
+    import models.user
     """
     after = """
-    from yosai_intel_dashboard.src.infrastructure.config.utils import a
-    import yosai_intel_dashboard.src.infrastructure.config.utils
-    from yosai_intel_dashboard.src.infrastructure.monitoring.metrics import b
-    import yosai_intel_dashboard.src.infrastructure.monitoring.metrics
-    from yosai_intel_dashboard.src.infrastructure.security.auth import c
-    import yosai_intel_dashboard.src.infrastructure.security.helpers
-    from yosai_intel_dashboard.src.adapters.api.client import d
-    import yosai_intel_dashboard.src.adapters.api.client
-    from yosai_intel_dashboard.src.adapters.api.plugins.extra import e
-    import yosai_intel_dashboard.src.adapters.api.plugins.extra
+    from yosai_intel_dashboard.src.core.domain.user import a
+    import yosai_intel_dashboard.src.core.domain.user
     """
     result = _run_update(tmp_path, before)
     assert result == textwrap.dedent(after)
@@ -41,15 +25,15 @@ def test_update_imports_patterns(tmp_path: Path) -> None:
 
 def test_update_imports_cli(tmp_path: Path) -> None:
     file_path = tmp_path / "example.py"
-    file_path.write_text("from config import x\n")
+    file_path.write_text("from models import x\n")
     main([str(tmp_path)])
-    expected = "from yosai_intel_dashboard.src.infrastructure.config import x\n"
+    expected = "from yosai_intel_dashboard.src.core.domain import x\n"
     assert file_path.read_text() == expected
 
 
 def test_update_imports_report_and_verify(tmp_path: Path) -> None:
     bad = tmp_path / "bad.py"
-    bad.write_text("from config import y\n")
+    bad.write_text("from models import y\n")
     report = tmp_path / "changes.txt"
     exit_code = main([
         str(tmp_path),
@@ -57,7 +41,7 @@ def test_update_imports_report_and_verify(tmp_path: Path) -> None:
         "--report",
         str(report),
     ])
-    expected = "from yosai_intel_dashboard.src.infrastructure.config import y\n"
+    expected = "from yosai_intel_dashboard.src.core.domain import y\n"
     assert bad.read_text() == expected
     assert report.read_text().strip() == str(bad)
     assert exit_code == 0

--- a/tests/scripts/test_verify_imports.py
+++ b/tests/scripts/test_verify_imports.py
@@ -4,7 +4,7 @@ from scripts.verify_imports import verify_paths, main
 
 def test_verify_paths_detects_legacy(tmp_path: Path) -> None:
     file = tmp_path / "bad.py"
-    file.write_text("from config import x\n")
+    file.write_text("from models import x\n")
     result = verify_paths([tmp_path])
     assert result == 1
 
@@ -12,7 +12,7 @@ def test_verify_paths_detects_legacy(tmp_path: Path) -> None:
 def test_verify_cli_passes_when_clean(tmp_path: Path) -> None:
     file = tmp_path / "good.py"
     file.write_text(
-        "from yosai_intel_dashboard.src.infrastructure.config import x\n"
+        "from yosai_intel_dashboard.src.core.domain import x\n"
     )
     exit_code = main([str(tmp_path)])
     assert exit_code == 0

--- a/yosai_intel_dashboard/src/adapters/api/__init__.py
+++ b/yosai_intel_dashboard/src/adapters/api/__init__.py
@@ -1,0 +1,8 @@
+
+"""Expose legacy :mod:`api` package under ``src.adapters`` namespace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__path__.append(str(Path(__file__).resolve().parents[4] / "api"))

--- a/yosai_intel_dashboard/src/core/__init__.py
+++ b/yosai_intel_dashboard/src/core/__init__.py
@@ -1,0 +1,17 @@
+
+"""Compatibility package for new clean architecture layout.
+
+This module exposes the existing ``core`` package under the
+``yosai_intel_dashboard.src`` namespace so that imports using the new
+path continue to work until the package is fully migrated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Include the legacy ``core`` package in the module search path.  This
+# mirrors the behaviour of a namespace package and allows statements like
+# ``import yosai_intel_dashboard.src.core.service_container`` to resolve
+# to the modules in the top-level ``core`` package.
+__path__.append(str(Path(__file__).resolve().parents[3] / "core"))

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -12,6 +12,10 @@ __all__ = [
 ]
 
 from importlib import import_module
+from pathlib import Path
+
+# Allow importing modules from the legacy top-level ``config`` package.
+__path__.append(str(Path(__file__).resolve().parents[4] / "config"))
 
 
 def __getattr__(name: str):

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -1,0 +1,8 @@
+
+"""Expose legacy :mod:`monitoring` package under ``src`` namespace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__path__.append(str(Path(__file__).resolve().parents[4] / "monitoring"))

--- a/yosai_intel_dashboard/src/infrastructure/security/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/__init__.py
@@ -1,0 +1,8 @@
+
+"""Expose legacy :mod:`security` package under ``src`` namespace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__path__.append(str(Path(__file__).resolve().parents[4] / "security"))

--- a/yosai_intel_dashboard/src/services/__init__.py
+++ b/yosai_intel_dashboard/src/services/__init__.py
@@ -1,0 +1,8 @@
+
+"""Expose legacy :mod:`services` package under ``src`` namespace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__path__.append(str(Path(__file__).resolve().parents[3] / "services"))


### PR DESCRIPTION
## Summary
- stop rewriting imports for packages that haven't moved yet
- adjust tests to verify only models imports are rewritten
- add runtime compatibility layers so src packages load legacy modules
- stub model metrics in tests

## Testing
- `pytest tests/scripts/test_update_imports.py tests/scripts/test_verify_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688380cda25c8320ae58394841bc0fa5