### PR TITLE
Add gateway security headers middleware

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,3 +21,13 @@ python scripts/vault_rotate.py
 ```
 
 In emergency situations follow the [break glass procedure](break_glass.md).
+
+## Gateway Security Headers
+
+The gateway adds several HTTP response headers to improve security:
+
+- `Content-Security-Policy: default-src 'self'`
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+
+These headers are applied globally by middleware and help prevent content injection attacks, framing vulnerabilities, and MIME type sniffing.

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -261,6 +261,7 @@ func main() {
 	limiter := mw.NewRateLimiter(rlClient, *rlConf)
 	limiter.SetWindow(window)
 	g.UseRateLimit(limiter)
+	g.UseSecurityHeaders()
 
 	addr := ":8080"
 	if port := os.Getenv("PORT"); port != "" {

--- a/gateway/internal/gateway/gateway.go
+++ b/gateway/internal/gateway/gateway.go
@@ -71,6 +71,11 @@ func (g *Gateway) UseRBAC(s *rbac.RBACService, perm string) {
 	g.router.Use(imw.RequirePermission(s, perm))
 }
 
+// UseSecurityHeaders adds default security headers to all responses.
+func (g *Gateway) UseSecurityHeaders() {
+	g.router.Use(imw.SecurityHeaders())
+}
+
 // Handler returns the root HTTP handler.
 func (g *Gateway) Handler() http.Handler {
 	return g.plugins.BuildMiddlewareChain(g.router)

--- a/gateway/internal/middleware/security_headers.go
+++ b/gateway/internal/middleware/security_headers.go
@@ -1,0 +1,15 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets recommended security headers for all responses.
+func SecurityHeaders() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", "default-src 'self'")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/gateway/internal/middleware/security_headers_test.go
+++ b/gateway/internal/middleware/security_headers_test.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	h := SecurityHeaders()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Header().Get("Content-Security-Policy") == "" {
+		t.Fatal("missing Content-Security-Policy")
+	}
+	if resp.Header().Get("X-Frame-Options") != "DENY" {
+		t.Fatalf("unexpected X-Frame-Options: %s", resp.Header().Get("X-Frame-Options"))
+	}
+	if resp.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("unexpected X-Content-Type-Options: %s", resp.Header().Get("X-Content-Type-Options"))
+	}
+}


### PR DESCRIPTION
## Summary
- add `SecurityHeaders` middleware to set CSP, X-Frame-Options and X-Content-Type-Options
- expose `UseSecurityHeaders` on Gateway and enable it in the gateway main
- document the new headers

## Testing
- `go test ./...` *(fails: NewGoBreaker redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68866690acb48320aa3c43cce2da23dc