### PR TITLE
Refactor legacy scanning utilities

### DIFF
--- a/tools/find_legacy_files.py
+++ b/tools/find_legacy_files.py
@@ -1,78 +1,12 @@
+"""CLI to find potential legacy files."""
+
+from __future__ import annotations
+
 import argparse
-import datetime
 import os
-import re
-import subprocess
 from pathlib import Path
-from typing import Iterable, Tuple
 
-PATTERNS = [
-    r"old",
-    r"backup",
-    r"copy",
-    r"temp",
-    r"tmp",
-    r"deprecated",
-    r"legacy",
-    r"_v\d+",
-    r"\d{4}",
-    r"\.bak$",
-    r"\.old$",
-    r"\.orig$",
-]
-
-IGNORE_DIRS = {".git", "node_modules", "__pycache__", "venv"}
-
-
-def matches_patterns(path: Path) -> str | None:
-    for pat in PATTERNS:
-        if re.search(pat, path.name, re.IGNORECASE):
-            return pat
-    return None
-
-
-def last_commit_timestamp(path: Path) -> int | None:
-    try:
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%ct", "--", str(path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        if result.stdout.strip():
-            return int(result.stdout.strip())
-    except subprocess.CalledProcessError:
-        return None
-    return None
-
-
-def older_than_months(timestamp: int, months: int) -> bool:
-    dt = datetime.datetime.fromtimestamp(timestamp)
-    return (datetime.datetime.now() - dt).days >= months * 30
-
-
-def scan(root: Path) -> Iterable[Tuple[Path, list[str]]]:
-    for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
-        for filename in filenames:
-            path = Path(dirpath) / filename
-            reasons: list[str] = []
-            match = matches_patterns(path)
-            if match:
-                reasons.append(f"name matches '{match}'")
-            try:
-                mtime = path.stat().st_mtime
-                if older_than_months(int(mtime), 6):
-                    reasons.append("no modification in last 6 months")
-            except OSError:
-                pass
-
-            commit_ts = last_commit_timestamp(path)
-            if commit_ts and older_than_months(commit_ts, 12):
-                reasons.append("no commit in last year")
-
-            if reasons:
-                yield path, reasons
+from tools.legacy_utils import IGNORE_DIRS, scan_legacy_files
 
 
 def main() -> None:
@@ -80,7 +14,7 @@ def main() -> None:
     parser.add_argument("--delete", action="store_true", help="Delete matched files")
     args = parser.parse_args()
 
-    for path, reasons in scan(Path(".")):
+    for path, reasons in scan_legacy_files(Path("."), ignore_dirs=IGNORE_DIRS):
         print(f"{path}  # {', '.join(reasons)}")
         if args.delete:
             try:

--- a/tools/legacy_code_detector.py
+++ b/tools/legacy_code_detector.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import json
 import re
-import subprocess
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -13,6 +12,12 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 import yaml
+from tools.legacy_utils import (
+    PATTERNS as DEFAULT_PATTERNS,
+    git_last_commit,
+    iter_files,
+    matches_patterns,
+)
 
 
 @dataclass
@@ -25,10 +30,7 @@ class FileInfo:
 class LegacyCodeDetector:
     """Detect deprecated usage and analyze legacy files."""
 
-    NAME_PATTERNS = re.compile(
-        r"(old|backup|copy|temp|deprecated|test|\d{4}|v\d+)|\.(bak|old|orig)$",
-        re.IGNORECASE,
-    )
+    FILE_PATTERNS = list(DEFAULT_PATTERNS) + [r"test"]
     DEPRECATED_OBJECTS = {"DataLoadingService"}
     DEFAULT_DEPRECATED_IMPORTS = ["services.analytics.data_loader"]
 
@@ -44,7 +46,9 @@ class LegacyCodeDetector:
             self.rules = yaml.safe_load(Path(rules_path).read_text()) or {}
         self.deprecated_imports: List[str] = self.rules.get("deprecated_imports", [])
         self.deprecated_imports.extend(self.DEFAULT_DEPRECATED_IMPORTS)
