### PR TITLE
Clean up imports for analytics services

### DIFF
--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -1,36 +1,36 @@
-import logging
+import os
 import time
+from pathlib import Path
+import json
 
 from fastapi import (
-    Depends,
-    Header,
-    HTTPException,
-    status,
     APIRouter,
-    UploadFile,
+    Depends,
+    FastAPI,
     File,
     Form,
-    FastAPI,
+    Header,
+    HTTPException,
+    UploadFile,
+    status,
 )
-from yosai_framework.service import BaseService
-from shared.errors.types import ErrorCode
-from yosai_framework.errors import ServiceError
 from jose import jwt
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
-from pathlib import Path
-import json
+from yosai_framework.errors import ServiceError
+from yosai_framework.service import BaseService
 
 from config import get_database_config
-from config.validate import validate_required_env
-from services.analytics_microservice import async_queries
-from services.common.async_db import close_pool, create_pool, get_pool
-from services.common import async_db
 from infrastructure.discovery.health_check import (
     register_health_check,
     setup_health_checks,
 )
+from services.analytics_microservice import async_queries
+from services.common import async_db
+from services.common.async_db import close_pool, create_pool, get_pool
+from services.common.secrets import get_secret
+from shared.errors.types import ErrorCode
 
 
 SERVICE_NAME = "analytics-microservice"
@@ -43,8 +43,6 @@ async def _db_check(_: FastAPI) -> bool:
 
 
 register_health_check(app, "database", _db_check)
-
-from services.common.secrets import get_secret
 
 _SECRET_PATH = "secret/data/jwt#secret"
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-
 """Analytics Service - Enhanced with Unique Patterns Analysis.
 
 Uploaded files are validated with
@@ -8,12 +6,15 @@ Uploaded files are validated with
 processing to ensure they are present, non-empty and within the configured size
 limits.
 """
+
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Dict, List, Protocol
 
 try:
     from typing import override


### PR DESCRIPTION
## Summary
- remove unused imports and adjust order
- add blank line after docstring and move `__future__` import
- fix missing os import in microservice app
- ensure imports adhere to PEP8 style

## Testing
- `ruff check services/analytics_service.py`
- `ruff check services/analytics_microservice/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6884983de2b883209e21ce8c27f87178