### PR TITLE
Add shared DataValidator for analytics

### DIFF
--- a/services/analytics/upload_analytics.py
+++ b/services/analytics/upload_analytics.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from core.security_validator import SecurityValidator
+from validation.data_validator import DataValidator, DataValidatorProtocol
 from services.analytics_summary import summarize_dataframe
 from services.chunked_analysis import analyze_with_chunking
 from services.upload_processing import (
@@ -26,9 +26,10 @@ def summarize_dataframes(dfs: List[pd.DataFrame]) -> Dict[str, Any]:
 
 
 def run_anomaly_detection(
-    df: pd.DataFrame, validator: SecurityValidator
+    df: pd.DataFrame, validator: DataValidatorProtocol | None = None
 ) -> Dict[str, Any]:
     """Run anomaly detection using chunked analysis."""
+    validator = validator or DataValidator(required_columns=["timestamp", "person_id"])
     return analyze_with_chunking(df, validator, ["anomaly"])
 
 

--- a/services/chunked_analysis.py
+++ b/services/chunked_analysis.py
@@ -11,6 +11,7 @@ from dask.distributed import Client, LocalCluster
 
 from analytics.chunked_analytics_controller import ChunkedAnalyticsController
 from config.config import get_analytics_config
+from validation.data_validator import DataValidator
 from validation.security_validator import SecurityValidator
 
 from .result_formatting import regular_analysis
@@ -25,6 +26,10 @@ def _validate_dataframe(
     original_rows = len(df)
     csv_bytes = df.to_csv(index=False).encode("utf-8")
     validator.validate_file_upload("data.csv", csv_bytes)
+    df_validator = DataValidator(required_columns=["timestamp", "person_id"])
+    result = df_validator.validate_dataframe(df)
+    if not result.valid:
+        raise ValueError("; ".join(result.issues or []))
     needs_chunking = True
     validated_rows = len(df)
     logger.info(

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from validation.data_validator import DataValidator
+
+
+def test_data_validator_missing_cols():
+    df = pd.DataFrame({"a": [1]})
+    validator = DataValidator(required_columns=["a", "b"])
+    result = validator.validate_dataframe(df)
+    assert not result.valid
+    assert "missing_columns" in result.issues[0]
+
+
+def test_data_validator_empty_df():
+    df = pd.DataFrame()
+    validator = DataValidator()
+    result = validator.validate_dataframe(df)
+    assert not result.valid
+    assert "empty_dataframe" in result.issues
+
+
+def test_data_validator_suspicious_columns():
+    df = pd.DataFrame({"=cmd": [1], "b": [2]})
+    validator = DataValidator()
+    result = validator.validate_dataframe(df)
+    assert not result.valid
+    assert any("suspicious_column_names" in issue for issue in result.issues)

--- a/utils/scipy_compat.py
+++ b/utils/scipy_compat.py
@@ -7,6 +7,8 @@ import unicodedata
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from validation.data_validator import DataValidator, DataValidatorProtocol
+
 import numpy as np
 import pandas as pd
 logger = logging.getLogger(__name__)
@@ -43,9 +45,16 @@ def sanitize_unicode_data(data: Any) -> Any:
 
 class StatisticalAnomalyDetector:
     """Modular statistical anomaly detector with Unicode safety."""
-    
-    def __init__(self, logger: Optional[logging.Logger] = None):
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        validator: DataValidatorProtocol | None = None,
+    ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.validator = validator or DataValidator(
+            required_columns=["timestamp", "person_id"]
+        )
     
     def _safe_zscore_calculation(self, data: np.ndarray) -> np.ndarray:
         """Calculate Z-scores with error handling."""
@@ -67,25 +76,13 @@ class StatisticalAnomalyDetector:
             self.logger.warning(f"Z-score calculation failed: {e}")
             return np.zeros_like(data)
     
-    def _validate_dataframe(self, df: pd.DataFrame) -> bool:
-        """Validate DataFrame for anomaly detection."""
-        required_columns = ['timestamp', 'person_id']
-        
-        if df.empty:
-            self.logger.warning("Empty DataFrame provided")
-            return False
-        
-        missing_cols = [col for col in required_columns if col not in df.columns]
-        if missing_cols:
-            self.logger.warning(f"Missing required columns: {missing_cols}")
-            return False
-        
-        return True
-    
     def detect_frequency_anomalies(self, df: pd.DataFrame) -> List[Dict[str, Any]]:
         """Detect frequency-based anomalies with Unicode safety."""
-        if not self._validate_dataframe(df):
+        result = self.validator.validate_dataframe(df)
+        if not result.valid:
+            self.logger.warning("; ".join(result.issues or []))
             return []
+        df = result.sanitized if result.sanitized is not None else df
         
         anomalies: List[Dict[str, Any]] = []
         
@@ -144,8 +141,11 @@ class StatisticalAnomalyDetector:
     
     def detect_statistical_anomalies(self, df: pd.DataFrame, sensitivity: float) -> List[Dict[str, Any]]:
         """Detect statistical anomalies using Z-score and IQR methods with Unicode safety."""
-        if not self._validate_dataframe(df):
+        result = self.validator.validate_dataframe(df)
+        if not result.valid:
+            self.logger.warning("; ".join(result.issues or []))
             return []
+        df = result.sanitized if result.sanitized is not None else df
         
         anomalies: List[Dict[str, Any]] = []
         

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -4,6 +4,13 @@ from .core import ValidationResult, Validator
 from .factory import create_file_validator, create_security_validator
 from .file_validator import FileValidator
 from .security_validator import SecurityValidator
+from .data_validator import (
+    DataValidator,
+    DataValidatorProtocol,
+    EmptyDataRule,
+    MissingColumnsRule,
+    SuspiciousColumnNameRule,
+)
 from .rules import CompositeValidator, ValidationRule
 
 __all__ = [
@@ -13,6 +20,11 @@ __all__ = [
     "CompositeValidator",
     "SecurityValidator",
     "FileValidator",
+    "DataValidator",
+    "DataValidatorProtocol",
+    "MissingColumnsRule",
+    "EmptyDataRule",
+    "SuspiciousColumnNameRule",
     "create_file_validator",
     "create_security_validator",
 ]

--- a/validation/data_validator.py
+++ b/validation/data_validator.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+import pandas as pd
+
+from .core import ValidationResult
+from .rules import CompositeValidator, ValidationRule
+
+
+class DataValidatorProtocol(Protocol):
+    """Protocol for dataframe validators."""
+
+    def validate_dataframe(self, df: pd.DataFrame) -> ValidationResult:
+        ...
+
+
+class DataValidationRule(ValidationRule, Protocol):
+    """Rule interface specialized for :class:`pandas.DataFrame`."""
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:  # type: ignore[override]
+        ...
+
+
+class MissingColumnsRule(DataValidationRule):
+    def __init__(self, required: Iterable[str]) -> None:
+        self.required = list(required)
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:  # type: ignore[override]
+        missing = [c for c in self.required if c not in df.columns]
+        if missing:
+            return ValidationResult(False, df, [f"missing_columns:{','.join(missing)}"])
+        return ValidationResult(True, df)
+
+
+class EmptyDataRule(DataValidationRule):
+    def validate(self, df: pd.DataFrame) -> ValidationResult:  # type: ignore[override]
+        if df.empty:
+            return ValidationResult(False, df, ["empty_dataframe"])
+        return ValidationResult(True, df)
+
+
+class SuspiciousColumnNameRule(DataValidationRule):
+    def __init__(self, prefixes: Iterable[str] | None = None) -> None:
+        self.prefixes = [p.lower() for p in (prefixes or ["=", "+", "-", "@", "cmd", "system"])]
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:  # type: ignore[override]
+        suspicious = [c for c in df.columns if any(str(c).lower().startswith(p) for p in self.prefixes)]
+        if suspicious:
+            return ValidationResult(False, df, [f"suspicious_column_names:{','.join(map(str, suspicious))}"])
+        return ValidationResult(True, df)
+
+
+class DataValidator(CompositeValidator, DataValidatorProtocol):
+    """Validate pandas DataFrames using configurable rules."""
+
+    def __init__(
+        self,
+        required_columns: Iterable[str] | None = None,
+        suspicious_prefixes: Iterable[str] | None = None,
+        extra_rules: Iterable[DataValidationRule] | None = None,
+    ) -> None:
+        rules: list[ValidationRule] = [EmptyDataRule()]
+        if required_columns:
+            rules.append(MissingColumnsRule(required_columns))
+        rules.append(SuspiciousColumnNameRule(suspicious_prefixes))
+        if extra_rules:
+            rules.extend(extra_rules)
+        super().__init__(rules)
+
+    def validate_dataframe(self, df: pd.DataFrame) -> ValidationResult:
+        return self.validate(df)
+
+
+__all__ = [
+    "DataValidatorProtocol",
+    "DataValidationRule",
+    "MissingColumnsRule",
+    "EmptyDataRule",
+    "SuspiciousColumnNameRule",
+    "DataValidator",
+]


### PR DESCRIPTION
## Summary
- add `DataValidator` with rules for empty data, missing columns and suspicious names
- expose validator utilities from `validation` package
- use `DataValidator` in `scipy_compat` detector and chunked analysis
- default to validator in `run_anomaly_detection`
- test the new validator

## Testing
- `pytest tests/test_data_validator.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_688392cb132c83209a46f32f972b367d