### PR TITLE
Add compatibility wrappers for missing modules

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.adapter`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.adapter")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/analytics_endpoints.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_endpoints.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.analytics_endpoints`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.analytics_endpoints")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.analytics_router`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.analytics_router")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/api_app.py
+++ b/yosai_intel_dashboard/src/adapters/api/api_app.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.api_app`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.api_app")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/callbacks_endpoint.py
+++ b/yosai_intel_dashboard/src/adapters/api/callbacks_endpoint.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.callbacks_endpoint`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.callbacks_endpoint")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/plugin_performance.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugin_performance.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.plugin_performance`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.plugin_performance")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
+++ b/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.risk_scoring`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.risk_scoring")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/settings_endpoint.py
+++ b/yosai_intel_dashboard/src/adapters/api/settings_endpoint.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.settings_endpoint`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.settings_endpoint")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/adapters/api/spec.py
+++ b/yosai_intel_dashboard/src/adapters/api/spec.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `api.spec`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("api.spec")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/advanced_cache.py
+++ b/yosai_intel_dashboard/src/core/advanced_cache.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.advanced_cache`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.advanced_cache")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/advanced_query_optimizer.py
+++ b/yosai_intel_dashboard/src/core/advanced_query_optimizer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.advanced_query_optimizer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.advanced_query_optimizer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/audit_logger.py
+++ b/yosai_intel_dashboard/src/core/audit_logger.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.audit_logger`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.audit_logger")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/auth.py
+++ b/yosai_intel_dashboard/src/core/auth.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.auth`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.auth")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/base_database_service.py
+++ b/yosai_intel_dashboard/src/core/base_database_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.base_database_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.base_database_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/base_model.py
+++ b/yosai_intel_dashboard/src/core/base_model.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.base_model`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.base_model")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/cache.py
+++ b/yosai_intel_dashboard/src/core/cache.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.cache`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.cache")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/cache_manager.py
+++ b/yosai_intel_dashboard/src/core/cache_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.cache_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.cache_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/cache_warmer.py
+++ b/yosai_intel_dashboard/src/core/cache_warmer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.cache_warmer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.cache_warmer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/caching.py
+++ b/yosai_intel_dashboard/src/core/caching.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.caching`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.caching")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/callback_controller.py
+++ b/yosai_intel_dashboard/src/core/callback_controller.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.callback_controller`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.callback_controller")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/callback_events.py
+++ b/yosai_intel_dashboard/src/core/callback_events.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.callback_events`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.callback_events")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/callback_manager.py
+++ b/yosai_intel_dashboard/src/core/callback_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.callback_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.callback_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/callback_modules.py
+++ b/yosai_intel_dashboard/src/core/callback_modules.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.callback_modules`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.callback_modules")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/callback_registry.py
+++ b/yosai_intel_dashboard/src/core/callback_registry.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.callback_registry`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.callback_registry")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/config.py
+++ b/yosai_intel_dashboard/src/core/config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/container.py
+++ b/yosai_intel_dashboard/src/core/container.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.container`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.container")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/cpu_optimizer.py
+++ b/yosai_intel_dashboard/src/core/cpu_optimizer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.cpu_optimizer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.cpu_optimizer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/dash_profile.py
+++ b/yosai_intel_dashboard/src/core/dash_profile.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.dash_profile`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.dash_profile")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/deprecation.py
+++ b/yosai_intel_dashboard/src/core/deprecation.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.deprecation`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.deprecation")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/error_handlers.py
+++ b/yosai_intel_dashboard/src/core/error_handlers.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.error_handlers`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.error_handlers")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/error_handling.py
+++ b/yosai_intel_dashboard/src/core/error_handling.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.error_handling`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.error_handling")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/events.py
+++ b/yosai_intel_dashboard/src/core/events.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.events`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.events")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/exceptions.py
+++ b/yosai_intel_dashboard/src/core/exceptions.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.exceptions`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.exceptions")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/flask_protocol.py
+++ b/yosai_intel_dashboard/src/core/flask_protocol.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.flask_protocol`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.flask_protocol")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
+++ b/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.hierarchical_cache_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.hierarchical_cache_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
+++ b/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.intelligent_multilevel_cache`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.intelligent_multilevel_cache")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/interfaces.py
+++ b/yosai_intel_dashboard/src/core/interfaces.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.interfaces`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.interfaces")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/json_serialization_plugin.py
+++ b/yosai_intel_dashboard/src/core/json_serialization_plugin.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.json_serialization_plugin`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.json_serialization_plugin")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/lazystring_json_provider.py
+++ b/yosai_intel_dashboard/src/core/lazystring_json_provider.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.lazystring_json_provider`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.lazystring_json_provider")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/logging.py
+++ b/yosai_intel_dashboard/src/core/logging.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.logging`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.logging")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/logging_config.py
+++ b/yosai_intel_dashboard/src/core/logging_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.logging_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.logging_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/master_callback_system.py
+++ b/yosai_intel_dashboard/src/core/master_callback_system.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.master_callback_system`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.master_callback_system")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/memory_manager.py
+++ b/yosai_intel_dashboard/src/core/memory_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.memory_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.memory_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/performance.py
+++ b/yosai_intel_dashboard/src/core/performance.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.performance`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.performance")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/performance_file_processor.py
+++ b/yosai_intel_dashboard/src/core/performance_file_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.performance_file_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.performance_file_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/performance_monitor.py
+++ b/yosai_intel_dashboard/src/core/performance_monitor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.performance_monitor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.performance_monitor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/protocols.py
+++ b/yosai_intel_dashboard/src/core/protocols.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.protocols`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.protocols")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/query_optimizer.py
+++ b/yosai_intel_dashboard/src/core/query_optimizer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.query_optimizer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.query_optimizer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/rbac.py
+++ b/yosai_intel_dashboard/src/core/rbac.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.rbac`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.rbac")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/secret_manager.py
+++ b/yosai_intel_dashboard/src/core/secret_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.secret_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.secret_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/secrets_validator.py
+++ b/yosai_intel_dashboard/src/core/secrets_validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.secrets_validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.secrets_validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/security.py
+++ b/yosai_intel_dashboard/src/core/security.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.security`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.security")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/security_patterns.py
+++ b/yosai_intel_dashboard/src/core/security_patterns.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.security_patterns`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.security_patterns")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/security_validator.py
+++ b/yosai_intel_dashboard/src/core/security_validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.security_validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.security_validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/service_container.py
+++ b/yosai_intel_dashboard/src/core/service_container.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.service_container`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.service_container")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/theme_manager.py
+++ b/yosai_intel_dashboard/src/core/theme_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.theme_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.theme_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/truly_unified_callbacks.py
+++ b/yosai_intel_dashboard/src/core/truly_unified_callbacks.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.truly_unified_callbacks`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.truly_unified_callbacks")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/unicode.py
+++ b/yosai_intel_dashboard/src/core/unicode.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.unicode`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.unicode")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/unicode_decode.py
+++ b/yosai_intel_dashboard/src/core/unicode_decode.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.unicode_decode`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.unicode_decode")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/unicode_enhanced.py
+++ b/yosai_intel_dashboard/src/core/unicode_enhanced.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.unicode_enhanced`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.unicode_enhanced")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/core/unicode_utils.py
+++ b/yosai_intel_dashboard/src/core/unicode_utils.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `core.unicode_utils`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("core.unicode_utils")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -14,8 +14,13 @@ __all__ = [
 from importlib import import_module
 
 
-def __getattr__(name: str):
-    if name in {"DatabaseError", "ConnectionRetryExhausted", "ConnectionValidationFailed", "UnicodeEncodingError"}:
+def __getattr__(name: str) -> object:
+    if name in {
+        "DatabaseError",
+        "ConnectionRetryExhausted",
+        "ConnectionValidationFailed",
+        "UnicodeEncodingError",
+    }:
         module = import_module(f"{__name__}.database_exceptions")
         return getattr(module, name)
     if name == "execute_secure_query":

--- a/yosai_intel_dashboard/src/infrastructure/config/app_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/app_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.app_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.app_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/base.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.base`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.base")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/base_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.base_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.base_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/base_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base_loader.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.base_loader`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.base_loader")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/cache_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/cache_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.cache_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.cache_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/cache_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/cache_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.cache_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.cache_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.complete_service_registration`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.complete_service_registration")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/config_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_loader.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.config_loader`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.config_loader")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.config_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.config_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/config_transformer.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_transformer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.config_transformer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.config_transformer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/config_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.config_validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.config_validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.connection_pool`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.connection_pool")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/connection_retry.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/connection_retry.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.connection_retry`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.connection_retry")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/constants.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/constants.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.constants`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.constants")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.database_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.database_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/dev_mode.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dev_mode.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.dev_mode`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.dev_mode")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.dynamic_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.dynamic_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/env_overrides.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/env_overrides.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.env_overrides`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.env_overrides")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/environment.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/environment.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.environment`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.environment")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/environment_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/environment_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.environment_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.environment_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.hierarchical_loader`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.hierarchical_loader")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/kafka_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/kafka_config.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.kafka_config`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.kafka_config")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/proto_adapter.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/proto_adapter.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.proto_adapter`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.proto_adapter")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/protocols.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/protocols.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.protocols`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.protocols")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/pydantic_models.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/pydantic_models.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.pydantic_models`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.pydantic_models")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.schema`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.schema")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/secrets_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secrets_validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.secrets_validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.secrets_validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.secure_config_manager`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.secure_config_manager")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/service_integration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/service_integration.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.service_integration`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.service_integration")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/service_registration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/service_registration.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.service_registration`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.service_registration")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.unicode_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.unicode_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/unified_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unified_loader.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.unified_loader`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.unified_loader")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/validate.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/validate.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.validate`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.validate")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/infrastructure/config/validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `config.validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("config.validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/ab_testing.py
+++ b/yosai_intel_dashboard/src/services/ab_testing.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.ab_testing`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.ab_testing")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/ai_device_generator.py
+++ b/yosai_intel_dashboard/src/services/ai_device_generator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.ai_device_generator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.ai_device_generator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/ai_mapping_store.py
+++ b/yosai_intel_dashboard/src/services/ai_mapping_store.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.ai_mapping_store`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.ai_mapping_store")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/ai_suggestions.py
+++ b/yosai_intel_dashboard/src/services/ai_suggestions.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.ai_suggestions`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.ai_suggestions")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/analytics_generator.py
+++ b/yosai_intel_dashboard/src/services/analytics_generator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.analytics_generator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.analytics_generator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/analytics_processing.py
+++ b/yosai_intel_dashboard/src/services/analytics_processing.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.analytics_processing`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.analytics_processing")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/analytics_processor.py
+++ b/yosai_intel_dashboard/src/services/analytics_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.analytics_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.analytics_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.analytics_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.analytics_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/analytics_summary.py
+++ b/yosai_intel_dashboard/src/services/analytics_summary.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.analytics_summary`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.analytics_summary")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/api_gateway_planner.py
+++ b/yosai_intel_dashboard/src/services/api_gateway_planner.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.api_gateway_planner`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.api_gateway_planner")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/async_file_processor.py
+++ b/yosai_intel_dashboard/src/services/async_file_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.async_file_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.async_file_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/base_database_service.py
+++ b/yosai_intel_dashboard/src/services/base_database_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.base_database_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.base_database_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/cached_analytics.py
+++ b/yosai_intel_dashboard/src/services/cached_analytics.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.cached_analytics`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.cached_analytics")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/chunked_analysis.py
+++ b/yosai_intel_dashboard/src/services/chunked_analysis.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.chunked_analysis`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.chunked_analysis")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/configuration_service.py
+++ b/yosai_intel_dashboard/src/services/configuration_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.configuration_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.configuration_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/data_enhancer.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.data_enhancer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.data_enhancer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/data_handler.py
+++ b/yosai_intel_dashboard/src/services/data_handler.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.data_handler`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.data_handler")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/database_analytics_service.py
+++ b/yosai_intel_dashboard/src/services/database_analytics_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.database_analytics_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.database_analytics_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/database_retriever.py
+++ b/yosai_intel_dashboard/src/services/database_retriever.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.database_retriever`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.database_retriever")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/db_analytics_helper.py
+++ b/yosai_intel_dashboard/src/services/db_analytics_helper.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.db_analytics_helper`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.db_analytics_helper")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/device_learning_service.py
+++ b/yosai_intel_dashboard/src/services/device_learning_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.device_learning_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.device_learning_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/door_mapping_service.py
+++ b/yosai_intel_dashboard/src/services/door_mapping_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.door_mapping_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.door_mapping_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/enhanced_column_classifier.py
+++ b/yosai_intel_dashboard/src/services/enhanced_column_classifier.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.enhanced_column_classifier`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.enhanced_column_classifier")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/event_publisher.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.event_publisher`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.event_publisher")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/event_streaming_service.py
+++ b/yosai_intel_dashboard/src/services/event_streaming_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.event_streaming_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.event_streaming_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/export_service.py
+++ b/yosai_intel_dashboard/src/services/export_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.export_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.export_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/feature_flags.py
+++ b/yosai_intel_dashboard/src/services/feature_flags.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.feature_flags`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.feature_flags")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/file_processor_service.py
+++ b/yosai_intel_dashboard/src/services/file_processor_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.file_processor_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.file_processor_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/index_optimizer_cli.py
+++ b/yosai_intel_dashboard/src/services/index_optimizer_cli.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.index_optimizer_cli`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.index_optimizer_cli")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/input_validator.py
+++ b/yosai_intel_dashboard/src/services/input_validator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.input_validator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.input_validator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/interfaces.py
+++ b/yosai_intel_dashboard/src/services/interfaces.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.interfaces`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.interfaces")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/kafka_consumer.py
+++ b/yosai_intel_dashboard/src/services/kafka_consumer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.kafka_consumer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.kafka_consumer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/kafka_producer.py
+++ b/yosai_intel_dashboard/src/services/kafka_producer.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.kafka_producer`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.kafka_producer")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
+++ b/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.metadata_enhancement_engine`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.metadata_enhancement_engine")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/microservices_architect.py
+++ b/yosai_intel_dashboard/src/services/microservices_architect.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.microservices_architect`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.microservices_architect")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/optimized_queries.py
+++ b/yosai_intel_dashboard/src/services/optimized_queries.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.optimized_queries`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.optimized_queries")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/progress_events.py
+++ b/yosai_intel_dashboard/src/services/progress_events.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.progress_events`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.progress_events")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/rabbitmq_client.py
+++ b/yosai_intel_dashboard/src/services/rabbitmq_client.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.rabbitmq_client`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.rabbitmq_client")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/registry.py
+++ b/yosai_intel_dashboard/src/services/registry.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.registry`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.registry")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/result_formatting.py
+++ b/yosai_intel_dashboard/src/services/result_formatting.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.result_formatting`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.result_formatting")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/stream_processor.py
+++ b/yosai_intel_dashboard/src/services/stream_processor.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.stream_processor`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.stream_processor")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/summary_report_generator.py
+++ b/yosai_intel_dashboard/src/services/summary_report_generator.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.summary_report_generator`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.summary_report_generator")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/summary_reporter.py
+++ b/yosai_intel_dashboard/src/services/summary_reporter.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.summary_reporter`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.summary_reporter")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/summary_reporting.py
+++ b/yosai_intel_dashboard/src/services/summary_reporting.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.summary_reporting`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.summary_reporting")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/task_queue.py
+++ b/yosai_intel_dashboard/src/services/task_queue.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.task_queue`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.task_queue")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/task_queue_protocol.py
+++ b/yosai_intel_dashboard/src/services/task_queue_protocol.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.task_queue_protocol`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.task_queue_protocol")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/unified_file_controller.py
+++ b/yosai_intel_dashboard/src/services/unified_file_controller.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.unified_file_controller`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.unified_file_controller")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/upload_data_service.py
+++ b/yosai_intel_dashboard/src/services/upload_data_service.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.upload_data_service`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.upload_data_service")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload_processing.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.upload_processing`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.upload_processing")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper for `config.database_exceptions`."""
+"""Compatibility wrapper for `services.websocket_server`."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ __all__: list[str] = []
 def _load() -> None:
     global _mod, __all__
     if _mod is None:
-        _mod = importlib.import_module("config.database_exceptions")
+        _mod = importlib.import_module("services.websocket_server")
         __all__ = getattr(
             _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
         )


### PR DESCRIPTION
## Summary
- create lightweight wrappers in `src` packages to re-export modules from their original locations
- annotate `__getattr__` in infrastructure config

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}')` *(fails: bandit)*

------
https://chatgpt.com/codex/tasks/task_e_688380cbe7c88320bf925f8ea27a0932