### PR TITLE
Add threat assessment endpoint

### DIFF
--- a/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/services/analytics_microservice/tests/test_endpoints_async.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import importlib.util
 import os
 import pathlib
 import sys
-import types
 import time
+import types
+from dataclasses import dataclass
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from fastapi import FastAPI
 from jose import jwt
 
 SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2]
@@ -37,7 +41,6 @@ def load_app(jwt_secret: str = "secret") -> tuple:
 
     prom_stub.Instrumentator = lambda: DummyInstr()
     sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
-
 
     db_stub = types.ModuleType("services.common.async_db")
     db_stub.create_pool = AsyncMock()
@@ -77,8 +80,6 @@ def load_app(jwt_secret: str = "secret") -> tuple:
     yf_config_stub.ServiceConfig = DummyCfg
     yf_config_stub.load_config = lambda path: DummyCfg()
     sys.modules["yosai_framework.config"] = yf_config_stub
-    import yosai_framework.service as yf_service
-    yf_service.load_config = yf_config_stub.load_config
 
     redis_stub = types.ModuleType("redis")
     redis_async = types.ModuleType("redis.asyncio")
@@ -91,6 +92,145 @@ def load_app(jwt_secret: str = "secret") -> tuple:
     queries_stub.fetch_dashboard_summary = AsyncMock(return_value={"status": "ok"})
     queries_stub.fetch_access_patterns = AsyncMock(return_value={"days": 7})
     sys.modules["services.analytics_microservice.async_queries"] = queries_stub
+
+    health_stub = types.ModuleType("infrastructure.discovery.health_check")
+    health_stub.register_health_check = lambda *a, **k: None
+    health_stub.setup_health_checks = lambda app: None
+    health_stub.DependencyHealthMiddleware = lambda app: app
+    sys.modules["infrastructure.discovery.health_check"] = health_stub
+
+    service_stub = types.ModuleType("yosai_framework.service")
+
+    class DummyService:
+        def __init__(self):
+            self.app = FastAPI()
+            self.app.state.live = True
+            self.app.state.ready = True
+            self.app.state.startup_complete = True
+
+        def stop(self):
+            pass
+
+    class DummyBuilder:
+        def __init__(self, name: str):
+            self
+
+        def with_logging(self, *a, **k):
+            return self
+
+        def with_metrics(self, *a, **k):
+            return self
+
+        def with_health(self):
+            return self
+
+        def build(self):
+            return DummyService()
+
+    service_stub.BaseService = DummyService
+    service_stub.ServiceBuilder = DummyBuilder
+    sys.modules["yosai_framework.service"] = service_stub
+    yf_pkg = types.ModuleType("yosai_framework")
+    yf_pkg.ServiceBuilder = DummyBuilder
+    yf_pkg.BaseService = DummyService
+    errors_stub = types.ModuleType("yosai_framework.errors")
+
+    class ServiceError(Exception):
+        pass
+
+    errors_stub.ServiceError = ServiceError
+    sys.modules["yosai_framework"] = yf_pkg
+    sys.modules["yosai_framework.errors"] = errors_stub
+
+    secrets_stub = types.ModuleType("services.common.secrets")
+    secrets_stub.get_secret = lambda path: "secret"
+    sys.modules["services.common.secrets"] = secrets_stub
+
+    # Stub analytics modules used by threat_assessment endpoint
+    fe_stub = types.ModuleType("analytics.feature_extraction")
+    fe_stub.extract_event_features = lambda df, logger=None: df
+
+    ad_stub = types.ModuleType("analytics.anomaly_detection")
+
+    @dataclass
+    class DummyResult:
+        total_anomalies: int = 0
+        severity_distribution: dict = None
+        detection_summary: dict = None
+        risk_assessment: dict = None
+        recommendations: list = None
+        processing_metadata: dict = None
+
+    class DummyDetector:
+        def analyze_anomalies(self, df):
+            return DummyResult(
+                severity_distribution={},
+                detection_summary={},
+                risk_assessment={"risk_score": 0},
+                recommendations=[],
+                processing_metadata={},
+            )
+
+    ad_stub.AnomalyDetector = DummyDetector
+
+    sp_stub = types.ModuleType("analytics.security_patterns")
+
+    @dataclass
+    class DummyAssessment:
+        overall_score: int = 0
+        risk_level: str = "low"
+        confidence_interval: tuple = (0.0, 0.0)
+        threat_indicators: list = None
+        pattern_analysis: dict = None
+        recommendations: list = None
+
+    class DummyAnalyzer:
+        def analyze_security_patterns(self, df):
+            return DummyAssessment(
+                threat_indicators=[],
+                pattern_analysis={},
+                recommendations=[],
+            )
+
+    sp_stub.SecurityPatternsAnalyzer = DummyAnalyzer
+
+    analytics_pkg = types.ModuleType("analytics")
+    analytics_pkg.feature_extraction = fe_stub
+    analytics_pkg.anomaly_detection = ad_stub
+    analytics_pkg.security_patterns = sp_stub
+    sys.modules["analytics"] = analytics_pkg
+    sys.modules["analytics.feature_extraction"] = fe_stub
+    sys.modules["analytics.anomaly_detection"] = ad_stub
+    sys.modules["analytics.security_patterns"] = sp_stub
+
+    # Minimal stubs for unicode and validation utilities
+    core_unicode = types.ModuleType("core.unicode")
+    core_unicode.sanitize_for_utf8 = lambda x: x
+    core_pkg = types.ModuleType("core")
+    core_pkg.unicode = core_unicode
+    sys.modules["core"] = core_pkg
+    sys.modules["core.unicode"] = core_unicode
+
+    unicode_stub = types.ModuleType("utils.unicode_handler")
+
+    class DummyHandler:
+        @staticmethod
+        def sanitize(obj):
+            return obj
+
+    unicode_stub.UnicodeHandler = DummyHandler
+    sys.modules["utils.unicode_handler"] = unicode_stub
+
+    val_stub = types.ModuleType("validation.unicode_validator")
+
+    class DummyValidator:
+        def validate_dataframe(self, df):
+            return df
+
+    val_stub.UnicodeValidator = DummyValidator
+    sys.modules["validation.unicode_validator"] = val_stub
+
+    sys.modules.setdefault("hvac", types.ModuleType("hvac"))
 
     os.environ["JWT_SECRET"] = jwt_secret
 
