### PR TITLE
Refactor config access

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -289,6 +289,22 @@ class DynamicConfigManager(BaseConfigLoader):
 dynamic_config = DynamicConfigManager()
 
 
+class ConfigHelper:
+    """Convenience accessors for frequently used configuration values."""
+
+    @staticmethod
+    def ai_confidence_threshold() -> float:
+        return dynamic_config.get_ai_confidence_threshold()
+
+    @staticmethod
+    def max_upload_size_mb() -> int:
+        return dynamic_config.get_max_upload_size_mb()
+
+    @staticmethod
+    def upload_chunk_size() -> int:
+        return dynamic_config.get_upload_chunk_size()
+
+
 def diagnose_upload_config():
     """Diagnostic function to check upload configuration"""
     import os

--- a/core/config.py
+++ b/core/config.py
@@ -4,50 +4,49 @@ from __future__ import annotations
 
 from typing import Any
 
-from config.constants import DEFAULT_CHUNK_SIZE, UploadLimits, FileProcessingLimits
 from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
 from core.protocols import ConfigurationProtocol
 
 
 def get_ai_confidence_threshold() -> float:
-    """Default confidence threshold for AI based features."""
-    return 0.85
+    """Return the AI confidence threshold from the dynamic configuration."""
+    return dynamic_config.get_ai_confidence_threshold()
 
 
 def get_upload_chunk_size() -> int:
-    """Default chunk size for uploads."""
-    return DEFAULT_CHUNK_SIZE
+    """Return the upload chunk size from the dynamic configuration."""
+    return dynamic_config.get_upload_chunk_size()
 
 
 def get_max_parallel_uploads() -> int:
-    """Number of parallel uploads allowed."""
-    return UploadLimits.MAX_PARALLEL_UPLOADS
+    """Return the maximum number of parallel uploads from the dynamic configuration."""
+    return dynamic_config.get_max_parallel_uploads()
 
 
 def get_validator_rules() -> dict:
-    """Return validator rules for uploads."""
-    return UploadLimits.VALIDATOR_RULES
+    """Return validator rules for uploads from the dynamic configuration."""
+    return dynamic_config.get_validator_rules()
 
 
 def get_max_upload_size_mb() -> int:
-    """Maximum upload size allowed in megabytes."""
-    return FileProcessingLimits.MAX_FILE_UPLOAD_SIZE_MB
+    """Return the maximum upload size in megabytes from the dynamic configuration."""
+    return dynamic_config.get_max_upload_size_mb()
 
 
 def get_max_upload_size_bytes() -> int:
-    """Maximum upload size allowed in bytes."""
-    return get_max_upload_size_mb() * 1024 * 1024
+    """Return the maximum upload size in bytes from the dynamic configuration."""
+    return dynamic_config.get_max_upload_size_bytes()
 
 
 def validate_large_file_support() -> bool:
-    """Whether large file uploads are supported."""
-    return get_max_upload_size_mb() >= 50
+    """Return ``True`` if large file uploads are supported."""
+    return dynamic_config.validate_large_file_support()
 
 
 def get_db_pool_size() -> int:
-    """Default database connection pool size."""
-    return 10
+    """Return the configured database pool size."""
+    return dynamic_config.get_db_pool_size()
 
 
 def get_max_display_rows(config: ConfigurationProtocol = dynamic_config) -> int:

--- a/data_enhancer.py
+++ b/data_enhancer.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""Entry point for the standalone data enhancer CLI."""
-
-from services.data_enhancer import run_data_enhancer
-
-if __name__ == "__main__":
-    run_data_enhancer()

--- a/services/data_enhancer/app.py
+++ b/services/data_enhancer/app.py
@@ -30,11 +30,6 @@ from .config import (
     DynamicConfigurationService,
 )
 
-try:  # Optional fallback service
-    from .config import FallbackConfigService
-except Exception:  # pragma: no cover - fallback may not exist
-    FallbackConfigService = None
-
 if CONTAINER_AVAILABLE:
     from core.service_container import ServiceContainer
 
@@ -240,13 +235,7 @@ class MultiBuildingDataEnhancer:
         if AI_DOOR_SERVICE_AVAILABLE:
             try:
                 # Try to create proper config for the service
-                config = None
-                if CONFIG_SERVICE_AVAILABLE:
-                    config = DynamicConfigurationService()
-                elif FallbackConfigService is not None:
-                    config = FallbackConfigService()
-                else:
-                    config = None
+                config = DynamicConfigurationService() if CONFIG_SERVICE_AVAILABLE else None
 
                 # Try to use the real service
                 door_service = DoorMappingService(config)

--- a/services/data_enhancer/config.py
+++ b/services/data_enhancer/config.py
@@ -43,29 +43,12 @@ except Exception:  # pragma: no cover - optional dependency
     CONFIG_SERVICE_AVAILABLE = False
     logger.warning("⚠️ Configuration Service not available")
 
-    from utils.config_resolvers import (
-        resolve_ai_confidence_threshold,
-        resolve_max_upload_size_mb,
-        resolve_upload_chunk_size,
-    )
-
-    class FallbackConfigService:
-        def get_ai_confidence_threshold(self) -> float:
-            return resolve_ai_confidence_threshold()
-
-        def get_max_upload_size_mb(self) -> int:
-            return resolve_max_upload_size_mb()
-
-        def get_upload_chunk_size(self) -> int:
-            return resolve_upload_chunk_size()
-
 
 __all__ = [
     "AI_COLUMN_SERVICE_AVAILABLE",
     "AI_DOOR_SERVICE_AVAILABLE",
     "CONTAINER_AVAILABLE",
     "CONFIG_SERVICE_AVAILABLE",
-    "FallbackConfigService",
     "DoorMappingService",
     "get_door_mapping_service",
     "ServiceContainer",


### PR DESCRIPTION
## Summary
- centralize repeated helpers in `config/dynamic_config.py`
- refactor `core/config.py` to delegate to the dynamic config instance
- simplify `services/data_enhancer` configuration handling
- drop duplicate `data_enhancer.py` CLI entry

## Testing
- `python -m py_compile config/dynamic_config.py core/config.py services/data_enhancer/app.py services/data_enhancer/config.py`
- `pytest tests/test_dynamic_config_validation.py tests/test_config_loader.py -q` *(fails: ImportError circular import)*

------
https://chatgpt.com/codex/tasks/task_e_68875b0c884c8320b4fad89ef23e6a8a