### PR TITLE
Implement service communication layer

### DIFF
--- a/infrastructure/communication/__init__.py
+++ b/infrastructure/communication/__init__.py
@@ -1,0 +1,17 @@
+"""Unified service communication primitives."""
+
+from .protocols import MessageBus, ServiceClient
+from .rest_client import AsyncRestClient, RetryPolicy, create_service_client, CircuitBreakerOpen
+from .message_queue import AsyncQueueClient
+from .circuit_breaker import CircuitBreaker
+
+__all__ = [
+    "MessageBus",
+    "ServiceClient",
+    "AsyncRestClient",
+    "AsyncQueueClient",
+    "RetryPolicy",
+    "create_service_client",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+]

--- a/infrastructure/communication/circuit_breaker.py
+++ b/infrastructure/communication/circuit_breaker.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when the circuit is open and requests are blocked."""
+
+
+class CircuitBreaker:
+    """Simple asynchronous circuit breaker."""
+
+    def __init__(self, failure_threshold: int, recovery_timeout: int, *, name: str | None = None) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._failures = 0
+        self._opened_at: float | None = None
+        self._state = "closed"
+        self._lock = asyncio.Lock()
+        self._name = name or "circuit"
+
+    async def record_success(self) -> None:
+        async with self._lock:
+            self._failures = 0
+            self._opened_at = None
+            self._state = "closed"
+
+    async def record_failure(self) -> None:
+        async with self._lock:
+            self._failures += 1
+            if self._failures >= self.failure_threshold and self._state != "open":
+                self._state = "open"
+                self._opened_at = time.time()
+
+    async def allows_request(self) -> bool:
+        async with self._lock:
+            if self._state == "open":
+                if self._opened_at and time.time() - self._opened_at >= self.recovery_timeout:
+                    self._state = "half_open"
+                    return True
+                return False
+            return True
+
+    async def __aenter__(self) -> "CircuitBreaker":
+        if not await self.allows_request():
+            raise CircuitBreakerOpen(f"{self._name} circuit open")
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if exc is None:
+            await self.record_success()
+        else:
+            await self.record_failure()
+
+    def __call__(self, func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        cb = self
+
+        async def wrapper(*args, **kwargs):
+            if not await cb.allows_request():
+                raise CircuitBreakerOpen(f"{cb._name} circuit open")
+            try:
+                result = await func(*args, **kwargs)
+            except Exception:
+                await cb.record_failure()
+                raise
+            else:
+                await cb.record_success()
+                return result
+
+        return wrapper
+

--- a/infrastructure/communication/message_queue.py
+++ b/infrastructure/communication/message_queue.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Dict
+
+from .protocols import MessageBus
+
+
+class AsyncQueueClient(MessageBus):
+    """In-memory async message queue used for testing."""
+
+    def __init__(self) -> None:
+        self._queues: Dict[str, asyncio.Queue[Any]] = {}
+
+    async def publish(self, topic: str, message: Any) -> None:
+        queue = self._queues.setdefault(topic, asyncio.Queue())
+        await queue.put(message)
+
+    async def subscribe(
+        self, topic: str, handler: Callable[[Any], Awaitable[None]]
+    ) -> None:
+        queue = self._queues.setdefault(topic, asyncio.Queue())
+        while True:
+            msg = await queue.get()
+            await handler(msg)
+            queue.task_done()
+

--- a/infrastructure/communication/protocols.py
+++ b/infrastructure/communication/protocols.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Protocol
+
+
+class MessageBus(Protocol):
+    """Asynchronous message bus protocol."""
+
+    async def publish(self, topic: str, message: Any) -> None:
+        """Publish *message* to *topic*."""
+        ...
+
+    async def subscribe(
+        self, topic: str, handler: Callable[[Any], Awaitable[None]]
+    ) -> None:
+        """Invoke *handler* for each message from *topic*."""
+        ...
+
+
+class ServiceClient(Protocol):
+    """Protocol for asynchronous service clients."""
+
+    async def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Execute an HTTP request and return the decoded response."""
+        ...
+

