### PR TITLE
Centralize validation config helpers

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -1,10 +1,14 @@
 """Application-wide constants for Yōsai Intel Dashboard."""
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 
 # Default chunk size used across services when reading or uploading large files
 DEFAULT_CHUNK_SIZE: int = 50_000
+# File extensions supported across upload services
+UPLOAD_ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 
 
 class SecurityLimits:

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,3 +1,4 @@
+from .config_utils import common_init, create_config_methods
 from .model_registry import ModelRegistry
 
-__all__ = ["ModelRegistry"]
+__all__ = ["ModelRegistry", "create_config_methods", "common_init"]

--- a/services/common/config_utils.py
+++ b/services/common/config_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Shared configuration helpers for validation classes."""
+
+from typing import Any
+
+
+def create_config_methods(cls: Any) -> Any:
+    """Attach legacy accessor methods used across validators."""
+    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
+    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
+    cls.get_upload_chunk_size = lambda self: self.chunk_size
+    return cls
+
+
+def common_init(self: Any, config: Any | None = None) -> None:
+    """Initialize configuration defaults."""
+    self.config = config or {}
+    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
+    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
+    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
+
+
+__all__ = ["create_config_methods", "common_init"]

--- a/services/data_processing/file_handler.py
+++ b/services/data_processing/file_handler.py
@@ -1,40 +1,29 @@
 """Unified file validation and security handling."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
 from config.constants import DEFAULT_CHUNK_SIZE
+from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from core.unicode import (
     process_large_csv_content,
-    sanitize_for_utf8,
     sanitize_dataframe,
+    sanitize_for_utf8,
 )
+from services.common.config_utils import common_init, create_config_methods
 from services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,
 )
 from services.data_processing.unified_upload_validator import UnifiedUploadValidator
-from utils.file_utils import safe_decode_with_unicode_handling
 from upload_types import ValidationResult
-
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
+from utils.file_utils import safe_decode_with_unicode_handling
 
 
 def process_file_simple(

--- a/services/data_processing/unified_file_validator.py
+++ b/services/data_processing/unified_file_validator.py
@@ -13,44 +13,26 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from config.constants import UPLOAD_ALLOWED_EXTENSIONS
 from config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from core.unicode import (
     UnicodeProcessor,
+    safe_unicode_decode,
     sanitize_dataframe,
     sanitize_for_utf8,
-    safe_unicode_decode,
 )
+from services.common.config_utils import common_init, create_config_methods
+from services.data_processing.validation_utils import _lazy_string_validator
 from upload_types import ValidationResult
-from .unified_upload_validator import UnifiedUploadValidator
+
 from .common import process_dataframe
-
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
-
-
-def _lazy_string_validator() -> Any:
-    """Import :class:`SecurityValidator` lazily from the new package."""
-    from validation.security_validator import SecurityValidator as StringValidator
-
-    return StringValidator()
-
+from .unified_upload_validator import UnifiedUploadValidator
 
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
-ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
+ALLOWED_EXTENSIONS = UPLOAD_ALLOWED_EXTENSIONS
 
 
 logger = logging.getLogger(__name__)

--- a/services/data_processing/unified_upload_validator.py
+++ b/services/data_processing/unified_upload_validator.py
@@ -13,39 +13,21 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from config.constants import UPLOAD_ALLOWED_EXTENSIONS
 from config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 from core.performance import get_performance_monitor
 from core.protocols import ConfigurationProtocol
 from core.unicode import UnicodeProcessor, sanitize_dataframe, sanitize_for_utf8
+from services.common.config_utils import common_init, create_config_methods
+from services.data_processing.validation_utils import _lazy_string_validator
 from upload_types import ValidationResult
-from .dataframe_utils import process_dataframe
 from utils.file_utils import safe_decode_with_unicode_handling
 
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
-
-
-def _lazy_string_validator() -> Any:
-    """Import :class:`SecurityValidator` lazily from the new validation package."""
-    from validation.security_validator import SecurityValidator as StringValidator
-
-    return StringValidator()
-
+from .dataframe_utils import process_dataframe
 
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\- ]{1,100}$")
-ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
+ALLOWED_EXTENSIONS = UPLOAD_ALLOWED_EXTENSIONS
 
 
 logger = logging.getLogger(__name__)

--- a/services/data_processing/validation_utils.py
+++ b/services/data_processing/validation_utils.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Shared helpers for validation utilities."""
+
+from typing import Any
+
+
+def _lazy_string_validator() -> Any:
+    """Load :class:`SecurityValidator` lazily to avoid heavy imports."""
+    from validation.security_validator import SecurityValidator as StringValidator
+
+    return StringValidator()
+
+
+__all__ = ["_lazy_string_validator"]

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -3,6 +3,8 @@ Door Mapping Service - Business logic for device attribute assignment
 Handles AI model data processing and manual override management
 """
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -13,6 +15,7 @@ import pandas as pd
 # ADD after existing imports
 from services.ai_device_generator import AIDeviceGenerator
 from services.common import ModelRegistry
