### PR TITLE
Use centralized file validator

### DIFF
--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -18,6 +18,7 @@ from analytics_core.utils.unicode_processor import UnicodeHelper
 from services.data_processing.unified_file_validator import (
     safe_decode_with_unicode_handling,
 )
+from validation import FileValidator
 from utils.protocols import SafeDecoderProtocol
 from utils.memory_utils import memory_safe
 
@@ -57,46 +58,26 @@ class FileProcessorService(BaseService):
         self,
         config: ConfigurationServiceProtocol,
         decoder: SafeDecoderProtocol = safe_decode_with_unicode_handling,
+        validator: FileValidator | None = None,
     ) -> None:
         super().__init__("file-processor", "")
         self.start()
         self.config = config
         self.max_file_size_mb = config.get_max_upload_size_mb()
         self._decoder = decoder
+        self._validator = validator or FileValidator(
+            max_size_mb=self.max_file_size_mb,
+            allowed_ext=self.ALLOWED_EXTENSIONS,
+        )
 
     def _do_initialize(self) -> None:
         """Initialize file processor"""
         pass  # No special initialization needed
 
     def validate_file(self, filename: str, content: bytes) -> Dict[str, Any]:
-        """Validate uploaded file"""
+        """Validate uploaded file using :class:`FileValidator`."""
         filename = UnicodeHelper.clean_text(filename)
-        issues = []
-
-        # Check file extension
-        file_ext = Path(filename).suffix.lower()
-        if file_ext not in self.ALLOWED_EXTENSIONS:
-            issues.append(
-                f"File type {file_ext} not allowed. Allowed: {self.ALLOWED_EXTENSIONS}"
-            )
-
-        # Check file size
-        size_mb = len(content) / (1024 * 1024)
-        if size_mb > self.max_file_size_mb:
-            issues.append(
-                f"File too large: {size_mb:.1f}MB > {self.max_file_size_mb}MB"
-            )
-
-        # Check for empty file
-        if len(content) == 0:
-            issues.append("File is empty")
-
-        return {
-            "valid": len(issues) == 0,
-            "issues": issues,
-            "size_mb": size_mb,
-            "extension": file_ext,
-        }
+        return self._validator.validate_file_upload(filename, content)
 
     @memory_safe(max_memory_mb=500)
     def process_file(self, file_content: bytes, filename: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- inject `FileValidator` into `FileProcessorService`
- delegate validation to `FileValidator.validate_file_upload`

## Testing
- `pytest tests/test_validation_framework.py::test_file_validator_rules -q` *(fails: ImportError: cannot import name 'execute_secure_query')*

------
https://chatgpt.com/codex/tasks/task_e_68838fe1ba248320b659df2246621e9c