### PR TITLE
Remove openpyxl and xlsxwriter

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,7 +8,6 @@ selenium>=4.20.0
 requests>=2.32.0
 pydantic==2.11.7
 pandas==2.1.4
-openpyxl>=3.0.0
 scipy==1.11.3
 sqlparse==0.5.3
 plotly==5.15.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -105,7 +105,6 @@ nest-asyncio==1.6.0
 nodeenv==1.9.1
 numpy==1.26.4
 oauthlib==3.3.1
-openpyxl==3.1.5
 opentelemetry-api==1.35.0
 opentelemetry-sdk==1.35.0
 opentelemetry-exporter-jaeger==1.35.0
@@ -217,5 +216,4 @@ websockets==11.0.3
 Werkzeug==2.3.7
 wsproto==1.2.0
 WTForms==3.2.1
-xlsxwriter==3.2.5
 zipp==3.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,8 +55,6 @@ confluent-kafka==2.11.0
 fastavro==1.11.1
 
 # New dependencies for enhanced functionality
-openpyxl==3.1.5
-xlsxwriter==3.2.5
 python-dateutil==2.9.0.post0
 dill==0.3.9
 

--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -174,7 +174,6 @@ dash-bootstrap-components>=1.4.0
 plotly>=5.15.0
 
 # Data processing
-openpyxl>=3.0.0
 xlrd>=2.0.0
 
 # Web framework


### PR DESCRIPTION
## Summary
- delete openpyxl and xlsxwriter from runtime and test requirements
- drop openpyxl from Mac dependency script
- regenerate requirements.lock without those packages

## Testing
- `pip check`
- `pytest -k ""` *(fails: Missing required test dependencies)*
- `pip-compile requirements.txt --output-file requirements.lock --no-header --no-annotate` *(fails: resolution impossible)*

------
https://chatgpt.com/codex/tasks/task_e_6887502432d08320a0a0f70f7bafef16