### PR TITLE
Refactor file processors

### DIFF
--- a/memory_safe_processor.py
+++ b/memory_safe_processor.py
@@ -1,33 +1,22 @@
 from __future__ import annotations
 
-import io
 import logging
-from typing import IO, Iterable, Union
 
-import pandas as pd
 
-from utils.memory_utils import check_memory_limit
+
 from config.constants import DEFAULT_CHUNK_SIZE
+
+from services.data_processing.base_file_processor import BaseFileProcessor
 
 
 logger = logging.getLogger(__name__)
 
 
-class FileProcessor:
+class FileProcessor(BaseFileProcessor):
     """Process CSV files in chunks while guarding memory usage."""
 
     def __init__(self, chunk_size: int = DEFAULT_CHUNK_SIZE, *, max_memory_mb: int = 500) -> None:
-        self.chunk_size = chunk_size
-        self.max_memory_mb = max_memory_mb
-
-    def read_large_csv(self, file_like: Union[str, IO[str]]) -> pd.DataFrame:
-        """Read ``file_like`` in chunks and concatenate safely."""
-        reader = pd.read_csv(file_like, chunksize=self.chunk_size)
-        chunks: list[pd.DataFrame] = []
-        for chunk in reader:
-            check_memory_limit(self.max_memory_mb, logger)
-            chunks.append(chunk)
-        return pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+        super().__init__(chunk_size=chunk_size, max_memory_mb=max_memory_mb)
 
 
 __all__ = ["FileProcessor"]

--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -7,6 +7,7 @@ from .file_handler import FileHandler, process_file_simple
 # the new class here and optionally expose it under the old name for backward
 # compatibility.
 from .file_processor import UnicodeFileProcessor
+from .base_file_processor import BaseFileProcessor
 
 # Provide the legacy name ``FileProcessor`` for callers that still import it
 # from ``services.data_processing``.
@@ -73,4 +74,5 @@ __all__ = [
     "FileFormatError",
     "FileSizeError",
     "FileSecurityError",
+    "BaseFileProcessor",
 ]

--- a/services/data_processing/base_file_processor.py
+++ b/services/data_processing/base_file_processor.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from typing import IO, Iterable, List, Union, Callable
+
+import pandas as pd
+
+from analytics_core.utils.unicode_processor import UnicodeHelper
+from utils.file_utils import safe_decode_with_unicode_handling
+from utils.memory_utils import check_memory_limit
+from config.constants import DEFAULT_CHUNK_SIZE
+
+logger = logging.getLogger(__name__)
+
+
+class BaseFileProcessor:
+    """Shared helpers for file processing operations."""
+
+    ENCODING_PRIORITY = [
+        "utf-8",
+        "utf-8-sig",
+        "utf-16",
+        "utf-16-le",
+        "utf-16-be",
+        "latin1",
+        "cp1252",
+        "iso-8859-1",
+        "ascii",
+    ]
+
+    CSV_OPTIONS = {
+        "low_memory": False,
+        "dtype": str,
+        "keep_default_na": False,
+        "na_filter": False,
+        "skipinitialspace": True,
+    }
+
+    def __init__(
+        self,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        *,
+        max_memory_mb: int = 500,
+        decoder: Callable[[bytes, str], str] = safe_decode_with_unicode_handling,
+    ) -> None:
+        self.chunk_size = chunk_size
+        self.max_memory_mb = max_memory_mb
+        self._decoder = decoder
+
+    def decode_with_fallback(self, content: bytes) -> str:
+        """Decode ``content`` trying multiple encodings."""
+        encoding = None
+        try:
+            import chardet as chardet_module  # type: ignore
+        except ImportError:  # pragma: no cover - optional dependency
+            chardet_module = None
+        if chardet_module is not None:
+            detected = chardet_module.detect(content)
+            encoding = detected.get("encoding")
+        if encoding:
+            try:
+                text = self._decoder(content, encoding)
+                if self._is_reasonable_text(text):
+                    logger.debug("Decoded content using detected %s", encoding)
+                    return text
+            except Exception:
+                pass
+        for enc in self.ENCODING_PRIORITY:
+            try:
+                text = self._decoder(content, enc)
+                if self._is_reasonable_text(text):
+                    logger.debug("Decoded content using %s", enc)
+                    return text
+            except Exception:
+                continue
+        from core.unicode import safe_unicode_decode
+
+        logger.warning("All encodings failed, using replacement characters")
+        return safe_unicode_decode(content, "utf-8")
+
+    def decode_with_surrogate_handling(self, data: bytes, encoding: str) -> str:
+        """Decode ``data`` and strip surrogate code points."""
+        try:
+            text = data.decode(encoding, errors="surrogatepass")
+        except Exception:
+            text = data.decode(encoding, errors="replace")
+        return UnicodeHelper.clean_text(text)
+
+    def _is_reasonable_text(self, text: str) -> bool:
+        if not text.strip():
+            return False
+        replacement_ratio = text.count("\ufffd") / len(text)
+        if replacement_ratio > 0.1:
+            return False
+        printable = sum(1 for c in text if c.isprintable() or c.isspace())
+        return (printable / len(text)) > 0.7
+
+    def read_large_csv(self, file_like: Union[str, IO[str]]) -> pd.DataFrame:
+        """Read ``file_like`` in chunks and concatenate."""
+        reader = pd.read_csv(file_like, chunksize=self.chunk_size)
+        chunks: List[pd.DataFrame] = []
+        for chunk in reader:
+            check_memory_limit(self.max_memory_mb, logger)
+            chunks.append(chunk)
+        return pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+
+    def sanitize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return UnicodeHelper.sanitize_dataframe(df)
+
+
+__all__ = ["BaseFileProcessor"]

