### PR TITLE
Add Unicode sanitization middleware and helpers

### DIFF
--- a/file_conversion/storage_manager.py
+++ b/file_conversion/storage_manager.py
@@ -13,6 +13,7 @@ from core.callback_events import CallbackEvent
 from core.callbacks import UnifiedCallbackManager
 from core.container import get_unicode_processor
 from core.protocols import UnicodeProcessorProtocol
+from utils.io_helpers import read_json, write_json
 
 _logger = logging.getLogger(__name__)
 
@@ -38,16 +39,14 @@ class StorageManager:
     def _load_metadata(self) -> None:
         try:
             if self._metadata_path.exists():
-                with open(self._metadata_path, "r", encoding="utf-8") as fh:
-                    self._metadata = json.load(fh)
+                self._metadata = read_json(self._metadata_path)
         except Exception as exc:  # pragma: no cover - best effort
             _logger.error("Failed to load metadata: %s", exc)
             self._metadata = {}
 
     def _save_metadata(self) -> None:
         try:
-            with open(self._metadata_path, "w", encoding="utf-8") as fh:
-                json.dump(self._metadata, fh, indent=2, default=str)
+            write_json(self._metadata_path, self._metadata)
         except Exception as exc:  # pragma: no cover - best effort
             _logger.error("Failed to save metadata: %s", exc)
 

--- a/plugins/ai_classification/database/csv_storage.py
+++ b/plugins/ai_classification/database/csv_storage.py
@@ -6,6 +6,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from utils.io_helpers import read_json, write_json
+from utils.unicode_handler import UnicodeHandler
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,10 +38,10 @@ class CSVStorageRepository:
         try:
             file_path = self._get_session_file_path(session_id)
             if file_path.exists():
-                with open(file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    self.sessions[session_id] = data
-                    return data
+                data = read_json(file_path)
+                self.sessions[session_id] = data
+                logger.info("Sanitized read from %s", file_path)
+                return data
         except Exception as e:
             logger.error(f"Failed to load session {session_id}: {e}")
         return None
@@ -54,8 +57,8 @@ class CSVStorageRepository:
                 "session_id": session_id,
             }
 
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(data_with_meta, f, indent=2, ensure_ascii=False)
+            write_json(file_path, data_with_meta)
+            logger.info("Sanitized write to %s", file_path)
 
             self.sessions[session_id] = data_with_meta
             logger.info(f"Session {session_id} saved to file")
@@ -212,8 +215,8 @@ class CSVStorageRepository:
                 "saved_at": datetime.now().isoformat(),
             }
 
