### PR TITLE
Add prediction API for analytics microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,8 @@ manager.execute_query_with_retry("SELECT 1")
 - **Async analytics microservice**: FastAPI implementation using an async
   database engine and Redis cache
   ([docs](docs/analytics_async_migration.md)).
+  Models can be managed via `/api/v1/models/register` and predictions are
+  available at `/api/v1/models/{name}/predict` by posting `{"data": [...]}`.
 
 
 - **device_learning_service.py**: Persists learned device mappings ([docs](docs/device_learning_service.md))

--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -343,6 +343,66 @@
           }
         }
       }
+    },
+    "/api/v1/models/{name}/predict": {
+      "post": {
+        "tags": [
+          "models"
+        ],
+        "summary": "Predict",
+        "operationId": "predict_api_v1_models__name__predict_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -407,6 +467,20 @@
         },
         "type": "object",
         "title": "PatternsRequest"
+      },
+      "PredictionRequest": {
+        "properties": {
+          "data": {
+            "items": {},
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PredictionRequest"
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
## Summary
- enable health check middleware earlier
- preload active models during startup
- add model prediction endpoint
- document model prediction usage in README
- update OpenAPI spec
- adjust tests for new functionality

## Testing
- `pytest -q services/analytics_microservice/tests`

------
https://chatgpt.com/codex/tasks/task_e_6885fd54cd508320ab827588445bcdd2