### PR TITLE
Add centralized DataValidator for analytics

### DIFF
--- a/services/chunked_analysis.py
+++ b/services/chunked_analysis.py
@@ -12,6 +12,7 @@ from dask.distributed import Client, LocalCluster
 from analytics.chunked_analytics_controller import ChunkedAnalyticsController
 from config.config import get_analytics_config
 from validation.security_validator import SecurityValidator
+from validation.data_validator import DataValidator
 
 from .result_formatting import regular_analysis
 
@@ -19,14 +20,22 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_dataframe(
-    df: pd.DataFrame, validator: SecurityValidator
+    df: pd.DataFrame,
+    validator: SecurityValidator,
 ) -> tuple[int, int, bool]:
-    """Validate ``df`` and return original and validated row counts."""
+    """Validate ``df`` using :class:`DataValidator`."""
+
     original_rows = len(df)
     csv_bytes = df.to_csv(index=False).encode("utf-8")
     validator.validate_file_upload("data.csv", csv_bytes)
-    needs_chunking = True
+
+    df_validator = DataValidator()
+    result = df_validator.validate_dataframe(df)
+    if not result.valid:
+        logger.warning("Data issues detected: %s", result.issues)
+
     validated_rows = len(df)
+    needs_chunking = True
     logger.info(
         "📋 After validation: %s rows, chunking needed: %s",
         f"{validated_rows:,}",

--- a/utils/scipy_compat.py
+++ b/utils/scipy_compat.py
@@ -9,11 +9,13 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+
+from validation.data_validator import DataValidator, DataValidatorProtocol
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "detect_frequency_anomalies",
-    "detect_statistical_anomalies", 
+    "detect_statistical_anomalies",
     "calculate_severity_from_zscore",
     "get_stats_module",
     "sanitize_unicode_data",
@@ -43,76 +45,76 @@ def sanitize_unicode_data(data: Any) -> Any:
 
 class StatisticalAnomalyDetector:
     """Modular statistical anomaly detector with Unicode safety."""
-    
-    def __init__(self, logger: Optional[logging.Logger] = None):
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        validator: DataValidatorProtocol | None = None,
+    ) -> None:
         self.logger = logger or logging.getLogger(__name__)
-    
+        self.validator: DataValidatorProtocol = validator or DataValidator(
+            required_columns=["timestamp", "person_id"]
+        )
+
     def _safe_zscore_calculation(self, data: np.ndarray) -> np.ndarray:
         """Calculate Z-scores with error handling."""
         try:
             # Ensure data is numeric
             data = np.asarray(data, dtype=float)
-            
+
             if len(data) < 2:
                 return np.zeros_like(data)
-            
+
             # Remove infinite values
             finite_mask = np.isfinite(data)
             if not np.any(finite_mask):
                 return np.zeros_like(data)
-            
+
             return stats.zscore(data)
-            
+
         except Exception as e:
             self.logger.warning(f"Z-score calculation failed: {e}")
             return np.zeros_like(data)
-    
+
     def _validate_dataframe(self, df: pd.DataFrame) -> bool:
-        """Validate DataFrame for anomaly detection."""
-        required_columns = ['timestamp', 'person_id']
-        
-        if df.empty:
-            self.logger.warning("Empty DataFrame provided")
-            return False
-        
-        missing_cols = [col for col in required_columns if col not in df.columns]
-        if missing_cols:
-            self.logger.warning(f"Missing required columns: {missing_cols}")
-            return False
-        
-        return True
-    
+        """Validate ``df`` using the configured :class:`DataValidator`."""
+
+        result = self.validator.validate_dataframe(df)
+        if not result.valid:
+            self.logger.warning("Data validation issues: %s", result.issues)
+        return result.valid
+
     def detect_frequency_anomalies(self, df: pd.DataFrame) -> List[Dict[str, Any]]:
         """Detect frequency-based anomalies with Unicode safety."""
         if not self._validate_dataframe(df):
             return []
-        
+
         anomalies: List[Dict[str, Any]] = []
-        
+
         try:
             # Sanitize string columns
             df_clean = df.copy()
             for col in df_clean.select_dtypes(include=['object']).columns:
                 df_clean[col] = df_clean[col].apply(sanitize_unicode_data)
