### PR TITLE
Enable strict mypy in event client

### DIFF
--- a/analytics/clients/event_client/pyproject.toml
+++ b/analytics/clients/event_client/pyproject.toml
@@ -45,8 +45,7 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
-# TODO: enable "strict" once all these individual checks are passing
-# strict = true
+strict = true
 
 # List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
 warn_unused_configs = true


### PR DESCRIPTION
## Summary
- enable strict mypy mode in event client

## Testing
- `PYTHONPATH=analytics/clients/event_client mypy -p openapi_client` *(fails: 104 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688737d85c208320bada2c44d8dae7f5