### PR TITLE
Add UnicodeHandler utilities

### DIFF
--- a/infrastructure/__init__.py
+++ b/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing src infrastructure modules."""
+from __future__ import annotations
+from pathlib import Path
+
+__path__.append(str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard" / "src" / "infrastructure"))

--- a/yosai_intel_dashboard/src/infrastructure/encoding/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/encoding/__init__.py
@@ -1,0 +1,3 @@
+"""Encoding utilities for the dashboard."""
+
+__all__ = ["UnicodeHandler"]

--- a/yosai_intel_dashboard/src/infrastructure/encoding/unicode_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/encoding/unicode_handler.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""High level Unicode handling utilities."""
+
+from typing import Any, List, Tuple
+import unicodedata
+
+from core.unicode import clean_surrogate_chars
+from security.unicode_security_validator import UnicodeSecurityValidator
+
+
+_ZERO_WIDTH = [
+    "\u200b",
+    "\u200c",
+    "\u200d",
+    "\u2060",
+]
+
+
+class UnicodeHandler:
+    """Utility class for sanitizing and validating Unicode text."""
+
+    _validator = UnicodeSecurityValidator()
+
+    @staticmethod
+    def _remove_zero_width(text: str) -> str:
+        for ch in _ZERO_WIDTH:
+            text = text.replace(ch, "")
+        return text
+
+    @classmethod
+    def sanitize(cls, text: Any) -> str:
+        cleaned = clean_surrogate_chars(str(text))
+        cleaned = cleaned.replace("\ufeff", "")
+        cleaned = cls._remove_zero_width(cleaned)
+        cleaned = cls._validator.validate_and_sanitize(cleaned)
+        try:
+            cleaned = unicodedata.normalize("NFC", cleaned)
+        except Exception:
+            pass
+        return cleaned
+
+    @staticmethod
+    def validate_utf8(data: bytes) -> bool:
+        try:
+            data.decode("utf-8")
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def repair_text(cls, text: Any) -> Tuple[str, List[str]]:
+        issues: List[str] = []
+        original = str(text)
+        cleaned = clean_surrogate_chars(original)
+        if cleaned != original:
+            issues.append("surrogates_removed")
+        if "\ufeff" in cleaned:
+            issues.append("bom_removed")
+            cleaned = cleaned.replace("\ufeff", "")
+        pre_zero = cleaned
+        cleaned = cls._remove_zero_width(cleaned)
+        if cleaned != pre_zero:
+            issues.append("zero_width_removed")
+        cleaned = cls._validator.validate_and_sanitize(cleaned)
+        try:
+            normalized = unicodedata.normalize("NFC", cleaned)
+            if normalized != cleaned:
+                issues.append("normalized")
+            cleaned = normalized
+        except Exception:
+            issues.append("normalization_failed")
+        return cleaned, issues
+
+
+__all__ = ["UnicodeHandler"]

--- a/yosai_intel_dashboard/tests/encoding/test_unicode_handler.py
+++ b/yosai_intel_dashboard/tests/encoding/test_unicode_handler.py
@@ -1,0 +1,73 @@
+import sys
+import types
+import unicodedata
+from pathlib import Path
+
+# ensure repo root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+# stub heavy dependencies required by imported modules
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))
+if "pydantic" not in sys.modules:
+    pydantic_stub = types.ModuleType("pydantic")
+    class BaseModel: ...
+    def Field(*args, **kwargs): return None
+    def model_validator(*args, **kwargs):
+        def wrapper(fn):
+            return fn
+        return wrapper
+    ConfigDict = dict
+    pydantic_stub.BaseModel = BaseModel
+    pydantic_stub.Field = Field
+    pydantic_stub.model_validator = model_validator
+    pydantic_stub.ConfigDict = ConfigDict
+    sys.modules["pydantic"] = pydantic_stub
+
+sys.modules.setdefault("google", types.ModuleType("google"))
+if "google.protobuf" not in sys.modules:
+    proto_pkg = types.ModuleType("google.protobuf")
+    proto_pkg.json_format = types.ModuleType("google.protobuf.json_format")
+    internal_mod = types.ModuleType("google.protobuf.internal")
+    internal_mod.builder = object
+    proto_pkg.internal = internal_mod
+    sys.modules["google.protobuf"] = proto_pkg
+    sys.modules["google.protobuf.json_format"] = proto_pkg.json_format
+    sys.modules["google.protobuf.internal"] = internal_mod
+
+# Provide lightweight stubs for core and security modules used by UnicodeHandler
+core_unicode = types.ModuleType("core.unicode")
+def clean_surrogate_chars(text: str) -> str:
+    return text.encode("utf-16", "surrogatepass").decode("utf-16", "ignore")
+core_unicode.clean_surrogate_chars = clean_surrogate_chars
+sys.modules["core.unicode"] = core_unicode
+
+security_validator = types.ModuleType("security.unicode_security_validator")
+class UnicodeSecurityValidator:
+    def validate_and_sanitize(self, text: str) -> str:
+        cleaned = "".join(ch for ch in text if ord(ch) < 0x10000)
+        return unicodedata.normalize("NFC", cleaned)
+security_validator.UnicodeSecurityValidator = UnicodeSecurityValidator
+sys.modules["security.unicode_security_validator"] = security_validator
+
+from infrastructure.encoding.unicode_handler import UnicodeHandler
+
+
+def test_sanitize_removes_surrogates_and_normalizes():
+    text = "\ufeff\u200bA\ud83d\ude00"
+    assert UnicodeHandler.sanitize(text) == "A"
+
+
+def test_validate_utf8():
+    assert UnicodeHandler.validate_utf8(b"valid")
+    assert not UnicodeHandler.validate_utf8(b"\xff\xff")
+
+
+def test_repair_text_reports_issues():
+    repaired, issues = UnicodeHandler.repair_text("\ufeffA\u200b\ud800")
+    assert repaired == "A"
+    assert {
+        "surrogates_removed",
+        "bom_removed",
+        "zero_width_removed",
+    }.issubset(set(issues))


### PR DESCRIPTION
## Summary
- add compatibility path so infrastructure modules map to src package
- implement `UnicodeHandler` with sanitize, UTF-8 validation and text repair helpers
- test the new encoding utilities

## Testing
- `pytest -q yosai_intel_dashboard/tests/encoding/test_unicode_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a7460c00832083895466050ae09f