### PR TITLE
Convert schema registry and feature flags to async

### DIFF
--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-import requests
+import aiohttp
+import pytest
 from pathlib import Path
 
 spec = importlib.util.spec_from_file_location(
@@ -17,74 +18,98 @@ spec.loader.exec_module(schema_registry)
 SchemaRegistryClient = schema_registry.SchemaRegistryClient
 
 
-def test_get_schema(monkeypatch):
-    def fake_get(url: str, timeout: int):
-        assert url == "http://sr/subjects/test/versions/latest"
-        resp = MagicMock()
-        resp.json.return_value = {
-            "id": 1,
-            "version": 1,
-            "schema": '{"type":"record","name":"t","fields":[]}',
-        }
-        resp.raise_for_status = lambda: None
-        return resp
+class DummyRequest:
+    def __init__(self, data: dict):
+        self.resp = MagicMock()
+        self.resp.json = AsyncMock(return_value=data)
+        self.resp.raise_for_status = lambda: None
 
-    monkeypatch.setattr(requests, "get", fake_get)
+    async def __aenter__(self):
+        return self.resp
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySession:
+    def __init__(self, data: dict):
+        self.data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url: str, timeout=None):
+        assert url == "http://sr/subjects/test/versions/latest"
+        return DummyRequest(self.data)
+
+    def post(self, url: str, json=None, headers=None, timeout=None):
+        return DummyRequest(self.data)
+
+
+def test_get_schema(monkeypatch, async_runner):
+    data = {
+        "id": 1,
+        "version": 1,
+        "schema": '{"type":"record","name":"t","fields":[]}',
+    }
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: DummySession(data))
     client = SchemaRegistryClient("http://sr")
-    info = client.get_schema("test")
+    info = async_runner(client.get_schema("test"))
     assert info.id == 1
     assert info.version == 1
     assert info.schema["name"] == "t"
 
 
-def test_get_schema_cached(monkeypatch):
+def test_get_schema_cached(monkeypatch, async_runner):
     calls = []
 
-    def fake_get(url: str, timeout: int):
-        calls.append(url)
-        resp = MagicMock()
-        resp.json.return_value = {
-            "id": 1,
-            "version": 1,
-            "schema": '{"type":"record","name":"t","fields":[]}',
-        }
-        resp.raise_for_status = lambda: None
-        return resp
+    class CountSession(DummySession):
+        def get(self, url: str, timeout=None):
+            calls.append(url)
+            return super().get(url, timeout)
 
-    monkeypatch.setattr(requests, "get", fake_get)
+    data = {
+        "id": 1,
+        "version": 1,
+        "schema": '{"type":"record","name":"t","fields":[]}',
+    }
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: CountSession(data))
     client = SchemaRegistryClient("http://sr")
-    first = client.get_schema("test")
-    second = client.get_schema("test")
+    first = async_runner(client.get_schema("test"))
+    second = async_runner(client.get_schema("test"))
     assert first is second
     assert len(calls) == 1
 
 
-def test_check_compatibility(monkeypatch):
-    def fake_post(url: str, json: dict, headers: dict, timeout: int):
-        assert url == "http://sr/compatibility/subjects/test/versions/latest"
-        resp = MagicMock()
-        resp.json.return_value = {"is_compatible": True}
-        resp.raise_for_status = lambda: None
-        return resp
+def test_check_compatibility(monkeypatch, async_runner):
+    data = {"is_compatible": True}
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    class CompatSession(DummySession):
+        def post(self, url: str, json=None, headers=None, timeout=None):
+            assert url == "http://sr/compatibility/subjects/test/versions/latest"
+            return DummyRequest(data)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: CompatSession(data))
     client = SchemaRegistryClient("http://sr")
-    assert client.check_compatibility(
-        "test", {"type": "record", "name": "t", "fields": []}
+    assert async_runner(
+        client.check_compatibility("test", {"type": "record", "name": "t", "fields": []})
     )
 
 
-def test_register_schema(monkeypatch):
-    def fake_post(url: str, json: dict, headers: dict, timeout: int):
-        assert url == "http://sr/subjects/test-value/versions"
-        resp = MagicMock()
-        resp.json.return_value = {"version": 2}
-        resp.raise_for_status = lambda: None
-        return resp
+def test_register_schema(monkeypatch, async_runner):
+    data = {"version": 2}
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    class RegSession(DummySession):
+        def post(self, url: str, json=None, headers=None, timeout=None):
+            assert url == "http://sr/subjects/test-value/versions"
+            return DummyRequest(data)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: RegSession(data))
     client = SchemaRegistryClient("http://sr")
-    version = client.register_schema(
-        "test-value", {"type": "record", "name": "t", "fields": []}
+    version = async_runner(
+        client.register_schema("test-value", {"type": "record", "name": "t", "fields": []})
     )
     assert version == 2


### PR DESCRIPTION
## Summary
- migrate `SchemaRegistryClient` to use `aiohttp` and async calls
- load feature flags using `aiohttp`/`aiofiles`
- update watcher thread
- adapt unit tests for async schema registry

## Testing
- `pytest tests/test_schema_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a77f9f048320a4d86b4e09865bb1