### PR TITLE
Replace axios with shared api client

### DIFF
--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -5,7 +5,7 @@ import { FilePreview } from "./FilePreview";
 import { ColumnMappingModal } from "./ColumnMappingModal";
 import { DeviceMappingModal } from "./DeviceMappingModal";
 import { UploadedFile, ProcessingStatus as Status } from "./types";
-import axios from "axios";
+import { api } from "../../api/client";
 
 const CONCURRENCY_LIMIT = parseInt(
   process.env.REACT_APP_UPLOAD_CONCURRENCY || "3",
@@ -70,12 +70,12 @@ const Upload: React.FC = () => {
     );
 
     try {
-      const response = await axios.post(`${API_URL}/api/v1/upload`, formData);
+      const response = await api.post(`${API_URL}/api/v1/upload`, formData);
       const { job_id } = response.data;
 
       const poll = setInterval(async () => {
         try {
-          const res = await axios.get(
+          const res = await api.get(
             `${API_URL}/api/v1/upload/status/${job_id}`,
           );
           const progress = res.data.progress ?? 0;

--- a/src/components/upload/useCallbackApi.ts
+++ b/src/components/upload/useCallbackApi.ts
@@ -1,10 +1,10 @@
-import axios from 'axios';
+import { api } from '../../api/client';
 
 const API_URL = process.env.REACT_APP_API_URL || '/api';
 
 export const useCallbackApi = () => {
   const toggleCustomField = async (selected: string) => {
-    const res = await axios.post(`${API_URL}/v1/callbacks/toggle-custom-field`, { selected_value: selected });
+    const res = await api.post(`${API_URL}/v1/callbacks/toggle-custom-field`, { selected_value: selected });
     return res.data;
   };
 


### PR DESCRIPTION
## Summary
- use shared api client in Upload page
- use shared api client in callback helpers

## Testing
- `npm test -- --coverage --watchAll=false` *(fails: coverage threshold not met and some Jest syntax errors)*
- `pytest -q` *(fails: ModuleNotFoundError due to missing services.resilience)*

------
https://chatgpt.com/codex/tasks/task_e_6886668262748320a15322693d0d1881