### PR TITLE
Normalize API routes

### DIFF
--- a/api/analytics_endpoints.py
+++ b/api/analytics_endpoints.py
@@ -15,9 +15,9 @@ from services.security import require_permission
 
 logger = logging.getLogger(__name__)
 
-analytics_bp = Blueprint("analytics", __name__, url_prefix="/api/v1/analytics")
-graphs_bp = Blueprint("graphs", __name__, url_prefix="/api/v1/graphs")
-export_bp = Blueprint("export", __name__, url_prefix="/api/v1/export")
+analytics_bp = Blueprint("analytics", __name__, url_prefix="/v1/analytics")
+graphs_bp = Blueprint("graphs", __name__, url_prefix="/v1/graphs")
+export_bp = Blueprint("export", __name__, url_prefix="/v1/export")
 
 handler = ErrorHandler()
 
@@ -76,7 +76,7 @@ MOCK_DATA = {
 
 @analytics_bp.route("/patterns", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="Get pattern analytics", tags=["analytics"])
+@doc(description="Get pattern analytics", tags=["analytics"], responses={200: "Success", 500: "Server Error"})
 @use_kwargs(AnalyticsQuerySchema, location="query")
 @marshal_with(AnalyticsResponseSchema)
 def get_patterns_analysis(**args):
@@ -88,7 +88,7 @@ def get_patterns_analysis(**args):
 
 @analytics_bp.route("/sources", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="List data sources", tags=["analytics"])
+@doc(description="List data sources", tags=["analytics"], responses={200: "Success"})
 @marshal_with(AnalyticsResponseSchema)
 def get_data_sources():
     return jsonify({"sources": [{"value": "test", "label": "Test Data Source"}]})
@@ -96,7 +96,7 @@ def get_data_sources():
 
 @analytics_bp.route("/health", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="Analytics service health", tags=["analytics"])
+@doc(description="Analytics service health", tags=["analytics"], responses={200: "Success"})
 @marshal_with(AnalyticsResponseSchema)
 def analytics_health():
     return jsonify({"status": "healthy", "service": "minimal"})
@@ -104,7 +104,7 @@ def analytics_health():
 
 @graphs_bp.route("/chart/<chart_type>", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="Get chart data", params={"chart_type": "Chart type"}, tags=["graphs"])
+@doc(description="Get chart data", params={"chart_type": "Chart type"}, tags=["graphs"], responses={200: "Success", 400: "Invalid chart", 500: "Server Error"})
 @use_kwargs(AnalyticsQuerySchema, location="query")
 @marshal_with(AnalyticsResponseSchema)
 def get_chart_data(chart_type, **args):
@@ -123,7 +123,7 @@ def get_chart_data(chart_type, **args):
 
 @export_bp.route("/analytics/json", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="Export analytics as JSON", tags=["export"])
+@doc(description="Export analytics as JSON", tags=["export"], responses={200: "Success"})
 @use_kwargs(AnalyticsQuerySchema, location="query")
 def export_analytics_json(**args):
     facility = request.args.get("facility_id", "default")
@@ -145,7 +145,7 @@ def register_analytics_blueprints(app):
 
 @graphs_bp.route("/available-charts", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="List available charts", tags=["graphs"])
+@doc(description="List available charts", tags=["graphs"], responses={200: "Success"})
 @marshal_with(AnalyticsResponseSchema)
 def get_available_charts():
     """Get list of available chart types."""
@@ -176,7 +176,7 @@ def get_available_charts():
 
 @export_bp.route("/formats", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="List export formats", tags=["export"])
+@doc(description="List export formats", tags=["export"], responses={200: "Success"})
 @marshal_with(AnalyticsResponseSchema)
 def get_export_formats():
     """Get available export formats."""
@@ -191,7 +191,7 @@ def get_export_formats():
 @analytics_bp.route("/all", methods=["GET"])
 @analytics_bp.route("/<source_type>", methods=["GET"])
 @require_permission("analytics.read")
-@doc(description="Get analytics by source", params={"source_type": "Source type"}, tags=["analytics"])
+@doc(description="Get analytics by source", params={"source_type": "Source type"}, tags=["analytics"], responses={200: "Success", 500: "Server Error"})
 @use_kwargs(AnalyticsQuerySchema, location="query")
 @marshal_with(AnalyticsResponseSchema)
 def get_analytics_by_source(source_type="all", **args):

--- a/api/callbacks_endpoint.py
+++ b/api/callbacks_endpoint.py
@@ -1,107 +1,153 @@
 from flask import Blueprint, jsonify, request
+from error_handling import ErrorCategory, ErrorHandler
+from yosai_framework.errors import CODE_TO_STATUS
+from shared.errors.types import ErrorCode
+from flask_apispec import doc
 
 """Expose legacy Dash callback logic as Flask endpoints."""
 
 
-callbacks_bp = Blueprint("callbacks", __name__, url_prefix="/api/v1/callbacks")
+callbacks_bp = Blueprint("callbacks", __name__, url_prefix="/v1/callbacks")
+
+handler = ErrorHandler()
 
 
 @callbacks_bp.post("/toggle-custom-field")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_toggle_custom_field():
     from components.column_verification import toggle_custom_field
-    data = request.get_json(force=True)
-    selected_value = data.get("selected_value")
-    result = toggle_custom_field(selected_value)
-    return jsonify(result)
+    try:
+        data = request.get_json(force=True)
+        selected_value = data.get("selected_value")
+        result = toggle_custom_field(selected_value)
+        return jsonify(result)
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/save-column-mappings")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_save_column_mappings():
     from components.column_verification import save_column_mappings_callback
-    payload = request.get_json(force=True)
-    n_clicks = payload.get("n_clicks")
-    column_values = payload.get("column_values", [])
-    custom_values = payload.get("custom_values", [])
-    uploaded_files = payload.get("uploaded_files", {})
-    message, color = save_column_mappings_callback(
-        n_clicks, column_values, custom_values, uploaded_files
-    )
-    return jsonify({"message": message, "color": color})
+    try:
+        payload = request.get_json(force=True)
+        n_clicks = payload.get("n_clicks")
+        column_values = payload.get("column_values", [])
+        custom_values = payload.get("custom_values", [])
+        uploaded_files = payload.get("uploaded_files", {})
+        message, color = save_column_mappings_callback(
+            n_clicks, column_values, custom_values, uploaded_files
+        )
+        return jsonify({"message": message, "color": color})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/toggle-device-verification")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_toggle_device_verification():
     from components.device_verification import toggle_device_verification_modal
-    data = request.get_json(force=True)
-    confirm = data.get("confirm_clicks")
-    cancel = data.get("cancel_clicks")
-    is_open = data.get("is_open", False)
-    result = toggle_device_verification_modal(confirm, cancel, is_open)
-    return jsonify({"is_open": result})
+    try:
+        data = request.get_json(force=True)
+        confirm = data.get("confirm_clicks")
+        cancel = data.get("cancel_clicks")
+        is_open = data.get("is_open", False)
+        result = toggle_device_verification_modal(confirm, cancel, is_open)
+        return jsonify({"is_open": result})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/mark-device-edited")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_mark_device_edited():
     from components.device_verification import mark_device_as_edited
-    data = request.get_json(force=True)
-    floor = data.get("floor")
-    access = data.get("access")
-    special = data.get("special")
-    security = data.get("security")
-    result = mark_device_as_edited(floor, access, special, security)
-    return jsonify({"edited": result})
+    try:
+        data = request.get_json(force=True)
+        floor = data.get("floor")
+        access = data.get("access")
+        special = data.get("special")
+        security = data.get("security")
+        result = mark_device_as_edited(floor, access, special, security)
+        return jsonify({"edited": result})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/toggle-simple-device-modal")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_toggle_simple_device_modal():
     from components.simple_device_mapping import toggle_simple_device_modal
-    data = request.get_json(force=True)
-    open_clicks = data.get("open_clicks")
-    cancel_clicks = data.get("cancel_clicks")
-    save_clicks = data.get("save_clicks")
-    is_open = data.get("is_open", False)
-    result = toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open)
-    return jsonify({"is_open": result})
+    try:
+        data = request.get_json(force=True)
+        open_clicks = data.get("open_clicks")
+        cancel_clicks = data.get("cancel_clicks")
+        save_clicks = data.get("save_clicks")
+        is_open = data.get("is_open", False)
+        result = toggle_simple_device_modal(open_clicks, cancel_clicks, save_clicks, is_open)
+        return jsonify({"is_open": result})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/save-user-inputs")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_save_user_inputs():
     from components.simple_device_mapping import save_user_inputs
