### PR TITLE
Refactor logging to use f-strings

### DIFF
--- a/core/advanced_cache.py
+++ b/core/advanced_cache.py
@@ -41,7 +41,7 @@ class AdvancedCacheManager:
             await self._redis.ping()
             logger.info("Advanced cache manager connected to Redis")
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Failed to connect to Redis: %s", exc)
+            logger.error(f"Failed to connect to Redis: {exc}")
             self._redis = None
 
     # ------------------------------------------------------------------
@@ -67,7 +67,7 @@ class AdvancedCacheManager:
                 data = await self._redis.get(full_key)
                 return json.loads(data.decode("utf-8")) if data is not None else None
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis GET failed for %s: %s", full_key, exc)
+                logger.warning(f"Redis GET failed for {full_key}: {exc}")
                 return None
         # Fallback to memory
         if key not in self._memory:
@@ -91,7 +91,7 @@ class AdvancedCacheManager:
                     await self._redis.set(full_key, payload)
                 return
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis SET failed for %s: %s", full_key, exc)
+                logger.warning(f"Redis SET failed for {full_key}: {exc}")
         # Fallback to memory
         expiry = time.time() + expire if expire else None
         self._memory[key] = (value, expiry)
@@ -105,7 +105,7 @@ class AdvancedCacheManager:
                 if removed:
                     return True
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis DEL failed for %s: %s", full_key, exc)
+                logger.warning(f"Redis DEL failed for {full_key}: {exc}")
         return self._memory.pop(key, None) is not None
 
     # ------------------------------------------------------------------
@@ -114,7 +114,7 @@ class AdvancedCacheManager:
             try:
                 await self._redis.flushdb()
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis FLUSHDB failed: %s", exc)
+                logger.warning(f"Redis FLUSHDB failed: {exc}")
         self._memory.clear()
 
     # ------------------------------------------------------------------

--- a/core/auth.py
+++ b/core/auth.py
@@ -99,7 +99,7 @@ def _get_jwks(domain: str) -> dict:
         with urlopen(jwks_url, timeout=timeout) as resp:
             jwks = json.load(resp)
     except (URLError, socket.timeout) as exc:
-        logger.warning("Failed to fetch JWKS from %s: %s", jwks_url, exc)
+        logger.warning(f"Failed to fetch JWKS from {jwks_url}: {exc}")
         if cached:
             return cached[0]
         raise

--- a/core/cache.py
+++ b/core/cache.py
@@ -20,7 +20,7 @@ def init_app(app) -> None:
             config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 300},
         )
     except Exception as exc:  # pragma: no cover - fallback
-        logger.error("Cache initialization failed: %s", exc)
+        logger.error(f"Cache initialization failed: {exc}")
         _fallback_init(app)
 
 

--- a/core/cache_manager.py
+++ b/core/cache_manager.py
@@ -134,7 +134,7 @@ class RedisCacheManager(CacheManager):
         try:
             await self._redis.ping()
         except Exception as exc:  # pragma: no cover - fallback
-            logger.error("Redis unavailable: %s", exc)
+            logger.error(f"Redis unavailable: {exc}")
             self._redis = None
         await self._fallback.start()
 
@@ -153,7 +153,7 @@ class RedisCacheManager(CacheManager):
                 if data is not None:
                     return json.loads(data.decode("utf-8"))
             except Exception as exc:  # pragma: no cover - fallback
-                logger.warning("Redis GET failed for %s: %s", key, exc)
+                logger.warning(f"Redis GET failed for {key}: {exc}")
         return await self._fallback.get(key)
 
     async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
@@ -167,7 +167,7 @@ class RedisCacheManager(CacheManager):
                     await self._redis.set(self._full_key(key), payload)
                 return
             except Exception as exc:  # pragma: no cover - fallback
-                logger.warning("Redis SET failed for %s: %s", key, exc)
+                logger.warning(f"Redis SET failed for {key}: {exc}")
         await self._fallback.set(key, value, ttl)
 
     async def delete(self, key: str) -> bool:
@@ -177,7 +177,7 @@ class RedisCacheManager(CacheManager):
                 if removed:
                     return True
             except Exception as exc:  # pragma: no cover - fallback
