### PR TITLE
Add bearerAuth security for analytics endpoints

### DIFF
--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -131,8 +131,19 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/v1/analytics/get_access_patterns_analysis": {
@@ -179,8 +190,19 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/v1/models/register": {
@@ -440,6 +462,13 @@
           "type"
         ],
         "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update `analytics_microservice_openapi.json` with bearerAuth scheme
- secure analytics endpoints and document 401/403 responses

## Testing
- `pre-commit run --files docs/analytics_microservice_openapi.json`

------
https://chatgpt.com/codex/tasks/task_e_6885fcd0ca2c832096f8c99a3454ae00