### PR TITLE
Refactor analytics service architecture

### DIFF
--- a/services/analytics/core/exceptions.py
+++ b/services/analytics/core/exceptions.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Analytics domain specific exceptions."""
+
+from core.exceptions import YosaiBaseException
+
+
+class AnalyticsError(YosaiBaseException):
+    """Base class for analytics errors."""
+
+
+class DataLoadError(AnalyticsError):
+    """Raised when data loading fails."""
+
+
+class ValidationFailure(AnalyticsError):
+    """Raised when validation fails."""
+
+
+class TransformationError(AnalyticsError):
+    """Raised when dataframe transformation fails."""
+
+
+class CalculationError(AnalyticsError):
+    """Raised when metric calculation fails."""
+
+
+class AggregationError(AnalyticsError):
+    """Raised when aggregation fails."""
+
+
+class AnalysisError(AnalyticsError):
+    """Raised when high level analysis fails."""
+
+
+class RepositoryError(AnalyticsError):
+    """Raised when repository access fails."""
+
+
+class CacheError(AnalyticsError):
+    """Raised when caching fails."""
+
+
+class PersistenceError(AnalyticsError):
+    """Raised when persistence initialization fails."""
+
+
+class EventError(AnalyticsError):
+    """Raised for event system errors."""
+
+
+__all__ = [
+    "AnalyticsError",
+    "DataLoadError",
+    "ValidationFailure",
+    "TransformationError",
+    "CalculationError",
+    "AggregationError",
+    "AnalysisError",
+    "RepositoryError",
+    "CacheError",
+    "PersistenceError",
+    "EventError",
+]

--- a/services/analytics/core/interfaces.py
+++ b/services/analytics/core/interfaces.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Protocol definitions for analytics services."""
+
+from typing import Protocol, Dict, Any, List
+import pandas as pd
+
+
+class LoaderProtocol(Protocol):
+    """Load and prepare raw analytics data."""
+
+    def load_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        ...
+
+    def clean_uploaded_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        ...
+
+    def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        ...
+
+    def load_patterns_dataframe(self, data_source: str | None) -> tuple[pd.DataFrame, int]:
+        ...
+
+
+class ValidatorProtocol(Protocol):
+    """Validate uploaded content."""
+
+    def validate_input(self, value: str, field_name: str = "input") -> Dict[str, Any]:
+        ...
+
+    def validate_file_upload(self, filename: str, content: bytes) -> Dict[str, Any]:
+        ...
+
+
+class TransformerProtocol(Protocol):
+    """Transform dataframes for analytics."""
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        ...
+
+    def diagnose(self, df: pd.DataFrame) -> Dict[str, Any]:
+        ...
+
+
+class CalculatorProtocol(Protocol):
+    """Perform metrics calculations."""
+
+    def calculate_stats(self, df: pd.DataFrame) -> tuple[int, int, int, int]:
+        ...
+
+    def analyze_users(self, df: pd.DataFrame, unique_users: int) -> tuple[list[str], list[str], list[str]]:
+        ...
+
+    def analyze_devices(self, df: pd.DataFrame, unique_devices: int) -> tuple[list[str], list[str], list[str]]:
+        ...
+
+    def log_analysis_summary(self, result_total: int, original_rows: int) -> None:
+        ...
+
+    def analyze_patterns(self, df: pd.DataFrame, original_rows: int) -> Dict[str, Any]:
+        ...
+
+
+class AggregatorProtocol(Protocol):
+    """Aggregate dataframe metrics."""
+
+    def aggregate(self, df: pd.DataFrame, groupby: List[str], metrics: List[str]) -> pd.DataFrame:
+        ...
+
+
+class AnalyzerProtocol(Protocol):
+    """Analyze prepared data for patterns."""
+
+    def analyze(self, df: pd.DataFrame, original_rows: int) -> Dict[str, Any]:
+        ...
+
+
+class RepositoryProtocol(Protocol):
+    """Access analytics data from a persistence layer."""
+
+    def get_analytics(self) -> Dict[str, Any]:
+        ...
+
+
+class CacheProtocol(Protocol):
+    """Provide caching helpers."""
+
+    def cache(self, name: str, ttl: int) -> Any:
+        ...
+
+
+class PersistenceProtocol(Protocol):
+    """Initialize persistence resources."""
+
+    def initialize(self, database: Any | None) -> tuple[Any | None, Any, Any]:
+        ...
+
+
+class EventPublisherProtocol(Protocol):
+    """Publish analytics events."""
+
+    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+        ...
+
+
+class EventSubscriberProtocol(Protocol):
+    """Subscribe to analytics events."""
+
+    def subscribe(self, event: str, handler: Any) -> None:
+        ...