-                logger.warning("Redis DEL failed for %s: %s", key, exc)
+                logger.warning(f"Redis DEL failed for {key}: {exc}")
         return await self._fallback.delete(key)
 
     async def clear(self) -> None:
@@ -185,7 +185,7 @@ class RedisCacheManager(CacheManager):
             try:
                 await self._redis.flushdb()
             except Exception as exc:  # pragma: no cover - fallback
-                logger.warning("Redis FLUSHDB failed: %s", exc)
+                logger.warning(f"Redis FLUSHDB failed: {exc}")
         await self._fallback.clear()
 
     def get_lock(self, key: str, timeout: int = 10):

--- a/core/callback_manager.py
+++ b/core/callback_manager.py
@@ -73,7 +73,7 @@ class CallbackManager(BaseModel):
                 results.append(result)
                 self._record_metric(event, start)
             except Exception as exc:  # pragma: no cover - log and continue
-                logger.exception("Callback error on %s: %s", event.name, exc)
+                logger.exception(f"Callback error on {event.name}: {exc}")
                 self._record_metric(event, start, error=True)
                 results.append(None)
         return results
@@ -95,7 +95,7 @@ class CallbackManager(BaseModel):
                 results.append(result)
                 self._record_metric(event, start)
             except Exception as exc:  # pragma: no cover - log and continue
-                logger.exception("Callback error on %s: %s", event.name, exc)
+                logger.exception(f"Callback error on {event.name}: {exc}")
                 self._record_metric(event, start, error=True)
                 results.append(None)
         return results

--- a/core/callback_modules.py
+++ b/core/callback_modules.py
@@ -49,14 +49,14 @@ class CallbackModuleRegistry(BaseModel):
         module_id = module.COMPONENT_ID
 
         if module_id in self._modules:
-            logger.warning("Module %s already registered", module_id)
+            logger.warning(f"Module {module_id} already registered")
             return False
 
         callback_ids = module.get_callback_ids()
         conflicts = [cid for cid in callback_ids if cid in self._registered_ids]
         if conflicts:
             logger.error(
-                "Module %s has conflicting callbacks: %s", module_id, conflicts
+                f"Module {module_id} has conflicting callbacks: {conflicts}"
             )
             return False
 
@@ -76,9 +76,9 @@ class CallbackModuleRegistry(BaseModel):
         for module_id, module in self._modules.items():
             try:
                 module.register_callbacks(manager)
-                logger.info("Initialized module: %s", module_id)
+                logger.info(f"Initialized module: {module_id}")
             except Exception as exc:  # pragma: no cover - defensive
-                logger.error("Failed to initialize %s: %s", module_id, exc)
+                logger.error(f"Failed to initialize {module_id}: {exc}")
 
 
 __all__ = ["CallbackModule", "CallbackModuleRegistry"]

--- a/core/callback_registry.py
+++ b/core/callback_registry.py
@@ -66,18 +66,15 @@ class GlobalCallbackRegistry(BaseModel):
         if callback_id in self.registered_callbacks:
             existing = self.callback_sources.get(callback_id, "unknown")
             logger.warning(
-                "Callback ID '%s' already registered by %s, "
-                "skipping registration from %s",
-                callback_id,
-                existing,
-                module_name,
+                f"Callback ID '{callback_id}' already registered by {existing}, "
+                f"skipping registration from {module_name}"
             )
             return False
 
         self.registered_callbacks.add(callback_id)
         self.registration_sources[callback_id] = module_name
         self.registration_order.append(callback_id)
-        logger.debug("Registered callback '%s' from %s", callback_id, module_name)
+        logger.debug(f"Registered callback '{callback_id}' from {module_name}")
         return True
 
     def get_conflicts(self) -> Dict[str, str]:
@@ -98,9 +95,7 @@ class GlobalCallbackRegistry(BaseModel):
                 cid: self.callback_sources.get(cid, "unknown") for cid in duplicates
             }
             logger.info(
-                "Skipping duplicate callback registration from %s: %s",
-                source_module,
-                existing,
+                f"Skipping duplicate callback registration from {source_module}: {existing}"
             )
             return False
 
