### PR TITLE
Replace print statements with logging

### DIFF
--- a/start_api.py
+++ b/start_api.py
@@ -3,6 +3,8 @@ import sys
 import os
 import logging
 
+logger = logging.getLogger(__name__)
+
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -19,9 +21,9 @@ def main() -> None:
     # Expose the DI container on the FastAPI state for access by services
     app.state.container = container
 
-    print("\n🚀 Starting Yosai Intel Dashboard API...")
-    print(f"   Available at: http://localhost:{API_PORT}")
-    print(f"   Health check: http://localhost:{API_PORT}/health")
+    logger.info("\n🚀 Starting Yosai Intel Dashboard API...")
+    logger.info(f"   Available at: http://localhost:{API_PORT}")
+    logger.info(f"   Health check: http://localhost:{API_PORT}/health")
 
     import uvicorn
 
@@ -29,4 +31,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/tools/find_legacy_files.py
+++ b/tools/find_legacy_files.py
@@ -3,8 +3,11 @@ import datetime
 import os
 import re
 import subprocess
+import logging
 from pathlib import Path
 from typing import Iterable, Tuple
+
+logger = logging.getLogger(__name__)
 
 PATTERNS = [
     r"old",
@@ -81,14 +84,15 @@ def main() -> None:
     args = parser.parse_args()
 
     for path, reasons in scan(Path(".")):
-        print(f"{path}  # {', '.join(reasons)}")
+        logger.info(f"{path}  # {', '.join(reasons)}")
         if args.delete:
             try:
                 os.remove(path)
-                print(f"Removed {path}")
+                logger.info(f"Removed {path}")
             except OSError as exc:
-                print(f"Failed to remove {path}: {exc}")
+                logger.error(f"Failed to remove {path}: {exc}")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/tools/legacy_code_detector.py
+++ b/tools/legacy_code_detector.py
@@ -6,6 +6,7 @@ import ast
 import json
 import re
 import subprocess
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -13,6 +14,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -308,14 +311,15 @@ def main() -> None:
     results = {"deprecated_usage": deprecated, "legacy": legacy, "analysis": analysis}
 
     if args.json:
-        print(json.dumps(results, indent=2, default=str))
+        logger.info(json.dumps(results, indent=2, default=str))
     else:
-        print(detector.generate_report(analysis, root))
+        logger.info(detector.generate_report(analysis, root))
         for file, issues in deprecated.items():
-            print(f"\n{file}")
+            logger.info(f"\n{file}")
             for issue in issues:
-                print(f"  - {issue}")
+                logger.info(f"  - {issue}")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/utils/create_navbar_assets.py
+++ b/utils/create_navbar_assets.py
@@ -216,12 +216,14 @@ def main():
     """
     Main function to create missing navbar assets.
     """
-    print("🎨 Creating Navbar Assets")
-    print("=" * 50)
+    logger.info("🎨 Creating Navbar Assets")
+    logger.info("=" * 50)
     
     # Check existing icons
     existing = check_existing_icons()
-    print(f"📁 Existing icons: {', '.join(existing) if existing else 'None'}")
+    logger.info(
+        f"📁 Existing icons: {', '.join(existing) if existing else 'None'}"
+    )
     
     # Create missing icons  
     results = create_missing_icons()
@@ -230,24 +232,32 @@ def main():
     successful = [name for name, success in results.items() if success]
     failed = [name for name, success in results.items() if not success]
     
-    print(f"\n✅ Successfully created: {', '.join(successful) if successful else 'None'}")
-    print(f"❌ Failed to create: {', '.join(failed) if failed else 'None'}")
+    logger.info(
+        f"\n✅ Successfully created: {', '.join(successful) if successful else 'None'}"
+    )
+    logger.info(f"❌ Failed to create: {', '.join(failed) if failed else 'None'}")
     
     if not PIL_AVAILABLE:
-        print("\n⚠️  PIL/Pillow not available - created placeholder files")
-        print("   Install Pillow for better icon generation: pip install Pillow")
+        logger.warning(
+            "\n⚠️  PIL/Pillow not available - created placeholder files"
+        )
+        logger.warning(
+            "   Install Pillow for better icon generation: pip install Pillow"
+        )
     
     total_created = len(successful)
     total_icons = len(ICON_DEFINITIONS)
     
-    print(f"\n📊 Summary: {total_created}/{total_icons} icons available")
+    logger.info(f"\n📊 Summary: {total_created}/{total_icons} icons available")
     
     if total_created == total_icons:
-        print("🎉 All navbar icons created successfully!")
+        logger.info("🎉 All navbar icons created successfully!")
     elif total_created > 0:
-        print("⚠️  Some icons created - navbar will use FontAwesome fallbacks for missing icons")
+        logger.info(
+            "⚠️  Some icons created - navbar will use FontAwesome fallbacks for missing icons"
+        )
     else:
-        print("❌ No icons created - navbar will use FontAwesome fallbacks")
+        logger.info("❌ No icons created - navbar will use FontAwesome fallbacks")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch CLI scripts to use the logging module
- keep helpful info output when scripts are run directly

## Testing
- `python -m py_compile start_api.py utils/create_navbar_assets.py tools/legacy_code_detector.py tools/find_legacy_files.py`
- `pytest -k "nonexistentpattern" -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_68875b0bd6a48320aca6a147f1592777