### PR TITLE
Add asyncio callback support

### DIFF
--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -75,6 +75,12 @@ def refresh(btn):
     return str(results[-1])
 ```
 
+For IO heavy steps you can execute the group concurrently:
+
+```python
+results = await ops.execute_group_async("refresh", btn)
+```
+
 ## Consolidated Callback Management
 
 A single startup task should orchestrate all callback registration steps to prevent duplicated logic:

--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -16,6 +16,9 @@ on `TrulyUnifiedCallbacks`,
 4. Organize multi-step operations using `UnifiedCallbackManager` imported from
    `core.callbacks` (alias of `TrulyUnifiedCallbacks`) and call `execute_group`
    within Dash callbacks.
+5. `trigger_async` now executes callbacks concurrently. Use
+   `UnifiedCallbackManager.execute_group_async` to run operations in parallel
+   when they are IO bound.
 
 
 All modules must migrate to this API before upgrading. The legacy wrappers are


### PR DESCRIPTION
## Summary
- run event callbacks concurrently and add `execute_group_async`
- document new asynchronous operations
- update callback tests

## Testing
- `pytest tests/test_unified_callback_manager.py::test_execute_group_async -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6887055b284483209e175486dcf499d4