### PR TITLE
Add psutil/tracemalloc profiling scripts

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -50,6 +50,17 @@ jobs:
             --prom-url http://localhost:9090 \
             --rate 50 --duration 60 | tee load_test_results.json
 
+      - name: Profile analytics service
+        run: |
+          CID=$(docker compose -f load-tests/docker-compose.yml ps -q analytics-service)
+          docker exec "$CID" python -m monitoring.psutil_profile 1 --duration 5 --interval 1 > psutil_analytics.log
+
+      - name: Upload profiling results
+        uses: actions/upload-artifact@v4
+        with:
+          name: psutil-profile
+          path: psutil_analytics.log
+
       - name: Upload throughput results
         uses: actions/upload-artifact@v4
         with:

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -277,3 +277,25 @@ With the default settings the system should handle more than 2,500 events per
 minute while keeping the average processing latency under a second.  Metrics
 are scraped from the gateway at `http://localhost:9090` and can be visualised
 using the example Grafana dashboard in `dashboards/performance/load_test.json`.
+
+### Psutil and Tracemalloc Profiling
+
+Two helper scripts under `monitoring/` capture runtime resource usage.
+
+* `psutil_profile.py` monitors a running PID or executes a command while recording CPU and memory usage.
+
+  ```bash
+  python -m monitoring.psutil_profile 1234 --duration 30 --interval 1 --output profile.json
+  ```
+
+  To profile a new command:
+
+  ```bash
+  python -m monitoring.psutil_profile python my_script.py --duration 10
+  ```
+
+* `tracemalloc_profile.py` runs a Python script with `tracemalloc` enabled and prints the top allocation sites. A snapshot can be saved for later analysis.
+
+  ```bash
+  python -m monitoring.tracemalloc_profile scripts/my_job.py --snapshot allocs.snap
+  ```

--- a/monitoring/psutil_profile.py
+++ b/monitoring/psutil_profile.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Lightweight CPU and memory profiler using ``psutil``."""
+
+import argparse
+import json
+import psutil
+import subprocess
+import time
+from typing import List, Dict
+
+
+def profile_pid(pid: int, interval: float, duration: float) -> List[Dict[str, float]]:
+    """Collect CPU and RSS memory usage for the given process."""
+    proc = psutil.Process(pid)
+    data = []
+    end = time.time() + duration
+    while time.time() < end:
+        cpu = proc.cpu_percent(interval=interval)
+        rss = proc.memory_info().rss / (1024 * 1024)
+        data.append({"timestamp": time.time(), "cpu_percent": cpu, "rss_mb": rss})
+    return data
+
+
+def profile_command(cmd: List[str], interval: float, duration: float) -> List[Dict[str, float]]:
+    """Run ``cmd`` as a subprocess and profile it."""
+    proc = subprocess.Popen(cmd)
+    try:
+        return profile_pid(proc.pid, interval, duration)
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile a process with psutil")
+    parser.add_argument("target", nargs="+", help="PID or command to execute")
+    parser.add_argument("--interval", type=float, default=1.0, help="Sampling interval in seconds")
+    parser.add_argument("--duration", type=float, default=10.0, help="Total profiling time in seconds")
+    parser.add_argument("--output", help="Optional JSON output file")
+    args = parser.parse_args()
+
+    if len(args.target) == 1 and args.target[0].isdigit():
+        records = profile_pid(int(args.target[0]), args.interval, args.duration)
+    else:
+        records = profile_command(args.target, args.interval, args.duration)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(records, f, indent=2)
+    else:
+        for r in records:
+            print(f"{r['timestamp']:.0f} cpu={r['cpu_percent']:.1f}% rss={r['rss_mb']:.1f}MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/tracemalloc_profile.py
+++ b/monitoring/tracemalloc_profile.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Run a Python script and record memory allocations using ``tracemalloc``."""
+
+import argparse
+import tracemalloc
+import runpy
+import time
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a script with tracemalloc enabled")
+    parser.add_argument("script", help="Python module or script path to execute")
+    parser.add_argument("--snapshot", help="Optional file to save the final snapshot")
+    parser.add_argument("--frames", type=int, default=25, help="Number of stack frames to capture")
+    args = parser.parse_args()
+
+    tracemalloc.start(args.frames)
+    start = time.perf_counter()
+    runpy.run_path(args.script, run_name="__main__")
+    duration = time.perf_counter() - start
+    snapshot = tracemalloc.take_snapshot()
+
+    top = snapshot.statistics("lineno")[:10]
+    print(f"Executed {args.script} in {duration:.2f}s; top allocations:")
+    for stat in top:
+        print(stat)
+
+    if args.snapshot:
+        snapshot.dump(args.snapshot)
+        print(f"Snapshot written to {args.snapshot}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add lightweight psutil and tracemalloc profiling helpers
- document how to run the profiling scripts
- upload psutil profile logs from performance CI job

## Testing
- `pip install -r requirements-test.txt` *(fails: large output truncated but indicates packages installed)*
- `pytest -k 'nothing'` *(fails: 255 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68873263c3648320847dd2d65201ef8d