### PR TITLE
Introduce UnicodeValidator protocol

### DIFF
--- a/analytics/access_trends.py
+++ b/analytics/access_trends.py
@@ -106,14 +106,14 @@ class AccessTrendsAnalyzer:
         df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
-        from security.unicode_security_handler import UnicodeSecurityHandler
+        from validation import UnicodeValidator
+
+        validator = UnicodeValidator()
 
         string_columns = df_clean.select_dtypes(include=["object"]).columns
         for col in string_columns:
             df_clean[col] = (
-                df_clean[col]
-                .astype(str)
-                .apply(UnicodeSecurityHandler.sanitize_unicode_input)
+                df_clean[col].astype(str).apply(validator.validate_text)
             )
 
         # Convert timestamp

--- a/analytics/feature_extraction.py
+++ b/analytics/feature_extraction.py
@@ -5,7 +5,9 @@ from typing import Optional
 
 import pandas as pd
 
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation import UnicodeValidator
+
+_validator = UnicodeValidator()
 
 __all__ = ["extract_event_features"]
 
@@ -25,7 +27,7 @@ def extract_event_features(
         string_cols = df_clean.select_dtypes(include=["object"]).columns
         for col in string_cols:
             df_clean[col] = df_clean[col].astype(str).apply(
-                UnicodeSecurityHandler.sanitize_unicode_input
+                _validator.validate_text
             )
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("Unicode sanitization failed: %s", exc)

--- a/analytics/security_patterns/data_prep.py
+++ b/analytics/security_patterns/data_prep.py
@@ -19,14 +19,14 @@ def prepare_security_data(
     df_clean = df.copy(deep=False)
 
     # Handle Unicode issues
-    from security.unicode_security_handler import UnicodeSecurityHandler
+    from validation import UnicodeValidator
+
+    validator = UnicodeValidator()
 
     string_columns = df_clean.select_dtypes(include=["object"]).columns
     for col in string_columns:
         df_clean[col] = (
-            df_clean[col]
-            .astype(str)
-            .apply(UnicodeSecurityHandler.sanitize_unicode_input)
+            df_clean[col].astype(str).apply(validator.validate_text)
         )
 
     # Ensure required columns exist

--- a/analytics/security_score_calculator.py
+++ b/analytics/security_score_calculator.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas import Series, DataFrame
 
 # Unicode-safe string handling
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation import UnicodeValidator
 
 
 @dataclass
@@ -51,10 +51,11 @@ class SecurityScoreCalculator:
     def __init__(self, config: Optional[SecurityCalculationConfig] = None):
         self.config = config or SecurityCalculationConfig()
         self.logger = logging.getLogger(__name__)
+        self.validator = UnicodeValidator()
 
     def sanitize_unicode_text(self, text: str) -> str:
-        """Sanitize ``text`` using the shared security handler."""
-        return UnicodeSecurityHandler.sanitize_unicode_input(text)
+        """Sanitize ``text`` using :class:`UnicodeValidator`."""
+        return self.validator.validate_text(text)
 
     def validate_dataframe(self, df: pd.DataFrame) -> Tuple[bool, str]:
         """Validate required columns exist and add missing ones"""

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -158,14 +158,14 @@ class UserBehaviorAnalyzer:
         df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
-        from security.unicode_security_handler import UnicodeSecurityHandler
+        from validation import UnicodeValidator
+
+        validator = UnicodeValidator()
 
         string_columns = df_clean.select_dtypes(include=["object"]).columns
         for col in string_columns:
             df_clean[col] = (
-                df_clean[col]
-                .astype(str)
-                .apply(UnicodeSecurityHandler.sanitize_unicode_input)
+                df_clean[col].astype(str).apply(validator.validate_text)
             )
 
         # Ensure required columns

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -8,6 +8,7 @@ from core.exceptions import ValidationError
 from .attack_detection import AttackDetection
 from .secrets_validator import SecretsValidator, register_health_endpoint
 from .unicode_security_validator import UnicodeSecurityValidator
+from validation import UnicodeValidator
 from .validation_exceptions import SecurityViolation
 from .secure_query_wrapper import (
     execute_secure_sql,
@@ -43,6 +44,7 @@ __all__ = [
 
     # Specialized validators
     "UnicodeSecurityValidator",
+    "UnicodeValidator",
     "UnicodeSurrogateValidator",
     "SurrogateHandlingConfig",
 

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - optional AI suggestions
         return {}
 
 
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation import UnicodeValidator
 from services.interfaces import get_upload_data_service
 from utils.preview_utils import serialize_dataframe_preview
 
@@ -110,8 +110,9 @@ def get_analysis_type_options() -> List[Dict[str, str]]:
 
 def clean_analysis_data_unicode(df: pd.DataFrame) -> pd.DataFrame:
     """Return DataFrame sanitized for Unicode issues."""
+    validator = UnicodeValidator()
     try:
-        return UnicodeSecurityHandler.sanitize_dataframe(df)
+        return validator.validate_dataframe(df)
     except Exception as exc:  # pragma: no cover - best effort
         logger.exception("Unicode sanitization failed: %s", exc)
         return df

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -4,6 +4,7 @@ from .core import ValidationResult, Validator
 from .factory import create_file_validator, create_security_validator
 from .file_validator import FileValidator
 from .security_validator import SecurityValidator
+from .unicode_validator import UnicodeValidator
 from .rules import CompositeValidator, ValidationRule
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "ValidationRule",
     "CompositeValidator",
     "SecurityValidator",
+    "UnicodeValidator",
     "FileValidator",
     "create_file_validator",
     "create_security_validator",

--- a/validation/unicode_validator.py
+++ b/validation/unicode_validator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Central Unicode validation utilities."""
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+import re
+import unicodedata
+
+import pandas as pd  # type: ignore[import]
+
+from security.unicode_security_validator import (
+    UnicodeSecurityValidator,
+    UnicodeSecurityConfig,
+)
+
+_DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
+
+
+@runtime_checkable
+class UnicodeValidatorProtocol(Protocol):
+    """Protocol for Unicode validation operations."""
+
+    def validate_text(self, text: Any) -> str:
+        """Return sanitized Unicode text."""
+
+    def validate_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return ``df`` with all object columns sanitized."""
+
+
+@dataclass
+class UnicodeValidator(UnicodeValidatorProtocol):
+    """Enterprise Unicode validator using :class:`UnicodeSecurityValidator`."""
+
+    config: UnicodeSecurityConfig = UnicodeSecurityConfig()
+
+    def __post_init__(self) -> None:
+        self._validator = UnicodeSecurityValidator(config=self.config)
+
+    # ------------------------------------------------------------------
+    def validate_text(self, text: Any) -> str:
+        sanitized = self._validator.validate_and_sanitize(text)
+        try:
+            sanitized = unicodedata.normalize(self.config.normalize_form, sanitized)
+        except Exception:
+            pass
+        return _DANGEROUS_PREFIX_RE.sub("", sanitized)
+
+    # ------------------------------------------------------------------
+    def validate_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self._validator.validate_dataframe(df)
+
+
+__all__ = ["UnicodeValidator", "UnicodeValidatorProtocol"]


### PR DESCRIPTION
## Summary
- add `UnicodeValidator` implementing a protocol-based validator
- export through `validation` and reference from `security`
- switch modules to use the new validator over ad-hoc handlers

## Testing
- `pytest -q` *(fails: ImportError missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688392272c908320925bacaaa8bdfa4d