### PR TITLE
Add configurable WS URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,5 @@ DEBUG=1
 # Frontend Configuration
 REACT_APP_API_BASE=/v1
 # Base path for frontend API requests
+REACT_APP_WS_URL=localhost:5001
+# WebSocket base URL for the frontend

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ HashiCorp Vault or AWS Secrets Manager as described in
 [docs/secret_management.md](docs/secret_management.md). Vault deployment
 details are provided in [docs/vault_integration.md](docs/vault_integration.md).
 
+#### Frontend WebSocket URL
+
+Set `REACT_APP_WS_URL` to override the host used for WebSocket connections.
+When unset the front end falls back to `window.location.host`.
+
 ### RBAC Setup
 
 Apply the initial database schema before enabling role based access

--- a/src/hooks/useUploadWebSocket.test.ts
+++ b/src/hooks/useUploadWebSocket.test.ts
@@ -45,4 +45,16 @@ describe('useUploadWebSocket', () => {
 
     expect(MockSocket.instance).not.toBe(firstInstance);
   });
+
+  it('uses REACT_APP_WS_URL when provided', () => {
+    process.env.REACT_APP_WS_URL = 'example.com:1234';
+    const { result } = renderHook(() => useUploadWebSocket());
+
+    act(() => {
+      result.current.subscribeToUploadProgress('abc', jest.fn());
+    });
+
+    expect(MockSocket.instance?.url).toBe('ws://example.com:1234/ws/upload/abc');
+    delete process.env.REACT_APP_WS_URL;
+  });
 });

--- a/src/hooks/useUploadWebSocket.ts
+++ b/src/hooks/useUploadWebSocket.ts
@@ -6,10 +6,11 @@ interface ProgressCallback {
 
 export const useUploadWebSocket = () => {
   const sockets = useRef<Record<string, WebSocket>>({});
+  const baseUrl = process.env.REACT_APP_WS_URL || window.location.host;
 
   const subscribeToUploadProgress = (taskId: string, cb: ProgressCallback) => {
     if (sockets.current[taskId]) return;
-    const ws = new WebSocket(`ws://localhost:5001/ws/upload/${taskId}`);
+    const ws = new WebSocket(`ws://${baseUrl}/ws/upload/${taskId}`);
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       if (data.progress !== undefined) {


### PR DESCRIPTION
## Summary
- allow useUploadWebSocket to read `REACT_APP_WS_URL`
- document new variable
- note example `.env` configuration
- test URL construction

## Testing
- `npm test` *(fails: Jest couldn't parse axios imports)*

------
https://chatgpt.com/codex/tasks/task_e_688666821ff0832096cf55f4a1346840