### PR TITLE
Add websocket reconnection with backoff

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -7,24 +7,49 @@ export const useWebSocket = (
   const [data, setData] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+  const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptRef = useRef(0);
+  const stoppedRef = useRef(false);
 
-  useEffect(() => {
+  const connect = () => {
     const fullUrl = path.startsWith('ws')
       ? path
       : `ws://${window.location.host}${path}`;
     const ws = socketFactory ? socketFactory(fullUrl) : new WebSocket(fullUrl);
     wsRef.current = ws;
 
-    ws.onopen = () => setIsConnected(true);
-    ws.onclose = () => setIsConnected(false);
+    ws.onopen = () => {
+      setIsConnected(true);
+      attemptRef.current = 0;
+    };
+    ws.onclose = () => {
+      setIsConnected(false);
+      if (!stoppedRef.current) {
+        const delay = Math.min(1000 * 2 ** attemptRef.current, 30000);
+        attemptRef.current += 1;
+        retryTimeout.current = setTimeout(connect, delay);
+      }
+    };
     ws.onmessage = (ev: MessageEvent) => setData(ev.data as string);
+  };
+
+  const cleanup = () => {
+    stoppedRef.current = true;
+    if (retryTimeout.current) {
+      clearTimeout(retryTimeout.current);
+    }
+    wsRef.current?.close();
+  };
+  useEffect(() => {
+    stoppedRef.current = false;
+    connect();
 
     return () => {
-      ws.close();
+      cleanup();
     };
   }, [path, socketFactory]);
 
-  return { data, isConnected };
+  return { data, isConnected, cleanup };
 };
 
 export default useWebSocket;


### PR DESCRIPTION
## Summary
- reconnect automatically in `useWebSocket` using exponential backoff
- expose `cleanup` to allow cancelling retries
- test reconnection logic and cleanup behaviour

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fd92e0c08320a66e33b99291e1b1