--- a/services/analytics/data/loader.py
+++ b/services/analytics/data/loader.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+
+from config.dynamic_config import dynamic_config
+from services.controllers.upload_controller import UploadProcessingController
+from services.data_processing.processor import Processor
+
+logger = logging.getLogger(__name__)
+
+ROW_LIMIT_WARNING = dynamic_config.analytics.row_limit_warning
+LARGE_DATA_THRESHOLD = dynamic_config.analytics.large_data_threshold
+
+
+class DataLoader:
+    """Load and prepare data for analytics operations."""
+
+    def __init__(
+        self, controller: UploadProcessingController, processor: Processor
+    ) -> None:
+        self.controller = controller
+        self.processor = processor
+        self.upload_processor = controller.upload_processor
+
+    # ------------------------------------------------------------------
+    # Delegated helpers
+    # ------------------------------------------------------------------
+    def load_uploaded_data(self) -> Dict[str, pd.DataFrame]:
+        return self.controller.load_uploaded_data()
+
+    def clean_uploaded_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.controller.clean_uploaded_dataframe(df)
+
+    def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        return self.controller.summarize_dataframe(df)
+
+    def analyze_with_chunking(
+        self, df: pd.DataFrame, analysis_types: List[str]
+    ) -> Dict[str, Any]:
+        return self.controller.analyze_with_chunking(df, analysis_types)
+
+    def diagnose_data_flow(self, df: pd.DataFrame) -> Dict[str, Any]:
+        return self.controller.diagnose_data_flow(df)
+
+    def get_real_uploaded_data(self) -> Dict[str, Any]:
+        return self.controller.get_real_uploaded_data()
+
+    def get_analytics_with_fixed_processor(self) -> Dict[str, Any]:
+        return self.controller.get_analytics_with_fixed_processor()
+
+    # ------------------------------------------------------------------
+    # Pattern analysis helper
+    # ------------------------------------------------------------------
+    def load_patterns_dataframe(
+        self, data_source: str | None
+    ) -> Tuple[pd.DataFrame, int]:
+        """Return dataframe and original row count for pattern analysis."""
+        if data_source == "database":
+            df, _meta = self.processor.get_processed_database()
+            uploaded_data = {"database": df} if not df.empty else {}
+        else:
+            uploaded_data = self.upload_processor.load_uploaded_data()
+
+        if not uploaded_data:
+            return pd.DataFrame(), 0
+
+        all_dfs: List[pd.DataFrame] = []
+        total_original_rows = 0
+
+        logger.info("\U0001f4c1 Found %s uploaded files", len(uploaded_data))
+        for filename, df in uploaded_data.items():
+            original_rows = len(df)
+            total_original_rows += original_rows
+            logger.info("   %s: %s rows", filename, f"{original_rows:,}")
+
+            cleaned_df = self.upload_processor.clean_uploaded_dataframe(df)
+            all_dfs.append(cleaned_df)
+            logger.info("   After cleaning: %s rows", f"{len(cleaned_df):,}")
+
+        combined_df = (
+            all_dfs[0] if len(all_dfs) == 1 else pd.concat(all_dfs, ignore_index=True)
+        )
+
+        final_rows = len(combined_df)
+        logger.info("\U0001f4ca COMBINED DATASET: %s total rows", f"{final_rows:,}")
+
+        if final_rows != total_original_rows:
+            logger.warning(
+                "\u26a0\ufe0f  Data loss detected: %s \u2192 %s",
+                f"{total_original_rows:,}",
+                f"{final_rows:,}",
+            )
+
+        if final_rows == ROW_LIMIT_WARNING and total_original_rows > ROW_LIMIT_WARNING:
+            logger.error(
+                "\U0001f6a8 FOUND %s ROW LIMIT in unique patterns analysis!",
+                ROW_LIMIT_WARNING,
+            )
+            logger.error("   Original rows: %s", f"{total_original_rows:,}")
+            logger.error("   Final rows: %s", f"{final_rows:,}")
+        elif final_rows > LARGE_DATA_THRESHOLD:
+            logger.info("\u2705 Processing large dataset: %s rows", f"{final_rows:,}")
+
+        return combined_df, total_original_rows
+
+
+__all__ = ["DataLoader"]

