### PR TITLE
Integrate QueryClientProvider

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,23 +9,28 @@ import {
   Settings
 } from './pages';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ZustandProvider } from './state';
 
 import "./index.css";
+const queryClient = new QueryClient();
 const rootEl = document.getElementById('root');
 if (rootEl) {
   const root = ReactDOM.createRoot(rootEl as HTMLElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Navigate to="/upload" replace />} />
-          <Route path="/upload" element={<Upload />} />
-          <Route path="/analytics" element={<Analytics />} />
-          <Route path="/graphs" element={<Graphs />} />
-          <Route path="/export" element={<Export />} />
-          <Route path="/settings" element={<Settings />} />
-        </Routes>
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Navigate to="/upload" replace />} />
+            <Route path="/upload" element={<Upload />} />
+            <Route path="/analytics" element={<Analytics />} />
+            <Route path="/graphs" element={<Graphs />} />
+            <Route path="/export" element={<Export />} />
+            <Route path="/settings" element={<Settings />} />
+          </Routes>
+        </BrowserRouter>
+      </QueryClientProvider>
 
     </React.StrictMode>
   );
@@ -36,9 +41,11 @@ if (rtEl) {
   const rtRoot = ReactDOM.createRoot(rtEl as HTMLElement);
   rtRoot.render(
     <React.StrictMode>
-      <ZustandProvider>
-        <RealTimeAnalyticsPage />
-      </ZustandProvider>
+      <QueryClientProvider client={queryClient}>
+        <ZustandProvider>
+          <RealTimeAnalyticsPage />
+        </ZustandProvider>
+      </QueryClientProvider>
     </React.StrictMode>
   );
 }


### PR DESCRIPTION
## Summary
- add missing Zustand provider export
- create QueryClient and wrap roots

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fd902f0483209aa6dd9040c2b45b