### PR TITLE
Remove duplicate unicode decoder

### DIFF
--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -9,15 +9,17 @@ from config.dynamic_config import dynamic_config
 from config.constants import DEFAULT_CHUNK_SIZE
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode import process_large_csv_content, sanitize_for_utf8, sanitize_dataframe
+from core.unicode import (
+    process_large_csv_content,
+    sanitize_for_utf8,
+    sanitize_dataframe,
+)
 from services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,
 )
-from services.data_processing.unified_upload_validator import (
-    UnifiedUploadValidator,
-    safe_decode_with_unicode_handling,
-)
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from utils.file_utils import safe_decode_with_unicode_handling
 from upload_types import ValidationResult
 
 

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -17,7 +17,12 @@ from config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
-from core.unicode import UnicodeProcessor, sanitize_dataframe, sanitize_for_utf8, safe_unicode_decode
+from core.unicode import (
+    UnicodeProcessor,
+    sanitize_dataframe,
+    sanitize_for_utf8,
+    safe_unicode_decode,
+)
 from upload_types import ValidationResult
 from .unified_upload_validator import UnifiedUploadValidator
 from .common import process_dataframe
@@ -49,15 +54,6 @@ ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 
 
 logger = logging.getLogger(__name__)
-
-
-def safe_decode_with_unicode_handling(data: bytes, encoding: str) -> str:
-    """Decode bytes using ``encoding`` and sanitize output."""
-
-    text = safe_unicode_decode(data, encoding)
-
-    cleaned = sanitize_for_utf8(text)
-    return cleaned.replace("\ufffd", "")
 
 
 def safe_decode_file(contents: str) -> Optional[bytes]:
@@ -159,7 +155,9 @@ class UnifiedFileValidator:
         if max_size_mb is not None:
             self.max_size_mb = max_size_mb
         self._string_validator = _lazy_string_validator()
-        self._basic_validator = UnifiedUploadValidator(self.max_size_mb, config=self.config)
+        self._basic_validator = UnifiedUploadValidator(
+            self.max_size_mb, config=self.config
+        )
 
     def _sanitize_string(self, value: str) -> str:
         cleaned = sanitize_for_utf8(str(value))
@@ -269,7 +267,6 @@ class UnifiedFileValidator:
 __all__ = [
     "UnifiedFileValidator",
     "ValidationResult",
-    "safe_decode_with_unicode_handling",
     "safe_decode_file",
     "process_dataframe",
     "validate_dataframe_content",

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -15,9 +15,7 @@ from services.configuration_service import ConfigurationServiceProtocol
 from .stream_processor import StreamProcessor
 from core.unicode import process_large_csv_content
 from analytics_core.utils.unicode_processor import UnicodeHelper
-from services.data_processing.unified_file_validator import (
-    safe_decode_with_unicode_handling,
-)
+from utils.file_utils import safe_decode_with_unicode_handling
 from utils.protocols import SafeDecoderProtocol
 from utils.memory_utils import memory_safe
 
@@ -243,4 +241,3 @@ class FileProcessorService(BaseService):
 
         printable = sum(1 for c in text if c.isprintable() or c.isspace())
         return (printable / len(text)) > 0.7
-


### PR DESCRIPTION
## Summary
- deduplicate safe_decode_with_unicode_handling implementation
- update imports to use utils.file_utils version
- remove obsolete export from unified_file_validator

## Testing
- `black utils/file_utils.py services/data_processing/unified_file_validator.py services/data_processing/file_handler.py services/file_processor_service.py`
- `pytest -q` *(fails: ImportError: cannot import name 'execute_secure_query')*

------
https://chatgpt.com/codex/tasks/task_e_688391ce25648320b15322d1e40aec3d