### PR TITLE
Add resilience package init

### DIFF
--- a/services/resilience/__init__.py
+++ b/services/resilience/__init__.py
@@ -1,0 +1,9 @@
+from .metrics import circuit_breaker_state, start_metrics_server
+from .circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+__all__ = [
+    "circuit_breaker_state",
+    "start_metrics_server",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+]


### PR DESCRIPTION
## Summary
- expose resilience circuit breaker metrics and classes via `services.resilience`
- make `services/resilience` a proper Python package for imports

## Testing
- `pip install -r requirements-test.txt` *(fails: line length truncated but installation succeeded)*
- `pytest -q tests/resilience/test_service_client.py` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6885fd6e41308320892c98715046c854