### PR TITLE
Add UnicodeHandler wrapper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,9 @@ critical vulnerabilities are detected. Download the artifact from the
   `unicode_toolkit` package. Import the new helpers such as
   `TextProcessor` and `SQLProcessor` to clean input and safely encode SQL
   statements. See the migration section below for details.
+- **Unified Unicode Handler**: the `UnicodeHandler` class delegates to
+  `QueryUnicodeHandler` and `FileUnicodeHandler` so all sanitization
+  relies on the same `core.unicode` implementation.
 - **Event Driven Callbacks**: Plugins react to events via the unified
   `TrulyUnifiedCallbacks` manager.
   This single interface replaces previous callback controllers.
@@ -869,7 +872,8 @@ implementations can be swapped in for tests. Helper functions like
 
 Unicode handling is now provided by the standalone `unicode_toolkit`
 package. Legacy helpers from `core.unicode` remain as thin wrappers
-around this library. Detect outdated usage and validate the migration
+around this library. A convenience `UnicodeHandler` class combines the
+file and query utilities so you can migrate incrementally. Detect outdated usage and validate the migration
 with the helper tools:
 
 ```bash

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -22,6 +22,7 @@ from .config_manager import ConfigManager, get_config, reload_config
 from .secure_config_manager import SecureConfigManager
 from .environment_processor import EnvironmentProcessor
 from .secure_db import execute_secure_query
+from .unicode_handler import UnicodeHandler
 from .protocols import (
     ConfigLoaderProtocol,
     ConfigTransformerProtocol,
@@ -128,6 +129,7 @@ __all__ = [
     "PerformanceConstants",
     "CSSConstants",
     "execute_secure_query",
+    "UnicodeHandler",
 ]
 
 def get_monitoring_config() -> Dict[str, Any]:

--- a/config/unicode_handler.py
+++ b/config/unicode_handler.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""High level interface aggregating Unicode helpers."""
+
+from pathlib import Path
+from typing import Any, Callable
+import logging
+
+from core.container import get_unicode_processor
+from core.protocols import UnicodeProcessorProtocol
+
+from .unicode_processor import (
+    FileUnicodeHandler,
+    QueryUnicodeHandler,
+    UnicodeSecurityValidator,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UnicodeHandler:
+    """Convenience wrapper combining common Unicode operations."""
+
+    def __init__(self, processor: UnicodeProcessorProtocol | None = None) -> None:
+        self.processor = processor or get_unicode_processor()
+
+    # ------------------------------------------------------------------
+    # Text helpers
+    def clean_text(self, text: Any) -> str:
+        return self.processor.safe_encode_text(text)
+
+    def decode_bytes(self, data: bytes, encoding: str = "utf-8") -> str:
+        return self.processor.safe_decode_text(data, encoding)
+
+    def process_dict(self, data: Any) -> Any:
+        return self.processor.process_dict(data)
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    def encode_query(
+        self,
+        query: str,
+        *,
+        on_surrogate: Callable[[str], None] | None = None,
+    ) -> str:
+        return QueryUnicodeHandler.handle_unicode_query(
+            query,
+            processor=self.processor,
+            on_surrogate=on_surrogate,
+        )
+
+    def encode_params(
+        self,
+        params: Any,
+        *,
+        on_surrogate: Callable[[str], None] | None = None,
+    ) -> Any:
+        return QueryUnicodeHandler.handle_query_parameters(
+            params,
+            processor=self.processor,
+            on_surrogate=on_surrogate,
+        )
+
+    # ------------------------------------------------------------------
+    # File helpers
+    def clean_file_content(
+        self,
+        content: str | bytes,
+        *,
+        on_surrogate: Callable[[str], None] | None = None,
+    ) -> str:
+        return FileUnicodeHandler.handle_file_content(
+            content,
+            processor=self.processor,
+            on_surrogate=on_surrogate,
+        )
+
+    def clean_filename(
+        self,
+        name: str | Path,
+        *,
+        on_surrogate: Callable[[str], None] | None = None,
+    ) -> str:
+        return FileUnicodeHandler.handle_filename(
+            name,
+            processor=self.processor,
+            on_surrogate=on_surrogate,
+        )
+
+    # ------------------------------------------------------------------
+    # Security helpers
+    def sanitize_input(self, text: Any) -> str:
+        return UnicodeSecurityValidator.validate_input(text)
+
+    def check_for_attacks(self, text: Any) -> bool:
+        return UnicodeSecurityValidator.check_for_attacks(text)
+
+
+__all__ = ["UnicodeHandler"]

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -32,6 +32,15 @@ from unicode_toolkit import sanitize_dataframe
 clean_df = sanitize_dataframe(df, progress=True)
 ```
 
+### Unified Handler
+```python
+from config.unicode_handler import UnicodeHandler
+
+handler = UnicodeHandler()
+safe_query = handler.encode_query(query)
+clean_name = handler.clean_filename("data\ud800.csv")
+```
+
 ### Using `unicode_toolkit`
 
 Install the library with `pip install unicode_toolkit` and replace old

--- a/tests/test_unicode_handler_class.py
+++ b/tests/test_unicode_handler_class.py
@@ -1,0 +1,17 @@
+import pytest
+
+from config.unicode_handler import UnicodeHandler
+
+
+def test_handler_encodes_query_surrogates():
+    handler = UnicodeHandler()
+    text = "SELECT" + chr(0xD800) + "1"
+    result = handler.encode_query(text)
+    assert result == "SELECT1"
+
+
+def test_handler_clean_filename():
+    handler = UnicodeHandler()
+    name = "=bad" + chr(0xDC00) + ".csv"
+    clean = handler.clean_filename(name)
+    assert "bad" in clean and "\udc00" not in clean


### PR DESCRIPTION
## Summary
- implement new `UnicodeHandler` wrapper in config
- export it via `config.__init__`
- mention the handler in README and migration guide
- provide unit tests

## Testing
- `pytest -q tests/test_unicode_handler_class.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a74a9bb88320bafd97d21416fb59