### PR TITLE
Add validation unit tests

### DIFF
--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+
+from core.exceptions import ValidationError
+from validation.security_validator import SecurityValidator
+from security.xss_validator import XSSPrevention
+from validation.unicode_validator import UnicodeValidator
+from security.unicode_security_validator import UnicodeSecurityConfig
+from security.business_logic_validator import BusinessLogicValidator
+
+
+# ----------------------------------------------------------------------
+# SecurityValidator validate_input / XSSPrevention.sanitize_html_output
+# ----------------------------------------------------------------------
+
+def test_validate_input_valid():
+    validator = SecurityValidator()
+    result = validator.validate_input("safe text")
+    assert result == {"valid": True, "sanitized": "safe text"}
+
+
+def test_validate_input_invalid():
+    validator = SecurityValidator()
+    with pytest.raises(ValidationError):
+        validator.validate_input("<script>alert('x')</script>")
+
+
+def test_validate_output_valid():
+    assert XSSPrevention.sanitize_html_output("hello") == "hello"
+
+
+def test_validate_output_invalid():
+    result = XSSPrevention.sanitize_html_output("<script>alert('x')</script>")
+    assert "<" not in result and ">" not in result
+
+
+# ----------------------------------------------------------------------
+# UnicodeValidator
+# ----------------------------------------------------------------------
+
+def test_unicode_validator_text():
+    validator = UnicodeValidator(UnicodeSecurityConfig(strict_mode=False))
+    text = "A\ud800B"
+    assert validator.validate_text(text) == "AB"
+
+
+def test_unicode_validator_dataframe():
+    validator = UnicodeValidator(UnicodeSecurityConfig(strict_mode=False))
+    df = pd.DataFrame({"col": ["bad\u202E", "ok"]})
+    cleaned = validator.validate_dataframe(df)
+    assert "\u202E" not in cleaned.iloc[0, 0]
+    assert cleaned.iloc[0, 0] == "bad"
+
+
+# ----------------------------------------------------------------------
+# BusinessLogicValidator
+# ----------------------------------------------------------------------
+
+def test_business_validator_valid():
+    validator = BusinessLogicValidator()
+    assert validator.validate("data") == "data"
+
+
+def test_business_validator_invalid():
+    validator = BusinessLogicValidator()
+    with pytest.raises(ValidationError):
+        validator.validate(None)


### PR DESCRIPTION
## Summary
- add tests for SecurityValidator, UnicodeValidator, and BusinessLogicValidator
- ensure UnicodeValidator works in non-strict mode

## Testing
- `pytest -q tests/core/test_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a7565b708320b6b1e046026ad8a5