### PR TITLE
Replace sample secrets and document management

### DIFF
--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -63,6 +63,15 @@ fetch the secret with a name matching the requested key. With the
 `VAULT_ADDR` and `VAULT_TOKEN` environment variables. Keys may include a
 field selector like `secret/data/db#password` to read specific values.
 
+## Kubernetes Secrets
+
+The `k8s/base/secrets.yaml` file in the repository is provided only as a
+template. It contains placeholder values such as `<managed-secret>` so that
+real credentials are never stored in Git. Supply the actual values using your
+deployment pipeline or reference a sealed secret created by your cluster's
+secret manager. Patch the manifest at deploy time or mount the secrets from an
+external system to keep them out of version control.
+
 ### AWS Secrets Manager Configuration
 
 `SecureConfigManager` also understands strings starting with `"aws-secrets:"`.

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: yosai-dev
 type: Opaque
 stringData:
-  AUTH0_CLIENT_ID: dev-client-id
-  AUTH0_CLIENT_SECRET: dev-client-secret
-  KAFKA_USERNAME: ""
-  KAFKA_PASSWORD: ""
+  # Values are populated by the deployment pipeline. Do not store real
+  # secrets in version control.
+  AUTH0_CLIENT_ID: "<managed-secret>"
+  AUTH0_CLIENT_SECRET: "<managed-secret>"
+  KAFKA_USERNAME: "<managed-secret>"
+  KAFKA_PASSWORD: "<managed-secret>"


### PR DESCRIPTION
## Summary
- avoid committing real secrets in `k8s/base/secrets.yaml`
- describe how to manage Kubernetes secrets in the docs

## Testing
- `pre-commit run --files k8s/base/secrets.yaml docs/secret_management.md`
- `pytest tests/test_config_loader.py::test_config_loader` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6886668f98c883208c4ef03e54e5282f