-    data = request.get_json(force=True)
-    floors = data.get("floors", [])
-    security = data.get("security", [])
-    access = data.get("access", [])
-    special = data.get("special", [])
-    devices = data.get("devices", [])
-    status = save_user_inputs(floors, security, access, special, devices)
-    return jsonify({"status": status})
+    try:
+        data = request.get_json(force=True)
+        floors = data.get("floors", [])
+        security = data.get("security", [])
+        access = data.get("access", [])
+        special = data.get("special", [])
+        devices = data.get("devices", [])
+        status = save_user_inputs(floors, security, access, special, devices)
+        return jsonify({"status": status})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/apply-ai-device-suggestions")
+@doc(tags=["callbacks"], responses={200: "Success", 500: "Server Error"})
 def api_apply_ai_device_suggestions():
     from components.simple_device_mapping import apply_ai_device_suggestions
-    data = request.get_json(force=True)
-    suggestions = data.get("suggestions", {})
-    devices = data.get("devices", [])
-    floors, access, special, security = apply_ai_device_suggestions(suggestions, devices)
-    return jsonify({
-        "floors": floors,
-        "access": access,
-        "special": special,
-        "security": security,
-    })
+    try:
+        data = request.get_json(force=True)
+        suggestions = data.get("suggestions", {})
+        devices = data.get("devices", [])
+        floors, access, special, security = apply_ai_device_suggestions(suggestions, devices)
+        return jsonify({
+            "floors": floors,
+            "access": access,
+            "special": special,
+            "security": security,
+        })
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
 
 
 @callbacks_bp.post("/populate-simple-device-modal")
