### PR TITLE
Add @override decorators

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -12,6 +12,11 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol
 
+try:  # Python 3.12+
+    from typing import override
+except ImportError:  # pragma: no cover - fallback for older versions
+    from typing_extensions import override
+
 import pandas as pd
 
 from config.dynamic_config import dynamic_config
@@ -216,6 +221,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
         """Get analytics from database."""
         return self.database_retriever.get_analytics()
 
+    @override
     @cache_with_lock(_cache_manager, ttl=300)
     def get_dashboard_summary(self) -> Dict[str, Any]:
         """Get a basic dashboard summary"""
@@ -328,15 +334,18 @@ class AnalyticsService(AnalyticsServiceProtocol):
     # ------------------------------------------------------------------
     # AnalyticsProviderProtocol implementation
     # ------------------------------------------------------------------
+    @override
     def process_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Alias for :meth:`process_data` required by ``AnalyticsProviderProtocol``."""
         return self.process_data(df)
 
+    @override
     def process_data(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Process ``df`` and return a metrics dictionary."""
         cleaned = self.clean_uploaded_dataframe(df)
         return self.summarize_dataframe(cleaned)
 
+    @override
     def get_metrics(self) -> Dict[str, Any]:
         """Return current analytics metrics."""
         return self.get_analytics_status()
@@ -344,6 +353,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
     # ------------------------------------------------------------------
     # Placeholder implementations for abstract methods
     # ------------------------------------------------------------------
+    @override
     def analyze_access_patterns(
         self, days: int, user_id: str | None = None
     ) -> Dict[str, Any]:
@@ -355,6 +365,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
         )
         return {"patterns": [], "days": days, "user_id": user_id}
 
+    @override
     def detect_anomalies(
         self, data: pd.DataFrame, sensitivity: float = 0.5
     ) -> List[Dict[str, Any]]:
@@ -362,6 +373,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
         logger.debug("detect_anomalies called with sensitivity=%s", sensitivity)
         return []
 
+    @override
     def generate_report(
         self, report_type: str, params: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/services/metadata_enhancement_engine.py
+++ b/services/metadata_enhancement_engine.py
@@ -29,6 +29,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Protocol, runtime_checkable
 
+try:  # Python 3.12+
+    from typing import override
+except ImportError:  # pragma: no cover - fallback for older versions
+    from typing_extensions import override
+
 import pandas as pd
 
 from core.service_container import ServiceContainer
@@ -127,6 +132,7 @@ class MetadataEnhancementEngine(MetadataEnhancementProtocol):
         self.compliance = ComplianceChecker()
 
     # ------------------------------------------------------------------
+    @override
     def enhance_metadata(self) -> Dict[str, Any]:
         """Run enhancement pipeline and return aggregated results."""
         uploaded = self.upload_data_service.get_uploaded_data()

--- a/services/upload_data_service.py
+++ b/services/upload_data_service.py
@@ -1,6 +1,11 @@
 import logging
 from typing import Any, Dict, List
 
+try:  # Python 3.12+
+    from typing import override
+except ImportError:  # pragma: no cover - fallback for older versions
+    from typing_extensions import override
+
 import pandas as pd
 
 from core.service_container import ServiceContainer
@@ -17,19 +22,24 @@ class UploadDataService(UploadDataServiceProtocol):
     def __init__(self, store: UploadedDataStore = uploaded_data_store) -> None:
         self.store = store
 
+    @override
     def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
         return self.store.get_all_data()
 
+    @override
     def get_uploaded_filenames(self) -> List[str]:
         return self.store.get_filenames()
 
+    @override
     def clear_uploaded_data(self) -> None:
         self.store.clear_all()
         logger.info("Uploaded data cleared")
 
+    @override
     def get_file_info(self) -> Dict[str, Dict[str, Any]]:
         return self.store.get_file_info()
 
+    @override
     def load_dataframe(self, filename: str) -> pd.DataFrame:
         return self.store.load_dataframe(filename)
 


### PR DESCRIPTION
## Summary
- import `override` with fallback to `typing_extensions`
- annotate protocol implementations in analytics, upload service, and metadata engine

## Testing
- `pytest tests/test_upload_data_service.py -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_68839650b96083209ba60a7ba38a97cc