### PR TITLE
Enforce explicit Vault token

### DIFF
--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -120,10 +120,11 @@ For local development a Vault dev server can be used. Start Vault with:
 vault server -dev
 ```
 
-The services default to `http://127.0.0.1:8200` and token `root` when
-`YOSAI_ENV` is set to `development`. In production deployments
-`VAULT_ADDR` and `VAULT_TOKEN` must be provided via environment variables
-or the accompanying Kubernetes `ConfigMap` and `Secret` manifests.
+The services default to `http://127.0.0.1:8200` when `YOSAI_ENV` is set to
+`development`. Provide `VAULT_TOKEN` explicitly using the token printed by
+the dev server. In all deployments `VAULT_ADDR` and `VAULT_TOKEN` must be
+supplied via environment variables or the accompanying Kubernetes
+`ConfigMap` and `Secret` manifests.
 
 Secrets are fetched through `services.common.secrets.get_secret()` which
 uses an in-memory cache. Call `invalidate_secret()` after rotating a

--- a/services/common/secrets.py
+++ b/services/common/secrets.py
@@ -15,7 +15,6 @@ def _init_client() -> VaultClient:
 
     if env == "development":
         addr = addr or "http://127.0.0.1:8200"
-        token = token or "root"
 
     if not addr or not token:
         raise RuntimeError("VAULT_ADDR and VAULT_TOKEN must be set")


### PR DESCRIPTION
## Summary
- require `VAULT_TOKEN` environment variable in `secrets._init_client`
- document that a dev server token must be provided

## Testing
- `pip install hvac==2.3.0 cryptography`
- `pip install PyYAML psutil pandas==2.1.4 pydantic==2.11.7`
- `python - <<'EOF'
import types, sys, pytest
services = types.ModuleType('services')
resilience = types.ModuleType('services.resilience')
metrics = types.ModuleType('services.resilience.metrics')
metrics.circuit_breaker_state = types.SimpleNamespace(labels=lambda *a, **k: types.SimpleNamespace(inc=lambda *a, **kw: None))
resilience.metrics = metrics
services.resilience = resilience
sys.modules['services'] = services
sys.modules['services.resilience'] = resilience
sys.modules['services.resilience.metrics'] = metrics
pytest.main(['tests/test_secure_config_manager.py::test_vault_secret_resolution','tests/test_secure_config_manager.py::test_missing_vault_credentials','-q'])
EOF

------
https://chatgpt.com/codex/tasks/task_e_6885fcd2b91c8320b215b3f4fd080dab