### PR TITLE
Rename analytics microservice routes

### DIFF
--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -97,10 +97,10 @@
         }
       }
     },
-    "/api/v1/analytics/get_dashboard_summary": {
+    "/api/v1/analytics/dashboard-summary": {
       "post": {
         "summary": "Dashboard Summary",
-        "operationId": "dashboard_summary_api_v1_analytics_get_dashboard_summary_post",
+        "operationId": "dashboard_summary_api_v1_analytics_dashboard_summary_post",
         "parameters": [
           {
             "name": "authorization",
@@ -135,10 +135,10 @@
         }
       }
     },
-    "/api/v1/analytics/get_access_patterns_analysis": {
+    "/api/v1/analytics/access-patterns": {
       "post": {
         "summary": "Access Patterns",
-        "operationId": "access_patterns_api_v1_analytics_get_access_patterns_analysis_post",
+        "operationId": "access_patterns_api_v1_analytics_access_patterns_post",
         "parameters": [
           {
             "name": "authorization",

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -159,13 +159,13 @@ async def _shutdown() -> None:
     service.stop()
 
 
-@app.post("/api/v1/analytics/get_dashboard_summary")
+@app.post("/api/v1/analytics/dashboard-summary")
 async def dashboard_summary(_: None = Depends(verify_token)):
     pool = await get_pool()
     return await async_queries.fetch_dashboard_summary(pool)
 
 
-@app.post("/api/v1/analytics/get_access_patterns_analysis")
+@app.post("/api/v1/analytics/access-patterns")
 async def access_patterns(req: PatternsRequest, _: None = Depends(verify_token)):
     pool = await get_pool()
     return await async_queries.fetch_access_patterns(pool, req.days)

--- a/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/services/analytics_microservice/tests/test_endpoints_async.py
@@ -137,7 +137,7 @@ async def test_dashboard_summary_endpoint():
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
-            "/api/v1/analytics/get_dashboard_summary", headers=headers
+            "/api/v1/analytics/dashboard-summary", headers=headers
         )
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
@@ -151,7 +151,7 @@ async def test_unauthorized_request():
     module, _, _ = load_app()
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/api/v1/analytics/get_dashboard_summary")
+        resp = await client.post("/api/v1/analytics/dashboard-summary")
         assert resp.status_code == 401
         assert resp.json() == {
             "detail": {"code": "unauthorized", "message": "unauthorized"}


### PR DESCRIPTION
## Summary
- update analytics microservice endpoints to noun-based paths
- keep tests in sync
- refresh OpenAPI document

## Testing
- `pytest services/analytics_microservice/tests/test_endpoints_async.py::test_dashboard_summary_endpoint -q` *(fails: ImportError: cannot import name 'DatabaseSettings' from 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6885fcd07c1c8320a9d445004d1df643