### PR TITLE
Move plugin protocols to core package

### DIFF
--- a/core/json_serialization_plugin.py
+++ b/core/json_serialization_plugin.py
@@ -3,6 +3,8 @@ Self-Contained JSON Serialization Plugin
 Handles all JSON serialization issues internally with minimal external dependencies
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import asdict, dataclass, is_dataclass
@@ -11,8 +13,8 @@ from typing import Any, Dict, Optional, cast
 
 import pandas as pd
 
+from core.protocols.plugin import PluginMetadata
 from core.serialization import SafeJSONSerializer
-from services.data_processing.core.protocols import PluginMetadata
 
 from .base_model import BaseModel
 

--- a/core/plugins/dependency_resolver.py
+++ b/core/plugins/dependency_resolver.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import DefaultDict, Dict, List, Set
 
-
-from services.data_processing.core.protocols import PluginProtocol
+from core.protocols.plugin import PluginProtocol
 
 
 class CircularDependencyError(ValueError):

--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import importlib
 import logging
@@ -8,13 +10,13 @@ from typing import Any, Dict, List
 
 from config import ConfigManager
 from core.callbacks import UnifiedCallbackManager
-from core.service_container import ServiceContainer
-from services.data_processing.core.protocols import (
+from core.protocols.plugin import (
     CallbackPluginProtocol,
     PluginPriority,
     PluginProtocol,
     PluginStatus,
 )
+from core.service_container import ServiceContainer
 
 from .dependency_resolver import PluginDependencyResolver
 

--- a/core/plugins/performance_manager.py
+++ b/core/plugins/performance_manager.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 from core.base_model import BaseModel
-from services.data_processing.core.protocols import PluginProtocol
+from core.protocols.plugin import PluginProtocol
 
 from .manager import ThreadSafePluginManager
 

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -7,9 +7,9 @@ from dash import Dash
 
 from config import ConfigManager
 from core.callbacks import UnifiedCallbackManager
-from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager
-from services.data_processing.core.protocols import PluginProtocol
+from core.protocols.plugin import PluginProtocol
+from core.service_container import ServiceContainer
 from services.registry import registry as service_registry
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints

--- a/core/protocols/__init__.py
+++ b/core/protocols/__init__.py
@@ -18,9 +18,9 @@ from typing import (
     runtime_checkable,
 )
 
-from .callback_events import CallbackEvent
-
 import pandas as pd
+
+from core.callback_events import CallbackEvent
 
 
 @runtime_checkable
@@ -109,7 +109,9 @@ class FileProcessorProtocol(Protocol):
         ...
 
     @abstractmethod
-    def read_uploaded_file(self, contents: str, filename: str) -> Tuple[pd.DataFrame, str]:
+    def read_uploaded_file(
+        self, contents: str, filename: str
+    ) -> Tuple[pd.DataFrame, str]:
         """Read an uploaded file and return a DataFrame and error."""
         ...
 
@@ -462,7 +464,7 @@ class UnicodeProcessorProtocol(Protocol):
         ...
 
 
-from .service_container import ServiceContainer
+from core.service_container import ServiceContainer
 
 
 def _get_container(

--- a/core/protocols/plugin.py
+++ b/core/protocols/plugin.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+class PluginStatus(Enum):
+    """Plugin lifecycle status"""
+
+    DISCOVERED = "discovered"
+    LOADED = "loaded"
+    CONFIGURED = "configured"
+    STARTED = "started"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+class PluginPriority(Enum):
+    """Plugin loading priority"""
+
+    CRITICAL = 0
+    HIGH = 10
+    NORMAL = 50
+    LOW = 100
+
+
+@dataclass
+class PluginMetadata:
+    """Plugin metadata definition"""
+
+    name: str
+    version: str
+    description: str
+    author: str
+    priority: PluginPriority = PluginPriority.NORMAL
+    dependencies: Optional[List[str]] = None
+    config_section: Optional[str] = None
+    enabled_by_default: bool = True
+    min_yosai_version: Optional[str] = None
+    max_yosai_version: Optional[str] = None
+
+
+@runtime_checkable
+class PluginProtocol(Protocol):
+    """Core plugin protocol that all plugins must implement"""
+
+    @property
+    def metadata(self) -> PluginMetadata: ...
+
+    def load(self, container: Any, config: Dict[str, Any]) -> bool: ...
+
+    def configure(self, config: Dict[str, Any]) -> bool: ...
+
+    def start(self) -> bool: ...
+
+    def stop(self) -> bool: ...
+
+    def health_check(self) -> Dict[str, Any]: ...
+
+
+@runtime_checkable
+class CallbackPluginProtocol(PluginProtocol, Protocol):
+    """Protocol for plugins that register Dash callbacks"""
+
+    def register_callbacks(self, manager: Any, container: Any) -> bool: ...
+
+
+@runtime_checkable
+class ServicePluginProtocol(PluginProtocol, Protocol):
+    """Protocol for plugins that provide services"""
+
+    def get_service_definitions(self) -> Dict[str, Any]: ...
+
+
+@runtime_checkable
+class PluginManagerProtocol(Protocol):
+    """Protocol for plugin management"""
+
+    def discover_plugins(self) -> List[PluginProtocol]: ...
+
+    def load_plugin(self, plugin: PluginProtocol) -> bool: ...
+
+    def get_plugin_status(self, plugin_name: str) -> PluginStatus: ...

--- a/plugins/ai_classification/plugin.py
+++ b/plugins/ai_classification/plugin.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 from .config import AIClassificationConfig, get_ai_config
 from .database.csv_storage import CSVStorageRepository
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 class AIClassificationPlugin:
     """Enhanced plugin implementing CSV related services"""
+
+from __future__ import annotations
 
     metadata = PluginMetadata(
         name="ai_classification",

--- a/plugins/lazystring_fix_plugin.py
+++ b/plugins/lazystring_fix_plugin.py
@@ -7,9 +7,9 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Any
 
+from core.protocols.plugin import PluginMetadata
 from core.serialization import SafeJSONSerializer
 from core.unicode import sanitize_unicode_input
-from services.data_processing.core.protocols import PluginMetadata
 
 # Optional Babel import
 try:

--- a/tests/integration/test_plugin_health_endpoint.py
+++ b/tests/integration/test_plugin_health_endpoint.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
+import enum
+import importlib.util
 import sys
 import types
-import importlib.util
-import enum
+
 from flask.json.provider import DefaultJSONProvider
 
 # Minimal services stubs
 spec = importlib.util.spec_from_file_location(
-    "services.data_processing.core.protocols", "tests/stubs/protocols_stub.py"
+    "core.protocols.plugin", "tests/stubs/protocols_stub.py"
 )
 protocols_mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(protocols_mod)
@@ -27,14 +30,15 @@ sys.modules["services"] = services_mod
 sys.modules["services.registry"] = registry_mod
 sys.modules["services.data_processing"] = data_proc_mod
 sys.modules["services.data_processing.core"] = core_mod
-sys.modules["services.data_processing.core.protocols"] = protocols_mod
+sys.modules["core.protocols.plugin"] = protocols_mod
 
 import pytest
 from flask import Flask
-from core.service_container import ServiceContainer
-from core.plugins.manager import PluginManager
+
 from config import create_config_manager
-from services.data_processing.core.protocols import PluginMetadata
+from core.plugins.manager import PluginManager
+from core.protocols.plugin import PluginMetadata
+from core.service_container import ServiceContainer
 
 
 class EnumJSONProvider(DefaultJSONProvider):

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -1,4 +1,6 @@
 # flake8: noqa: E402
+from __future__ import annotations
+
 import asyncio
 import json
 import shutil
@@ -8,8 +10,8 @@ import types
 
 import dash
 import dash_bootstrap_components as dbc
-from dash import dcc, html
 import pytest
+from dash import dcc, html
 
 # Stub heavy optional analytics dependencies
 for _mod in (
@@ -27,11 +29,11 @@ if "scipy" not in sys.modules:
 sys.modules.setdefault("scipy.stats", types.ModuleType("scipy.stats"))
 sys.modules["scipy"].stats = sys.modules["scipy.stats"]
 
+from config import create_config_manager
 from core.events import EventBus
 from core.plugins.auto_config import setup_plugins
 from core.service_container import ServiceContainer
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from config import create_config_manager
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")
@@ -50,7 +52,7 @@ def _build_plugin(tmp_path):
     plugin_code = """
 from dash import Output, Input
 from dash.exceptions import PreventUpdate
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 from core.plugins.callback_unifier import CallbackUnifier
 
 class SamplePlugin:

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import sys
 import time
@@ -14,7 +16,7 @@ from core.service_container import ServiceContainer
 def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:
     """Install minimal protocol stubs under services.data_processing.core."""
 
-    protocols = types.ModuleType("services.data_processing.core.protocols")
+    protocols = types.ModuleType("core.protocols.plugin")
 
     class PluginPriority(Enum):
         CRITICAL = 0
@@ -63,7 +65,7 @@ def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:
     monkeypatch.setitem(sys.modules, "services.data_processing.core", core_pkg)
     monkeypatch.setitem(
         sys.modules,
-        "services.data_processing.core.protocols",
+        "core.protocols.plugin",
         protocols,
     )
 

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import os
 import sys
-import pytest
 
+import pytest
 from dash import Dash, Input, Output
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.json_serialization_plugin import JsonSerializationPlugin
 from core.plugins.auto_config import setup_plugins
 from core.plugins.callback_unifier import CallbackUnifier
 from core.plugins.decorators import safe_callback
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
+from core.service_container import ServiceContainer
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 
@@ -35,7 +37,7 @@ def _create_package(tmp_path):
     (pkg / "__init__.py").write_text("")
     plugin_code = """
 from dash import Output, Input
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 from core.plugins.callback_unifier import CallbackUnifier
 
 class AutoPlugin:

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,11 +1,14 @@
-import pytest
+from __future__ import annotations
+
 import sys
 
+import pytest
+
+from config import create_config_manager
 from core.plugins.dependency_resolver import PluginDependencyResolver
 from core.plugins.manager import PluginManager
+from core.protocols.plugin import PluginMetadata
 from core.service_container import ServiceContainer
-from config import create_config_manager
-from services.data_processing.core.protocols import PluginMetadata
 
 
 class DummyPlugin:
@@ -69,7 +72,7 @@ def test_manager_cycle_logging(tmp_path, caplog, mock_auth_env):
     pkg = _create_pkg(tmp_path, "cyclepkg")
     (pkg / "plug_a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class PlugA:
     metadata = PluginMetadata(
@@ -96,7 +99,7 @@ def create_plugin():
     )
     (pkg / "plug_b.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class PlugB:
     metadata = PluginMetadata(
@@ -144,7 +147,7 @@ def test_manager_unknown_dependency_logging(tmp_path, caplog, mock_auth_env):
     pkg = _create_pkg(tmp_path, "unkpkg")
     (pkg / "plug_a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class PlugA:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
+from core.service_container import ServiceContainer
 
 
 class SimplePlugin:
@@ -57,7 +59,7 @@ def test_load_all_plugins(tmp_path):
     plugin_file = pkg_dir / "plug.py"
     plugin_file.write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class Plug:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import importlib
 import sys
 import types
 from pathlib import Path
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginMetadata, PluginStatus
+from core.protocols.plugin import PluginMetadata, PluginStatus
+from core.service_container import ServiceContainer
 
 
 class DummyPlugin:
@@ -111,7 +113,7 @@ def test_load_all_plugins(tmp_path, monkeypatch):
     plugin_module = pkg_dir / "plugin_a.py"
     plugin_module.write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class Plugin:
     metadata = PluginMetadata(

--- a/tests/test_plugin_manager_cycle_logging.py
+++ b/tests/test_plugin_manager_cycle_logging.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import sys
+import types
+
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.service_container import ServiceContainer
-import types
 
 
 class DummyConfigManager:
@@ -18,7 +21,7 @@ def _create_cycle_pkg(tmp_path):
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / "a.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class APlugin:
     metadata = PluginMetadata(
@@ -45,7 +48,7 @@ def create_plugin():
     )
     (pkg_dir / "b.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class BPlugin:
     metadata = PluginMetadata(
@@ -79,7 +82,7 @@ def _create_missing_dep_pkg(tmp_path):
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / "plug.py").write_text(
         """
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 class P:
     metadata = PluginMetadata(

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import sys
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from services.data_processing.core.protocols import PluginPriority
+from core.protocols.plugin import PluginPriority
+from core.service_container import ServiceContainer
 
 
 def test_priority_order(tmp_path):
@@ -14,7 +16,7 @@ def test_priority_order(tmp_path):
     plugin_a = pkg_dir / "plugin_a.py"
     plugin_a.write_text(
         """
-from services.data_processing.core.protocols import PluginPriority
+from core.protocols.plugin import PluginPriority
 class PluginA:
     class metadata:
         name = 'a'
@@ -33,7 +35,7 @@ def create_plugin():
     plugin_b = pkg_dir / "plugin_b.py"
     plugin_b.write_text(
         """
-from services.data_processing.core.protocols import PluginPriority
+from core.protocols.plugin import PluginPriority
 class PluginB:
     class metadata:
         name = 'b'

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import time
 from concurrent.futures import ThreadPoolExecutor
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.plugins.manager import ThreadSafePluginManager
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
+from core.service_container import ServiceContainer
 
 
 class ConcurrencyPlugin:

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -1,6 +1,8 @@
-import enum
-import pytest
+from __future__ import annotations
 
+import enum
+
+import pytest
 from dash import Dash, html
 from flask.json.provider import DefaultJSONProvider
 
@@ -15,12 +17,12 @@ class EnumJSONProvider(DefaultJSONProvider):
 import sys
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.plugins.unified_registry import UnifiedPluginRegistry
+from core.service_container import ServiceContainer
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 
 
 class DummyPlugin:

--- a/tests/utils/plugin_package_builder.py
+++ b/tests/utils/plugin_package_builder.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from contextlib import AbstractContextManager
 from pathlib import Path
-import textwrap
 
 
 class PluginPackageBuilder(AbstractContextManager):
@@ -50,7 +50,7 @@ class PluginPackageBuilder(AbstractContextManager):
         (self._pkg_path / "__init__.py").write_text("")
         plugin_code = f"""
 from dash import Output, Input
-from services.data_processing.core.protocols import PluginMetadata
+from core.protocols.plugin import PluginMetadata
 from core.plugins.callback_unifier import CallbackUnifier
 
 class AutoPlugin:


### PR DESCRIPTION
## Summary
- add `core.protocols.plugin` with plugin protocol classes
- convert `core.protocols` into a package
- update plugin and manager modules to import from the new location
- adjust tests and helper utilities for updated import path

## Testing
- `pre-commit` *(fails: Bandit issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6884a71fe7e88320809e1da2d37c0b86