### PR TITLE
Add unsubscribe functionality to UploadWebSocket hook

### DIFF
--- a/src/hooks/useUploadWebSocket.test.ts
+++ b/src/hooks/useUploadWebSocket.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act } from '@testing-library/react';
+import { useUploadWebSocket } from './useUploadWebSocket';
+
+class MockSocket {
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public close = jest.fn();
+  constructor(public url: string) {
+    MockSocket.instance = this;
+  }
+  static instance: MockSocket | null = null;
+}
+
+describe('useUploadWebSocket', () => {
+  beforeEach(() => {
+    (global as any).WebSocket = jest.fn((url: string) => new MockSocket(url));
+  });
+
+  it('subscribes to progress and can unsubscribe', () => {
+    const { result } = renderHook(() => useUploadWebSocket());
+    const cb = jest.fn();
+
+    act(() => {
+      result.current.subscribeToUploadProgress('1', cb);
+    });
+
+    act(() => {
+      MockSocket.instance?.onmessage?.({ data: JSON.stringify({ progress: 42 }) } as any);
+    });
+
+    expect(cb).toHaveBeenCalledWith(42);
+
+    const firstInstance = MockSocket.instance;
+
+    act(() => {
+      result.current.unsubscribe('1');
+    });
+
+    expect(firstInstance?.close).toHaveBeenCalled();
+
+    act(() => {
+      result.current.subscribeToUploadProgress('1', cb);
+    });
+
+    expect(MockSocket.instance).not.toBe(firstInstance);
+  });
+});

--- a/src/hooks/useUploadWebSocket.ts
+++ b/src/hooks/useUploadWebSocket.ts
@@ -22,7 +22,15 @@ export const useUploadWebSocket = () => {
     sockets.current[taskId] = ws;
   };
 
-  return { subscribeToUploadProgress };
+  const unsubscribe = (taskId: string) => {
+    const ws = sockets.current[taskId];
+    if (ws) {
+      ws.close();
+      delete sockets.current[taskId];
+    }
+  };
+
+  return { subscribeToUploadProgress, unsubscribe };
 };
 
 export default useUploadWebSocket;


### PR DESCRIPTION
## Summary
- add ability to unsubscribe from upload progress
- expose unsubscribe method from the hook
- test websocket unsubscribe logic

## Testing
- `npm install --silent` *(fails: node modules not installed)*
- `CI=true npm test -- src/hooks/useUploadWebSocket.test.ts` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fd93b8a48320909dea794a67eb50