### PR TITLE
Switch analytics endpoints to GET

### DIFF
--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -98,9 +98,9 @@
       }
     },
     "/api/v1/analytics/dashboard-summary": {
-      "post": {
+      "get": {
         "summary": "Dashboard Summary",
-        "operationId": "dashboard_summary_api_v1_analytics_dashboard_summary_post",
+        "operationId": "dashboard_summary_api_v1_analytics_dashboard_summary_get",
         "parameters": [
           {
             "name": "authorization",
@@ -147,9 +147,9 @@
       }
     },
     "/api/v1/analytics/access-patterns": {
-      "post": {
+      "get": {
         "summary": "Access Patterns",
-        "operationId": "access_patterns_api_v1_analytics_access_patterns_post",
+        "operationId": "access_patterns_api_v1_analytics_access_patterns_get",
         "parameters": [
           {
             "name": "authorization",
@@ -160,18 +160,14 @@
               "default": "",
               "title": "Authorization"
             }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer", "default": 7, "title": "Days"}
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PatternsRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -430,17 +426,6 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
-      },
-      "PatternsRequest": {
-        "properties": {
-          "days": {
-            "type": "integer",
-            "title": "Days",
-            "default": 7
-          }
-        },
-        "type": "object",
-        "title": "PatternsRequest"
       },
       "ValidationError": {
         "properties": {

--- a/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/services/analytics_microservice/tests/test_endpoints_async.py
@@ -298,7 +298,7 @@ async def test_dashboard_summary_endpoint():
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post(
+        resp = await client.get(
             "/api/v1/analytics/dashboard-summary", headers=headers
         )
         assert resp.status_code == 200
@@ -313,7 +313,7 @@ async def test_unauthorized_request():
     module, _, _ = load_app()
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/api/v1/analytics/dashboard-summary")
+        resp = await client.get("/api/v1/analytics/dashboard-summary")
         assert resp.status_code == 401
         assert resp.json() == {
             "detail": {"code": "unauthorized", "message": "unauthorized"}
@@ -333,8 +333,8 @@ async def test_internal_error_response():
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post(
-            "/api/v1/analytics/get_dashboard_summary",
+        resp = await client.get(
+            "/api/v1/analytics/dashboard-summary",
             headers=headers,
         )
         assert resp.status_code == 500

--- a/services/migration/adapter.py
+++ b/services/migration/adapter.py
@@ -147,12 +147,27 @@ class AnalyticsServiceAdapter(ServiceAdapter, AnalyticsServiceProtocol):
     async def _call_microservice(self, method: str, params: Dict[str, Any]) -> Any:
         async with self.circuit_breaker:
             async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{self.microservice_url}/v1/analytics/{method}",
-                    json=params,
-                    timeout=aiohttp.ClientTimeout(total=30.0),
-                ) as response:
-                    return await response.json()
+                if method == "get_dashboard_summary":
+                    async with session.get(
+                        f"{self.microservice_url}/v1/analytics/dashboard-summary",
+                        params=params,
+                        timeout=aiohttp.ClientTimeout(total=30.0),
+                    ) as response:
+                        return await response.json()
+                elif method == "get_access_patterns_analysis":
+                    async with session.get(
+                        f"{self.microservice_url}/v1/analytics/access-patterns",
+                        params=params,
+                        timeout=aiohttp.ClientTimeout(total=30.0),
+                    ) as response:
+                        return await response.json()
+                else:
+                    async with session.post(
+                        f"{self.microservice_url}/v1/analytics/{method}",
+                        json=params,
+                        timeout=aiohttp.ClientTimeout(total=30.0),
+                    ) as response:
+                        return await response.json()
 
     # ``AnalyticsServiceProtocol`` methods ---------------------------------
     async def get_dashboard_summary_async(self) -> Dict[str, Any]:

--- a/tests/integration/test_e2e_gateway.py
+++ b/tests/integration/test_e2e_gateway.py
@@ -73,8 +73,8 @@ def test_gateway_end_to_end(tmp_path):
         start_metrics = requests.get(metrics_url, timeout=30)
         start_total = get_total_requests(start_metrics.text)
 
-        resp = requests.post(
-            f"http://{g_host}:{g_port}/api/v1/analytics/get_dashboard_summary",
+        resp = requests.get(
+            f"http://{g_host}:{g_port}/api/v1/analytics/dashboard-summary",
             timeout=30,
         )
         assert resp.status_code == 200

--- a/tests/integration/test_gateway_failure_modes.py
+++ b/tests/integration/test_gateway_failure_modes.py
@@ -50,8 +50,8 @@ def test_gateway_breaker_counts_on_downtime(tmp_path):
 
         for _ in range(6):
             try:
-                requests.post(
-                    f"http://{g_host}:{g_port}/api/v1/analytics/get_dashboard_summary",
+                requests.get(
+                    f"http://{g_host}:{g_port}/api/v1/analytics/dashboard-summary",
                     timeout=5,
                 )
             except requests.RequestException:

--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -126,7 +126,7 @@ def test_requests_without_valid_token_return_401():
     client = TestClient(app_module.app)
 
     # No Authorization header
-    resp = client.post("/api/v1/analytics/get_dashboard_summary")
+    resp = client.get("/api/v1/analytics/dashboard-summary")
     assert resp.status_code == 401
 
     # Expired token
@@ -135,8 +135,8 @@ def test_requests_without_valid_token_return_401():
         "test",
         algorithm="HS256",
     )
-    resp = client.post(
-        "/api/v1/analytics/get_dashboard_summary",
+    resp = client.get(
+        "/api/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {bad_token}"},
     )
     assert resp.status_code == 401
@@ -147,8 +147,8 @@ def test_requests_without_valid_token_return_401():
         "test",
         algorithm="HS256",
     )
-    resp = client.post(
-        "/api/v1/analytics/get_dashboard_summary",
+    resp = client.get(
+        "/api/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {good_token}"},
     )
     assert resp.status_code == 200

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -63,5 +63,5 @@ def test_analytics_service_adapter_microservice(monkeypatch):
     migration_adapter.register_migration_services(container)
 
     adapter = container.get("analytics_service")
-    expected = client.post("/api/v1/analytics/get_dashboard_summary").json()
+    expected = client.get("/api/v1/analytics/dashboard-summary").json()
     assert adapter.get_dashboard_summary() == expected

--- a/tests/services/test_analytics_microservice_app.py
+++ b/tests/services/test_analytics_microservice_app.py
@@ -98,8 +98,8 @@ def _token(secret: str) -> str:
 def test_dashboard_summary_endpoint(app_fixture):
     client, dummy = app_fixture
     token = _token("secret")
-    resp = client.post(
-        "/api/v1/analytics/get_dashboard_summary",
+    resp = client.get(
+        "/api/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -110,9 +110,9 @@ def test_dashboard_summary_endpoint(app_fixture):
 def test_access_patterns_endpoint(app_fixture):
     client, dummy = app_fixture
     token = _token("secret")
-    resp = client.post(
-        "/api/v1/analytics/get_access_patterns_analysis",
-        json={"days": 3},
+    resp = client.get(
+        "/api/v1/analytics/access-patterns",
+        params={"days": 3},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- change dashboard summary and access patterns routes to GET
- update microservice adapter for new endpoints
- adjust tests for updated paths
- refresh analytics microservice OpenAPI spec

## Testing
- `pytest tests/services/test_analytics_microservice_app.py services/analytics_microservice/tests/test_endpoints_async.py -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886668a114c8320830933553fca2661