+from services.common.config_utils import common_init, create_config_methods
 from services.configuration_service import (
     ConfigurationServiceProtocol,
     DynamicConfigurationService,
@@ -20,20 +23,6 @@ from services.configuration_service import (
 from services.learning.src.api.consolidated_service import get_learning_service
 
 logger = logging.getLogger(__name__)
-
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
 
 
 @dataclass

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -2,6 +2,8 @@
 File Processing Service for Yōsai Intel Dashboard
 """
 
+from __future__ import annotations
+
 import csv
 import io
 import json
@@ -11,16 +13,16 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from services.configuration_service import ConfigurationServiceProtocol
-from .stream_processor import StreamProcessor
-from core.unicode import process_large_csv_content
 from analytics_core.utils.unicode_processor import UnicodeHelper
+from config.constants import UPLOAD_ALLOWED_EXTENSIONS
+from core.unicode import process_large_csv_content
+from services.configuration_service import ConfigurationServiceProtocol
 from utils.file_utils import safe_decode_with_unicode_handling
-
-from utils.protocols import SafeDecoderProtocol
 from utils.memory_utils import memory_safe
-
+from utils.protocols import SafeDecoderProtocol
 from yosai_framework.service import BaseService
+
+from .stream_processor import StreamProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +30,7 @@ logger = logging.getLogger(__name__)
 class FileProcessorService(BaseService):
     """File processing service implementation"""
 
-    ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
+    ALLOWED_EXTENSIONS = UPLOAD_ALLOWED_EXTENSIONS
 
     # Encoding detection order for robust decoding
     ENCODING_PRIORITY = [

--- a/services/input_validator.py
+++ b/services/input_validator.py
@@ -1,32 +1,17 @@
 """Backward compatibility wrapper for :class:`UnifiedUploadValidator`."""
+
 from __future__ import annotations
 
 from typing import Any, Optional
 
-
-from services.data_processing.unified_upload_validator import (
-    UnifiedUploadValidator,
-    _lazy_string_validator,
-)
-from upload_types import ValidationResult
+from services.common.config_utils import common_init, create_config_methods
 from services.configuration_service import (
     ConfigurationServiceProtocol,
     DynamicConfigurationService,
 )
-
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
+from services.data_processing.unified_upload_validator import UnifiedUploadValidator
+from services.data_processing.validation_utils import _lazy_string_validator
+from upload_types import ValidationResult
 
 
 @create_config_methods
@@ -43,4 +28,3 @@ class InputValidator(UnifiedUploadValidator):
         if max_size_mb is not None:
             self.max_size_mb = max_size_mb
         self._string_validator = _lazy_string_validator()
-

--- a/upload_validator.py
+++ b/upload_validator.py
@@ -1,27 +1,14 @@
 """Compatibility wrapper around :class:`UnifiedUploadValidator`."""
+
 from __future__ import annotations
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 from config.dynamic_config import dynamic_config
 from core.protocols import ConfigurationProtocol
-
+from services.common.config_utils import common_init, create_config_methods
 from services.data_processing.unified_upload_validator import UnifiedUploadValidator
 from upload_types import ValidationResult
-
-
-def create_config_methods(cls):
-    cls.get_ai_confidence_threshold = lambda self: self.ai_threshold
-    cls.get_max_upload_size_mb = lambda self: self.max_size_mb
-    cls.get_upload_chunk_size = lambda self: self.chunk_size
-    return cls
-
-
-def common_init(self, config=None):
-    self.config = config or {}
-    self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-    self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-    self.chunk_size = self.config.get("upload_chunk_size", 1048576)
 
 UploadValidator = UnifiedUploadValidator
 
@@ -38,4 +25,3 @@ class UploadValidator(UnifiedUploadValidator):
         common_init(self, config)
         if max_size_mb is not None:
             self.max_size_mb = max_size_mb
-


### PR DESCRIPTION
## Summary
- centralize duplicate config helpers into `config_utils`
- share lazy validator helper
- export helpers via `services.common`
- use shared upload constants across services
- modernize imports with `from __future__ import annotations`

## Testing
- `pre-commit run --files config/constants.py services/common/__init__.py services/common/config_utils.py services/data_processing/file_handler.py services/data_processing/unified_file_validator.py services/data_processing/unified_upload_validator.py services/door_mapping_service.py services/file_processor_service.py services/input_validator.py services/data_processing/validation_utils.py upload_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_68842cf576dc8320afe75c14f553b166