### PR TITLE
Fix truncated recommendations

### DIFF
--- a/simple_analysis_report.md
+++ b/simple_analysis_report.md
@@ -89,3 +89,11 @@ Found 2 instances:
 - SQLite
 
 ## Recommendations
+
+To improve overall quality and maintainability:
+
+1. Add missing Python docstrings and split long functions into smaller helpers.
+2. Handle errors explicitly in Go code to avoid silent failures.
+3. Replace `var` declarations with `const` or `let` and enable strict mode for JavaScript files.
+4. Remove debug-only code before deployment.
+5. Document API contracts for every microservice to keep interfaces clear.

--- a/yosai_analysis_report.md
+++ b/yosai_analysis_report.md
@@ -89,3 +89,11 @@ Found 2 instances:
 - SQLite
 
 ## Recommendations
+
+To improve overall quality and maintainability:
+
+1. Add missing Python docstrings and split long functions into smaller helpers.
+2. Handle errors explicitly in Go code to avoid silent failures.
+3. Replace `var` declarations with `const` or `let` and enable strict mode for JavaScript files.
+4. Remove debug-only code before deployment.
+5. Document API contracts for every microservice to keep interfaces clear.


### PR DESCRIPTION
## Summary
- expand the Recommendations section in simple_analysis_report.md
- expand the Recommendations section in yosai_analysis_report.md

## Testing
- `pytest -q` *(fails: 245 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68875b0c8bc48320b475eee5cfb1728f