--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from analytics_core.utils.unicode_processor import UnicodeHelper
-from config.constants import UPLOAD_ALLOWED_EXTENSIONS
+from config.constants import UPLOAD_ALLOWED_EXTENSIONS, DEFAULT_CHUNK_SIZE
 from core.unicode import process_large_csv_content
 from services.configuration_service import ConfigurationServiceProtocol
 from utils.file_utils import safe_decode_with_unicode_handling
@@ -22,28 +22,19 @@ from utils.memory_utils import memory_safe
 from utils.protocols import SafeDecoderProtocol
 from yosai_framework.service import BaseService
 
+from services.data_processing.base_file_processor import BaseFileProcessor
+from validation.file_validator import FileValidator
+
 from .stream_processor import StreamProcessor
 
 logger = logging.getLogger(__name__)
 
 
-class FileProcessorService(BaseService):
+class FileProcessorService(BaseService, BaseFileProcessor):
     """File processing service implementation"""
 
     ALLOWED_EXTENSIONS = UPLOAD_ALLOWED_EXTENSIONS
 
-    # Encoding detection order for robust decoding
-    ENCODING_PRIORITY = [
-        "utf-8",
-        "utf-8-sig",
-        "utf-16",
-        "utf-16-le",
-        "utf-16-be",
-        "latin1",
-        "cp1252",
-        "iso-8859-1",
-        "ascii",
-    ]
 
     # Default CSV parsing options
     CSV_OPTIONS: Dict[str, Any] = {
@@ -59,12 +50,16 @@ class FileProcessorService(BaseService):
         config: ConfigurationServiceProtocol,
         decoder: SafeDecoderProtocol = safe_decode_with_unicode_handling,
         validator: FileValidator | None = None,
+        *,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
-        super().__init__("file-processor", "")
+        BaseService.__init__(self, "file-processor", "")
+        BaseFileProcessor.__init__(
+            self, chunk_size=chunk_size, decoder=decoder
+        )
         self.start()
         self.config = config
         self.max_file_size_mb = config.get_max_upload_size_mb()
-        self._decoder = decoder
         self._validator = validator or FileValidator(
             max_size_mb=self.max_file_size_mb,
             allowed_ext=self.ALLOWED_EXTENSIONS,
@@ -106,10 +101,10 @@ class FileProcessorService(BaseService):
         if len(content) > 10 * 1024 * 1024:
             text_content = process_large_csv_content(content)
         else:
-            text_content = self._decode_with_fallback(content)
+            text_content = self.decode_with_fallback(content)
 
         # Sanitize any surrogate characters that may remain after decoding
-        text_content = self._decode_with_surrogate_handling(
+        text_content = self.decode_with_surrogate_handling(
             text_content.encode("utf-8", "surrogatepass"),
             "utf-8",
         )
@@ -148,7 +143,7 @@ class FileProcessorService(BaseService):
     def _process_json(self, content: bytes) -> pd.DataFrame:
         """Process JSON file with robust decoding."""
         logger.debug("Processing JSON content")
-        text_content = self._decode_with_fallback(content)
+        text_content = self.decode_with_fallback(content)
 
         try:
             data = json.loads(text_content)
@@ -173,54 +168,3 @@ class FileProcessorService(BaseService):
         except Exception as e:
             raise ValueError(f"Error reading Excel file: {e}")
 
-    def _decode_with_fallback(self, content: bytes) -> str:
-        """Decode bytes using multiple encodings with basic heuristics."""
-        encoding = None
-        try:
-            import chardet as chardet_module  # type: ignore
-        except ImportError:  # pragma: no cover - optional dependency
-            chardet_module = None
-        if chardet_module is not None:
-            detected = chardet_module.detect(content)
-            encoding = detected.get("encoding")
-        if encoding:
-            try:
-                text = self._decoder(content, encoding)
-                if self._is_reasonable_text(text):
-                    logger.debug("Decoded content using detected %s", encoding)
-                    return text
-            except Exception:
-                pass
-
-        for enc in self.ENCODING_PRIORITY:
-            try:
-                text = self._decoder(content, enc)
-                if self._is_reasonable_text(text):
-                    logger.debug("Decoded content using %s", enc)
-                    return text
-            except Exception:
-                continue
-        from core.unicode import safe_unicode_decode
-
-        logger.warning("All encodings failed, using replacement characters")
-        return safe_unicode_decode(content, "utf-8")
-
-    def _decode_with_surrogate_handling(self, data: bytes, encoding: str) -> str:
-        """Decode ``data`` and remove surrogate code points."""
-        try:
-            text = data.decode(encoding, errors="surrogatepass")
-        except Exception:
-            text = data.decode(encoding, errors="replace")
-        return UnicodeHelper.clean_text(text)
-
-    def _is_reasonable_text(self, text: str) -> bool:
-        """Basic check to ensure decoded text looks valid."""
-        if not text.strip():
-            return False
-
-        replacement_ratio = text.count("\ufffd") / len(text)
-        if replacement_ratio > 0.1:
-            return False
-
-        printable = sum(1 for c in text if c.isprintable() or c.isspace())
-        return (printable / len(text)) > 0.7

--- a/tests/test_file_processor_service_surrogates.py
+++ b/tests/test_file_processor_service_surrogates.py
@@ -18,7 +18,7 @@ from core.unicode import sanitize_unicode_input
 def test_decode_with_surrogate_pairs():
     svc = FileProcessorService(FakeConfiguration())
     data = "col\nval\ud83d\ude00".encode("utf-8", "surrogatepass")
-    text = svc._decode_with_surrogate_handling(data, "utf-8")
+    text = svc.decode_with_surrogate_handling(data, "utf-8")
     assert "val" in text
     assert "\ud83d" not in text
     assert "\ude00" not in text


### PR DESCRIPTION
## Summary
- extract a `BaseFileProcessor` with decoding and chunk helpers
- use the base class in `FileProcessorService` and memory-safe variant
- expose `BaseFileProcessor` from the data processing package
- adjust tests for new method names

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_68848ee0b1448320bc0f7ec85427044d