--- a/infrastructure/communication/rest_client.py
+++ b/infrastructure/communication/rest_client.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, MutableMapping
+from uuid import uuid4
+
+import aiohttp
+import structlog
+
+from .circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+from .protocols import ServiceClient
+
+
+@dataclass
+class RetryPolicy:
+    max_attempts: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    exponential_base: float = 2.0
+
+
+class AsyncRestClient(ServiceClient):
+    """Asynchronous HTTP client with retries and circuit breaker."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 5.0,
+        retry_policy: RetryPolicy | None = None,
+        failure_threshold: int = 5,
+        recovery_timeout: int = 60,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self.retry_policy = retry_policy or RetryPolicy()
+        self.circuit_breaker = CircuitBreaker(
+            failure_threshold, recovery_timeout, name=base_url
+        )
+        self.log: structlog.BoundLogger = structlog.get_logger(__name__)
+
+    # ------------------------------------------------------------------
+    async def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        url = self.base_url + path
+        headers: MutableMapping[str, str] = kwargs.pop("headers", {}) or {}
+        request_id = headers.get("X-Request-ID", uuid4().hex)
+        headers["X-Request-ID"] = request_id
+        kwargs["headers"] = headers
+        attempt = 0
+        delay = self.retry_policy.base_delay
+        log = self.log.bind(request_id=request_id, url=url, method=method)
+
+        while True:
+            try:
+                async with self.circuit_breaker:
+                    async with aiohttp.ClientSession() as session:
+                        async with session.request(
+                            method,
+                            url,
+                            timeout=self.timeout,
+                            **kwargs,
+                        ) as resp:
+                            log.info("request", status=resp.status)
+                            resp.raise_for_status()
+                            ctype = resp.headers.get("Content-Type", "")
+                            if "application/json" in ctype:
+                                return await resp.json()
+                            return await resp.text()
+            except CircuitBreakerOpen:
+                log.warning("circuit_open")
+                raise
+            except Exception as exc:
+                attempt += 1
+                log.warning("request_failed", attempt=attempt, error=str(exc))
+                if attempt >= self.retry_policy.max_attempts:
+                    raise
+                await asyncio.sleep(delay)
+                delay = min(
+                    delay * self.retry_policy.exponential_base,
+                    self.retry_policy.max_delay,
+                )
+
+
+# ----------------------------------------------------------------------
+
+def create_service_client(service_name: str) -> ServiceClient:
+    """Create a service client resolving *service_name* URL from env vars."""
+    env = f"{service_name.upper()}_SERVICE_URL"
+    base_url = os.getenv(env, f"http://{service_name}")
+    return AsyncRestClient(base_url)
+
+
+__all__ = ["AsyncRestClient", "RetryPolicy", "create_service_client", "CircuitBreakerOpen"]

--- a/infrastructure/tests/test_communication.py
+++ b/infrastructure/tests/test_communication.py
@@ -1,0 +1,48 @@
+import asyncio
+from infrastructure.communication import AsyncRestClient, AsyncQueueClient
+
+class DummyRequest:
+    async def __aenter__(self):
+        return DummyResponse()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummyResponse:
+    status = 200
+    headers = {"Content-Type": "application/json"}
+    async def json(self):
+        return {"ok": True}
+    async def text(self):
+        return "{}"
+    def raise_for_status(self):
+        pass
+
+class DummySession:
+    def request(self, *args, **kwargs):
+        return DummyRequest()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def test_rest_client_request(monkeypatch):
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: DummySession())
+    client = AsyncRestClient("http://service")
+    result = asyncio.run(client.request("GET", "/ping"))
+    assert result == {"ok": True}
+
+def test_queue_publish_consume():
+    q = AsyncQueueClient()
+    result = []
+    async def handler(msg):
+        result.append(msg)
+    async def run_all():
+        consumer = asyncio.create_task(q.subscribe("t", handler))
+        await q.publish("t", 1)
+        await asyncio.sleep(0.05)
+        consumer.cancel()
+    asyncio.run(run_all())
+    assert result == [1]


### PR DESCRIPTION
## Summary
- add unified communication package with protocols for message bus and service client
- implement asynchronous REST client with retry logic and circuit breaker
- implement in-memory async message queue
- expose service client factory for easier use
- test new communication utilities

## Testing
- `PYTHONPATH=. pytest infrastructure/tests/test_communication.py -q`
- `pytest -q` *(fails: 187 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884a50681a883208c8b1fa53bbc1a46