### PR TITLE
Add async model registry method

### DIFF
--- a/services/common/model_registry.py
+++ b/services/common/model_registry.py
@@ -1,8 +1,10 @@
+import asyncio
 import logging
 import os
+import warnings
 from typing import Optional
 
-import requests
+import aiohttp
 
 logger = logging.getLogger(__name__)
 
@@ -14,22 +16,44 @@ class ModelRegistry:
         self.base_url = (
             base_url or os.getenv("MODEL_REGISTRY_URL", "http://localhost:8080")
         ).rstrip("/")
-        self.session = requests.Session()
+        self._session: aiohttp.ClientSession | None = None
 
-    def get_active_version(
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def get_active_version_async(
         self, model_name: str, default: Optional[str] = None
     ) -> Optional[str]:
         """Return the active version for *model_name* or *default* if lookup fails."""
         try:
-            resp = self.session.get(
-                f"{self.base_url}/models/{model_name}/active", timeout=2
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return data.get("version", default)
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/models/{model_name}/active",
+                timeout=aiohttp.ClientTimeout(total=2),
+            ) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                return data.get("version", default)
         except Exception as exc:  # pragma: no cover - network failures
             logger.warning("model registry lookup failed for %s: %s", model_name, exc)
             return default
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    def get_active_version(
+        self, model_name: str, default: Optional[str] = None
+    ) -> Optional[str]:
+        """Synchronous wrapper for :meth:`get_active_version_async`."""
+        warnings.warn(
+            "get_active_version is deprecated, use get_active_version_async",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return asyncio.run(self.get_active_version_async(model_name, default))
 
 
 __all__ = ["ModelRegistry"]

--- a/tests/test_model_registry_async.py
+++ b/tests/test_model_registry_async.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+import types
+import asyncio
+
+import pytest
+
+services_path = pathlib.Path(__file__).resolve().parents[1] / "services"
+stub_pkg = types.ModuleType("services")
+stub_pkg.__path__ = [str(services_path)]
+sys.modules["services"] = stub_pkg
+
+from services.common.model_registry import ModelRegistry
+
+class DummyResponse:
+    status = 200
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def json(self):
+        return {"version": "v1"}
+    def raise_for_status(self):
+        pass
+
+class DummySession:
+    closed = False
+
+    def get(self, url, timeout=None):
+        return DummyResponse()
+
+    async def close(self):
+        self.closed = True
+
+def test_get_active_version_async(monkeypatch):
+    registry = ModelRegistry("http://example.com")
+    monkeypatch.setattr(registry, "_session", DummySession())
+    version = asyncio.run(registry.get_active_version_async("foo"))
+    assert version == "v1"


### PR DESCRIPTION
## Summary
- support async lookups in `services/common/model_registry.py`
- deprecate the sync wrapper
- test async `get_active_version_async`

## Testing
- `pytest tests/test_model_registry_async.py tests/resilience/test_service_client.py::test_k8s_resolver -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a7718d9083208e03ac6f7389aefb