@@ -108,10 +103,7 @@ class GlobalCallbackRegistry(BaseModel):
             register_func()
         except Exception as exc:  # pragma: no cover - defensive
             logger.error(
-                "Failed to register callbacks %s from %s: %s",
-                list(callback_ids),
-                source_module,
-                exc,
+                f"Failed to register callbacks {list(callback_ids)} from {source_module}: {exc}"
             )
             return False
 
@@ -246,7 +238,7 @@ def safe_callback_registration(callback_id: str, module_name: str = "unknown"):
         @functools.wraps(register_func)
         def wrapper(*args, **kwargs):
             if _callback_registry.is_registered(callback_id):
-                logger.info("Skipping duplicate callback registration: %s", callback_id)
+                logger.info(f"Skipping duplicate callback registration: {callback_id}")
                 return None
             result = register_func(*args, **kwargs)
             _callback_registry.register(callback_id, module_name)
@@ -277,9 +269,7 @@ def handle_register_with_deduplication(
 
     if _callback_registry.is_registered(callback_id):
         logger.info(
-            "Skipping duplicate callback registration: %s from %s",
-            callback_id,
-            source_module,
+            f"Skipping duplicate callback registration: {callback_id} from {source_module}"
         )
         return lambda func: func
 

--- a/core/dash_profile.py
+++ b/core/dash_profile.py
@@ -17,7 +17,7 @@ def handle_profile(callback_id: str):
                 duration_ms = (time.perf_counter() - start) * 1000
                 if duration_ms > 100:
                     logging.warning(
-                        "Callback %s took %.2f ms", callback_id, duration_ms
+                        f"Callback {callback_id} took {duration_ms:.2f} ms"
                     )
                 return result
 
@@ -29,7 +29,7 @@ def handle_profile(callback_id: str):
             result = func(*args, **kwargs)
             duration_ms = (time.perf_counter() - start) * 1000
             if duration_ms > 100:
-                logging.warning("Callback %s took %.2f ms", callback_id, duration_ms)
+                logging.warning(f"Callback {callback_id} took {duration_ms:.2f} ms")
             return result
 
         return sync_wrapper

--- a/core/intelligent_multilevel_cache.py
+++ b/core/intelligent_multilevel_cache.py
@@ -62,7 +62,7 @@ class IntelligentMultiLevelCache:
             await self._redis.ping()
             logger.info("Intelligent cache connected to Redis")
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Redis unavailable: %s", exc)
+            logger.error(f"Redis unavailable: {exc}")
             self._redis = None
 
     # ------------------------------------------------------------------
@@ -101,11 +101,11 @@ class IntelligentMultiLevelCache:
                 else:
                     await self._redis.set(self._full_key(key), data)
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis SET failed for %s: %s", key, exc)
+                logger.warning(f"Redis SET failed for {key}: {exc}")
         try:
             (self.disk_path / f"{self._full_key(key)}.json").write_bytes(data)
         except Exception as exc:  # pragma: no cover - best effort
-            logger.warning("Disk write failed for %s: %s", key, exc)
+            logger.warning(f"Disk write failed for {key}: {exc}")
 
     # ------------------------------------------------------------------
     async def get(
@@ -135,7 +135,7 @@ class IntelligentMultiLevelCache:
                         self._record_memory(key, obj["value"], expiry)
                         return obj["value"]
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis GET failed for %s: %s", key, exc)
+                logger.warning(f"Redis GET failed for {key}: {exc}")
 
         file = self.disk_path / f"{self._full_key(key)}.json"
         if file.exists():
@@ -148,7 +148,7 @@ class IntelligentMultiLevelCache:
                     await self.set(key, obj["value"], ttl=int(expiry - now) if expiry else ttl)
                     return obj["value"]
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Disk read failed for %s: %s", key, exc)
+                logger.warning(f"Disk read failed for {key}: {exc}")
 
         if loader:
             value = await loader()

--- a/core/monitoring/user_experience_metrics.py
+++ b/core/monitoring/user_experience_metrics.py
@@ -45,7 +45,7 @@ class AlertDispatcher:
                     timeout=5,
                 )
             except Exception as exc:  # pragma: no cover - network
-                self.logger.warning("Slack alert failed: %s", exc)
+                self.logger.warning(f"Slack alert failed: {exc}")
 
     # ------------------------------------------------------------------
     async def _send_slack_async(self, message: str) -> None:
@@ -58,7 +58,7 @@ class AlertDispatcher:
                         timeout=aiohttp.ClientTimeout(total=5),
                     )
             except Exception as exc:  # pragma: no cover - network
