### PR TITLE
Add prediction API to analytics microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ manager.execute_query_with_retry("SELECT 1")
 
 
 - **device_learning_service.py**: Persists learned device mappings ([docs](docs/device_learning_service.md))
+- **Model predictions**: POST data to `/api/v1/models/{name}/predict` to run the active model and receive predictions
 - Caching and performance optimization
 - Modular and testable
 

--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -406,6 +406,18 @@
         ],
         "title": "Body_rollback_api_v1_models__name__rollback_post"
       },
+      "Body_predict_api_v1_models__name__predict_post": {
+        "properties": {
+          "data": {
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "Body_predict_api_v1_models__name__predict_post"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -462,6 +474,66 @@
           "type"
         ],
         "title": "ValidationError"
+      }
+    },
+    "/api/v1/models/{name}/predict": {
+      "post": {
+        "tags": [
+          "models"
+        ],
+        "summary": "Predict",
+        "operationId": "predict_api_v1_models__name__predict_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_predict_api_v1_models__name__predict_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "securitySchemes": {

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 from pathlib import Path
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -20,6 +21,8 @@ from jose import jwt
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
+import joblib
+import redis.asyncio as aioredis
 
 
 from config import get_database_config
@@ -112,8 +115,25 @@ def verify_token(authorization: str = Header("")) -> None:
         )
 
 
+def preload_active_models() -> None:
+    """Load active models from the registry into memory."""
+    app.state.models = {}
+    for name, registry in app.state.model_registry.items():
+        for entry in registry:
+            if entry.get("active"):
+                try:
+                    model = joblib.load(entry["path"])
+                    entry["object"] = model
+                    app.state.models[name] = model
+                except Exception:  # pragma: no cover - ignore invalid models
+                    pass
+
 class PatternsRequest(BaseModel):
     days: int = 7
+
+
+class PredictRequest(BaseModel):
+    data: Any
 
 
 @app.on_event("startup")
@@ -136,6 +156,7 @@ async def _startup() -> None:
     app.state.model_dir = Path(os.environ.get("MODEL_DIR", "model_store"))
     app.state.model_dir.mkdir(parents=True, exist_ok=True)
     app.state.model_registry = {}
+    preload_active_models()
     app.state.ready = True
     app.state.startup_complete = True
 
@@ -229,6 +250,12 @@ async def register_model(
     dest_path.write_bytes(contents)
     meta = {"name": name, "version": version, "path": str(dest_path)}
     meta["active"] = True
+    try:
+        model_obj = joblib.load(dest_path)
+        meta["object"] = model_obj
+        app.state.models[name] = model_obj
+    except Exception:  # pragma: no cover - invalid model file
+        meta["object"] = None
     registry = app.state.model_registry.setdefault(name, [])
     for entry in registry:
         entry["active"] = False
@@ -263,7 +290,37 @@ async def rollback(
         raise HTTPException(status_code=404, detail="version not found")
     for entry in registry:
         entry["active"] = entry["version"] == version
+
+    preload_active_models()
     return {"name": name, "active_version": version}
+
+
+@models_router.post("/{name}/predict")
+@rate_limit_decorator()
+async def predict(
+    name: str,
+    req: PredictRequest,
+    _: None = Depends(verify_token),
+):
+    registry = app.state.model_registry.get(name)
+    if not registry:
+        raise HTTPException(status_code=404, detail="model not found")
+    active = next((e for e in registry if e.get("active")), None)
+    if not active:
+        raise HTTPException(status_code=404, detail="no active version")
+    model_obj = active.get("object")
+    if model_obj is None:
+        try:
+            model_obj = joblib.load(active["path"])
+            active["object"] = model_obj
+            app.state.models[name] = model_obj
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+    try:
+        result = model_obj.predict(req.data)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return {"predictions": result}
 
 
 app.include_router(models_router)


### PR DESCRIPTION
## Summary
- preload models into memory at startup
- register loaded model when uploading
- add `/api/v1/models/{name}/predict` endpoint
- document usage and update OpenAPI
- test prediction route

## Testing
- `flake8 services/analytics_microservice/app.py services/analytics_microservice/tests/test_endpoints_async.py`
- `mypy services/analytics_microservice/app.py services/analytics_microservice/tests/test_endpoints_async.py` *(fails: missing stubs & invalid syntax in unrelated module)*
- `pytest services/analytics_microservice/tests` *(fails: import errors due to missing heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_688605a9d3a48320b3aefe43cf8a7736