-        self.deprecated_dependencies: List[str] = self.rules.get("deprecated_dependencies", [])
+        self.deprecated_dependencies: List[str] = self.rules.get(
+            "deprecated_dependencies", []
+        )
         self.languages = languages or ["python"]
         self.exclude_dirs = exclude_dirs or {
             ".git",
@@ -71,15 +75,14 @@ class LegacyCodeDetector:
         self.imports: Dict[Path, Set[str]] = {}
         self.defines: Set[str] = set()
         self.issues: Dict[str, List[str]] = defaultdict(list)
+        self.file_patterns = self.FILE_PATTERNS
 
     # ------------------------------------------------------------------
     # helpers used by analyzer section
     def _iter_files(self, root: Path, extensions: List[str]) -> List[Path]:
         files: List[Path] = []
-        for ext in extensions:
-            for fpath in root.rglob(f"*{ext}"):
-                if any(ex in fpath.parts for ex in self.exclude_dirs):
-                    continue
+        for fpath in iter_files(root, self.exclude_dirs):
+            if fpath.suffix in extensions:
                 files.append(fpath)
         return files
 
@@ -93,14 +96,11 @@ class LegacyCodeDetector:
             ".jsx": "JavaScript",
             ".tsx": "TypeScript",
         }
-        for p in root.rglob("*"):
-            if p.is_file():
-                if any(ex in p.parts for ex in self.exclude_dirs):
-                    continue
-                stats["total_files"] += 1
-                lang = ext_to_lang.get(p.suffix.lower())
-                if lang:
-                    stats["files_by_type"][lang].append(p)
+        for p in iter_files(root, self.exclude_dirs):
+            stats["total_files"] += 1
+            lang = ext_to_lang.get(p.suffix.lower())
+            if lang:
+                stats["files_by_type"][lang].append(p)
         return stats
 
     def _analyze_python(self, root: Path) -> Dict:
@@ -115,10 +115,17 @@ class LegacyCodeDetector:
                 for node in ast.walk(tree):
                     if isinstance(node, ast.FunctionDef):
                         sig = f"{node.name}({','.join(arg.arg for arg in node.args.args)})"
-                        signatures[sig].append({"file": str(py_file.relative_to(root)), "line": node.lineno})
+                        signatures[sig].append(
+                            {
+                                "file": str(py_file.relative_to(root)),
+                                "line": node.lineno,
+                            }
+                        )
                 for match in re.finditer(r"\.encode\(\)|\.decode\(\)", content):
                     line_no = content[: match.start()].count("\n") + 1
-                    unicode_issues.append({"file": str(py_file.relative_to(root)), "line": line_no})
+                    unicode_issues.append(
+                        {"file": str(py_file.relative_to(root)), "line": line_no}
+                    )
             except Exception as exc:  # pragma: no cover - robustness
                 self.issues["parse_errors"].append(f"{py_file}: {exc}")
         for sig, locs in signatures.items():
@@ -139,7 +146,9 @@ class LegacyCodeDetector:
                     content = fpath.read_text(encoding="utf-8", errors="ignore")
                     for match in re.finditer(pattern, content):
                         line_no = content[: match.start()].count("\n") + 1
-                        issues[lang].append({"file": str(fpath.relative_to(root)), "line": line_no})
+                        issues[lang].append(
+                            {"file": str(fpath.relative_to(root)), "line": line_no}
+                        )
                 except Exception:
                     continue
         total = sum(len(v) for v in issues.values())
@@ -149,24 +158,12 @@ class LegacyCodeDetector:
     # legacy detection helpers (former LegacyDetector)
     def _gather_python_files(self, root: Path) -> None:
         self.python_files = []
-        for path in root.rglob("*.py"):
-            if any(part in self.exclude_dirs for part in path.parts):
-                continue
-            self.python_files.append(path)
+        for path in iter_files(root, self.exclude_dirs):
+            if path.suffix == ".py":
+                self.python_files.append(path)
 
     def _git_last_commit(self, root: Path, path: Path) -> datetime | None:
-        try:
-            ts = subprocess.check_output(
-                ["git", "log", "-1", "--format=%ct", str(path)],
-                cwd=root,
-                stderr=subprocess.DEVNULL,
-                text=True,
-            ).strip()
-            if ts:
-                return datetime.fromtimestamp(int(ts))
-        except Exception:
-            pass
-        return None
+        return git_last_commit(path, cwd=root)
 
     def _collect_file_info(self, root: Path) -> None:
         self.infos = {}
@@ -207,7 +204,11 @@ class LegacyCodeDetector:
             content = path.read_text(encoding="utf-8", errors="ignore")
             issues: List[str] = []
             for mod in self.deprecated_imports:
