### PR TITLE
Add model drift detection and metrics tests

### DIFF
--- a/tests/monitoring/test_model_performance_monitor_drift.py
+++ b/tests/monitoring/test_model_performance_monitor_drift.py
@@ -1,0 +1,59 @@
+import types
+from types import SimpleNamespace
+import sys
+
+# minimal config stub to avoid heavy imports
+cfg_mod = types.ModuleType("config")
+
+class DatabaseSettings:
+    def __init__(self, type: str = "sqlite", **_: object) -> None:
+        self.type = type
+
+cfg_mod.DatabaseSettings = DatabaseSettings
+cfg_mod.dynamic_config = SimpleNamespace(performance=SimpleNamespace(memory_usage_threshold_mb=1024))
+sys.modules["config"] = cfg_mod
+sys.modules["config.dynamic_config"] = cfg_mod
+
+# minimal performance monitor stub
+perf_mod = types.ModuleType("core.performance")
+class MetricType(SimpleNamespace):
+    FILE_PROCESSING = "file"
+
+perf_mod.MetricType = MetricType
+perf_mod.get_performance_monitor = lambda: SimpleNamespace(record_metric=lambda *a, **k: None, aggregated_metrics={})
+sys.modules["core.performance"] = perf_mod
+
+# extend prometheus metrics stub
+prom_mod = types.ModuleType("monitoring.prometheus.model_metrics")
+prom_mod.update_model_metrics = lambda *a, **k: None
+prom_mod.start_model_metrics_server = lambda *a, **k: None
+sys.modules["monitoring.prometheus.model_metrics"] = prom_mod
+
+# Stub services.resilience.metrics to avoid heavy deps
+metrics_mod = types.ModuleType("services.resilience.metrics")
+metrics_mod.circuit_breaker_state = SimpleNamespace(labels=lambda *a, **k: SimpleNamespace(inc=lambda *a, **k: None))
+resilience_pkg = types.ModuleType("services.resilience")
+resilience_pkg.metrics = metrics_mod
+sys.modules.setdefault("services", types.ModuleType("services"))
+sys.modules.setdefault("services.resilience", resilience_pkg)
+sys.modules.setdefault("services.resilience.metrics", metrics_mod)
+
+import monitoring.model_performance_monitor as mpm
+
+
+def test_relative_drift_detection():
+    baseline = mpm.ModelMetrics(accuracy=1.0, precision=0.5, recall=0.5)
+    monitor = mpm.ModelPerformanceMonitor(baseline=baseline, drift_threshold=0.1)
+    metrics = mpm.ModelMetrics(accuracy=0.85, precision=0.55, recall=0.5)
+    assert monitor.detect_drift(metrics)
+    metrics_ok = mpm.ModelMetrics(accuracy=0.95, precision=0.55, recall=0.5)
+    assert not monitor.detect_drift(metrics_ok)
+
+
+def test_metrics_server_started(monkeypatch):
+    called = []
+    monkeypatch.setattr(mpm, "start_model_metrics_server", lambda: called.append(True))
+    mpm._model_performance_monitor = None
+    monitor = mpm.get_model_performance_monitor()
+    assert called
+    assert isinstance(monitor, mpm.ModelPerformanceMonitor)

--- a/tests/test_model_performance_monitor.py
+++ b/tests/test_model_performance_monitor.py
@@ -2,6 +2,33 @@ from types import SimpleNamespace, ModuleType
 import sys
 from datetime import datetime
 
+# minimal config stub to avoid heavy imports
+cfg_mod = ModuleType("config")
+
+class DatabaseSettings:
+    def __init__(self, type: str = "sqlite", **_: object) -> None:
+        self.type = type
+
+cfg_mod.DatabaseSettings = DatabaseSettings
+cfg_mod.dynamic_config = SimpleNamespace(performance=SimpleNamespace(memory_usage_threshold_mb=1024))
+sys.modules["config"] = cfg_mod
+sys.modules["config.dynamic_config"] = cfg_mod
+
+# minimal performance monitor stub
+perf_mod = ModuleType("core.performance")
+class MetricType(SimpleNamespace):
+    FILE_PROCESSING = "file"
+
+perf_mod.MetricType = MetricType
+perf_mod.get_performance_monitor = lambda: SimpleNamespace(record_metric=lambda *a, **k: None, aggregated_metrics={})
+sys.modules["core.performance"] = perf_mod
+
+# extend prometheus metrics stub
+prom_mod = ModuleType("monitoring.prometheus.model_metrics")
+prom_mod.update_model_metrics = lambda *a, **k: None
+prom_mod.start_model_metrics_server = lambda *a, **k: None
+sys.modules["monitoring.prometheus.model_metrics"] = prom_mod
+
 # stub services.resilience.metrics to avoid heavy deps
 metrics_mod = ModuleType("services.resilience.metrics")
 metrics_mod.circuit_breaker_state = SimpleNamespace(labels=lambda *a, **k: SimpleNamespace(inc=lambda: None))


### PR DESCRIPTION
## Summary
- extend model performance monitor with relative drift detection
- expose Prometheus server when creating global monitor
- create new test suite for model drift monitoring
- adjust existing tests to run without heavy dependencies

## Testing
- `LIGHTWEIGHT_SERVICES=1 pytest tests/test_model_performance_monitor.py tests/monitoring/test_model_performance_monitor_drift.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887325d9f208320ac0f935d21d172d2