+@doc(tags=["callbacks"], responses={200: "Success", 400: "Bad Request", 500: "Server Error"})
 def api_populate_simple_device_modal():
     from components.simple_device_mapping import populate_simple_device_modal
-    data = request.get_json(force=True)
-    is_open = data.get("is_open", False)
-    result = populate_simple_device_modal(is_open)
-    if isinstance(result, tuple) or hasattr(result, "to_plotly_json"):
-        return jsonify({"error": "unsupported return type"}), 400
-    if isinstance(result, dict) and "props" in result:
-        return jsonify({"error": "dash component returned"}), 400
-    # When using the service directly, the function returns a Modal or dash.no_update.
-    # For the API we simplify: True if modal should open otherwise False.
-    return jsonify({"open": result is not None})
+    try:
+        data = request.get_json(force=True)
+        is_open = data.get("is_open", False)
+        result = populate_simple_device_modal(is_open)
+        if isinstance(result, tuple) or hasattr(result, "to_plotly_json"):
+            return jsonify({"error": "unsupported return type"}), 400
+        if isinstance(result, dict) and "props" in result:
+            return jsonify({"error": "dash component returned"}), 400
+        # When using the service directly, the function returns a Modal or dash.no_update.
+        # For the API we simplify: True if modal should open otherwise False.
+        return jsonify({"open": result is not None})
+    except Exception as exc:
+        err = handler.handle(exc, ErrorCategory.INTERNAL)
+        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]

--- a/api/settings_endpoint.py
+++ b/api/settings_endpoint.py
@@ -51,8 +51,8 @@ def _save_settings(settings: dict) -> None:
             json.dump(settings, f)
 
 
