### PR TITLE
Introduce UnicodeValidator protocol

### DIFF
--- a/analytics/access_trends.py
+++ b/analytics/access_trends.py
@@ -106,15 +106,9 @@ class AccessTrendsAnalyzer:
         df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
-        from security.unicode_security_handler import UnicodeSecurityHandler
+        from validation.unicode_validator import UnicodeValidator
 
-        string_columns = df_clean.select_dtypes(include=["object"]).columns
-        for col in string_columns:
-            df_clean[col] = (
-                df_clean[col]
-                .astype(str)
-                .apply(UnicodeSecurityHandler.sanitize_unicode_input)
-            )
+        df_clean = UnicodeValidator().validate_dataframe(df_clean)
 
         # Convert timestamp
         if not pd.api.types.is_datetime64_any_dtype(df_clean["timestamp"]):

--- a/analytics/feature_extraction.py
+++ b/analytics/feature_extraction.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import pandas as pd
 
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation.unicode_validator import UnicodeValidator
 
 __all__ = ["extract_event_features"]
 
@@ -22,11 +22,8 @@ def extract_event_features(
 
     # Sanitize string columns
     try:
-        string_cols = df_clean.select_dtypes(include=["object"]).columns
-        for col in string_cols:
-            df_clean[col] = df_clean[col].astype(str).apply(
-                UnicodeSecurityHandler.sanitize_unicode_input
-            )
+        validator = UnicodeValidator()
+        df_clean = validator.validate_dataframe(df_clean)
     except Exception as exc:  # pragma: no cover - log and continue
         logger.warning("Unicode sanitization failed: %s", exc)
 

--- a/analytics/security_patterns/data_prep.py
+++ b/analytics/security_patterns/data_prep.py
@@ -19,15 +19,10 @@ def prepare_security_data(
     df_clean = df.copy(deep=False)
 
     # Handle Unicode issues
-    from security.unicode_security_handler import UnicodeSecurityHandler
+    from validation.unicode_validator import UnicodeValidator
 
-    string_columns = df_clean.select_dtypes(include=["object"]).columns
-    for col in string_columns:
-        df_clean[col] = (
-            df_clean[col]
-            .astype(str)
-            .apply(UnicodeSecurityHandler.sanitize_unicode_input)
-        )
+    validator = UnicodeValidator()
+    df_clean = validator.validate_dataframe(df_clean)
 
     # Ensure required columns exist
     required_cols = ["timestamp", "person_id", "door_id", "access_result"]

--- a/analytics/security_score_calculator.py
+++ b/analytics/security_score_calculator.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas import Series, DataFrame
 
 # Unicode-safe string handling
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation.unicode_validator import UnicodeValidator
 
 
 @dataclass
@@ -51,10 +51,11 @@ class SecurityScoreCalculator:
     def __init__(self, config: Optional[SecurityCalculationConfig] = None):
         self.config = config or SecurityCalculationConfig()
         self.logger = logging.getLogger(__name__)
+        self._validator = UnicodeValidator()
 
     def sanitize_unicode_text(self, text: str) -> str:
-        """Sanitize ``text`` using the shared security handler."""
-        return UnicodeSecurityHandler.sanitize_unicode_input(text)
+        """Sanitize ``text`` using :class:`UnicodeValidator`."""
+        return self._validator.validate_text(text)
 
     def validate_dataframe(self, df: pd.DataFrame) -> Tuple[bool, str]:
         """Validate required columns exist and add missing ones"""

--- a/analytics/user_behavior.py
+++ b/analytics/user_behavior.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+from validation.unicode_validator import UnicodeValidator
 
 from monitoring.model_performance_monitor import (
     ModelMetrics,
@@ -17,6 +18,8 @@ KMeans = optional_import("sklearn.cluster.KMeans")
 DataConversionWarning = optional_import("sklearn.exceptions.DataConversionWarning")
 silhouette_score = optional_import("sklearn.metrics.silhouette_score")
 StandardScaler = optional_import("sklearn.preprocessing.StandardScaler")
+
+_validator = UnicodeValidator()
 
 if KMeans is None:  # pragma: no cover - fallback definitions
 
@@ -158,15 +161,7 @@ class UserBehaviorAnalyzer:
         df_clean = df.copy(deep=False)
 
         # Handle Unicode issues
-        from security.unicode_security_handler import UnicodeSecurityHandler
-
-        string_columns = df_clean.select_dtypes(include=["object"]).columns
-        for col in string_columns:
-            df_clean[col] = (
-                df_clean[col]
-                .astype(str)
-                .apply(UnicodeSecurityHandler.sanitize_unicode_input)
-            )
+        df_clean = _validator.validate_dataframe(df_clean)
 
         # Ensure required columns
         required_cols = ["timestamp", "person_id", "door_id", "access_result"]

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -22,6 +22,10 @@ def __getattr__(name: str):
         from validation.security_validator import SecurityValidator as _SV
 
         return _SV
+    if name == "UnicodeValidator":
+        from validation.unicode_validator import UnicodeValidator as _UV
+
+        return _UV
     if name in {"UnicodeSurrogateValidator", "SurrogateHandlingConfig"}:
         from .unicode_surrogate_validator import (
             SurrogateHandlingConfig as _SHC,
@@ -43,6 +47,7 @@ __all__ = [
 
     # Specialized validators
     "UnicodeSecurityValidator",
+    "UnicodeValidator",
     "UnicodeSurrogateValidator",
     "SurrogateHandlingConfig",
 

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -22,7 +22,7 @@ except Exception:  # pragma: no cover - optional AI suggestions
         return {}
 
 
-from security.unicode_security_handler import UnicodeSecurityHandler
+from validation.unicode_validator import UnicodeValidator
 from services.interfaces import get_upload_data_service
 from utils.preview_utils import serialize_dataframe_preview
 
@@ -111,7 +111,7 @@ def get_analysis_type_options() -> List[Dict[str, str]]:
 def clean_analysis_data_unicode(df: pd.DataFrame) -> pd.DataFrame:
     """Return DataFrame sanitized for Unicode issues."""
     try:
-        return UnicodeSecurityHandler.sanitize_dataframe(df)
+        return UnicodeValidator().validate_dataframe(df)
     except Exception as exc:  # pragma: no cover - best effort
         logger.exception("Unicode sanitization failed: %s", exc)
         return df

--- a/utils/scipy_compat.py
+++ b/utils/scipy_compat.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import unicodedata
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+from validation.unicode_validator import UnicodeValidator
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -20,23 +20,18 @@ __all__ = [
 ]
 
 
+_validator = UnicodeValidator()
+
+
 def sanitize_unicode_data(data: Any) -> Any:
-    """Sanitize data to handle Unicode surrogate characters."""
+    """Sanitize data recursively using :class:`UnicodeValidator`."""
     if isinstance(data, str):
-        try:
-            # Remove surrogate characters that can't be encoded in UTF-8
-            cleaned = data.encode('utf-8', 'replace').decode('utf-8')
-            # Normalize Unicode characters
-            cleaned = unicodedata.normalize('NFKC', cleaned)
-            return cleaned
-        except (UnicodeError, ValueError):
-            # Fallback: remove all non-ASCII characters
-            return ''.join(char for char in data if ord(char) < 128)
-    elif isinstance(data, dict):
+        return _validator.validate_text(data)
+    if isinstance(data, dict):
         return {key: sanitize_unicode_data(value) for key, value in data.items()}
-    elif isinstance(data, list):
+    if isinstance(data, list):
         return [sanitize_unicode_data(item) for item in data]
-    elif isinstance(data, tuple):
+    if isinstance(data, tuple):
         return tuple(sanitize_unicode_data(item) for item in data)
     return data
 

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -4,6 +4,7 @@ from .core import ValidationResult, Validator
 from .factory import create_file_validator, create_security_validator
 from .file_validator import FileValidator
 from .security_validator import SecurityValidator
+from .unicode_validator import UnicodeValidator
 from .rules import CompositeValidator, ValidationRule
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "Validator",
     "ValidationRule",
     "CompositeValidator",
+    "UnicodeValidator",
     "SecurityValidator",
     "FileValidator",
     "create_file_validator",

--- a/validation/unicode_validator.py
+++ b/validation/unicode_validator.py
@@ -1,0 +1,39 @@
+"""Unicode validation protocol and default implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import pandas as pd
+
+from security.unicode_security_validator import UnicodeSecurityValidator, UnicodeSecurityConfig
+
+
+class UnicodeValidatorProtocol(Protocol):
+    """Protocol for Unicode validation operations."""
+
+    def validate_text(self, text: Any) -> str:
+        """Return sanitized ``text``."""
+
+    def validate_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return sanitized copy of ``df``."""
+
+
+@dataclass
+class UnicodeValidator(UnicodeValidatorProtocol):
+    """Concrete Unicode validator using :class:`UnicodeSecurityValidator`."""
+
+    validator: UnicodeSecurityValidator
+
+    def __init__(self, config: UnicodeSecurityConfig | None = None) -> None:
+        self.validator = UnicodeSecurityValidator(config=config)
+
+    def validate_text(self, text: Any) -> str:
+        return self.validator.validate_and_sanitize(text)
+
+    def validate_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.validator.validate_dataframe(df)
+
+
+__all__ = ["UnicodeValidator", "UnicodeValidatorProtocol"]


### PR DESCRIPTION
## Summary
- add a new UnicodeValidator protocol with a default implementation
- export UnicodeValidator from the validation package and reference it from the security package
- refactor utils and analytics modules to use UnicodeValidator for Unicode sanitation

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'execute_secure_query' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68839251161083208e83d9499d2ec1bc