### PR TITLE
Use UnifiedCallbackManager for security events

### DIFF
--- a/security/events.py
+++ b/security/events.py
@@ -1,24 +1,16 @@
 """Security event utilities."""
 from typing import Any
 from core.callback_events import CallbackEvent
+from core.callbacks import UnifiedCallbackManager
 
 SecurityEvent = CallbackEvent
 
-# Default callback implementation
-class DefaultSecurityCallbacks:
-    """Default security callback handler"""
-    def trigger(self, event, data=None):
-        """Default trigger - just log for now"""
-        import logging
-        logger = logging.getLogger(__name__)
-        logger.info(f"Security event: {event}, data: {data}")
-
-# Instance of callback handler - can be overridden at runtime
-security_unified_callbacks = DefaultSecurityCallbacks()
+# Default callback implementation now uses the unified manager
+security_unified_callbacks: UnifiedCallbackManager = UnifiedCallbackManager()
 
 def emit_security_event(event: SecurityEvent, data: dict | None = None) -> None:
     """Trigger *event* through ``security_unified_callbacks``."""
     if security_unified_callbacks:
-        security_unified_callbacks.trigger(event, data)
+        security_unified_callbacks.trigger_event(event, data)
 
 __all__ = ["SecurityEvent", "emit_security_event", "security_unified_callbacks"]

--- a/tests/security/test_events.py
+++ b/tests/security/test_events.py
@@ -1,0 +1,18 @@
+import pytest
+
+from security import events
+from security_callback_controller import SecurityEvent
+
+
+def test_threat_detected_dispatch(monkeypatch):
+    called = {}
+
+    def fake(event, data=None):
+        called['event'] = event
+        called['data'] = data
+
+    monkeypatch.setattr(events.security_unified_callbacks, 'trigger_event', fake)
+
+    events.emit_security_event(SecurityEvent.THREAT_DETECTED, {'x': 1})
+
+    assert called == {'event': SecurityEvent.THREAT_DETECTED, 'data': {'x': 1}}


### PR DESCRIPTION
## Summary
- replace the custom `DefaultSecurityCallbacks` with `UnifiedCallbackManager`
- adjust `emit_security_event` to use `trigger_event`
- add a test confirming threat events dispatch through the unified callback manager

## Testing
- `pytest tests/security/test_events.py::test_threat_detected_dispatch -q --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_6884a73cfac08320b772bad77ef8f15b