### PR TITLE
Add analytics WebSocket server integration

### DIFF
--- a/services/analytics/async_api.py
+++ b/services/analytics/async_api.py
@@ -23,6 +23,7 @@ from starlette.types import ASGIApp
 from core.cache_manager import CacheConfig, InMemoryCacheManager
 from core.events import EventBus
 from services.cached_analytics import CachedAnalyticsService
+from services.websocket_server import AnalyticsWebSocketServer
 from services.common.async_db import get_pool
 from services.security import require_permission
 from infrastructure.discovery.health_check import (
@@ -38,7 +39,8 @@ logger = logging.getLogger(__name__)
 
 event_bus = EventBus()
 cache_manager = InMemoryCacheManager(CacheConfig(timeout_seconds=300))
-analytics_service = CachedAnalyticsService(cache_manager)
+analytics_service = CachedAnalyticsService(cache_manager, event_bus=event_bus)
+ws_server: AnalyticsWebSocketServer | None = None
 
 app = FastAPI(dependencies=[Depends(require_permission("analytics.read"))])
 
@@ -55,7 +57,16 @@ async def get_service() -> CachedAnalyticsService:
 
 @app.on_event("startup")
 async def _startup() -> None:
+    global ws_server
     await cache_manager.start()
+    ws_server = AnalyticsWebSocketServer(event_bus)
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    await cache_manager.stop()
+    if ws_server is not None:
+        ws_server.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -208,4 +219,4 @@ async def analytics_sse() -> StreamingResponse:
     return StreamingResponse(_generator(), media_type="text/event-stream")
 
 
-__all__ = ["app", "get_service", "event_bus"]
+__all__ = ["app", "get_service", "event_bus", "ws_server"]

--- a/services/websocket_server.py
+++ b/services/websocket_server.py
@@ -59,5 +59,11 @@ class AnalyticsWebSocketServer:
                 self._broadcast_async(message), self._loop
             )
 
+    def stop(self) -> None:
+        """Stop the server thread and event loop."""
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=1)
+
 
 __all__ = ["AnalyticsWebSocketServer"]


### PR DESCRIPTION
## Summary
- broadcast analytics updates to WebSocket clients via `AnalyticsWebSocketServer`
- hook WebSocket server into async analytics API lifecycle
- emit analytics results to `EventBus`

## Testing
- `pip install -r requirements.txt -r requirements-test.txt` *(fails: ResolutionImpossible)*
- `pip install -r requirements.lock` *(fails: No matching distribution found)*
- `isort --check .` *(fails: imports incorrectly sorted)*
- `black --check .` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: would reformat)*
- `mypy --strict .` *(fails: cannot format files)*
- `bandit -r .` *(command not found)*
- `pytest` *(fails: missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688600a8754c83208cf7d1a4a46f82e7