--- a/services/analytics/data/transformer.py
+++ b/services/analytics/data/transformer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Dataframe transformation helpers."""
+
+from typing import Any, Dict
+import pandas as pd
+
+
+class DataTransformer:
+    """Simple dataframe transformer used in tests."""
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    def summarize(self, df: pd.DataFrame) -> Dict[str, Any]:
+        return {"rows": len(df), "columns": list(df.columns)}
+
+    def diagnose(self, df: pd.DataFrame) -> Dict[str, Any]:
+        return {"rows": len(df)}
+
+
+__all__ = ["DataTransformer"]

--- a/services/analytics/data/validator.py
+++ b/services/analytics/data/validator.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Validation helper for analytics uploads."""
+
+from typing import Dict
+import pandas as pd
+from validation.security_validator import SecurityValidator
+
+
+class Validator:
+    """Wrap :class:`SecurityValidator` for analytics pipelines."""
+
+    def __init__(self, validator: SecurityValidator | None = None) -> None:
+        self.validator = validator or SecurityValidator()
+
+    def validate_input(self, value: str, field_name: str = "input") -> Dict[str, any]:
+        return self.validator.validate_input(value, field_name)
+
+    def validate_file_upload(self, filename: str, content: bytes) -> Dict[str, any]:
+        return self.validator.validate_file_upload(filename, content)
+
+    # dataframe level hook used in some pipelines
+    def validate_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+
+__all__ = ["Validator"]

--- a/services/analytics/events/publisher.py
+++ b/services/analytics/events/publisher.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from core.protocols import EventBusProtocol
+from services.event_publisher import publish_event
+
+
+class Publisher:
+    """Publish analytics updates to an event bus."""
+
+    def __init__(self, event_bus: EventBusProtocol | None) -> None:
+        self.event_bus = event_bus
+
+    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+        publish_event(self.event_bus, payload, event)
+
+
+__all__ = ["Publisher"]

