### PR TITLE
Enforce 80% coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
           set -xe
           python tools/organize_imports.py --check
 
-      - name: PyTest
-        run: |
-          set -xe
-          LIGHTWEIGHT_SERVICES=1 pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=xml
+        - name: PyTest
+          run: |
+            set -xe
+            LIGHTWEIGHT_SERVICES=1 pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=xml --cov-fail-under=80
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ critical vulnerabilities are detected. Download the artifact from the
 Coverage results are uploaded to **Codecov** for every pull request. Open the
 `codecov` check from the PR status page to explore detailed line coverage and
 changes introduced by the branch.
+The CI pipeline enforces a minimum **80%** coverage threshold using
+`--cov-fail-under=80`.
 
 ## <span aria-hidden="true">📋</span> Features
 

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -100,7 +100,7 @@ Execute the full suite with coverage reporting. Enable the lightweight service
 implementations so heavy optional dependencies are not required:
 ```bash
 export LIGHTWEIGHT_SERVICES=1
-pytest --cov
+pytest --cov --cov-fail-under=80
 ```
 
 Static analysis and linting checks can be run as well:


### PR DESCRIPTION
## Summary
- fail CI if coverage drops below 80%
- document the `--cov-fail-under=80` threshold in README and docs

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md docs/test_setup.md`
- `LIGHTWEIGHT_SERVICES=1 pytest --maxfail=1 --disable-warnings -q --cov=. --cov-report=xml --cov-fail-under=80` *(fails: ImportError in analytics/anomaly_detection/tests/test_anomaly_modules.py)*

------
https://chatgpt.com/codex/tasks/task_e_6887325a95088320aacff55882a07a36