### PR TITLE
Refactor debug analytics script

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,4 +1,6 @@
 import importlib
+import importlib.util
+import importlib.machinery
 import pathlib
 import sys
 

--- a/tests/examples/test_debug_deep_analytics.py
+++ b/tests/examples/test_debug_deep_analytics.py
@@ -1,0 +1,47 @@
+from examples.debug_deep_analytics import (
+    create_test_dataset,
+    check_upload_store,
+    find_hardcoded_values,
+)
+
+
+def test_create_test_dataset():
+    df = create_test_dataset(10)
+    assert len(df) == 10
+    assert list(df.columns) == ["person_id", "door_id", "access_result", "timestamp"]
+
+
+def test_check_upload_store(tmp_path, monkeypatch):
+    import types, sys
+
+    class DummyStore:
+        def __init__(self):
+            self.data = {}
+
+        def add_file(self, filename, df):
+            self.data[filename] = df
+
+        def get_all_data(self):
+            return self.data
+
+        def clear_all(self):
+            self.data = {}
+
+    dummy_module = types.ModuleType("utils.upload_store")
+    dummy_store = DummyStore()
+    dummy_module.UploadedDataStore = DummyStore
+    dummy_module.uploaded_data_store = dummy_store
+    monkeypatch.setitem(sys.modules, "utils.upload_store", dummy_module)
+
+    df = create_test_dataset(5)
+    stored = check_upload_store(df)
+    assert stored is not None
+    assert len(stored) == 5
+
+
+def test_find_hardcoded_values(tmp_path):
+    py_file = tmp_path / "a.py"
+    py_file.write_text("x = 150\n# 150 in comment\n", encoding="utf-8")
+    results = find_hardcoded_values([str(tmp_path)])
+    assert len(results) == 1
+    assert results[0].startswith(str(py_file))


### PR DESCRIPTION
## Summary
- split monolithic function in `debug_deep_analytics.py` into reusable helpers
- patch `sitecustomize` to import required `importlib` modules
- add unit tests for new helper functions

## Testing
- `PYTHONPATH=. pytest tests/examples/test_debug_deep_analytics.py --confcutdir=tests/examples -q`

------
https://chatgpt.com/codex/tasks/task_e_6887052bd1e083208d5f7e5964bf80a6