### PR TITLE
Remove deprecated long mapping

### DIFF
--- a/analytics/clients/event_client/openapi_client/api_client.py
+++ b/analytics/clients/event_client/openapi_client/api_client.py
@@ -61,7 +61,7 @@ class ApiClient:
     PRIMITIVE_TYPES = (float, bool, bytes, str, int)
     NATIVE_TYPES_MAPPING = {
         'int': int,
-        'long': int, # TODO remove as only py3 is supported?
+        # Python 3 does not differentiate ``long`` from ``int``
         'float': float,
         'str': str,
         'bool': bool,
@@ -337,7 +337,7 @@ class ApiClient:
 
         If obj is None, return None.
         If obj is SecretStr, return obj.get_secret_value()
-        If obj is str, int, long, float, bool, return directly.
+        If obj is str, int, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is decimal.Decimal return string representation.
@@ -719,7 +719,7 @@ class ApiClient:
         :param data: str.
         :param klass: class literal.
 
-        :return: int, long, float, str, bool.
+        :return: int, float, str, bool.
         """
         try:
             return klass(data)


### PR DESCRIPTION
## Summary
- clean up legacy `long` entry from openapi client type mapping
- update serialization docstrings for Python 3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.base')*
- `pytest -k openapi_client -q` *(fails: ModuleNotFoundError: No module named 'config.base')*


------
https://chatgpt.com/codex/tasks/task_e_688737d6d40483208eea99c2baf0aa8c