-                if re.search(rf"^\s*from\s+{re.escape(mod)}\s+import|^\s*import\s+{re.escape(mod)}", content, re.MULTILINE):
+                if re.search(
+                    rf"^\s*from\s+{re.escape(mod)}\s+import|^\s*import\s+{re.escape(mod)}",
+                    content,
+                    re.MULTILINE,
+                ):
                     issues.append(f"deprecated import: {mod}")
             for obj in self.DEPRECATED_OBJECTS:
                 if obj in content:
@@ -243,9 +244,11 @@ class LegacyCodeDetector:
                     module_usage[mod].add(str(file))
 
         for path, info in self.infos.items():
-            if self.NAME_PATTERNS.search(path.name):
+            if matches_patterns(path, self.file_patterns):
                 suspect_names.append(str(path))
-            if (info.last_commit and info.last_commit < self.one_year) or info.mtime < self.six_months:
+            if (
+                info.last_commit and info.last_commit < self.one_year
+            ) or info.mtime < self.six_months:
                 stale_files.append(str(path))
             module_name = ".".join(path.with_suffix("").parts)
             if not module_usage.get(module_name):
@@ -279,7 +282,10 @@ class LegacyCodeDetector:
         return results
 
     def generate_report(self, results: Dict, root: Path) -> str:
-        lines = [f"Project: {root}", f"Total files: {results['structure']['total_files']}"]
+        lines = [
+            f"Project: {root}",
+            f"Total files: {results['structure']['total_files']}",
+        ]
         if "python" in results:
             py = results["python"]
             lines.append(f"Python files analyzed: {py['files_analyzed']}")

--- a/tools/legacy_utils.py
+++ b/tools/legacy_utils.py
@@ -1,0 +1,89 @@
+# Utility functions shared by legacy detection tools.
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple, Set
+
+PATTERNS = [
+    r"old",
+    r"backup",
+    r"copy",
+    r"temp",
+    r"tmp",
+    r"deprecated",
+    r"legacy",
+    r"_v\d+",
+    r"\d{4}",
+    r"\.bak$",
+    r"\.old$",
+    r"\.orig$",
+]
+
+IGNORE_DIRS: Set[str] = {".git", "node_modules", "__pycache__", "venv"}
+
+
+def matches_patterns(path: Path, patterns: Iterable[str] = PATTERNS) -> str | None:
+    """Return the pattern that matches the file name or ``None``."""
+    for pat in patterns:
+        if re.search(pat, path.name, re.IGNORECASE):
+            return pat
+    return None
+
+
+def iter_files(root: Path, ignore_dirs: Set[str] = IGNORE_DIRS) -> Iterator[Path]:
+    """Yield all files under ``root`` skipping ``ignore_dirs``."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
+        for filename in filenames:
+            yield Path(dirpath) / filename
+
+
+def git_last_commit(path: Path, *, cwd: Path | None = None) -> datetime | None:
+    """Return the last commit datetime for ``path`` if available."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct", "--", str(path)],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=cwd,
+        )
+        if result.stdout.strip():
+            return datetime.fromtimestamp(int(result.stdout.strip()))
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
+def older_than(dt: datetime, months: int) -> bool:
+    """Return ``True`` if ``dt`` is older than the given number of months."""
+    return (datetime.now() - dt).days >= months * 30
+
+
+def scan_legacy_files(
+    root: Path,
+    *,
+    ignore_dirs: Set[str] = IGNORE_DIRS,
+    patterns: Iterable[str] = PATTERNS,
+) -> Iterable[Tuple[Path, list[str]]]:
+    """Yield files considered legacy along with the reasons."""
+    for path in iter_files(root, ignore_dirs):
+        reasons: list[str] = []
+        match = matches_patterns(path, patterns)
+        if match:
+            reasons.append(f"name matches '{match}'")
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime)
+            if older_than(mtime, 6):
+                reasons.append("no modification in last 6 months")
+        except OSError:
+            pass
+        commit_dt = git_last_commit(path, cwd=root)
+        if commit_dt and older_than(commit_dt, 12):
+            reasons.append("no commit in last year")
+        if reasons:
+            yield path, reasons


### PR DESCRIPTION
## Summary
- create `legacy_utils` module with common scanning helpers
- reuse helpers in `find_legacy_files` CLI
- refactor `legacy_code_detector` to use shared utilities

## Testing
- `pytest tests/test_legacy_code_detector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68875b0eb7348320af293acdae421a95