### PR TITLE
Fix imports to new src namespace

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -15,7 +15,10 @@ from services.security import require_token
 
 csrf = CSRFProtect()
 
-from api.analytics_router import router as analytics_router, init_cache_manager
+from yosai_intel_dashboard.src.adapters.api.analytics_router import (
+    router as analytics_router,
+    init_cache_manager,
+)
 from settings_endpoint import settings_bp
 
 from config.constants import API_PORT

--- a/api/api_app.py
+++ b/api/api_app.py
@@ -1,4 +1,4 @@
-from api.adapter import create_api_app
+from yosai_intel_dashboard.src.adapters.api.adapter import create_api_app
 from config.constants import API_PORT
 
 app = create_api_app()

--- a/api/plugin_performance.py
+++ b/api/plugin_performance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from api.adapter import api_adapter
+from yosai_intel_dashboard.src.adapters.api.adapter import api_adapter
 from app import app
 from flask import abort, jsonify, request
 from marshmallow import Schema, fields

--- a/api/risk_scoring.py
+++ b/api/risk_scoring.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from api.adapter import api_adapter
+from yosai_intel_dashboard.src.adapters.api.adapter import api_adapter
 from app import app
 from flask import abort, jsonify, request
 from marshmallow import Schema, fields

--- a/api/spec.py
+++ b/api/spec.py
@@ -12,11 +12,15 @@ def create_flask_app() -> Flask:
     from upload_endpoint import upload_bp
     from device_endpoint import device_bp
     from mappings_endpoint import mappings_bp
-    from api.settings_endpoint import settings_bp
-    from api.analytics_endpoints import analytics_bp, graphs_bp, export_bp
+    from yosai_intel_dashboard.src.adapters.api.settings_endpoint import settings_bp
+    from yosai_intel_dashboard.src.adapters.api.analytics_endpoints import (
+        analytics_bp,
+        graphs_bp,
+        export_bp,
+    )
     from plugins.compliance_plugin.compliance_controller import compliance_bp
-    import api.plugin_performance as plugin_perf
-    import api.risk_scoring as risk
+    import yosai_intel_dashboard.src.adapters.api.plugin_performance as plugin_perf
+    import yosai_intel_dashboard.src.adapters.api.risk_scoring as risk
 
     app = Flask(__name__)
     app.register_blueprint(upload_bp)

--- a/scripts/generate_flask_openapi.py
+++ b/scripts/generate_flask_openapi.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from api.spec import create_spec
+from yosai_intel_dashboard.src.adapters.api.spec import create_spec
 
 
 def main() -> None:

--- a/start_api.py
+++ b/start_api.py
@@ -7,7 +7,7 @@ import logging
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Import Flask app directly from adapter
-from api.adapter import create_api_app
+from yosai_intel_dashboard.src.adapters.api.adapter import create_api_app
 from config.constants import API_PORT
 
 

--- a/tests/api/test_analytics_routes.py
+++ b/tests/api/test_analytics_routes.py
@@ -21,7 +21,9 @@ def _create_app(monkeypatch):
             pass
 
         async def get_analytics_summary(self, facility, date_range):
-            from api.analytics_endpoints import MOCK_DATA
+            from yosai_intel_dashboard.src.adapters.api.analytics_endpoints import (
+                MOCK_DATA
+            )
             return MOCK_DATA
 
     monkeypatch.setitem(
@@ -55,7 +57,9 @@ def _create_app(monkeypatch):
         types.SimpleNamespace(require_token=lambda f: f, require_permission=lambda p: (lambda f: f)),
     )
 
-    from api.analytics_endpoints import register_analytics_blueprints
+    from yosai_intel_dashboard.src.adapters.api.analytics_endpoints import (
+        register_analytics_blueprints
+    )
 
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "test-key"

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -21,7 +21,11 @@ def _create_app(monkeypatch, origins):
         register_analytics_blueprints=lambda app: None,
         init_cache_manager=lambda: None,
     )
-    monkeypatch.setitem(sys.modules, "api.analytics_endpoints", analytics_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.adapters.api.analytics_endpoints",
+        analytics_stub,
+    )
 
     container = types.SimpleNamespace(
         services={"file_processor": object()},
@@ -78,7 +82,9 @@ def _create_app(monkeypatch, origins):
         lambda: types.SimpleNamespace(cors_origins=origins),
     )
 
-    adapter = importlib.import_module("api.adapter")
+    adapter = importlib.import_module(
+        "yosai_intel_dashboard.src.adapters.api.adapter"
+    )
     return adapter.create_api_app()
 
 

--- a/tests/integration/test_api_csrf.py
+++ b/tests/integration/test_api_csrf.py
@@ -19,7 +19,11 @@ def _create_app(monkeypatch):
     analytics_stub = types.SimpleNamespace(
         register_analytics_blueprints=lambda app: None
     )
-    monkeypatch.setitem(sys.modules, "api.analytics_endpoints", analytics_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.adapters.api.analytics_endpoints",
+        analytics_stub,
+    )
 
     container = types.SimpleNamespace(
         services={"file_processor": DummyFileProcessor()},
@@ -32,7 +36,9 @@ def _create_app(monkeypatch):
     upload_endpoint = importlib.import_module("upload_endpoint")
     monkeypatch.setattr(upload_endpoint, "container", container, raising=False)
 
-    adapter = importlib.import_module("api.adapter")
+    adapter = importlib.import_module(
+        "yosai_intel_dashboard.src.adapters.api.adapter"
+    )
     return adapter.create_api_app()
 
 


### PR DESCRIPTION
## Summary
- point tools and endpoints to `yosai_intel_dashboard.src.adapters`
- adjust tests to reference new adapter paths

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'dynamic_config' from partially initialized module 'config.dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_6884981828d88320b737e2635cd9f275