### PR TITLE
Add dataframe hashing utility

### DIFF
--- a/models/ml/security_models.py
+++ b/models/ml/security_models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Training utilities for core ML models."""
 
-import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +10,8 @@ from typing import Any, Tuple
 import joblib
 import numpy as np
 import pandas as pd
+
+from utils.hashing import hash_dataframe
 
 from utils.sklearn_compat import optional_import
 from analytics.feature_extraction import extract_event_features
@@ -82,11 +83,6 @@ if keras is None:  # pragma: no cover - fallback definitions
             Adam = object
 
 
-# ---------------------------------------------------------------------------
-def _hash_dataframe(df: pd.DataFrame) -> str:
-    """Return SHA256 hash of ``df`` serialized as CSV."""
-    csv_bytes = df.to_csv(index=False).encode()
-    return hashlib.sha256(csv_bytes).hexdigest()
 
 
 @dataclass
@@ -271,7 +267,7 @@ def _register_model(
             recall=metrics.get("recall", 0.0),
         )
     )
-    dataset_hash = _hash_dataframe(df)
+    dataset_hash = hash_dataframe(df)
     with Path(f"{name}.joblib").open("wb") as fh:
         joblib.dump(model_obj, fh)
     record = registry.register_model(name, f"{name}.joblib", metrics, dataset_hash)

--- a/models/ml/training/pipeline.py
+++ b/models/ml/training/pipeline.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Tuple
-import hashlib
 import logging
 from pathlib import Path
 
 import pandas as pd
 import numpy as np
+
+from utils.hashing import hash_dataframe
 
 from utils.sklearn_compat import optional_import
 from models.ml import ModelRegistry
@@ -25,12 +26,6 @@ DaskLocalCluster = optional_import("dask.distributed.LocalCluster")
 mlflow = optional_import("mlflow")
 
 logger = logging.getLogger(__name__)
-
-
-def _hash_dataframe(df: pd.DataFrame) -> str:
-    """Return SHA256 hash of ``df`` serialized as CSV."""
-    csv_bytes = df.to_csv(index=False).encode()
-    return hashlib.sha256(csv_bytes).hexdigest()
 
 
 @dataclass
@@ -151,7 +146,7 @@ class TrainingPipeline:
         if target_column not in df:
             raise ValueError(f"target column '{target_column}' missing")
 
-        dataset_hash = _hash_dataframe(df)
+        dataset_hash = hash_dataframe(df)
         y = df[target_column].values
         X = (
             df.drop(columns=[target_column])

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -43,6 +43,7 @@ from .protocols import SafeDecoderProtocol
 from .file_utils import safe_decode_with_unicode_handling
 from .unicode_handler import UnicodeHandler
 from .io_helpers import read_json, write_json, read_text, write_text
+from .hashing import hash_dataframe
 
 __all__ = [
     "UnicodeProcessor",
@@ -82,4 +83,5 @@ __all__ = [
     "write_json",
     "read_text",
     "write_text",
+    "hash_dataframe",
 ]

--- a/utils/hashing.py
+++ b/utils/hashing.py
@@ -1,0 +1,26 @@
+"""Hashing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import pandas as pd
+
+
+def hash_dataframe(df: pd.DataFrame) -> str:
+    """Return SHA256 hash of ``df`` serialized as CSV.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to hash.
+
+    Returns
+    -------
+    str
+        SHA256 hex digest of the DataFrame contents.
+    """
+    csv_bytes = df.to_csv(index=False).encode()
+    return hashlib.sha256(csv_bytes).hexdigest()
+
+
+__all__ = ["hash_dataframe"]


### PR DESCRIPTION
## Summary
- add reusable `hash_dataframe` helper in utils
- use the helper in ml security_models and training pipeline

## Testing
- `python -m py_compile utils/hashing.py models/ml/security_models.py models/ml/training/pipeline.py`
- `bash scripts/install_test_deps.sh` *(fails: conflicting pytest versions)*
- `pytest -k "hash_dataframe" -q` *(fails: missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688666742b6483209d2cd638dc3c83cf