-@settings_bp.route("/api/v1/settings", methods=["GET"])
-@doc(description="Get user settings", tags=["settings"])
+@settings_bp.route("/v1/settings", methods=["GET"])
+@doc(description="Get user settings", tags=["settings"], responses={200: "Success"})
 @validate_output(SettingsSchema)
 def get_settings():
     """Return saved user settings or defaults."""
@@ -60,8 +60,8 @@ def get_settings():
     return settings, 200
 
 
-@settings_bp.route("/api/v1/settings", methods=["POST", "PUT"])
-@doc(description="Update user settings", tags=["settings"])
+@settings_bp.route("/v1/settings", methods=["POST", "PUT"])
+@doc(description="Update user settings", tags=["settings"], responses={200: "Success", 500: "Server Error"})
 @validate_input(SettingsSchema)
 @validate_output(SettingsSchema)
 def update_settings(payload: SettingsSchema):

--- a/device_endpoint.py
+++ b/device_endpoint.py
@@ -106,7 +106,11 @@ def build_device_mappings(
 
 
 @device_bp.route("/v1/ai/suggest-devices", methods=["POST"])
-@doc(description="Suggest device mappings", tags=["device"])
+@doc(
+    description="Suggest device mappings",
+    tags=["device"],
+    responses={200: "Success", 404: "File not found", 500: "Server Error"},
+)
 @validate_input(DeviceSuggestSchema)
 @validate_output(DeviceResponseSchema)
 def suggest_devices(payload: DeviceSuggestSchema):

--- a/docs/analytics_microservice_openapi.json
+++ b/docs/analytics_microservice_openapi.json
@@ -97,7 +97,7 @@
         }
       }
     },
-    "/api/v1/analytics/dashboard-summary": {
+    "/v1/analytics/dashboard-summary": {
       "get": {
         "summary": "Dashboard Summary",
         "operationId": "dashboard_summary_api_v1_analytics_dashboard_summary_get",
@@ -166,7 +166,7 @@
         ]
       }
     },
-    "/api/v1/analytics/access-patterns": {
+    "/v1/analytics/access-patterns": {
       "get": {
         "summary": "Access Patterns",
         "operationId": "access_patterns_api_v1_analytics_access_patterns_get",
@@ -221,7 +221,7 @@
         ]
       }
     },
