### PR TITLE
Add tests for unicode and dataframe validators

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from analytics.security_score_calculator import SecurityScoreCalculator
+from services.data_processing.unified_upload_validator import validate_dataframe_content
+
+
+def test_data_validator_missing_required_columns():
+    df = pd.DataFrame({"timestamp": ["2024-01-01"]})
+    valid, message = SecurityScoreCalculator().validate_dataframe(df)
+    assert not valid
+    assert "Missing required columns" in message
+
+
+def test_dataframe_validation_flags_dangerous_column():
+    df = pd.DataFrame({"=cmd": ["1"]})
+    result = validate_dataframe_content(df)
+    assert "suspicious_column_names" in result["issues"]

--- a/tests/test_unicode_validator.py
+++ b/tests/test_unicode_validator.py
@@ -1,0 +1,15 @@
+from unicode_toolkit import UnicodeValidator
+
+
+def test_unicode_validator_sanitizes_surrogates():
+    validator = UnicodeValidator()
+    text = "A" + "\ud800" + "B"
+    result = validator.validate_and_sanitize(text)
+    assert result == "AB"
+
+
+def test_unicode_validator_strips_dangerous_chars():
+    validator = UnicodeValidator()
+    dangerous = "bad\u202Etext"
+    sanitized = validator.validate_and_sanitize(dangerous)
+    assert "\u202E" not in sanitized


### PR DESCRIPTION
## Summary
- add tests for UnicodeValidator sanitization
- add tests for DataValidator DataFrame checks

## Testing
- `pytest tests/test_validation_framework.py tests/test_unicode_validator.py tests/test_data_validator.py -q` *(fails: ImportError: cannot import name 'execute_secure_query')*

------
https://chatgpt.com/codex/tasks/task_e_688393b3c97c8320a47484fcd0e6d8a4