### PR TITLE
Update API client generation workflow

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6,15 +6,6 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
-            },
-            "examples": {
-              "invalidRequest": {
-                "summary": "Invalid request",
-                "value": {
-                  "code": "bad_request",
-                  "message": "Invalid query parameter"
-                }
-              }
             }
           }
         },
@@ -25,15 +16,6 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
-            },
-            "examples": {
-              "resourceMissing": {
-                "summary": "Requested resource not found",
-                "value": {
-                  "code": "not_found",
-                  "message": "Event not found"
-                }
-              }
             }
           }
         },
@@ -73,6 +55,11 @@
         ],
         "type": "object"
       },
+      "AnalyticsUpdate": {
+        "additionalProperties": true,
+        "description": "Generic analytics update broadcast over WebSocket.",
+        "type": "object"
+      },
       "Error": {
         "properties": {
           "code": {
@@ -102,16 +89,29 @@
           }
         },
         "type": "object"
+      },
+      "WebhookAlertPayload": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
-      "apiKey": {
+      "csrfToken": {
+        "description": "Anti-CSRF token required for mutating operations",
         "in": "header",
-        "name": "X-API-Key",
+        "name": "X-CSRF-Token",
         "type": "apiKey"
       },
-      "bearerAuth": {
+      "jwtAuth": {
         "bearerFormat": "JWT",
+        "description": "Signed JWT present in the Authorization header",
         "scheme": "bearer",
         "type": "http"
       }
@@ -121,7 +121,7 @@
     "contact": {
       "email": "api-support@yosai.com"
     },
-    "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) or API key authentication.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
+    "description": "Physical security intelligence and access control API.\n\n# Authentication\nUse Bearer token (JWT) for inter-service communication and require an\n`X-CSRF-Token` header on state-changing requests.\n\n# Versioning\nAPI version is included in the URL path (e.g., /v2/events).\n",
     "license": {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
@@ -141,22 +141,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EventListResponse"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "A list of events",
-                    "value": {
-                      "events": [
-                        {
-                          "event_id": "evt_123",
-                          "person_id": "pers_456",
-                          "door_id": "door_1",
-                          "timestamp": "2024-05-01T10:00:00Z",
-                          "result": "granted"
-                        }
-                      ]
-                    }
-                  }
                 }
               }
             },
@@ -172,99 +156,18 @@
         "summary": "List access events",
         "tags": [
           "Events"
-        ],
-        "parameters": [
-          {
-            "name": "start_time",
-            "in": "query",
-            "description": "Return events occurring after this ISO-8601 timestamp",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "end_time",
-            "in": "query",
-            "description": "Return events occurring before this ISO-8601 timestamp",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of events to return",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "description": "Number of events to skip before starting to collect the result set",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
         ]
-      }
-    },
-    "/v2/events/{event_id}": {
-      "get": {
-        "summary": "Retrieve a single access event",
-        "operationId": "getAccessEvent",
-        "tags": [
-          "Events"
-        ],
-        "parameters": [
-          {
-            "name": "event_id",
-            "in": "path",
-            "description": "Unique identifier for the event",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccessEvent"
-                },
-                "examples": {
-                  "success": {
-                    "summary": "Event detail",
-                    "value": {
-                      "event_id": "evt_123",
-                      "person_id": "pers_456",
-                      "door_id": "door_1",
-                      "timestamp": "2024-05-01T10:00:00Z",
-                      "result": "granted"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
       }
     }
   },
+  "security": [
+    {
+      "jwtAuth": []
+    },
+    {
+      "csrfToken": []
+    }
+  ],
   "servers": [
     {
       "description": "Production",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "cssnano": "^7.1.0",
         "cypress": "^14.5.2",
         "cypress-axe": "^1.6.0",
+        "openapi-generator-cli": "^1.0.0",
         "pa11y": "^9.0.0",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
@@ -3698,19 +3699,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -11406,37 +11394,6 @@
         "node": "*"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
-      "integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.7"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -12032,13 +11989,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -17068,6 +17018,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-generator-cli": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-generator-cli/-/openapi-generator-cli-1.0.0.tgz",
+      "integrity": "sha512-gJ6YXQAkmoTYZ6kPG3rX9lHvVTh/bnWxfr6pDxjUfx+vSoE+JsuR4LDw+MrgH/7ezsJRFaljR66k0AlOXDW/eQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "openapi-generator-cli": "cli.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -18978,19 +18938,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -22236,22 +22183,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
-    },
-    "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.2.9"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
     },
     "node_modules/tabbable": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cssnano": "^7.1.0",
     "cypress": "^14.5.2",
     "cypress-axe": "^1.6.0",
-
+    "openapi-generator-cli": "^1.0.0",
     "pa11y": "^9.0.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",

--- a/scripts/generate_clients.sh
+++ b/scripts/generate_clients.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 SPEC=${1:-docs/openapi.json}
 
-npx openapi-generator-cli generate -i "$SPEC" -g go -o pkg/eventclient --package-name eventclient >/dev/null 2>&1
-npx openapi-generator-cli generate -i "$SPEC" -g python -o analytics/clients/event_client >/dev/null 2>&1
+npx --yes openapi-generator-cli generate -i "$SPEC" -g go -o pkg/eventclient --package-name eventclient >/dev/null 2>&1
+npx --yes openapi-generator-cli generate -i "$SPEC" -g python -o analytics/clients/event_client >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- pin `openapi-generator-cli` as a dev dependency
- use `npx --yes` in client generation script
- regenerate `docs/openapi.json`

## Testing
- `npm install --legacy-peer-deps`
- `go run .` *(in `api/openapi`)*
- `./scripts/generate_clients.sh docs/openapi.json`


------
https://chatgpt.com/codex/tasks/task_e_688720cf0fc08320967eb90cfe46a2b6