### PR TITLE
Switch analytics microservice to ServiceBuilder

### DIFF
--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -12,7 +12,7 @@ from fastapi import (
     Form,
     FastAPI,
 )
-from yosai_framework.service import BaseService
+from yosai_framework import ServiceBuilder
 from shared.errors.types import ErrorCode
 from yosai_framework.errors import ServiceError
 from jose import jwt
@@ -34,7 +34,13 @@ from infrastructure.discovery.health_check import (
 
 
 SERVICE_NAME = "analytics-microservice"
-service = BaseService(SERVICE_NAME, "")
+service = (
+    ServiceBuilder(SERVICE_NAME)
+    .with_logging()
+    .with_metrics("")
+    .with_health()
+    .build()
+)
 app = service.app
 
 

--- a/tests/test_yosai_framework_service.py
+++ b/tests/test_yosai_framework_service.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-from yosai_framework import service as svc_mod
+from yosai_framework import ServiceBuilder, service as svc_mod
 from yosai_framework.config import ServiceConfig
 
 
@@ -13,7 +13,14 @@ def _dummy_config(*_):
 
 def test_structlog_json(monkeypatch, caplog):
     monkeypatch.setattr(svc_mod, "load_config", _dummy_config)
-    svc = svc_mod.BaseService("test", "cfg")
+    svc = (
+        ServiceBuilder("test")
+        .with_config("cfg")
+        .with_logging()
+        .with_metrics("")
+        .with_health()
+        .build()
+    )
     with caplog.at_level(logging.INFO):
         svc.start()
         svc.log.info("hello")
@@ -26,7 +33,14 @@ def test_structlog_json(monkeypatch, caplog):
 
 def test_metrics_registered(monkeypatch):
     monkeypatch.setattr(svc_mod, "load_config", _dummy_config)
-    svc = svc_mod.BaseService("test", "cfg")
+    svc = (
+        ServiceBuilder("test")
+        .with_config("cfg")
+        .with_logging()
+        .with_metrics("")
+        .with_health()
+        .build()
+    )
     svc.start()
     names = svc_mod.REGISTRY._names_to_collectors.keys()
     assert "yosai_request_total" in names

--- a/yosai_framework/__init__.py
+++ b/yosai_framework/__init__.py
@@ -1,1 +1,4 @@
+from .service import BaseService
+from .builder import ServiceBuilder
 
+__all__ = ["BaseService", "ServiceBuilder"]

--- a/yosai_framework/builder.py
+++ b/yosai_framework/builder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from .service import BaseService
+
+
+class ServiceBuilder:
+    """Build ``BaseService`` instances with optional features."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.config_path = ""
+        self._logging = False
+        self._log_level = "INFO"
+        self._metrics = False
+        self._metrics_addr = ""
+        self._health = False
+
+    def with_config(self, path: str) -> "ServiceBuilder":
+        self.config_path = path
+        return self
+
+    def with_logging(self, level: str = "INFO") -> "ServiceBuilder":
+        self._logging = True
+        self._log_level = level
+        return self
+
+    def with_metrics(self, addr: str = "") -> "ServiceBuilder":
+        self._metrics = True
+        self._metrics_addr = addr
+        return self
+
+    def with_health(self) -> "ServiceBuilder":
+        self._health = True
+        return self
+
+    def build(self) -> BaseService:
+        service = BaseService(self.name, self.config_path)
+
+        if self._logging:
+            service.config.log_level = self._log_level
+        else:
+            service._setup_logging = lambda: None  # type: ignore[assignment]
+
+        if self._metrics:
+            service.config.metrics_addr = self._metrics_addr
+        else:
+            service._setup_metrics = lambda: None  # type: ignore[assignment]
+
+        if not self._health:
+            service.app.router.routes = [
+                r
+                for r in service.app.router.routes
+                if not getattr(r, "path", "").startswith("/health")
+            ]
+
+        return service


### PR DESCRIPTION
## Summary
- implement `ServiceBuilder` in `yosai_framework`
- build analytics microservice using the builder
- expose `ServiceBuilder` in package init
- update framework service tests for the new builder

## Testing
- `pytest tests/test_yosai_framework_service.py -q` *(fails: ImportError cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_68849817ac68832097ac416771289abd