### PR TITLE
Add async alerting

### DIFF
--- a/core/monitoring/user_experience_metrics.py
+++ b/core/monitoring/user_experience_metrics.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 
 import logging
 import smtplib
+import asyncio
 from dataclasses import dataclass
 from typing import Optional
 
 import requests
+
+try:  # pragma: no cover - optional dependency
+    import aiohttp
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None
+
+try:  # pragma: no cover - optional dependency
+    import aiosmtplib
+except Exception:  # pragma: no cover - optional dependency
+    aiosmtplib = None
 
 
 @dataclass
@@ -24,8 +35,8 @@ class AlertDispatcher:
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-    def send_alert(self, message: str) -> None:
-        """Dispatch alert message via configured channels."""
+    # ------------------------------------------------------------------
+    def _send_slack_sync(self, message: str) -> None:
         if self.config.slack_webhook:
             try:
                 requests.post(
@@ -36,6 +47,23 @@ class AlertDispatcher:
             except Exception as exc:  # pragma: no cover - network
                 self.logger.warning("Slack alert failed: %s", exc)
 
+    # ------------------------------------------------------------------
+    async def _send_slack_async(self, message: str) -> None:
+        if self.config.slack_webhook and aiohttp is not None:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    await session.post(
+                        self.config.slack_webhook,
+                        json={"text": message},
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    )
+            except Exception as exc:  # pragma: no cover - network
+                self.logger.warning("Slack alert failed: %s", exc)
+        elif self.config.slack_webhook:
+            self._send_slack_sync(message)
+
+    # ------------------------------------------------------------------
+    def _send_webhook_sync(self, message: str) -> None:
         if self.config.webhook_url:
             try:
                 requests.post(
@@ -46,6 +74,23 @@ class AlertDispatcher:
             except Exception as exc:  # pragma: no cover - network
                 self.logger.warning("Webhook alert failed: %s", exc)
 
+    # ------------------------------------------------------------------
+    async def _send_webhook_async(self, message: str) -> None:
+        if self.config.webhook_url and aiohttp is not None:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    await session.post(
+                        self.config.webhook_url,
+                        json={"message": message},
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    )
+            except Exception as exc:  # pragma: no cover - network
+                self.logger.warning("Webhook alert failed: %s", exc)
+        elif self.config.webhook_url:
+            self._send_webhook_sync(message)
+
+    # ------------------------------------------------------------------
+    def _send_email_sync(self, message: str) -> None:
         if self.config.email:
             try:
                 smtp = smtplib.SMTP("localhost")
@@ -53,3 +98,45 @@ class AlertDispatcher:
                 smtp.quit()
             except Exception as exc:  # pragma: no cover - external
                 self.logger.warning("Email alert failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    async def _send_email_async(self, message: str) -> None:
+        if self.config.email and aiosmtplib is not None:
+            try:
+                smtp = aiosmtplib.SMTP(hostname="localhost")
+                await smtp.connect()
+                await smtp.sendmail(
+                    "noreply@example.com",
+                    [self.config.email],
+                    message,
+                )
+                await smtp.quit()
+            except Exception as exc:  # pragma: no cover - external
+                self.logger.warning("Email alert failed: %s", exc)
+        elif self.config.email:
+            self._send_email_sync(message)
+
+    # ------------------------------------------------------------------
+    async def send_alert_async(self, message: str) -> None:
+        """Asynchronously dispatch alert via configured channels."""
+        await asyncio.gather(
+            self._send_slack_async(message),
+            self._send_webhook_async(message),
+            self._send_email_async(message),
+        )
+
+    # ------------------------------------------------------------------
+    def send_alert(self, message: str) -> None:
+        """Dispatch alert message via configured channels."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            # Running inside an event loop, fall back to synchronous sending
+            self._send_slack_sync(message)
+            self._send_webhook_sync(message)
+            self._send_email_sync(message)
+        else:
+            asyncio.run(self.send_alert_async(message))

--- a/monitoring/data_quality_monitor.py
+++ b/monitoring/data_quality_monitor.py
@@ -28,6 +28,17 @@ except Exception:  # pragma: no cover - metrics optional for tests
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from config.base import DataQualityThresholds
 
+else:  # pragma: no cover - runtime import for tests
+    try:
+        from config.base import DataQualityThresholds
+    except Exception:  # pragma: no cover - minimal fallback
+        class DataQualityThresholds:
+            max_missing_ratio: float = 0.1
+            max_outlier_ratio: float = 0.01
+            max_schema_violations: int = 0
+            max_avro_decode_failures: int = 0
+            max_compatibility_failures: int = 0
+
 try:  # pragma: no cover - optional dependency
     from config import get_monitoring_config
 except Exception:  # pragma: no cover - minimal fallback for tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # Packages required exclusively for running the tests
 pytest==8.4.1
+pytest-asyncio>=0.23
 pytest-cov>=2.12.0
 PyYAML>=6.0
 psutil>=5.9.0
@@ -14,6 +15,7 @@ plotly==5.15.0
 dask[distributed]==2024.4.1
 tqdm>=4.0
 aiohttp>=3.8
+aiosmtplib>=2.0
 testcontainers[postgresql,redis]==3.7.1
 prometheus_client==0.22.1
 numpy==1.26.4

--- a/tests/test_alert_dispatcher.py
+++ b/tests/test_alert_dispatcher.py
@@ -1,0 +1,102 @@
+import asyncio
+import pytest
+
+from core.monitoring.user_experience_metrics import AlertDispatcher, AlertConfig
+
+
+class DummyResp:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySession:
+    def __init__(self, calls):
+        self.calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, timeout=None):
+        self.calls.append((url, json))
+        return DummyResp()
+
+
+class DummySMTP:
+    def __init__(self, hostname="localhost"):
+        self.hostname = hostname
+        self.sent = []
+
+    async def connect(self):
+        pass
+
+    async def sendmail(self, from_addr, to_addrs, message):
+        self.sent.append((from_addr, to_addrs, message))
+
+    async def quit(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_send_alert_async(monkeypatch):
+    calls = []
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: DummySession(calls))
+    monkeypatch.setattr("aiosmtplib.SMTP", lambda hostname="localhost": DummySMTP(hostname))
+
+    dispatcher = AlertDispatcher(
+        AlertConfig(
+            slack_webhook="http://slack",
+            webhook_url="http://wh",
+            email="a@b.com",
+        )
+    )
+    await dispatcher.send_alert_async("hi")
+
+    assert ("http://slack", {"text": "hi"}) in calls
+    assert ("http://wh", {"message": "hi"}) in calls
+
+
+def test_send_alert_sync_fallback(monkeypatch):
+    calls = []
+
+    def dummy_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        class Resp:
+            pass
+        return Resp()
+
+    class DummySMTPBlocking:
+        def __init__(self, hostname="localhost"):
+            self.hostname = hostname
+        def sendmail(self, from_addr, to_addrs, message):
+            calls.append(("sendmail", from_addr, to_addrs, message))
+        def quit(self):
+            pass
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    monkeypatch.setattr("smtplib.SMTP", lambda host: DummySMTPBlocking(host))
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: (_ for _ in ()).throw(AssertionError("async called")))
+    monkeypatch.setattr("aiosmtplib.SMTP", lambda *a, **k: (_ for _ in ()).throw(AssertionError("async called")))
+
+    class Loop:
+        def is_running(self):
+            return True
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: Loop())
+
+    dispatcher = AlertDispatcher(
+        AlertConfig(
+            slack_webhook="http://slack",
+            webhook_url="http://wh",
+            email="a@b.com",
+        )
+    )
+    dispatcher.send_alert("hello")
+
+    assert ("http://slack", {"text": "hello"}) in calls
+    assert ("http://wh", {"message": "hello"}) in calls
+    assert ("sendmail", "noreply@example.com", ["a@b.com"], "hello") in calls


### PR DESCRIPTION
## Summary
- implement async Slack/email/webhook alerts
- provide sync fallbacks when called in a running event loop
- expose DataQualityThresholds for tests
- add tests for async alert dispatcher
- install aiosmtplib and pytest-asyncio for testing

## Testing
- `pytest tests/test_alert_dispatcher.py tests/test_data_quality_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a7763cb08320b49c7b318d46adef