### PR TITLE
Replace event loop calls with asyncio.run

### DIFF
--- a/core/service_container.py
+++ b/core/service_container.py
@@ -280,14 +280,14 @@ class ServiceContainer(BaseModel):
         if not hasattr(warmer, "warm"):
             return
 
-        try:
-            import asyncio
+        import asyncio
 
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
             asyncio.run(warmer.warm())
-        except RuntimeError:  # event loop already running
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(warmer.warm())
-            loop.close()
+        else:
+            asyncio.run_coroutine_threadsafe(warmer.warm(), loop).result()
 
     # ------------------------------------------------------------------
     def validate_registrations(self) -> Dict[str, List[str]]:

--- a/mde.py
+++ b/mde.py
@@ -220,11 +220,8 @@ class MVPTestApp(BaseDatabaseService):
                 logger.info(f"📁 Processing file: {filename}")
                 
                 # Use existing base code upload service
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                
                 assert self.upload_service is not None
-                result_dict = loop.run_until_complete(
+                result_dict = asyncio.run(
                     self.upload_service.process_uploaded_files([contents], [filename])
                 )
                 
@@ -232,7 +229,6 @@ class MVPTestApp(BaseDatabaseService):
                 upload_results = result_dict.get('upload_results', [])
                 preview_components = result_dict.get('file_preview_components', [])
                 file_info = result_dict.get('file_info_dict', {})
-                loop.close()
                 
                 logger.info(f"✅ Base code processing complete")
                 

--- a/services/migration/adapter.py
+++ b/services/migration/adapter.py
@@ -155,15 +155,17 @@ class AnalyticsServiceAdapter(ServiceAdapter, AnalyticsServiceProtocol):
                     return await response.json()
 
     # ``AnalyticsServiceProtocol`` methods ---------------------------------
+    async def get_dashboard_summary_async(self) -> Dict[str, Any]:
+        return await self.call("get_dashboard_summary")
+
     def get_dashboard_summary(self) -> Dict[str, Any]:
-        loop = asyncio.new_event_loop()
-        return loop.run_until_complete(self.call("get_dashboard_summary"))
+        return asyncio.run(self.get_dashboard_summary_async())
+
+    async def get_access_patterns_analysis_async(self, days: int = 7) -> Dict[str, Any]:
+        return await self.call("get_access_patterns_analysis", days=days)
 
     def get_access_patterns_analysis(self, days: int = 7) -> Dict[str, Any]:
-        loop = asyncio.new_event_loop()
-        return loop.run_until_complete(
-            self.call("get_access_patterns_analysis", days=days)
-        )
+        return asyncio.run(self.get_access_patterns_analysis_async(days))
 
     def process_dataframe(
         self, df: pd.DataFrame

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,9 +314,7 @@ def mock_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def async_runner() -> Generator[callable, None, None]:
     """Run async coroutines in a dedicated event loop."""
 
-    loop = asyncio.new_event_loop()
-    yield lambda coro: loop.run_until_complete(coro)
-    loop.close()
+    yield asyncio.run
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- refactor websocket server to run using `asyncio.run`
- expose async helpers in migration adapter
- avoid creating new event loop in ServiceContainer
- simplify upload handling in `mde.py`
- streamline async runner fixture

## Testing
- `python -m py_compile core/service_container.py mde.py services/migration/adapter.py services/websocket_server.py tests/conftest.py`
- `pytest tests/test_migration_adapter.py::TestMigrationAdapter::test_microservice_failure -q` *(fails: ModuleNotFoundError: No module named 'botocore')*

------
https://chatgpt.com/codex/tasks/task_e_6884a782c39883209a3f89a57a9caa1c