-                self.logger.warning("Slack alert failed: %s", exc)
+                self.logger.warning(f"Slack alert failed: {exc}")
         elif self.config.slack_webhook:
             self._send_slack_sync(message)
 
@@ -72,7 +72,7 @@ class AlertDispatcher:
                     timeout=5,
                 )
             except Exception as exc:  # pragma: no cover - network
-                self.logger.warning("Webhook alert failed: %s", exc)
+                self.logger.warning(f"Webhook alert failed: {exc}")
 
     # ------------------------------------------------------------------
     async def _send_webhook_async(self, message: str) -> None:
@@ -85,7 +85,7 @@ class AlertDispatcher:
                         timeout=aiohttp.ClientTimeout(total=5),
                     )
             except Exception as exc:  # pragma: no cover - network
-                self.logger.warning("Webhook alert failed: %s", exc)
+                self.logger.warning(f"Webhook alert failed: {exc}")
         elif self.config.webhook_url:
             self._send_webhook_sync(message)
 
@@ -97,7 +97,7 @@ class AlertDispatcher:
                 smtp.sendmail("noreply@example.com", [self.config.email], message)
                 smtp.quit()
             except Exception as exc:  # pragma: no cover - external
-                self.logger.warning("Email alert failed: %s", exc)
+                self.logger.warning(f"Email alert failed: {exc}")
 
     # ------------------------------------------------------------------
     async def _send_email_async(self, message: str) -> None:
@@ -112,7 +112,7 @@ class AlertDispatcher:
                 )
                 await smtp.quit()
             except Exception as exc:  # pragma: no cover - external
-                self.logger.warning("Email alert failed: %s", exc)
+                self.logger.warning(f"Email alert failed: {exc}")
         elif self.config.email:
             self._send_email_sync(message)
 

--- a/core/performance_file_processor.py
+++ b/core/performance_file_processor.py
@@ -78,7 +78,7 @@ class PerformanceFileProcessor:
                     try:
                         progress_callback(rows, mem_mb)
                     except Exception as exc:  # pragma: no cover - defensive
-                        self.logger.warning("Progress callback failed: %s", exc)
+                        self.logger.warning(f"Progress callback failed: {exc}")
 
                 if stream:
                     yield chunk
@@ -91,10 +91,7 @@ class PerformanceFileProcessor:
                 if buffer:
                     yield pd.concat(buffer, ignore_index=True)
             self.logger.info(
-                "Processed %s rows from %s (memory %.1f MB)",
-                rows,
-                file_path,
-                mem_mb,
+                f"Processed {rows} rows from {file_path} (memory {mem_mb:.1f} MB)"
             )
 
         gen = generator()

--- a/core/plugins/config/async_database_manager.py
+++ b/core/plugins/config/async_database_manager.py
@@ -45,7 +45,7 @@ class AsyncPostgreSQLManager:
                 await conn.execute("SELECT 1")
             return True
         except Exception as exc:  # pragma: no cover - best effort
-            logger.warning("Async DB health check failed: %s", exc)
+            logger.warning(f"Async DB health check failed: {exc}")
             return False
 
     async def close(self) -> None:

--- a/core/plugins/config/database_manager.py
+++ b/core/plugins/config/database_manager.py
@@ -95,7 +95,7 @@ class SQLiteDatabaseManager(IDatabaseManager):
                 success=True, connection=self.connection, connection_type="sqlite"
             )
         except Exception as e:
