### PR TITLE
Add error handling middleware

### DIFF
--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -22,9 +22,10 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from services.analytics_microservice.unicode_middleware import (
     UnicodeSanitizationMiddleware,
 )
+from error_handling.middleware import ErrorHandlingMiddleware
 from pydantic import BaseModel
 from yosai_framework.errors import ServiceError
-from yosai_framework.service import BaseService
+from yosai_framework import ServiceBuilder
 
 from config import get_database_config
 from infrastructure.discovery.health_check import (
@@ -40,13 +41,10 @@ from shared.errors.types import ErrorCode
 
 SERVICE_NAME = "analytics-microservice"
 service = (
-    ServiceBuilder(SERVICE_NAME)
-    .with_logging()
-    .with_metrics("")
-    .with_health()
-    .build()
+    ServiceBuilder(SERVICE_NAME).with_logging().with_metrics("").with_health().build()
 )
 app = service.app
+app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(UnicodeSanitizationMiddleware)
 
 
@@ -101,7 +99,6 @@ async def _startup() -> None:
     # Ensure the JWT secret can be retrieved on startup
     _jwt_secret()
 
-
     cfg = get_database_config()
     await create_pool(
         cfg.get_connection_string(),
@@ -150,7 +147,6 @@ async def health_ready() -> dict[str, str]:
         status_code=503,
         detail=ServiceError(ErrorCode.UNAVAILABLE, "not ready").to_dict(),
     )
-
 
 
 @app.on_event("shutdown")
@@ -203,12 +199,16 @@ async def list_versions(name: str, _: None = Depends(verify_token)):
     return {
         "name": name,
         "versions": [e["version"] for e in registry],
-        "active_version": next((e["version"] for e in registry if e.get("active")), None),
+        "active_version": next(
+            (e["version"] for e in registry if e.get("active")), None
+        ),
     }
 
 
 @models_router.post("/{name}/rollback")
-async def rollback(name: str, version: str = Form(...), _: None = Depends(verify_token)):
+async def rollback(
+    name: str, version: str = Form(...), _: None = Depends(verify_token)
+):
     registry = app.state.model_registry.get(name)
     if not registry:
         raise HTTPException(status_code=404, detail="model not found")
@@ -230,5 +230,9 @@ setup_health_checks(app)
 @app.on_event("startup")
 async def _write_openapi() -> None:
     """Persist OpenAPI schema for docs."""
-    docs_path = Path(__file__).resolve().parents[2] / "docs" / "analytics_microservice_openapi.json"
+    docs_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "analytics_microservice_openapi.json"
+    )
     docs_path.write_text(json.dumps(app.openapi(), indent=2))


### PR DESCRIPTION
## Summary
- add ErrorHandlingMiddleware for analytics microservice
- add ErrorHandlingMiddleware for event ingestion service
- test that unhandled exceptions are returned in standard format

## Testing
- `flake8 services/analytics_microservice/app.py services/event-ingestion/app.py services/analytics_microservice/tests/test_endpoints_async.py tests/services/test_event_ingestion_app.py`
- `black services/analytics_microservice/app.py services/event-ingestion/app.py services/analytics_microservice/tests/test_endpoints_async.py tests/services/test_event_ingestion_app.py`
- `python - <<'PY'
import os, sys, pytest
os.environ['LIGHTWEIGHT_SERVICES']='1'
sys.path.insert(0, '.')
import services
sys.exit(pytest.main(['-q']))
PY` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6885fcd1cd808320a6a88b9ffb80bad8