### PR TITLE
Consolidate CSV compliance callback

### DIFF
--- a/plugins/common_callbacks.py
+++ b/plugins/common_callbacks.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def csv_pre_process_callback(
+    services: Any,
+    file_path: str,
+    upload_context: Dict[str, Any] | None,
+    uploaded_by: str | None,
+) -> Dict[str, Any]:
+    """Run CSV compliance analysis and return standard callback response."""
+
+    if not services or not getattr(services, "csv_processor", None):
+        return {"status": "proceed"}
+
+    result = services.csv_processor.analyze_csv_compliance(
+        file_path,
+        upload_context or {},
+        uploaded_by,
+    )
+
+    if not result.get("authorized", True):
+        return {
+            "status": "block",
+            "reason": result.get("reason", "Compliance check failed"),
+            "details": result,
+        }
+
+    return {"status": "proceed", "compliance_metadata": result}
+
+__all__ = ["csv_pre_process_callback"]

--- a/plugins/compliance_plugin/plugin.py
+++ b/plugins/compliance_plugin/plugin.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, List, Optional
+
+from plugins.common_callbacks import csv_pre_process_callback
 from pathlib import Path
 
 from core.plugins.base import BasePlugin
@@ -217,26 +219,16 @@ class CompliancePlugin(BasePlugin):
     # Hook implementations
     def _hook_csv_pre_process(self, **kwargs) -> Dict[str, Any]:
         """Hook called before CSV processing"""
-        if not self.services or not self.services.csv_processor:
-            return {"status": "proceed"}
-
         file_path = kwargs.get("file_path")
-        upload_context = kwargs.get("upload_context", {})
+        upload_context = kwargs.get("upload_context")
         uploaded_by = kwargs.get("uploaded_by")
 
-        # Run compliance analysis
-        result = self.services.csv_processor.analyze_csv_compliance(
-            file_path, upload_context, uploaded_by
+        return csv_pre_process_callback(
+            self.services,
+            file_path,
+            upload_context,
+            uploaded_by,
         )
-
-        if not result.get("authorized", True):
-            return {
-                "status": "block",
-                "reason": result.get("reason", "Compliance check failed"),
-                "details": result,
-            }
-
-        return {"status": "proceed", "compliance_metadata": result}
 
     def _hook_csv_post_process(self, **kwargs) -> Dict[str, Any]:
         """Hook called after CSV processing"""

--- a/plugins/compliance_plugin/services/toggle_manager.py
+++ b/plugins/compliance_plugin/services/toggle_manager.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Set
 from core.rbac import require_role
 from services.data_processing.file_processor import FileProcessor
 from database.secure_exec import execute_command, execute_query
+from plugins.common_callbacks import csv_pre_process_callback
 
 logger = logging.getLogger(__name__)
 
@@ -627,9 +628,10 @@ class CompliancePlugin(BasePlugin):
 
         # Proceed with normal compliance checking
         if self.services and self.services.csv_processor:
-            result = self.services.csv_processor.analyze_csv_compliance(
+            result = csv_pre_process_callback(
+                self.services,
                 kwargs.get("file_path"),
-                kwargs.get("upload_context", {}),
+                kwargs.get("upload_context"),
                 kwargs.get("uploaded_by"),
             )
 


### PR DESCRIPTION
## Summary
- add `plugins/common_callbacks` with a reusable `csv_pre_process_callback`
- refactor compliance plugin and toggle manager to use the shared callback

## Testing
- `pytest -q tests/plugins/test_ai_classification_plugin.py` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_68870559903483209413a71ae458dee3