### PR TITLE
Add callbacks compatibility wrappers

### DIFF
--- a/yosai_intel_dashboard/src/core/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/core/callbacks/__init__.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper for `core.callbacks`."""
+
+from __future__ import annotations
+
+import importlib
+
+_mod: object | None = None
+__all__: list[str] = []
+
+
+def _load() -> None:
+    global _mod, __all__
+    if _mod is None:
+        _mod = importlib.import_module("core.callbacks")
+        __all__ = getattr(
+            _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
+        )
+
+
+def __getattr__(name: str) -> object:
+    _load()
+    return getattr(_mod, name)
+
+
+def __dir__() -> list[str]:
+    _load()
+    return __all__

--- a/yosai_intel_dashboard/src/core/callbacks/callback_controller.py
+++ b/yosai_intel_dashboard/src/core/callbacks/callback_controller.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper for `core.callback_controller`."""
+
+from __future__ import annotations
+
+import importlib
+
+_mod: object | None = None
+__all__: list[str] = []
+
+
+def _load() -> None:
+    global _mod, __all__
+    if _mod is None:
+        _mod = importlib.import_module("core.callback_controller")
+        __all__ = getattr(
+            _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
+        )
+
+
+def __getattr__(name: str) -> object:
+    _load()
+    return getattr(_mod, name)
+
+
+def __dir__() -> list[str]:
+    _load()
+    return __all__

--- a/yosai_intel_dashboard/src/core/callbacks/decorators.py
+++ b/yosai_intel_dashboard/src/core/callbacks/decorators.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper for `core.plugins.decorators`."""
+
+from __future__ import annotations
+
+import importlib
+
+_mod: object | None = None
+__all__: list[str] = []
+
+
+def _load() -> None:
+    global _mod, __all__
+    if _mod is None:
+        _mod = importlib.import_module("core.plugins.decorators")
+        __all__ = getattr(
+            _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
+        )
+
+
+def __getattr__(name: str) -> object:
+    _load()
+    return getattr(_mod, name)
+
+
+def __dir__() -> list[str]:
+    _load()
+    return __all__

--- a/yosai_intel_dashboard/src/core/callbacks/event_types.py
+++ b/yosai_intel_dashboard/src/core/callbacks/event_types.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper for `core.callback_events`."""
+
+from __future__ import annotations
+
+import importlib
+
+_mod: object | None = None
+__all__: list[str] = []
+
+
+def _load() -> None:
+    global _mod, __all__
+    if _mod is None:
+        _mod = importlib.import_module("core.callback_events")
+        __all__ = getattr(
+            _mod, "__all__", [n for n in dir(_mod) if not n.startswith("_")]
+        )
+
+
+def __getattr__(name: str) -> object:
+    _load()
+    return getattr(_mod, name)
+
+
+def __dir__() -> list[str]:
+    _load()
+    return __all__


### PR DESCRIPTION
## Summary
- create `callbacks` package inside `yosai_intel_dashboard/src/core`
- add wrappers for `callback_controller`, `event_types`, and `decorators`
- expose compatibility `__all__` for the underlying modules

## Testing
- `python -m py_compile yosai_intel_dashboard/src/core/callbacks/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a738bf688320bfba43d5336224b9