### PR TITLE
Add async analytics unit tests

### DIFF
--- a/tests/analytics/test_async_api.py
+++ b/tests/analytics/test_async_api.py
@@ -1,0 +1,25 @@
+import json
+from fastapi.testclient import TestClient
+
+from services.analytics.async_api import app, event_bus
+
+
+def test_health_endpoint():
+    client = TestClient(app)
+    resp = client.get("/api/v1/analytics/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_chart_bad_type():
+    client = TestClient(app)
+    resp = client.get("/api/v1/analytics/chart/bad")
+    assert resp.status_code == 400
+
+
+def test_websocket_updates():
+    client = TestClient(app)
+    with client.websocket_connect("/ws/analytics") as ws:
+        event_bus.publish("analytics_update", {"a": 1})
+        data = ws.receive_text()
+        assert json.loads(data)["a"] == 1

--- a/tests/analytics/test_async_repository.py
+++ b/tests/analytics/test_async_repository.py
@@ -1,0 +1,51 @@
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.analytics.async_repository import AsyncEventRepository
+
+
+class DummySession:
+    def __init__(self):
+        self.added = []
+        self.executed = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def begin(self):
+        return self
+
+    async def add(self, obj):
+        self.added.append(obj)
+
+    async def add_all(self, objs):
+        self.added.extend(objs)
+
+    async def execute(self, stmt):
+        self.executed.append(stmt)
+        return types.SimpleNamespace(rowcount=1, scalars=lambda: types.SimpleNamespace(all=lambda: []))
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_no_events():
+    factory = AsyncMock()
+    repo = AsyncEventRepository(session_factory=factory)
+    await repo.bulk_insert_events([])
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete():
+    sess = DummySession()
+    factory = AsyncMock(return_value=sess)
+    repo = AsyncEventRepository(session_factory=factory)
+    rc = await repo.update_event("e1", status="ok")
+    assert rc == 1
+    rc = await repo.delete_event("e1")
+    assert rc == 1
+    assert len(sess.executed) == 2

--- a/tests/analytics/test_async_service.py
+++ b/tests/analytics/test_async_service.py
@@ -1,0 +1,96 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from services.analytics.async_service import AsyncAnalyticsService
+
+
+class _DummyContext:
+    async def __aenter__(self):
+        return SimpleNamespace()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyPool:
+    def __init__(self):
+        self.acquire_calls = 0
+
+    async def acquire(self):
+        self.acquire_calls += 1
+        return _DummyContext()
+
+
+class DummyRepo:
+    def __init__(self):
+        self.pool = DummyPool()
+        self.summary_calls = 0
+        self.pattern_calls = 0
+
+    async def fetch_dashboard_summary(self, conn, days=7):
+        self.summary_calls += 1
+        return {"days": days}
+
+    async def fetch_access_patterns(self, conn, days=7):
+        self.pattern_calls += 1
+        return {"patterns": days}
+
+
+class DummyLock:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyCache:
+    def __init__(self):
+        self.data = {}
+        self.started = False
+        self.stopped = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    def get_lock(self, key):
+        return DummyLock()
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl):
+        self.data[key] = value
+
+
+@pytest.mark.asyncio
+async def test_dashboard_summary_caching():
+    repo = DummyRepo()
+    cache = DummyCache()
+    service = AsyncAnalyticsService(repo, cache_manager=cache)
+    await service.start()
+    res1 = await service.get_dashboard_summary(5)
+    res2 = await service.get_dashboard_summary(5)
+    await service.stop()
+    assert res1 == {"days": 5}
+    assert res2 == {"days": 5}
+    assert repo.summary_calls == 1
+    assert cache.started and cache.stopped
+
+
+@pytest.mark.asyncio
+async def test_combined_analytics_error():
+    repo = DummyRepo()
+
+    async def bad_fetch(*a, **k):
+        raise RuntimeError("boom")
+
+    repo.fetch_dashboard_summary = bad_fetch
+    service = AsyncAnalyticsService(repo, cache_manager=DummyCache())
+    result = await service.get_combined_analytics()
+    assert result["status"] == "error"

--- a/tests/analytics/test_async_workers.py
+++ b/tests/analytics/test_async_workers.py
@@ -1,0 +1,42 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from services.analytics import async_workers as workers
+
+
+class StubManager:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.cleared = False
+
+    async def start(self):
+        self.started = True
+
+    async def clear(self):
+        self.cleared = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop(monkeypatch):
+    mgr = StubManager()
+
+    async def fake_create():
+        return mgr
+
+    monkeypatch.setattr(workers, "create_advanced_cache_manager", fake_create)
+    queue: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+
+    await workers.start_workers(calc_interval=0, cache_refresh_interval=0, task_queue=queue)
+    await asyncio.sleep(0.1)
+    await queue.put(asyncio.sleep(0))
+    await asyncio.sleep(0.1)
+    await workers.stop_workers()
+
+    assert mgr.started
+    assert mgr.stopped

--- a/tests/analytics/test_timescale_queries.py
+++ b/tests/analytics/test_timescale_queries.py
@@ -1,0 +1,36 @@
+import pytest
+
+from services.analytics import timescale_queries as tq
+
+
+def test_build_queries():
+    q1 = tq.build_time_bucket_query("1 hour", table="t")
+    assert "1 hour" in str(q1)
+    q2 = tq.build_sliding_window_query(3600, 60, table="t")
+    assert "COUNT(*)" in str(q2)
+
+
+@pytest.mark.asyncio
+async def test_fetch_time_buckets(monkeypatch):
+    class DummyPool:
+        def __init__(self):
+            self.calls = []
+
+        async def fetch(self, query, start, end):
+            self.calls.append(query)
+            return [dict(bucket=1, value=2)]
+
+    pool = DummyPool()
+    res = await tq.fetch_time_buckets(pool, 1, 2)
+    assert res == [{"bucket": 1, "value": 2}]
+    assert pool.calls
+
+
+@pytest.mark.asyncio
+async def test_fetch_sliding_window_error(monkeypatch):
+    class DummyPool:
+        async def fetch(self, *a):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await tq.fetch_sliding_window(DummyPool(), 1, 2)


### PR DESCRIPTION
## Summary
- add tests for new async analytics modules
- cover async repository, service, worker and query helpers
- add minimal FastAPI API tests

## Testing
- `pytest --version`
- *tests did not run due to missing dependencies*

------
https://chatgpt.com/codex/tasks/task_e_6884625510b48320a651723bad85efe3