--- a/services/analytics/events/subscriber.py
+++ b/services/analytics/events/subscriber.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Event subscription helper."""
+
+from typing import Any
+from core.protocols import EventBusProtocol
+
+
+class Subscriber:
+    """Simple subscriber wrapper."""
+
+    def __init__(self, bus: EventBusProtocol | None) -> None:
+        self.bus = bus
+
+    def subscribe(self, event: str, handler: Any) -> None:
+        if self.bus:
+            self.bus.subscribe(event, handler)
+
+
+__all__ = ["Subscriber"]

--- a/services/analytics/orchestrator.py
+++ b/services/analytics/orchestrator.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Coordinator for analytics services."""
+
+import asyncio
+from typing import Any, Dict, List
+import pandas as pd
+
+from .core.interfaces import (
+    LoaderProtocol,
+    ValidatorProtocol,
+    TransformerProtocol,
+    CalculatorProtocol,
+    AggregatorProtocol,
+    AnalyzerProtocol,
+    RepositoryProtocol,
+    EventPublisherProtocol,
+)
+
+
+class AnalyticsOrchestrator:
+    """Coordinate analytics components via dependency injection."""
+
+    def __init__(
+        self,
+        loader: LoaderProtocol,
+        validator: ValidatorProtocol,
+        transformer: TransformerProtocol,
+        calculator: CalculatorProtocol,
+        aggregator: AggregatorProtocol,
+        analyzer: AnalyzerProtocol,
+        repository: RepositoryProtocol,
+        publisher: EventPublisherProtocol,
+    ) -> None:
+        self.loader = loader
+        self.validator = validator
+        self.transformer = transformer
+        self.calculator = calculator
+        self.aggregator = aggregator
+        self.analyzer = analyzer
+        self.repository = repository
+        self.publisher = publisher
+
+    # ------------------------------------------------------------------
+    def get_dashboard_summary(self) -> Dict[str, Any]:
+        data = self.loader.load_uploaded_data()
+        if not data:
+            return {"status": "no_data"}
+        df = pd.concat(list(data.values()), ignore_index=True)
+        df = self.transformer.transform(df)
+        summary = self.loader.summarize_dataframe(df)
+        self.publisher.publish(summary)
+        return summary
+
+    # ------------------------------------------------------------------
+    def process_uploaded_data_directly(self, uploaded: Dict[str, Any]) -> Dict[str, Any]:
+        return self.loader.controller.process_uploaded_data_directly(uploaded)  # type: ignore[attr-defined]
+
+    async def aprocess_uploaded_data_directly(self, uploaded: Dict[str, Any]) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.process_uploaded_data_directly, uploaded)
+
+    # ------------------------------------------------------------------
+    def regular_analysis(self, df: pd.DataFrame, analysis_types: List[str]) -> Dict[str, Any]:
+        from services.result_formatting import regular_analysis
+
+        return regular_analysis(df, analysis_types)
+
+    def get_real_uploaded_data(self) -> Dict[str, Any]:
+        return self.loader.get_real_uploaded_data()
+
+    def get_analytics_with_fixed_processor(self) -> Dict[str, Any]:
+        return self.loader.get_analytics_with_fixed_processor()
+
+    def get_database_analytics(self) -> Dict[str, Any]:
+        return self.repository.get_analytics()
+
+    def get_unique_patterns_analysis(self, data_source: str | None = None) -> Dict[str, Any]:
+        df, original_rows = self.loader.load_patterns_dataframe(data_source)
+        if df.empty:
+            return {"status": "no_data", "message": "No uploaded files available", "data_summary": {"total_records": 0}}
+        result = self.analyzer.analyze(df, original_rows)
+        self.publisher.publish(result)
+        return result
+
+
+__all__ = ["AnalyticsOrchestrator"]

--- a/services/analytics/processing/aggregator.py
+++ b/services/analytics/processing/aggregator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Aggregation helpers for analytics."""
+
+from typing import List
+import pandas as pd
+
+
+class Aggregator:
+    """Simple Pandas based aggregator."""
+
+    def aggregate(self, df: pd.DataFrame, groupby: List[str], metrics: List[str]) -> pd.DataFrame:
+        if not groupby or not metrics:
+            return df
+        return df.groupby(groupby)[metrics].sum().reset_index()
+
+
+__all__ = ["Aggregator"]

--- a/services/analytics/processing/analyzer.py
+++ b/services/analytics/processing/analyzer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""High level pattern analysis."""
+
+from typing import Dict, Any
+import pandas as pd
+
+from .calculator import Calculator
+
+
+class Analyzer:
+    """Perform pattern analysis using :class:`Calculator`."""
+
+    def __init__(self, calculator: Calculator | None = None) -> None:
+        self.calculator = calculator or Calculator()
+
+    def analyze(self, df: pd.DataFrame, original_rows: int) -> Dict[str, Any]:
+        return self.calculator.analyze_patterns(df, original_rows)
+
+
+__all__ = ["Analyzer"]