-            logger.error("SQLite connection failed: %s", e)
+            logger.error(f"SQLite connection failed: {e}")
             return ConnectionResult(
                 success=False,
                 connection=None,
@@ -114,7 +114,7 @@ class SQLiteDatabaseManager(IDatabaseManager):
             cur.close()
             return True
         except Exception as e:
-            logger.error("SQLite test query failed: %s", e)
+            logger.error(f"SQLite test query failed: {e}")
             return False
 
     def close_connection(self) -> None:
@@ -145,7 +145,7 @@ class SQLiteDatabaseManager(IDatabaseManager):
             conn.commit()
             return cur.rowcount
         except Exception as e:
-            logger.error("SQLite query failed: %s", e)
+            logger.error(f"SQLite query failed: {e}")
             raise
 
 

--- a/core/plugins/service_locator.py
+++ b/core/plugins/service_locator.py
@@ -49,7 +49,7 @@ class PluginServiceLocator(metaclass=_LocatorMeta):
             from plugins.ai_classification.config import get_ai_config
             from plugins.ai_classification.plugin import AIClassificationPlugin
         except Exception as exc:  # pragma: no cover - optional
-            logger.warning("AI classification plugin unavailable: %s", exc)
+            logger.warning(f"AI classification plugin unavailable: {exc}")
             return None
 
         plugin = AIClassificationPlugin(get_ai_config())
@@ -63,13 +63,13 @@ class PluginServiceLocator(metaclass=_LocatorMeta):
         try:
             from core.json_serialization_plugin import quick_start
         except Exception as exc:  # pragma: no cover - optional
-            logger.warning("JSON serialization plugin unavailable: %s", exc)
+            logger.warning(f"JSON serialization plugin unavailable: {exc}")
             return None
 
         try:
             return quick_start()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("JSON serialization plugin failed to start: %s", exc)
+            logger.warning(f"JSON serialization plugin failed to start: {exc}")
             return None
 
     # Public API -------------------------------------------------------

--- a/core/plugins/unified_registry.py
+++ b/core/plugins/unified_registry.py
@@ -44,7 +44,7 @@ class UnifiedPluginRegistry:
         try:
             self.plugin_manager.register_health_endpoint(app)
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to register plugin health endpoint: %s", exc)
+            logger.error(f"Failed to register plugin health endpoint: {exc}")
 
     # ------------------------------------------------------------------
     def register_plugin(self, plugin: PluginProtocol) -> bool:

--- a/core/rbac.py
+++ b/core/rbac.py
@@ -37,7 +37,7 @@ class RBACService:
                 if data is not None:
                     return data.decode("utf-8").split(",")
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis get failed for %s: %s", cache_key, exc)
+                logger.warning(f"Redis get failed for {cache_key}: {exc}")
         rows = await self.pool.fetch(
             "SELECT role FROM user_roles WHERE user_id=$1", user_id
         )
@@ -46,7 +46,7 @@ class RBACService:
             try:
                 await self.redis.setex(cache_key, self.ttl, ",".join(roles))
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis set failed for %s: %s", cache_key, exc)
+                logger.warning(f"Redis set failed for {cache_key}: {exc}")
         return roles
 
     # ------------------------------------------------------------------
@@ -58,7 +58,7 @@ class RBACService:
                 if data is not None:
                     return data.decode("utf-8").split(",")
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis get failed for %s: %s", cache_key, exc)
+                logger.warning(f"Redis get failed for {cache_key}: {exc}")
         rows = await self.pool.fetch(
             "SELECT permission FROM user_permissions WHERE user_id=$1", user_id
         )
@@ -67,7 +67,7 @@ class RBACService:
             try:
                 await self.redis.setex(cache_key, self.ttl, ",".join(perms))
             except Exception as exc:  # pragma: no cover - best effort
-                logger.warning("Redis set failed for %s: %s", cache_key, exc)
+                logger.warning(f"Redis set failed for {cache_key}: {exc}")
         return perms
 
     # ------------------------------------------------------------------

--- a/core/security.py
+++ b/core/security.py
@@ -343,7 +343,7 @@ def initialize_validation_callbacks() -> None:
         middleware.handle_registers(manager)
     except Exception as exc:  # pragma: no cover - log and continue
         logging.getLogger(__name__).warning(
-            "Failed to initialize validation callbacks: %s", exc
+            f"Failed to initialize validation callbacks: {exc}"
         )
 
 

--- a/core/serialization/safe_json.py
+++ b/core/serialization/safe_json.py
@@ -73,7 +73,7 @@ class SafeJSONSerializer:
             if hasattr(obj, "__dict__"):
                 return {k: self._sanitize(v) for k, v in vars(obj).items()}
         except Exception as exc:  # pragma: no cover - best effort
-            logger.warning("SafeJSONSerializer failed: %s", exc)
+            logger.warning(f"SafeJSONSerializer failed: {exc}")
             return sanitize_unicode_input(str(obj))
 
         return obj

--- a/core/state/centralized_state_manager.py
+++ b/core/state/centralized_state_manager.py
@@ -49,7 +49,7 @@ class CentralizedStateManager:
             try:
                 sub(state_snapshot, action)
             except Exception as exc:  # pragma: no cover - subscriber errors
-                logger.exception("State subscriber error: %s", exc)
+                logger.exception(f"State subscriber error: {exc}")
 
     # ------------------------------------------------------------------
     def subscribe(self, listener: Subscriber) -> Callable[[], None]:

--- a/core/theme_manager.py
+++ b/core/theme_manager.py
@@ -18,7 +18,7 @@ def sanitize_theme(theme: str | None) -> str:
     cleaned = sanitize_unicode_input(theme or "").lower()
     if cleaned in ALLOWED_THEMES:
         return cleaned
-    logger.debug("Invalid theme '%s', falling back to '%s'", theme, DEFAULT_THEME)
+    logger.debug(f"Invalid theme '{theme}', falling back to '{DEFAULT_THEME}'")
     return DEFAULT_THEME
 
 
@@ -74,4 +74,4 @@ def apply_theme_settings(app) -> None:
             else:
                 app.index_string = snippet + app.index_string
     except Exception as exc:  # pragma: no cover - best effort
-        logger.warning("Failed to apply theme settings: %s", exc)
+        logger.warning(f"Failed to apply theme settings: {exc}")

--- a/core/truly_unified_callbacks.py
+++ b/core/truly_unified_callbacks.py
@@ -155,7 +155,7 @@ class TrulyUnifiedCallbacks:
                         o, "allow_duplicate", False
                     )
                     if key in self._output_map and not allow_dup_output:
-                        logger.warning("Output '%s' conflict - allowing duplicate", key)
+                        logger.warning(f"Output '{key}' conflict - allowing duplicate")
 
                 wrapped = self.app.callback(
                     outputs,
@@ -251,13 +251,13 @@ class TrulyUnifiedCallbacks:
         """Log a summary of registered callbacks grouped by namespace."""
         with self._lock:
             for namespace, ids in self._namespaces.items():
-                logger.info("Callbacks for %s:", namespace)
+                logger.info(f"Callbacks for {namespace}:")
                 for cid in ids:
                     reg = self._dash_callbacks[cid]
                     outputs_str = ", ".join(
                         f"{o.component_id}.{o.component_property}" for o in reg.outputs
                     )
-                    logger.info("  %s -> %s", cid, outputs_str)
+                    logger.info(f"  {cid} -> {outputs_str}")
 
     # Event callbacks ---------------------------------------------------
     def register_event(
@@ -279,7 +279,7 @@ class TrulyUnifiedCallbacks:
                 if args and isinstance(args[0], str):
                     result = self.security.validate_input(args[0], "input")
                     if not result["valid"]:
-                        logger.error("Security validation failed: %s", result["issues"])
+                        logger.error(f"Security validation failed: {result['issues']}")
                         return None
                     args = (result["sanitized"],) + args[1:]
                 return original(*args, **kwargs)
@@ -424,7 +424,7 @@ class TrulyUnifiedCallbacks:
         component_id = getattr(component_class, "COMPONENT_ID", component_class.__name__)
 
         if component_id in self._registered_components:
-            logger.warning("Component %s already registered, skipping", component_id)
+            logger.warning(f"Component {component_id} already registered, skipping")
             return
 
         try:
@@ -432,9 +432,9 @@ class TrulyUnifiedCallbacks:
             if hasattr(component, "register_callbacks"):
                 component.register_callbacks(self)
                 self._registered_components.add(component_id)
-                logger.info("Registered callbacks for %s", component_id)
+                logger.info(f"Registered callbacks for {component_id}")
         except Exception as e:  # pragma: no cover - defensive
-            logger.error("Failed to register %s: %s", component_id, e)
+            logger.error(f"Failed to register {component_id}: {e}")
 
     # ------------------------------------------------------------------
     def register_all_callbacks(


### PR DESCRIPTION
## Summary
- modernize logging statements in `core/` with f-strings
- drop old `%s` style formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.resilience')*

------
https://chatgpt.com/codex/tasks/task_e_6887052d75e48320895de1059d915242