### PR TITLE
Document Flask adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This project follows a fully modular design built around a dependency injection 
 - [Analytics Async Service](docs/analytics_async_migration.md)
 - [Feature Store](docs/feature_store.md)
 - [Async Patterns](docs/async_patterns.md)
+- [API Adapter](docs/api.md)
 
 <p align="center">
   <img src="docs/architecture.svg" alt="High-level architecture diagram" width="600" />


### PR DESCRIPTION
## Summary
- explain how the Flask app mounts into FastAPI
- show CSRF and routing flow
- reference API Adapter docs in README

## Testing
- `pytest -k 'nonexistentpattern'` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688720ddf9bc8320a8708fe2d749de42