-            
+
             person_stats = df_clean.groupby('person_id').agg({
                 'timestamp': ['count', 'min', 'max'],
                 'access_granted': 'sum' if 'access_granted' in df_clean.columns else lambda x: len(x)
             }).round(2)
-            
+
             person_stats.columns = ['total_attempts', 'first_access', 'last_access', 'successful_attempts']
-            
+
             if len(person_stats) < 2:
                 return anomalies
-            
+
             # Use robust percentile-based threshold
             freq_threshold = person_stats['total_attempts'].quantile(0.95)
-            
+
             if freq_threshold <= 0:
                 return anomalies
-            
+
             high_freq_users = person_stats[person_stats['total_attempts'] > freq_threshold]
-            
+
             for person_id, stats_row in high_freq_users.iterrows():
                 # Calculate Z-score for this user's frequency
                 all_frequencies = person_stats['total_attempts'].values
@@ -120,7 +122,7 @@ class StatisticalAnomalyDetector:
                 z_scores = self._safe_zscore_calculation(all_frequencies)
                 user_idx = person_stats.index.get_loc(person_id)
                 user_zscore = z_scores[user_idx] if user_idx < len(z_scores) else 0
-                
+
                 anomaly_data = {
                     "type": "activity_burst",
                     "user_id": sanitize_unicode_data(str(person_id)),
@@ -134,56 +136,56 @@ class StatisticalAnomalyDetector:
                     "confidence": min(0.95, abs(user_zscore) / 4.0),
                     "timestamp": datetime.now()
                 }
-                
+
                 anomalies.append(sanitize_unicode_data(anomaly_data))
-                
+
         except Exception as exc:
             self.logger.warning(f"Frequency anomaly detection failed: {exc}")
-        
+
         return anomalies
-    
+
     def detect_statistical_anomalies(self, df: pd.DataFrame, sensitivity: float) -> List[Dict[str, Any]]:
         """Detect statistical anomalies using Z-score and IQR methods with Unicode safety."""
         if not self._validate_dataframe(df):
             return []
-        
+
         anomalies: List[Dict[str, Any]] = []
-        
+
         try:
             # Sanitize DataFrame
             df_clean = df.copy()
             for col in df_clean.select_dtypes(include=['object']).columns:
                 df_clean[col] = df_clean[col].apply(sanitize_unicode_data)
-            
+
             # Ensure timestamp is datetime
             if not pd.api.types.is_datetime64_any_dtype(df_clean['timestamp']):
                 df_clean['timestamp'] = pd.to_datetime(df_clean['timestamp'], errors='coerce')
-            
+
             # Remove rows with invalid timestamps
             df_clean = df_clean.dropna(subset=['timestamp'])
-            
+
             if len(df_clean) < 5:  # Need minimum data for statistics
                 return anomalies
-            
+
             # Hourly access pattern analysis
             hourly_access = df_clean.groupby(df_clean['timestamp'].dt.hour).size()
-            
+
             if len(hourly_access) < 2:
                 return anomalies
-            
+
             # Calculate Z-scores for hourly patterns
             z_scores = self._safe_zscore_calculation(hourly_access.values)
-            
+
             # Adaptive threshold based on sensitivity
             threshold = 3.0 * (1 - sensitivity) if sensitivity > 0 else 3.0
             threshold = max(2.0, min(5.0, threshold))  # Clamp between 2-5
-            
+
             anomalous_hours = hourly_access[np.abs(z_scores) > threshold]
-            
+
             for hour, count in anomalous_hours.items():
                 hour_idx = hourly_access.index.get_loc(hour)
                 z_score = z_scores[hour_idx] if hour_idx < len(z_scores) else 0
