### PR TITLE
Add async messaging diagrams

### DIFF
--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -4,10 +4,25 @@
 sequenceDiagram
     participant Browser
     participant Server
+    participant MQ as Kafka/Redis
+    participant Worker
     participant DB as Database
+    participant EH as ErrorHandler
 
     Browser->>Server: HTTP request
     Server->>DB: Query / Update
     DB-->>Server: Result
     Server-->>Browser: Rendered response
+    Server-->>MQ: Publish event
+    MQ-->>Worker: Consume
+    Worker-->>Server: Callback result
+    Worker->>EH: Error occurred?
+    EH-->>Server: Raise or log
 ```
+
+## Retry Logic and Circuit Breakers
+
+Services publish events using `with_retry` and `CircuitBreaker` from
+`core.error_handling`. Retries use exponential backoff and failures increment the
+circuit breaker metrics. When a breaker opens, subsequent messages are rejected
+and the error handler notifies the caller so issues surface quickly.

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -1,6 +1,7 @@
 # System Flow Diagram
 
-This diagram illustrates how the frontend interacts with the service layer, plugins, and the database.
+This diagram illustrates how the frontend interacts with the service layer, plugins,
+the database and the asynchronous messaging components.
 
 ```mermaid
 flowchart TD
@@ -10,5 +11,20 @@ flowchart TD
     Services --> PluginManager
     PluginManager --> Plugins
     Plugins -->|Register callbacks| UI
+    Services -->|Publish events| MQ[(Kafka/Redis)]
+    MQ --> Worker[Background Worker]
+    Worker -->|Invoke callbacks| UI
+    Services -->|Errors| ErrorHandler
+    MQ -->|Errors| ErrorHandler
+    ErrorHandler -->|Bubble up| UI
 ```
+
+## Retry Logic and Circuit Breakers
+
+The `core.error_handling` module provides a `CircuitBreaker` class and
+`with_retry` decorator that wrap external calls. Services publish events to Kafka
+or Redis through these utilities so that temporary failures are retried with
+exponential backoff. When the breaker opens, further calls raise a
+`CircuitBreakerError` which is captured by the global error handler and reported
+back to the UI.
 


### PR DESCRIPTION
## Summary
- expand system and data flow diagrams to show async events
- document Kafka/Redis event publishing, callbacks and failures
- mention retry logic and circuit breakers from `core.error_handling`

## Testing
- `pre-commit run --files docs/system_diagram.md docs/data_flow.md`

------
https://chatgpt.com/codex/tasks/task_e_6884981a7dc48320a8b30fd07df3afac