### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           name: python-coverage
           path: coverage.xml
+      - name: Upload coverage to Codecov
+        if: matrix.job == 'python'
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - name: Run Go tests (gateway)
         if: matrix.job == 'go'
         working-directory: ./gateway

--- a/.github/workflows/microservices-ci-cd.yml
+++ b/.github/workflows/microservices-ci-cd.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           name: python-microservices-coverage
           path: coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - run: ./scripts/test-coverage.sh
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -100,6 +100,11 @@ jobs:
         with:
           name: python-coverage
           path: coverage.xml
+      - name: Upload coverage to Codecov
+        if: matrix.lang == 'python'
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - name: Set up Go
         if: matrix.lang == 'go'
         uses: actions/setup-go@v4

--- a/README.md
+++ b/README.md
@@ -489,6 +489,10 @@ as the **pip-audit-report** artifact. It runs on pull requests and fails when
 critical vulnerabilities are detected. Download the artifact from the
 **Actions** tab to review dependency vulnerability results.
 
+Coverage results are uploaded to **Codecov** for every pull request. Open the
+`codecov` check from the PR status page to explore detailed line coverage and
+changes introduced by the branch.
+
 ## <span aria-hidden="true">📋</span> Features
 
 - **Real-time Security Monitoring**: Live access control event monitoring


### PR DESCRIPTION
## Summary
- upload coverage reports to Codecov across CI workflows
- document how to access Codecov reports for pull requests

## Testing
- `pip install -r requirements-test.txt`
- `pip install -e .`
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6885fd74526c8320b2fd49f6be84c971