### PR TITLE
Finalize real-time websocket demo

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -28,3 +28,23 @@ Example message:
   "data_summary": {"total_records": 120}
 }
 ```
+
+## Demo Provider
+
+`services/websocket_data_provider.py` offers a small helper that periodically
+publishes sample analytics to the `EventBus`. When used together with
+`AnalyticsWebSocketServer` it enables a fully self-contained demo of the real
+-time dashboard:
+
+```python
+from core.events import EventBus
+from services.websocket_server import AnalyticsWebSocketServer
+from services.websocket_data_provider import WebSocketDataProvider
+
+bus = EventBus()
+server = AnalyticsWebSocketServer(bus)
+provider = WebSocketDataProvider(bus)
+```
+
+The provider runs on a background thread and can be stopped via
+`provider.stop()`.

--- a/services/websocket_data_provider.py
+++ b/services/websocket_data_provider.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Simple background publisher for analytics WebSocket demos."""
+
+import threading
+import time
+from typing import Any, Dict
+
+from core.protocols import EventBusProtocol
+from services.analytics_summary import generate_sample_analytics
+
+
+class WebSocketDataProvider:
+    """Publish sample analytics updates to an event bus periodically."""
+
+    def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+        self.event_bus = event_bus
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            payload: Dict[str, Any] = generate_sample_analytics()
+            self.event_bus.publish("analytics_update", payload)
+            self._stop.wait(self.interval)
+
+    def stop(self) -> None:
+        """Stop the provider thread."""
+        self._stop.set()
+        self._thread.join(timeout=1)
+
+
+__all__ = ["WebSocketDataProvider"]

--- a/src/hooks/useRealTimeAnalytics.ts
+++ b/src/hooks/useRealTimeAnalytics.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useWebSocket } from './useWebSocket';
 
 export interface RealTimeAnalytics {
   [key: string]: any;
@@ -9,26 +10,21 @@ export const useRealTimeAnalytics = (
   interval: number = 1000,
   socketFactory?: (url: string) => WebSocket,
 ) => {
+  const { data: raw } = useWebSocket(url, socketFactory);
   const [data, setData] = useState<RealTimeAnalytics | null>(null);
   const [summary, setSummary] = useState<RealTimeAnalytics | null>(null);
   const [charts, setCharts] = useState<RealTimeAnalytics | null>(null);
-  const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
-    const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
-    wsRef.current = ws;
-    ws.onmessage = (ev: MessageEvent) => {
+    if (raw) {
       try {
-        const parsed = JSON.parse(ev.data as string);
+        const parsed = JSON.parse(raw);
         setData(parsed);
       } catch {
         /* ignore malformed messages */
       }
-    };
-    return () => {
-      ws.close();
-    };
-  }, [url, socketFactory]);
+    }
+  }, [raw]);
 
   useEffect(() => {
     const id = setInterval(() => {

--- a/tests/test_websocket_data_provider.py
+++ b/tests/test_websocket_data_provider.py
@@ -1,0 +1,13 @@
+from core.events import EventBus
+from services.websocket_data_provider import WebSocketDataProvider
+import time
+
+
+def test_websocket_data_provider_publishes():
+    bus = EventBus()
+    events = []
+    bus.subscribe("analytics_update", lambda d: events.append(d))
+    provider = WebSocketDataProvider(bus, interval=0.01)
+    time.sleep(0.05)
+    provider.stop()
+    assert events


### PR DESCRIPTION
## Summary
- add `WebSocketDataProvider` utility for demo analytics
- document demo provider usage in `docs/websockets.md`
- extend `useRealTimeAnalytics` hook to use `useWebSocket`
- test provider publishes updates

## Testing
- `pytest tests/test_websocket_data_provider.py` *(fails: ImportError due to sitecustomize errors)*

------
https://chatgpt.com/codex/tasks/task_e_688705504f9083208993e87983fc20b1