### PR TITLE
Add missing module docstrings

### DIFF
--- a/database/baseline_metrics.py
+++ b/database/baseline_metrics.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Utilities for storing and retrieving baseline metrics.
+
+This module provides :class:`BaselineMetricsDB` which offers a simple
+interface for persisting baseline metrics in a relational database.
+Applications can use ``update_baseline`` and ``get_baseline`` to manage
+historical performance metrics.
+"""
+
 import logging
 from typing import Dict, List
 

--- a/database/connection_pool.py
+++ b/database/connection_pool.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+"""Thread-safe connection pool with circuit breaking.
+
+The :class:`EnhancedConnectionPool` provided here manages a pool of
+database connections while monitoring failures using a simple circuit
+breaker. Applications should create a pool with a factory function that
+returns new connections and then use ``acquire``/``release`` to control
+usage.
+"""
+
 import threading
 import time
 from typing import Any, Callable, Dict, List, Tuple

--- a/database/intelligent_connection_pool.py
+++ b/database/intelligent_connection_pool.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Adaptive connection pool that adjusts size based on usage.
+
+The :class:`IntelligentConnectionPool` automatically expands or shrinks
+its pool of connections depending on current demand. Use ``acquire`` and
+``release`` like a standard connection pool to obtain connections while
+metrics are tracked for analysis.
+"""
+
 import threading
 import time
 from typing import Callable, Dict, List, Tuple, Any

--- a/database/metrics.py
+++ b/database/metrics.py
@@ -1,3 +1,9 @@
+"""Prometheus counters for database query metrics.
+
+Import ``queries_total`` and ``query_errors_total`` to track how many
+database queries were executed and how many failed.
+"""
+
 from prometheus_client import Counter
 
 queries_total = Counter(

--- a/database/migrations.py
+++ b/database/migrations.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+"""Wrapper around Alembic commands for managing schema migrations.
+
+The :class:`MigrationManager` simplifies common upgrade and downgrade
+operations and keeps a small in-memory history for rollbacks.
+"""
+
 import logging
 from typing import List
 

--- a/database/performance_analyzer.py
+++ b/database/performance_analyzer.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+"""Tools for analysing database query performance.
+
+The :class:`DatabasePerformanceAnalyzer` records timing information for
+executed queries which can then be inspected for bottlenecks.
+"""
+
 import logging
 from typing import Any, Dict, List
 

--- a/database/types.py
+++ b/database/types.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+"""Type protocol definitions for database connections.
+
+The :class:`DatabaseConnection` protocol describes the minimal interface
+expected by the connection pools and helpers in this package.
+"""
+
 from typing import Any, Optional, Protocol
 
 

--- a/monitoring/prometheus/__init__.py
+++ b/monitoring/prometheus/__init__.py
@@ -1,1 +1,7 @@
 
+"""Prometheus metric definitions used across monitoring modules.
+
+Import from this package to register counters and gauges that expose
+application health and performance data.
+"""
+


### PR DESCRIPTION
## Summary
- document metrics and connection utilities in `database`
- document Prometheus package

## Testing
- `python -m compileall monitoring database`
- `pytest -k 'nonexistent' -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_688705560354832095760c3250f0937d