-    "/api/v1/models/register": {
+    "/v1/models/register": {
       "post": {
         "tags": [
           "models"
@@ -272,7 +272,7 @@
         }
       }
     },
-    "/api/v1/models/{name}": {
+    "/v1/models/{name}": {
       "get": {
         "tags": [
           "models"
@@ -322,7 +322,7 @@
         }
       }
     },
-    "/api/v1/models/{name}/rollback": {
+    "/v1/models/{name}/rollback": {
       "post": {
         "tags": [
           "models"
@@ -481,7 +481,7 @@
         "title": "ValidationError"
       }
     },
-    "/api/v1/models/{name}/predict": {
+    "/v1/models/{name}/predict": {
       "post": {
         "tags": [
           "models"

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ write `docs/analytics_microservice_openapi.json` and
 Legacy dashboards still rely on Flask routes for file uploads and admin views.
 `api/adapter.py` builds a Flask `app` and then mounts it inside the FastAPI
 service using `WSGIMiddleware`. FastAPI handles its own routes first (such as
-`/api/v1/analytics`) and forwards any remaining paths to the Flask app.
+`/v1/analytics`) and forwards any remaining paths to the Flask app.
 
 ```python
 from fastapi.middleware.wsgi import WSGIMiddleware
@@ -96,7 +96,7 @@ sequenceDiagram
 
 ## API Versioning
 
-All endpoints are prefixed with a version such as `/v1` or `/api/v1`.
+All endpoints are prefixed with a version such as `/v1`.
 The Go `versioning` module provides `VersionManager` middleware that extracts
 the version from the request path and attaches metadata to the context. The
 manager can mark versions as `active`, `deprecated`, or `sunset` to control
@@ -165,9 +165,9 @@ The following table lists the required role or permission for key API route grou
 | Route Prefix | Required Role | Required Permission |
 |--------------|---------------|--------------------|
 | `/admin` | `admin` | - |
-| `/api/v1/analytics` | - | `analytics.read` |
-| `/api/v1/events` | - | `events.write` |
-| `/api/v1/doors` | - | `doors.control` |
+| `/v1/analytics` | - | `analytics.read` |
+| `/v1/events` | - | `events.write` |
+| `/v1/doors` | - | `doors.control` |
 
 For details on internal streaming, alert dispatching and WebSocket messages see
 [Internal Service Interfaces](internal_services.md).

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -286,7 +286,7 @@ document.getElementById('save-consent-preferences').onclick = function() {
     });
     
     // Save consents via API
-    fetch('/api/v1/compliance/consent', {
+    fetch('/v1/compliance/consent', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
@@ -299,7 +299,7 @@ document.getElementById('save-consent-preferences').onclick = function() {
 
 document.getElementById('download-my-data').onclick = function() {
     // Request data export
-    fetch('/api/v1/compliance/dsar/request', {
+    fetch('/v1/compliance/dsar/request', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
@@ -313,7 +313,7 @@ document.getElementById('download-my-data').onclick = function() {
 
 document.getElementById('delete-my-data').onclick = function() {
     if (confirm('Are you sure you want to permanently delete all your data? This cannot be undone.')) {
-        fetch('/api/v1/compliance/dsar/request', {
+        fetch('/v1/compliance/dsar/request', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,7 +5,7 @@ This directory contains standard operating procedures for the Yosai Intel Dashbo
 ## Routine Operations
 
 - **Restart services** using `docker-compose restart <service>` or `kubectl rollout restart deployment/<service>`.
-- **Check health** endpoints at `/api/v1/health` and review Prometheus targets for scrape status.
+- **Check health** endpoints at `/v1/health` and review Prometheus targets for scrape status.
 - **View metrics** in Grafana dashboards under the `gateway`, `event-processor` and `database` folders.
 
 ## Incident Response

--- a/mappings_endpoint.py
+++ b/mappings_endpoint.py
@@ -47,7 +47,11 @@ class SuccessSchema(BaseModel):
 
 
 @mappings_bp.route("/v1/mappings/columns", methods=["POST"])
-@doc(description="Save column mappings", tags=["mappings"])
+@doc(
+    description="Save column mappings",
+    tags=["mappings"],
+    responses={200: "Success", 400: "Invalid input", 500: "Server Error"},
+)
 @validate_input(FileMappingSchema)
 @validate_output(SuccessSchema)
 def save_column_mappings_route(payload: FileMappingSchema):
@@ -75,7 +79,11 @@ def save_column_mappings_route(payload: FileMappingSchema):
 
 
 @mappings_bp.route("/v1/mappings/devices", methods=["POST"])
-@doc(description="Save device mappings", tags=["mappings"])
+@doc(
+    description="Save device mappings",
+    tags=["mappings"],
+    responses={200: "Success", 400: "Invalid input", 500: "Server Error"},
+)
 @validate_input(FileMappingSchema)
 @validate_output(SuccessSchema)
 def save_device_mappings_route(payload: FileMappingSchema):
@@ -103,7 +111,11 @@ def save_device_mappings_route(payload: FileMappingSchema):
 
 
 @mappings_bp.route("/v1/mappings/save", methods=["POST"])
-@doc(description="Save mappings", tags=["mappings"])
+@doc(
+    description="Save mappings",
+    tags=["mappings"],
+    responses={200: "Success", 500: "Server Error"},
+)
 @validate_input(MappingSaveSchema)
 @validate_output(SuccessSchema)
 def save_mappings(payload: MappingSaveSchema):
@@ -147,7 +159,11 @@ def save_mappings(payload: MappingSaveSchema):
 
 
 @mappings_bp.route("/v1/process-enhanced", methods=["POST"])
-@doc(description="Process data with mappings", tags=["mappings"])
+@doc(
+    description="Process data with mappings",
+    tags=["mappings"],
+    responses={200: "Success", 404: "Not Found", 500: "Server Error"},
+)
 @validate_input(ProcessSchema)
 @validate_output(SuccessSchema)
 def process_enhanced_data(payload: ProcessSchema):

--- a/tests/adapters/api/test_analytics_routes.py
+++ b/tests/adapters/api/test_analytics_routes.py
@@ -77,7 +77,7 @@ def _create_app(monkeypatch):
 def test_patterns_returns_json(monkeypatch):
     app = _create_app(monkeypatch)
     client = app.test_client()
-    resp = client.get("/api/v1/analytics/patterns")
+    resp = client.get("/v1/analytics/patterns")
     assert resp.status_code == 200
     assert resp.is_json
     assert "status" in resp.get_json()

--- a/tests/analytics/test_async_api.py
+++ b/tests/analytics/test_async_api.py
@@ -6,14 +6,14 @@ from services.analytics.async_api import app, event_bus
 
 def test_health_endpoint():
     client = TestClient(app)
-    resp = client.get("/api/v1/analytics/health")
+    resp = client.get("/v1/analytics/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "healthy"
 
 
 def test_chart_bad_type():
     client = TestClient(app)
-    resp = client.get("/api/v1/analytics/chart/bad")
+    resp = client.get("/v1/analytics/chart/bad")
     assert resp.status_code == 400
 
 
@@ -35,7 +35,7 @@ def test_generate_report_json(monkeypatch):
     monkeypatch.setattr(mod, "get_analytics_service", lambda: DummySvc())
     client = TestClient(app)
     resp = client.post(
-        "/api/v1/analytics/report",
+        "/v1/analytics/report",
         json={"type": "summary", "timeframe": "7d"},
     )
     assert resp.status_code == 200
@@ -55,7 +55,7 @@ def test_generate_report_file(monkeypatch):
     monkeypatch.setattr(mod, "get_analytics_service", lambda: DummySvc())
     client = TestClient(app)
     resp = client.post(
-        "/api/v1/analytics/report",
+        "/v1/analytics/report",
         json={"type": "summary", "format": "file"},
     )
     assert resp.status_code == 200

--- a/tests/integration/test_e2e_gateway.py
+++ b/tests/integration/test_e2e_gateway.py
@@ -74,7 +74,7 @@ def test_gateway_end_to_end(tmp_path):
         start_total = get_total_requests(start_metrics.text)
 
         resp = requests.get(
-            f"http://{g_host}:{g_port}/api/v1/analytics/dashboard-summary",
+            f"http://{g_host}:{g_port}/v1/analytics/dashboard-summary",
             timeout=30,
         )
         assert resp.status_code == 200

--- a/tests/integration/test_gateway_failure_modes.py
+++ b/tests/integration/test_gateway_failure_modes.py
@@ -51,7 +51,7 @@ def test_gateway_breaker_counts_on_downtime(tmp_path):
         for _ in range(6):
             try:
                 requests.get(
-                    f"http://{g_host}:{g_port}/api/v1/analytics/dashboard-summary",
+                    f"http://{g_host}:{g_port}/v1/analytics/dashboard-summary",
                     timeout=5,
                 )
             except requests.RequestException:

--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -126,7 +126,7 @@ def test_requests_without_valid_token_return_401():
     client = TestClient(app_module.app)
 
     # No Authorization header
-    resp = client.get("/api/v1/analytics/dashboard-summary")
+    resp = client.get("/v1/analytics/dashboard-summary")
     assert resp.status_code == 401
 
     # Expired token
@@ -136,7 +136,7 @@ def test_requests_without_valid_token_return_401():
         algorithm="HS256",
     )
     resp = client.get(
-        "/api/v1/analytics/dashboard-summary",
+        "/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {bad_token}"},
     )
     assert resp.status_code == 401
@@ -148,7 +148,7 @@ def test_requests_without_valid_token_return_401():
         algorithm="HS256",
     )
     resp = client.get(
-        "/api/v1/analytics/dashboard-summary",
+        "/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {good_token}"},
     )
     assert resp.status_code == 200

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -50,7 +50,7 @@ def test_analytics_service_adapter_microservice(monkeypatch):
     client = TestClient(app_module.app)
 
     async def _local_call(self, method: str, params: dict):
-        resp = client.post(f"/api/v1/analytics/{method}", json=params)
+        resp = client.post(f"/v1/analytics/{method}", json=params)
         return resp.json()
 
     monkeypatch.setattr(
@@ -63,5 +63,5 @@ def test_analytics_service_adapter_microservice(monkeypatch):
     migration_adapter.register_migration_services(container)
 
     adapter = container.get("analytics_service")
-    expected = client.get("/api/v1/analytics/dashboard-summary").json()
+    expected = client.get("/v1/analytics/dashboard-summary").json()
     assert adapter.get_dashboard_summary() == expected

--- a/tests/services/test_analytics_microservice_app.py
+++ b/tests/services/test_analytics_microservice_app.py
@@ -99,7 +99,7 @@ def test_dashboard_summary_endpoint(app_fixture):
     client, dummy = app_fixture
     token = _token("secret")
     resp = client.get(
-        "/api/v1/analytics/dashboard-summary",
+        "/v1/analytics/dashboard-summary",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -111,7 +111,7 @@ def test_access_patterns_endpoint(app_fixture):
     client, dummy = app_fixture
     token = _token("secret")
     resp = client.get(
-        "/api/v1/analytics/access-patterns",
+        "/v1/analytics/access-patterns",
         params={"days": 3},
 
         headers={"Authorization": f"Bearer {token}"},

--- a/tests/unit/gateway_rbac_test.go
+++ b/tests/unit/gateway_rbac_test.go
@@ -16,7 +16,7 @@ func TestGatewayRBACHeaders(t *testing.T) {
 
 	paths := []string{
 		"/api/v1/doors/foo",
-		"/api/v1/analytics/foo",
+                "/v1/analytics/foo",
 		"/api/v1/events/foo",
 		"/admin/foo",
 	}

--- a/token_endpoint.py
+++ b/token_endpoint.py
@@ -23,6 +23,7 @@ class AccessTokenResponse(BaseModel):
 @token_bp.route("/v1/token/refresh", methods=["POST"])
 @validate_input(RefreshRequest)
 @validate_output(AccessTokenResponse)
+@doc(description="Refresh access token", tags=["token"], responses={200: "Success", 401: "Unauthorized"})
 def refresh_token_endpoint(payload: RefreshRequest):
     new_token = refresh_access_token(payload.refresh_token)
     if not new_token:

--- a/upload_endpoint.py
+++ b/upload_endpoint.py
@@ -38,7 +38,11 @@ class StatusSchema(BaseModel):
 
 
 @upload_bp.route("/v1/upload", methods=["POST"])
-@doc(description="Upload a file", tags=["upload"])
+@doc(
+    description="Upload a file",
+    tags=["upload"],
+    responses={202: "Accepted", 400: "Invalid CSRF token", 500: "Server Error"},
+)
 @validate_input(UploadRequestSchema)
 @validate_output(UploadResponseSchema)
 def upload_files(payload: UploadRequestSchema):
@@ -91,7 +95,7 @@ def upload_files(payload: UploadRequestSchema):
 
 
 @upload_bp.route("/v1/upload/status/<job_id>", methods=["GET"])
-@doc(params={"job_id": "Upload job id"}, tags=["upload"])
+@doc(params={"job_id": "Upload job id"}, tags=["upload"], responses={200: "Success"})
 @validate_output(StatusSchema)
 def upload_status(job_id: str):
     """Return background processing status for ``job_id``."""


### PR DESCRIPTION
## Summary
- prefix blueprint routes with `/v1/`
- document status codes for endpoints
- format responses using `ErrorHandler`
- update API docs
- adjust analytics tests for new prefixes

## Testing
- `pytest tests/test_upload_endpoint.py tests/test_mappings_endpoint.py tests/analytics/test_async_api.py tests/services/test_analytics_microservice_app.py -q` *(fails: Missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68873259e4d08320b1916bb1c51ffc87