--- a/services/analytics/processing/calculator.py
+++ b/services/analytics/processing/calculator.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+
+from services.summary_report_generator import SummaryReportGenerator
+
+
+class Calculator:
+    """Perform analytics calculations for uploaded data."""
+
+    def __init__(self, generator: SummaryReportGenerator | None = None) -> None:
+        self.generator = generator or SummaryReportGenerator()
+
+    def calculate_stats(self, df: pd.DataFrame) -> Tuple[int, int, int, int]:
+        return self.generator.calculate_stats(df)
+
+    def analyze_users(
+        self, df: pd.DataFrame, unique_users: int
+    ) -> Tuple[List[str], List[str], List[str]]:
+        return self.generator.analyze_users(df, unique_users)
+
+    def analyze_devices(
+        self, df: pd.DataFrame, unique_devices: int
+    ) -> Tuple[List[str], List[str], List[str]]:
+        return self.generator.analyze_devices(df, unique_devices)
+
+    def log_analysis_summary(self, result_total: int, original_rows: int) -> None:
+        self.generator.log_analysis_summary(result_total, original_rows)
+
+    def analyze_patterns(self, df: pd.DataFrame, original_rows: int) -> Dict[str, Any]:
+        result = self.generator.analyze_patterns(df)
+        result_total = result["data_summary"]["total_records"]
+        self.log_analysis_summary(result_total, original_rows)
+        return result
+
+
+__all__ = ["Calculator"]

--- a/services/analytics/storage/cache.py
+++ b/services/analytics/storage/cache.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Caching helpers for analytics storage."""
+
+from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+
+
+_cache_manager = InMemoryCacheManager(CacheConfig())
+
+
+def cached(ttl: int):
+    return cache_with_lock(_cache_manager, ttl=ttl)
+
+
+__all__ = ["cached", "_cache_manager"]

--- a/services/analytics/storage/persistence.py
+++ b/services/analytics/storage/persistence.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Persistence initialization helpers."""
+
+from typing import Any, Tuple
+
+from services.helpers.database_initializer import initialize_database
+
+
+class PersistenceManager:
+    """Initialize database connections for analytics."""
+
+    def initialize(self, database: Any | None) -> Tuple[Any | None, Any, Any]:
+        return initialize_database(database)
+
+
+__all__ = ["PersistenceManager"]

--- a/services/analytics/storage/repository.py
+++ b/services/analytics/storage/repository.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Database repository for analytics."""
+
+from typing import Any, Dict
+
+from services.db_analytics_helper import DatabaseAnalyticsHelper
+
+
+class AnalyticsRepository:
+    """Provide access to analytics stored in a database."""
+
+    def __init__(self, helper: DatabaseAnalyticsHelper) -> None:
+        self.helper = helper
+
+    def get_analytics(self) -> Dict[str, Any]:
+        return self.helper.get_analytics()
+
+
+__all__ = ["AnalyticsRepository"]

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -32,14 +32,19 @@ from core.protocols import (
     StorageProtocol,
 )
 from models.ml import ModelRegistry
-from services.analytics.calculator import Calculator
-from services.analytics.data_loader import DataLoader
+from services.analytics.processing.calculator import Calculator
+from services.analytics.data.loader import DataLoader
+from services.analytics.data.validator import Validator
+from services.analytics.data.transformer import DataTransformer
+from services.analytics.processing.aggregator import Aggregator
+from services.analytics.processing.analyzer import Analyzer
+from services.analytics.storage.repository import AnalyticsRepository
+from services.analytics.events.publisher import Publisher
+from services.analytics.orchestrator import AnalyticsOrchestrator
 from services.analytics.protocols import DataProcessorProtocol
-from services.analytics.publisher import Publisher
 from services.analytics_summary import generate_sample_analytics
 from services.controllers.upload_controller import UploadProcessingController
 from services.data_processing.processor import Processor
-from services.database_retriever import DatabaseAnalyticsRetriever
 from services.helpers.database_initializer import initialize_database
 from services.interfaces import get_upload_data_service
 from services.summary_report_generator import SummaryReportGenerator
@@ -140,11 +145,25 @@ class AnalyticsService(AnalyticsServiceProtocol):
             self.db_helper,
             self.summary_reporter,
         ) = initialize_database(self.database)
-        self.database_retriever = DatabaseAnalyticsRetriever(self.db_helper)
         self.report_generator = SummaryReportGenerator()
         self.data_loader = DataLoader(self.upload_controller, self.processor)
+        self.validator = Validator(self.validation_service)
+        self.transformer = DataTransformer()
         self.calculator = Calculator(self.report_generator)
+        self.aggregator = Aggregator()
+        self.analyzer = Analyzer(self.calculator)
+        self.repository = AnalyticsRepository(self.db_helper)
         self.publisher = Publisher(self.event_bus)
+        self.orchestrator = AnalyticsOrchestrator(
+            loader=self.data_loader,
+            validator=self.validator,
+            transformer=self.transformer,
+            calculator=self.calculator,
+            aggregator=self.aggregator,
+            analyzer=self.analyzer,
+            repository=self.repository,
+            publisher=self.publisher,
+        )
 
     def _initialize_database(self) -> None:
         """Initialize database connection via helper."""
@@ -189,15 +208,13 @@ class AnalyticsService(AnalyticsServiceProtocol):
         self, uploaded_data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Process uploaded files using chunked streaming."""
