### PR TITLE
Document CPU/memory alerts for Prometheus

### DIFF
--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -24,6 +24,33 @@ to track how far the TimescaleDB copy lags behind the primary database. The
 alert rule defined in `monitoring/alerts.yml` fires when this value exceeds
 60&nbsp;seconds for five minutes.
 
+### CPU & Memory Alerts
+
+Prometheus also records CPU and memory usage for each pod. Edit
+`monitoring/prometheus/rules/app_alerts.yml` to trigger alerts when resource
+limits are approached. Example rules:
+
+```yaml
+- alert: CPUHighUsage
+  expr: avg(rate(container_cpu_usage_seconds_total[5m])) by (pod) > 0.8
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: Pod CPU usage above 80% for 5 minutes
+- alert: MemoryHighUsage
+  expr: container_memory_usage_bytes{image!=""} /
+    container_spec_memory_limit_bytes{image!=""} > 0.9
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: Pod memory usage above 90% of limit
+```
+
+Import `monitoring/grafana/dashboards/unified-platform.json` into Grafana to view
+CPU and memory graphs based on these metrics.
+
 ## Performance Dashboards
 
 Prometheus scrapes metrics from `/metrics` using the sample

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -28,6 +28,31 @@ docker run -p 9090:9090 \
   prom/prometheus
 ```
 
+Additional alert rules can be added under
+`monitoring/prometheus/rules/app_alerts.yml`. Typical rules monitor CPU and
+memory consumption:
+
+```yaml
+- alert: CPUHighUsage
+  expr: avg(rate(container_cpu_usage_seconds_total[5m])) by (pod) > 0.8
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: Pod CPU usage above 80% for 5 minutes
+- alert: MemoryHighUsage
+  expr: container_memory_usage_bytes{image!=""} /
+    container_spec_memory_limit_bytes{image!=""} > 0.9
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: Pod memory usage above 90% of limit
+```
+
+Grafana can visualise these metrics using the dashboard template in
+`monitoring/grafana/dashboards/unified-platform.json`.
+
 ### Circuit Breaker Metrics
 
 Both the Python and Go services expose circuit breaker transitions using the


### PR DESCRIPTION
## Summary
- document CPU & memory alert rules in `performance_monitoring.md`
- expand operations guide with alert examples and Grafana dashboard import

## Testing
- `make lint` *(fails: flake8 missing, installed then fails with many errors)*
- `make test` *(fails: missing test dependencies yaml & psutil)*

------
https://chatgpt.com/codex/tasks/task_e_68870553b4f483209afedf421e660693