-                
+
                 anomaly_data = {
                     "type": "unusual_hour_activity",
                     "details": {
@@ -196,12 +198,12 @@ class StatisticalAnomalyDetector:
                     "confidence": min(0.95, abs(z_score) / 4.0),
                     "timestamp": datetime.now()
                 }
-                
+
                 anomalies.append(sanitize_unicode_data(anomaly_data))
-                
+
         except Exception as exc:
             self.logger.warning(f"Statistical anomaly detection failed: {exc}")
-        
+
         return anomalies
 
 
@@ -234,7 +236,7 @@ def calculate_severity_from_zscore(z_score: float) -> str:
     """Calculate severity level from Z-score with input validation."""
     try:
         z_score = float(abs(z_score))
-        
+
         if z_score >= 4.0:
             return "critical"
         elif z_score >= 3.5:

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -4,6 +4,7 @@ from .core import ValidationResult, Validator
 from .factory import create_file_validator, create_security_validator
 from .file_validator import FileValidator
 from .security_validator import SecurityValidator
+from .data_validator import DataValidator, DataValidatorProtocol
 from .rules import CompositeValidator, ValidationRule
 
 __all__ = [
@@ -13,6 +14,8 @@ __all__ = [
     "CompositeValidator",
     "SecurityValidator",
     "FileValidator",
+    "DataValidator",
+    "DataValidatorProtocol",
     "create_file_validator",
     "create_security_validator",
 ]

--- a/validation/data_validator.py
+++ b/validation/data_validator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable, Pattern, Protocol
+
+import pandas as pd
+
+from .core import ValidationResult
+from .rules import CompositeValidator, ValidationRule
+
+
+class DataValidatorProtocol(Protocol):
+    """Protocol for DataFrame validators."""
+
+    def validate_dataframe(self, df: pd.DataFrame) -> ValidationResult:
+        ...
+
+
+class EmptyDataRule(ValidationRule):
+    """Fail if the DataFrame is empty."""
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:
+        if df.empty:
+            return ValidationResult(False, df, ["empty_dataframe"])
+        return ValidationResult(True, df)
+
+
+class MissingColumnsRule(ValidationRule):
+    """Ensure required columns are present."""
+
+    def __init__(self, required: Iterable[str]) -> None:
+        self.required = list(required)
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:
+        missing = [c for c in self.required if c not in df.columns]
+        if missing:
+            issue = f"missing_columns:{','.join(missing)}"
+            return ValidationResult(False, df, [issue])
+        return ValidationResult(True, df)
+
+
+class SuspiciousColumnNameRule(ValidationRule):
+    """Detect suspicious column names that may indicate malicious input."""
+
+    DEFAULT_PATTERN = re.compile(r"(?i)^(?:=|\+|-|@)|cmd|system|drop|delete|exec")
+
+    def __init__(self, pattern: Pattern[str] | None = None) -> None:
+        self.pattern = pattern or self.DEFAULT_PATTERN
+
+    def validate(self, df: pd.DataFrame) -> ValidationResult:
+        suspicious = [c for c in df.columns if self.pattern.search(str(c))]
+        if suspicious:
+            issue = f"suspicious_columns:{','.join(map(str, suspicious))}"
+            return ValidationResult(False, df, [issue])
+        return ValidationResult(True, df)
+
+
+class DataValidator(CompositeValidator):
+    """Validate DataFrames for analytics modules."""
+
+    def __init__(
+        self,
+        required_columns: Iterable[str] | None = None,
+        rules: Iterable[ValidationRule] | None = None,
+        suspicious_pattern: Pattern[str] | None = None,
+    ) -> None:
+        base_rules = list(rules or [])
+        if required_columns:
+            base_rules.append(MissingColumnsRule(required_columns))
+        base_rules.append(EmptyDataRule())
+        base_rules.append(SuspiciousColumnNameRule(suspicious_pattern))
+        super().__init__(base_rules)
+
+    def validate_dataframe(self, df: pd.DataFrame) -> ValidationResult:
+        return self.validate(df)
+
+
+__all__ = [
+    "DataValidator",
+    "DataValidatorProtocol",
+    "EmptyDataRule",
+    "MissingColumnsRule",
+    "SuspiciousColumnNameRule",
+]


### PR DESCRIPTION
## Summary
- introduce `DataValidator` with rules for missing columns, empty data and suspicious names
- export DataValidator from validation package
- validate chunked analytics dataframes via DataValidator
- use DataValidator inside `StatisticalAnomalyDetector`

## Testing
- `flake8 validation/data_validator.py services/chunked_analysis.py` 
- `pytest tests/file_processing/test_chunk_cache.py::test_json_cache_roundtrip -q` *(fails: ImportError: cannot import name 'execute_secure_query')*

------
https://chatgpt.com/codex/tasks/task_e_688392e829308320831663c96bd078a8