### PR TITLE
Clarify env flag for running tests locally

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -84,8 +84,10 @@ npm run build-css  # or python tools/build_css.py
 
 ## 3. Run the Tests
 
-Execute the full suite with coverage reporting:
+Execute the full suite with coverage reporting. Enable the lightweight service
+implementations so heavy optional dependencies are not required:
 ```bash
+export LIGHTWEIGHT_SERVICES=1
 pytest --cov
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,13 @@ pip install -r tests/requirements-extra.txt
 
 When the optional packages are missing, tests depending on them are automatically skipped.
 
+Before running the suite locally, enable the lightweight service mode so heavy
+dependencies are stubbed out:
+
+```bash
+export LIGHTWEIGHT_SERVICES=1
+pytest
+```
 
 ## Query Count Checks
 


### PR DESCRIPTION
## Summary
- mention `LIGHTWEIGHT_SERVICES=1` when describing how to run the test suite
- show an example export command before calling pytest

## Testing
- `LIGHTWEIGHT_SERVICES=1 pytest tests/database/test_query_limits.py -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6885fd6f83d08320aac21cfc5b5a59c9