### PR TITLE
Add DataProcessor tests

### DIFF
--- a/tests/models/test_data_processor.py
+++ b/tests/models/test_data_processor.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import importlib.util
+import sys
+import types
+
+import pandas as pd
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "models" / "ml" / "data_processor.py"
+
+# Provide lightweight stubs to avoid heavy imports during module loading
+constants_mod = types.ModuleType("config.constants")
+constants_mod.DEFAULT_CHUNK_SIZE = 50_000
+sys.modules.setdefault("config.constants", constants_mod)
+
+memory_utils_mod = types.ModuleType("utils.memory_utils")
+memory_utils_mod.check_memory_limit = lambda *a, **k: None
+utils_pkg = types.ModuleType("utils")
+utils_pkg.memory_utils = memory_utils_mod
+sys.modules.setdefault("utils.memory_utils", memory_utils_mod)
+sys.modules.setdefault("utils", utils_pkg)
+
+spec = importlib.util.spec_from_file_location("data_processor", MODULE_PATH)
+dp_mod = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = dp_mod
+spec.loader.exec_module(dp_mod)  # type: ignore
+
+DataProcessor = dp_mod.DataProcessor
+ProcessorConfig = dp_mod.ProcessorConfig
+KafkaConfig = dp_mod.KafkaConfig
+
+
+def _patch_kafka(monkeypatch):
+    class DummyProducer:
+        instances = []
+        def __init__(self, conf):
+            self.conf = conf
+            DummyProducer.instances.append(self)
+        def flush(self):
+            pass
+    class DummyConsumer:
+        instances = []
+        def __init__(self, conf):
+            self.conf = conf
+            self.subscribed = None
+            DummyConsumer.instances.append(self)
+        def subscribe(self, topics):
+            self.subscribed = topics
+        def poll(self, timeout):
+            return None
+        def commit(self, asynchronous=True):
+            pass
+        def close(self):
+            pass
+    monkeypatch.setattr(dp_mod, "Producer", DummyProducer)
+    monkeypatch.setattr(dp_mod, "Consumer", DummyConsumer)
+    return DummyProducer, DummyConsumer
+
+
+def _patch_processing(monkeypatch):
+    monkeypatch.setattr(dp_mod, "check_memory_limit", lambda *a, **k: None)
+    monkeypatch.setattr(DataProcessor, "_cleanse", lambda self, df: df)
+    monkeypatch.setattr(DataProcessor, "_validate", lambda self, df: df)
+
+
+def test_process_file(tmp_path, monkeypatch):
+    _patch_processing(monkeypatch)
+    df = pd.DataFrame({"a": range(5), "b": list("abcde")})
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    cfg = ProcessorConfig(chunk_size=2, checkpoint_path=tmp_path / "chk")
+    proc = DataProcessor(cfg)
+    result = proc.process_file(str(csv_path))
+    assert result.reset_index(drop=True).equals(df)
+    assert cfg.checkpoint_path.read_text() == "2"
+    assert any(r.step == "batch_complete" for r in proc.lineage)
+
+
+def test_resume_from_checkpoint(tmp_path, monkeypatch):
+    _patch_processing(monkeypatch)
+    df = pd.DataFrame({"a": range(5), "b": list("abcde")})
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    chk_path = tmp_path / "chk"
+    chk_path.write_text("0")
+    cfg = ProcessorConfig(chunk_size=2, checkpoint_path=chk_path)
+    proc = DataProcessor(cfg)
+    result = proc.resume_from_checkpoint(str(csv_path))
+    expected = df.iloc[2:].reset_index(drop=True)
+    assert result.reset_index(drop=True).equals(expected)
+    assert chk_path.read_text() == "2"
+    assert any(r.step == "resume_complete" for r in proc.lineage)
+
+
+def test_kafka_init(monkeypatch):
+    DummyProducer, DummyConsumer = _patch_kafka(monkeypatch)
+    cfg = ProcessorConfig(
+        kafka=KafkaConfig(brokers="b:1", topic="t", group="g"),
+        checkpoint_path=Path("chk")
+    )
+    proc = DataProcessor(cfg)
+    assert isinstance(proc._producer, DummyProducer)
+    assert isinstance(proc._consumer, DummyConsumer)
+    assert proc._consumer.subscribed == [cfg.kafka.topic]


### PR DESCRIPTION
## Summary
- add tests for `models/ml/data_processor.py`

## Testing
- `python - <<'PY'
import sys, types
services_stub = types.ModuleType('services'); services_stub.__path__=[]
services_stub.registry = types.SimpleNamespace(get_service=lambda name: None)
sys.modules['services']=services_stub
res_pkg = types.ModuleType('services.resilience'); res_pkg.__path__=[]
sys.modules['services.resilience']=res_pkg
metrics_mod = types.ModuleType('services.resilience.metrics'); metrics_mod.circuit_breaker_state=object(); metrics_mod.start_metrics_server=lambda port=8003: None
sys.modules['services.resilience.metrics']=metrics_mod

import pytest
ret=pytest.main(["-q","tests/models/test_data_processor.py"])
print("exit", ret)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6885fd5857048320b0d91e9d0335c9d1