### PR TITLE
Add pagination to access patterns endpoint

### DIFF
--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -111,6 +111,26 @@
               "default": "",
               "title": "Authorization"
             }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Size"
+            }
           }
         ],
         "responses": {

--- a/services/analytics_microservice/async_queries.py
+++ b/services/analytics_microservice/async_queries.py
@@ -17,9 +17,15 @@ async def fetch_dashboard_summary(pool: asyncpg.Pool, days: int = 7) -> Dict[str
     return await _fetch_dashboard_summary(pool, days)
 
 
-async def fetch_access_patterns(pool: asyncpg.Pool, days: int = 7) -> Dict[str, Any]:
-    """Proxy to :func:`services.analytics.common_queries.fetch_access_patterns`."""
-    return await _fetch_access_patterns(pool, days)
+async def fetch_access_patterns(
+    pool: asyncpg.Pool,
+    days: int = 7,
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> Dict[str, Any]:
+    """Proxy to :func:`services.analytics.common_queries.fetch_access_patterns` with pagination."""
+    return await _fetch_access_patterns(pool, days, limit=limit, offset=offset)
 
 
 __all__ = ["fetch_dashboard_summary", "fetch_access_patterns"]

--- a/tests/services/test_analytics_microservice_app.py
+++ b/tests/services/test_analytics_microservice_app.py
@@ -111,10 +111,11 @@ def test_access_patterns_endpoint(app_fixture):
     client, dummy = app_fixture
     token = _token("secret")
     resp = client.post(
-        "/api/v1/analytics/get_access_patterns_analysis",
+        "/api/v1/analytics/access-patterns?page=1&size=50",
         json={"days": 3},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    assert resp.json() == {"days": 3}
+    assert resp.json()["page"] == 1
+    assert resp.json()["size"] == 50
     assert dummy.pattern_calls == [3]


### PR DESCRIPTION
## Summary
- add pagination options in access-patterns route
- support limit/offset in access-patterns query helpers
- document new query parameters in the OpenAPI spec
- update microservice test for renamed endpoint

## Testing
- `pytest tests/services/test_analytics_microservice_app.py::test_access_patterns_endpoint -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_68866691ff048320940363a4f10bcbb0