### PR TITLE
Add missing monitoring tests

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,4 +1,6 @@
 import importlib
+import importlib.util
+import importlib.machinery
 import pathlib
 import sys
 

--- a/tests/database/test_index_optimizer.py
+++ b/tests/database/test_index_optimizer.py
@@ -37,3 +37,33 @@ def test_analyze_index_usage_handles_error():
 
     opt = IndexOptimizer(BadConn())
     assert opt.analyze_index_usage() == []
+
+
+class PostgreSQLConnection:
+
+    def __init__(self):
+        self.queries = []
+
+    def execute_query(self, query, params=None):
+        self.queries.append((query, params))
+        if "pg_stat_user_indexes" in query:
+            return [
+                {
+                    "index_name": "idx_tbl_col1",
+                    "idx_scan": 1,
+                    "idx_tup_read": 2,
+                    "idx_tup_fetch": 3,
+                }
+            ]
+        if "pg_indexes" in query:
+            return [{"indexname": "idx_tbl_col1_col2"}]
+        return []
+
+
+def test_postgres_usage_and_recommend(monkeypatch):
+    conn = PostgreSQLConnection()
+    opt = IndexOptimizer(conn)
+    stats = opt.analyze_index_usage()
+    assert stats and stats[0]["index_name"] == "idx_tbl_col1"
+    stmts = opt.recommend_new_indexes("tbl", ["col1", "col2"])
+    assert not stmts  # index already exists

--- a/tests/test_kafka_health.py
+++ b/tests/test_kafka_health.py
@@ -1,0 +1,81 @@
+import types
+import sys
+
+import monitoring.kafka_health as kh
+
+
+class DummyBroker:
+    def __init__(self, id, host="localhost", port=9092):
+        self.id = id
+        self.host = host
+        self.port = port
+
+
+class DummyPartition:
+    def __init__(self, pid, replicas, isrs):
+        self.id = pid
+        self.replicas = list(range(replicas))
+        self.isrs = list(range(isrs))
+
+
+class DummyTopic:
+    def __init__(self, name, partitions):
+        self.topic = name
+        self.partitions = {p.id: p for p in partitions}
+
+
+class DummyMeta:
+    def __init__(self, brokers, topics):
+        self.brokers = {b.id: b for b in brokers}
+        self.topics = {t.topic: t for t in topics}
+
+
+class DummyTopicPartition:
+    def __init__(self, topic, partition):
+        self.topic = topic
+        self.partition = partition
+
+
+class DummyAdmin:
+    def __init__(self, meta):
+        self._meta = meta
+        self.consumer_groups = ["g1"]
+        self.offsets = {
+            "g1": {
+                DummyTopicPartition("t", 0): types.SimpleNamespace(offset=5)
+            }
+        }
+
+    def list_topics(self, timeout=5):
+        return self._meta
+
+    def list_consumer_groups(self, timeout=5):
+        return [(g, None) for g in self.consumer_groups]
+
+    def list_consumer_group_offsets(self, group, timeout=5):
+        return self.offsets[group]
+
+
+class DummyConsumer:
+    def __init__(self, watermarks):
+        self.watermarks = watermarks
+        self.closed = False
+
+    def get_watermark_offsets(self, tp, timeout=5):
+        return (0, self.watermarks.get((tp.topic, tp.partition), 0))
+
+    def close(self):
+        self.closed = True
+
+
+def test_check_cluster_health(monkeypatch):
+    meta = DummyMeta([DummyBroker(1)], [DummyTopic("t", [DummyPartition(0, 2, 2)])])
+    admin = DummyAdmin(meta)
+    monkeypatch.setattr(kh, "AdminClient", lambda cfg: admin)
+    monkeypatch.setattr(kh, "Consumer", lambda cfg: DummyConsumer({("t", 0): 10}))
+
+    health = kh.check_cluster_health("b:9092")
+
+    assert health["brokers"] == [{"id": 1, "host": "localhost", "port": 9092}]
+    assert not health["topics"]["t"]["under_replicated"]
+    assert health["consumer_lag"]["g1"]["t-0"] == 5

--- a/tests/test_model_performance_monitor.py
+++ b/tests/test_model_performance_monitor.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace, ModuleType
+import sys
+from datetime import datetime
+
+# stub services.resilience.metrics to avoid heavy deps
+metrics_mod = ModuleType("services.resilience.metrics")
+metrics_mod.circuit_breaker_state = SimpleNamespace(labels=lambda *a, **k: SimpleNamespace(inc=lambda: None))
+resilience_pkg = ModuleType("services.resilience")
+resilience_pkg.metrics = metrics_mod
+sys.modules.setdefault("services", ModuleType("services"))
+sys.modules.setdefault("services.resilience", resilience_pkg)
+sys.modules.setdefault("services.resilience.metrics", metrics_mod)
+
+import monitoring.model_performance_monitor as mpm
+
+
+class DummyMonitor:
+    def __init__(self):
+        self.metrics = []
+
+    def record_metric(self, name, value, mtype):
+        self.metrics.append((name, value, mtype))
+
+
+def test_log_metrics(monkeypatch):
+    perf = DummyMonitor()
+    monkeypatch.setattr(mpm, "get_performance_monitor", lambda: perf)
+    called = []
+    monkeypatch.setattr(mpm, "update_model_metrics", lambda m: called.append(True))
+
+    monitor = mpm.ModelPerformanceMonitor()
+    metrics = mpm.ModelMetrics(accuracy=1.0, precision=0.9, recall=0.8)
+    monitor.log_metrics(metrics)
+
+    assert len(perf.metrics) == 3
+    assert called
+
+
+def test_log_prediction():
+    records = []
+    logger = SimpleNamespace(info=lambda msg, extra=None: records.append(extra))
+    monitor = mpm.ModelPerformanceMonitor(logger=logger)
+    ts = datetime(2024, 1, 1)
+    monitor.log_prediction("h", {"x": 1}, timestamp=ts)
+
+    event = records[0]
+    assert event["input_hash"] == "h"
+    assert event["prediction"] == {"x": 1}
+    assert event["timestamp"] == ts.isoformat()
+
+
+def test_detect_drift():
+    baseline = mpm.ModelMetrics(accuracy=0.9, precision=0.8, recall=0.7)
+    monitor = mpm.ModelPerformanceMonitor(baseline=baseline, drift_threshold=0.05)
+    metrics_ok = mpm.ModelMetrics(accuracy=0.92, precision=0.8, recall=0.7)
+    assert not monitor.detect_drift(metrics_ok)
+    metrics_bad = mpm.ModelMetrics(accuracy=0.7, precision=0.8, recall=0.7)
+    assert monitor.detect_drift(metrics_bad)


### PR DESCRIPTION
## Summary
- add import utilities in `sitecustomize.py` so stubs work with Python 3.12
- extend `IndexOptimizer` tests for PostgreSQL paths
- add new Kafka health monitoring tests
- add tests for `ModelPerformanceMonitor`

## Testing
- `pytest -p no:tests.performance_plugin -q tests/test_ui_monitor.py tests/test_data_quality_monitor.py tests/database/test_index_optimizer.py tests/test_kafka_health.py tests/test_model_performance_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_688705416ad88320ac0098d4a21715f2