@@ -174,7 +314,9 @@ async def test_model_registry_endpoints(tmp_path):
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         files = {"file": ("model.bin", b"data")}
         data = {"name": "demo", "version": "1"}
-        resp = await client.post("/api/v1/models/register", headers=headers, data=data, files=files)
+        resp = await client.post(
+            "/api/v1/models/register", headers=headers, data=data, files=files
+        )
         assert resp.status_code == 200
         assert resp.json()["version"] == "1"
 
@@ -189,3 +331,34 @@ async def test_model_registry_endpoints(tmp_path):
         )
         assert resp.status_code == 200
         assert resp.json()["active_version"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_threat_assessment_endpoint():
+    module, _, _ = load_app()
+    token = jwt.encode(
+        {"sub": "svc", "iss": "gateway", "exp": int(time.time()) + 60},
+        "secret",
+        algorithm="HS256",
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    sample = [
+        {
+            "timestamp": "2024-01-01T00:00:00",
+            "person_id": "u1",
+            "door_id": "d1",
+            "access_result": "Granted",
+        }
+    ]
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/analytics/threat_assessment",
+            headers=headers,
+            json=sample,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "combined_risk_score" in data


### PR DESCRIPTION
## Summary
- import analytics modules in analytics microservice
- add `/api/v1/analytics/threat_assessment` route
- stub analytics and infrastructure modules for testing
- test new endpoint

## Testing
- `pre-commit run --files services/analytics_microservice/app.py services/analytics_microservice/tests/test_endpoints_async.py`
- `pytest -q services/analytics_microservice/tests/test_endpoints_async.py -k threat_assessment_endpoint`

------
https://chatgpt.com/codex/tasks/task_e_688600a0a4a083209a386d3140317ed3