-            with open(permanent_file, "w", encoding="utf-8") as f:
-                json.dump(permanent_data, f, indent=2, ensure_ascii=False)
+            write_json(permanent_file, permanent_data)
+            logger.info("Sanitized write to %s", permanent_file)
 
             logger.info(
                 f"Session {session_id} saved permanently for client {client_id}"

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -19,6 +19,9 @@ from fastapi import (
 from jose import jwt
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
+from services.analytics_microservice.unicode_middleware import (
+    UnicodeSanitizationMiddleware,
+)
 from pydantic import BaseModel
 from yosai_framework.errors import ServiceError
 from yosai_framework.service import BaseService
@@ -44,6 +47,7 @@ service = (
     .build()
 )
 app = service.app
+app.add_middleware(UnicodeSanitizationMiddleware)
 
 
 async def _db_check(_: FastAPI) -> bool:

--- a/services/analytics_microservice/unicode_middleware.py
+++ b/services/analytics_microservice/unicode_middleware.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Middleware sanitizing request data using :class:`UnicodeHandler`."""
+
+import logging
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from utils.unicode_handler import UnicodeHandler
+
+logger = logging.getLogger(__name__)
+
+
+class UnicodeSanitizationMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if request.query_params:
+            sanitized = {
+                k: UnicodeHandler.sanitize(v) for k, v in request.query_params.items()
+            }
+            request._query_params = request.query_params.__class__(sanitized)
+            logger.info("Sanitized query for %s", request.url.path)
+
+        if request.method in {"POST", "PUT", "PATCH"}:
+            body = await request.body()
+            try:
+                text = body.decode("utf-8")
+            except Exception:
+                text = ""
+            cleaned = UnicodeHandler.sanitize(text)
+            request._body = cleaned.encode("utf-8")
+            logger.info("Sanitized body for %s", request.url.path)
+
+        response = await call_next(request)
+        return response
+
+
+__all__ = ["UnicodeSanitizationMiddleware"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -41,6 +41,8 @@ from .mapping_helpers import standardize_column_names
 from .preview_utils import serialize_dataframe_preview
 from .protocols import SafeDecoderProtocol
 from .file_utils import safe_decode_with_unicode_handling
+from .unicode_handler import UnicodeHandler
+from .io_helpers import read_json, write_json, read_text, write_text
 
 __all__ = [
     "UnicodeProcessor",
@@ -75,4 +77,9 @@ __all__ = [
     "debug_callback_registration_flow",
     "find_repeated_imports",
     "print_registration_report",
+    "UnicodeHandler",
+    "read_json",
+    "write_json",
+    "read_text",
+    "write_text",
 ]

--- a/utils/io_helpers.py
+++ b/utils/io_helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""File I/O helpers applying :class:`UnicodeHandler` sanitization."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .unicode_handler import UnicodeHandler
+
+logger = logging.getLogger(__name__)
+
+
+def read_text(path: Path) -> str:
+    """Read text from ``path`` and sanitize the result."""
+    data = path.read_text(encoding="utf-8")
+    cleaned = UnicodeHandler.sanitize(data)
+    logger.info("Sanitized read from %s", path)
+    return cleaned
+
+
+def write_text(path: Path, data: str) -> None:
+    """Sanitize ``data`` and write it to ``path``."""
+    cleaned = UnicodeHandler.sanitize(data)
+    path.write_text(cleaned, encoding="utf-8")
+    logger.info("Sanitized write to %s", path)
+
+
+def read_json(path: Path) -> Any:
+    """Read JSON from ``path`` applying sanitization."""
+    text = read_text(path)
+    return json.loads(text)
+
+
+def write_json(path: Path, data: Any) -> None:
+    """Serialize ``data`` as JSON after sanitizing."""
+    cleaned = UnicodeHandler.sanitize(data)
+    path.write_text(
+        json.dumps(cleaned, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    logger.info("Sanitized write to %s", path)
+
+
+__all__ = ["read_text", "write_text", "read_json", "write_json"]

--- a/utils/unicode_handler.py
+++ b/utils/unicode_handler.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Unified Unicode sanitization wrapper."""
+
+import logging
+from typing import Any, Iterable, Mapping
+
+from core.unicode import sanitize_for_utf8
+
+logger = logging.getLogger(__name__)
+
+
+class UnicodeHandler:
+    """Utility class for sanitizing arbitrary data."""
+
+    @staticmethod
+    def sanitize(obj: Any) -> Any:
+        """Recursively sanitize ``obj`` for safe Unicode usage."""
+        if isinstance(obj, str):
+            return sanitize_for_utf8(obj)
+        if isinstance(obj, Mapping):
+            return {k: UnicodeHandler.sanitize(v) for k, v in obj.items()}
+        if isinstance(obj, Iterable) and not isinstance(obj, (bytes, bytearray)):
+            return type(obj)(UnicodeHandler.sanitize(v) for v in obj)
+        return obj
+
+
+__all__ = ["UnicodeHandler"]


### PR DESCRIPTION
## Summary
- add `UnicodeHandler` utility
- add `io_helpers` module for sanitized file I/O
- integrate Unicode sanitization middleware into analytics microservice
- sanitize database queries and results
- use sanitized file helpers in storage modules

## Testing
- `python -m py_compile utils/unicode_handler.py utils/io_helpers.py services/analytics_microservice/unicode_middleware.py repositories/implementations.py file_conversion/storage_manager.py plugins/ai_classification/database/csv_storage.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a7474a8c8320bc6854be2298d879