### PR TITLE
Refactor service factories

### DIFF
--- a/services/analytics/__init__.py
+++ b/services/analytics/__init__.py
@@ -1,8 +1,8 @@
 """Analytics Domain Public API."""
 
 from .async_service import AsyncAnalyticsService
-from .calculator import Calculator
-from .data_loader import DataLoader
+from .calculator import Calculator, create_calculator
+from .data_loader import DataLoader, create_loader
 from .metrics_calculator import MetricsCalculator
 from .preparation import prepare_dataframe
 from .protocols import (
@@ -11,7 +11,7 @@ from .protocols import (
     MetricsCalculatorProtocol,
     ReportGeneratorProtocol,
 )
-from .publisher import Publisher
+from .publisher import Publisher, create_publisher
 from .timescale_queries import (
     build_sliding_window_query,
     build_time_bucket_query,
@@ -35,8 +35,11 @@ __all__ = [
     "prepare_dataframe",
     "MetricsCalculator",
     "DataLoader",
+    "create_loader",
     "Calculator",
+    "create_calculator",
     "Publisher",
+    "create_publisher",
     "build_time_bucket_query",
     "build_sliding_window_query",
     "fetch_time_buckets",

--- a/services/analytics/calculator.py
+++ b/services/analytics/calculator.py
@@ -10,8 +10,8 @@ from services.summary_report_generator import SummaryReportGenerator
 class Calculator:
     """Perform analytics calculations for uploaded data."""
 
-    def __init__(self, generator: SummaryReportGenerator | None = None) -> None:
-        self.generator = generator or SummaryReportGenerator()
+    def __init__(self, generator: SummaryReportGenerator) -> None:
+        self.generator = generator
 
     def calculate_stats(self, df: pd.DataFrame) -> Tuple[int, int, int, int]:
         return self.generator.calculate_stats(df)
@@ -36,4 +36,12 @@ class Calculator:
         return result
 
 
-__all__ = ["Calculator"]
+def create_calculator(
+    generator: SummaryReportGenerator | None = None,
+) -> "Calculator":
+    """Create a :class:`Calculator` with default dependencies."""
+    generator = generator or SummaryReportGenerator()
+    return Calculator(generator)
+
+
+__all__ = ["Calculator", "create_calculator"]

--- a/services/analytics/data_loader.py
+++ b/services/analytics/data_loader.py
@@ -8,6 +8,8 @@ import pandas as pd
 from config.dynamic_config import dynamic_config
 from services.controllers.upload_controller import UploadProcessingController
 from services.data_processing.processor import Processor
+from services.interfaces import get_upload_data_service
+from validation.security_validator import SecurityValidator
 
 logger = logging.getLogger(__name__)
 
@@ -107,4 +109,22 @@ class DataLoader:
         return combined_df, total_original_rows
 
 
-__all__ = ["DataLoader"]
+def create_loader(
+    controller: UploadProcessingController | None = None,
+    processor: Processor | None = None,
+) -> "DataLoader":
+    """Create a :class:`DataLoader` with default dependencies."""
+    if controller is None:
+        validator = SecurityValidator()
+        processor = processor or Processor(validator=validator)
+        controller = UploadProcessingController(
+            validator,
+            processor,
+            get_upload_data_service(),
+        )
+    else:
+        processor = processor or Processor(validator=SecurityValidator())
+    return DataLoader(controller, processor)
+
+
+__all__ = ["DataLoader", "create_loader"]

--- a/services/analytics/publisher.py
+++ b/services/analytics/publisher.py
@@ -16,4 +16,9 @@ class Publisher:
         publish_event(self.event_bus, payload, event)
 
 
-__all__ = ["Publisher"]
+def create_publisher(event_bus: EventBusProtocol | None = None) -> "Publisher":
+    """Create a :class:`Publisher` with default dependencies."""
+    return Publisher(event_bus)
+
+
+__all__ = ["Publisher", "create_publisher"]


### PR DESCRIPTION
## Summary
- inject dependencies into service helpers
- add `create_loader`, `create_calculator` and `create_publisher` factories
- wire factories into `AnalyticsService`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_688462534ea883208688de588fab99ae