-        return self.upload_controller.process_uploaded_data_directly(uploaded_data)
+        return self.orchestrator.process_uploaded_data_directly(uploaded_data)
 
     async def aprocess_uploaded_data_directly(
         self, uploaded_data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Asynchronously process uploaded files."""
-        return await asyncio.to_thread(
-            self.upload_controller.process_uploaded_data_directly, uploaded_data
-        )
+        return await self.orchestrator.aprocess_uploaded_data_directly(uploaded_data)
 
     def load_uploaded_data(self) -> Dict[str, pd.DataFrame]:
         """Load uploaded data from the file upload page."""
@@ -262,11 +279,11 @@ class AnalyticsService(AnalyticsServiceProtocol):
     @cache_with_lock(_cache_manager, ttl=600)
     def _get_database_analytics(self) -> Dict[str, Any]:
         """Get analytics from database."""
-        return self.database_retriever.get_analytics()
+        return self.orchestrator.get_database_analytics()
 
     async def _aget_database_analytics(self) -> Dict[str, Any]:
         """Asynchronously get analytics from database."""
-        return await asyncio.to_thread(self.database_retriever.get_analytics)
+        return await asyncio.to_thread(self.orchestrator.get_database_analytics)
 
 
     @cache_with_lock(_cache_manager, ttl=300)
@@ -274,10 +291,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
     def get_dashboard_summary(self) -> Dict[str, Any]:
         """Get a basic dashboard summary"""
         try:
-            summary = self.get_analytics_from_uploaded_data()
-            self.publisher.publish(summary)
-
-            return summary
+            return self.orchestrator.get_dashboard_summary()
         except RuntimeError as e:
             logger.error(f"Dashboard summary failed: {e}")
             return {"status": "error", "message": str(e)}
@@ -338,31 +352,9 @@ class AnalyticsService(AnalyticsServiceProtocol):
 
         try:
             logger.info("🎯 Starting Unique Patterns Analysis")
-
-            df, original_rows = self._load_patterns_dataframe(data_source)
-            if df.empty:
-                logger.warning("❌ No uploaded data found for unique patterns analysis")
-                return {
-                    "status": "no_data",
-                    "message": "No uploaded files available",
-                    "data_summary": {"total_records": 0},
-                }
-
-            result = self._analyze_patterns(df, original_rows)
-
-            result_total = result["data_summary"]["total_records"]
-            self._log_analysis_summary(result_total, original_rows)
-
-            self.publisher.publish(result)
-
-            return result
-
+            return self.orchestrator.get_unique_patterns_analysis(data_source)
         except RuntimeError as e:
             logger.error(f"❌ Unique patterns analysis failed: {e}")
-            import traceback
-
-            traceback.print_exc()
-
             return {
                 "status": "error",
                 "message": f"Unique patterns analysis failed: {str(e)}",

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,24 @@
+import types
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+try:
+    import flask  # noqa: F401
+except Exception:
+    pytest.skip("flask not available", allow_module_level=True)
+
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_stub
+
+from services.analytics.processing.aggregator import Aggregator  # noqa: E402
+
+
+def test_aggregate():
+    df = pd.DataFrame({"g": ["a", "a", "b"], "x": [1, 2, 3]})
+    agg = Aggregator()
+    result = agg.aggregate(df, ["g"], ["x"])
+    assert set(result["g"]) == {"a", "b"}

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,24 @@
+import types
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+try:
+    import flask  # noqa: F401
+except Exception:
+    pytest.skip("flask not available", allow_module_level=True)
+
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_stub
+
+from services.analytics.processing.analyzer import Analyzer  # noqa: E402
+
+
+def test_analyze():
+    df = pd.DataFrame({"user": ["u1", "u1"], "device": ["d1", "d2"]})
+    analyzer = Analyzer()
+    res = analyzer.analyze(df, len(df))
+    assert res["data_summary"]["total_records"] == 2

--- a/tests/test_cache_service.py
+++ b/tests/test_cache_service.py
@@ -1,0 +1,11 @@
+from services.analytics.storage.cache import cached, _cache_manager
+
+
+@cached(ttl=1)
+def plus_one(x):
+    return x + 1
+
+
+def test_cached_decorator(monkeypatch):
+    assert plus_one(1) == 2
+    assert plus_one(1) == 2  # cached

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.calculator import Calculator  # noqa: E402
+from services.analytics.processing.calculator import Calculator  # noqa: E402
 
 
 def _make_df():

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.data_loader import DataLoader  # noqa: E402
+from services.analytics.data.loader import DataLoader  # noqa: E402
 
 
 class DummyUploadProc:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,15 @@
+from services.analytics.storage.persistence import PersistenceManager
+
+
+class DummyDB:
+    pass
+
+
+def test_initialize(monkeypatch):
+    pm = PersistenceManager()
+    monkeypatch.setattr(
+        'services.helpers.database_initializer.initialize_database',
+        lambda db: (db, 'helper', 'reporter'),
+    )
+    manager, helper, reporter = pm.initialize(DummyDB())
+    assert helper == 'helper'

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -34,7 +34,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.publisher import Publisher  # noqa: E402
+from services.analytics.events.publisher import Publisher  # noqa: E402
 
 
 class DummyBus:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,11 @@
+from services.analytics.storage.repository import AnalyticsRepository
+
+
+class DummyHelper:
+    def get_analytics(self):
+        return {"a": 1}
+
+
+def test_repository():
+    repo = AnalyticsRepository(DummyHelper())
+    assert repo.get_analytics() == {"a": 1}

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -1,0 +1,16 @@
+from services.analytics.events.subscriber import Subscriber
+
+
+class DummyBus:
+    def __init__(self):
+        self.called = False
+
+    def subscribe(self, event, handler):
+        self.called = True
+
+
+def test_subscribe():
+    bus = DummyBus()
+    sub = Subscriber(bus)
+    sub.subscribe('evt', lambda x: x)
+    assert bus.called

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,26 @@
+import types
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+try:
+    import flask  # noqa: F401
+except Exception:
+    pytest.skip("flask not available", allow_module_level=True)
+
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_stub
+
+from services.analytics.data.transformer import DataTransformer  # noqa: E402
+
+
+def test_transformer_basic():
+    df = pd.DataFrame({"a": [1, 2]})
+    t = DataTransformer()
+    assert t.transform(df).equals(df)
+    summary = t.summarize(df)
+    assert summary["rows"] == 2
+    assert "a" in summary["columns"]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,25 @@
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import flask  # noqa: F401
+except Exception:
+    pytest.skip("flask not available", allow_module_level=True)
+
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
+sys.modules["services"] = services_stub
+
+import pandas as pd
+from services.analytics.data.validator import Validator  # noqa: E402
+
+
+def test_validate_methods():
+    val = Validator()
+    assert val.validate_input("ok") == {"valid": True, "sanitized": "ok"}
+    assert val.validate_file_upload("a.txt", b"data")["valid"]
+    df = pd.DataFrame({"a": [1]})
+    assert val.validate_dataframe(df).equals(df)


### PR DESCRIPTION
## Summary
- define analytics service protocols and exceptions
- split analytics features into data, processing, storage and events packages
- implement `AnalyticsOrchestrator` and wire AnalyticsService to use it
- add unit tests for new components

## Testing
- `pytest tests/test_calculator.py tests/test_data_loader.py tests/test_publisher.py tests/test_validator.py tests/test_transformer.py tests/test_aggregator.py tests/test_analyzer.py tests/test_repository.py tests/test_cache_service.py tests/test_persistence.py tests/test_subscriber.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688462527b048320982d7e4cee86998a