### PR TITLE
Add plugin init error tests

### DIFF
--- a/plugins/ai_classification/plugin.py
+++ b/plugins/ai_classification/plugin.py
@@ -1,5 +1,7 @@
 """Enhanced AI Classification Plugin with CSV Processing"""
 
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -18,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 class AIClassificationPlugin:
     """Enhanced plugin implementing CSV related services"""
-
-from __future__ import annotations
 
     metadata = PluginMetadata(
         name="ai_classification",

--- a/tests/plugins/test_ai_classification_plugin.py
+++ b/tests/plugins/test_ai_classification_plugin.py
@@ -1,18 +1,74 @@
-import types
 from unittest.mock import MagicMock
+import sys
+import types
+import importlib.util
+from pathlib import Path
 
-import pytest
 
-from plugins.ai_classification.plugin import AIClassificationPlugin
+def _install_core_stub(monkeypatch):
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = []
+    protocols_pkg = types.ModuleType("core.protocols")
+    plugin_pkg = types.ModuleType("core.protocols.plugin")
+
+    class PluginMetadata:
+        def __init__(self, name, version, description, author):
+            self.name = name
+            self.version = version
+            self.description = description
+            self.author = author
+
+    plugin_pkg.PluginMetadata = PluginMetadata
+    protocols_pkg.plugin = plugin_pkg
+    core_pkg.protocols = protocols_pkg
+    # Minimal core.config stub for utils.config_resolvers
+    config_pkg = types.ModuleType("core.config")
+    config_pkg.get_ai_confidence_threshold = lambda: 0.5
+    config_pkg.get_max_upload_size_mb = lambda: 10
+    config_pkg.get_upload_chunk_size = lambda: 100
+    monkeypatch.setitem(sys.modules, "core.config", config_pkg)
+    monkeypatch.setitem(sys.modules, "core", core_pkg)
+    monkeypatch.setitem(sys.modules, "core.protocols", protocols_pkg)
+    monkeypatch.setitem(sys.modules, "core.protocols.plugin", plugin_pkg)
 
 
-def test_start_initializes_services(monkeypatch):
+def _load_ai_plugin(monkeypatch, repo_success=True):
+    _install_core_stub(monkeypatch)
+    path = Path("plugins/ai_classification/plugin.py")
+    import importlib
+    pkg = importlib.import_module("plugins.ai_classification")
+    spec = importlib.util.spec_from_file_location("plugins.ai_classification.plugin", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    pkg.plugin = module
+
     repo = MagicMock()
-    repo.initialize.return_value = True
+    repo.initialize.return_value = repo_success
+    repo_mod = types.ModuleType("plugins.ai_classification.database.csv_storage")
+    repo_mod.CSVStorageRepository = lambda p: repo
+    sys.modules["plugins.ai_classification.database.csv_storage"] = repo_mod
 
-    monkeypatch.setattr(
-        "plugins.ai_classification.plugin.CSVStorageRepository", lambda path: repo
-    )
+    service_names = {
+        "column_mapper": "ColumnMappingService",
+        "csv_processor": "CSVProcessorService",
+        "entry_classifier": "EntryClassificationService",
+        "floor_estimator": "FloorEstimationService",
+        "japanese_handler": "JapaneseTextHandler",
+    }
+    for mod_name, cls in service_names.items():
+        m = types.ModuleType(f"plugins.ai_classification.services.{mod_name}")
+        setattr(m, cls, object)
+        sys.modules[f"plugins.ai_classification.services.{mod_name}"] = m
+
+    spec.loader.exec_module(module)
+    return module.AIClassificationPlugin, repo
+
+
+def test_start_initializes_services(monkeypatch, mock_auth_env):
+    stub_preview = types.ModuleType("utils.preview_utils")
+    stub_preview.serialize_dataframe_preview = lambda df: []
+    monkeypatch.setitem(sys.modules, "utils.preview_utils", stub_preview)
+    AIClassificationPlugin, repo = _load_ai_plugin(monkeypatch, repo_success=True)
     monkeypatch.setattr(
         "plugins.ai_classification.plugin.JapaneseTextHandler", lambda cfg: "japan"
     )
@@ -51,3 +107,20 @@ def test_start_initializes_services(monkeypatch):
     }
     assert set(plugin.services.keys()) == expected_services
     repo.initialize.assert_called_once()
+
+
+def test_start_failure_logs_error(monkeypatch, caplog, mock_auth_env):
+    stub_preview = types.ModuleType("utils.preview_utils")
+    stub_preview.serialize_dataframe_preview = lambda df: []
+    monkeypatch.setitem(sys.modules, "utils.preview_utils", stub_preview)
+    AIClassificationPlugin, repo = _load_ai_plugin(monkeypatch, repo_success=False)
+
+    plugin = AIClassificationPlugin()
+    with caplog.at_level("ERROR"):
+        result = plugin.start()
+
+    assert result is False
+    assert not plugin.is_started
+    assert any(
+        "failed to start plugin" in record.getMessage() for record in caplog.records
+    )

--- a/tests/plugins/test_compliance_plugin.py
+++ b/tests/plugins/test_compliance_plugin.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import sys
+import types
+
+import importlib.util
+from pathlib import Path
+
+def _load_compliance_plugin(monkeypatch, db_success=True, services_success=True):
+    path = Path("plugins/compliance_plugin/plugin.py")
+    spec = importlib.util.spec_from_file_location("plugins.compliance_plugin.plugin", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+
+    base_mod = types.ModuleType("core.plugins.base")
+    class BasePlugin:
+        def __init__(self):
+            pass
+    base_mod.BasePlugin = BasePlugin
+    monkeypatch.setitem(sys.modules, "core.plugins.base", base_mod)
+
+    db = MagicMock()
+    db.ensure_schema.return_value = db_success
+    monkeypatch.setitem(sys.modules, "plugins.compliance_plugin.database", types.ModuleType("db"))
+    sys.modules["plugins.compliance_plugin.database"].ComplianceDatabase = lambda conn: db
+
+    services = MagicMock()
+    services.initialize.return_value = services_success
+    monkeypatch.setitem(sys.modules, "plugins.compliance_plugin.services", types.ModuleType("svc"))
+    sys.modules["plugins.compliance_plugin.services"].ComplianceServices = lambda c, cfg: services
+
+    monkeypatch.setitem(sys.modules, "plugins.compliance_plugin.api", types.ModuleType("api"))
+    sys.modules["plugins.compliance_plugin.api"].ComplianceAPI = lambda c, cfg: None
+    monkeypatch.setitem(sys.modules, "plugins.compliance_plugin.middleware", types.ModuleType("mw"))
+    sys.modules["plugins.compliance_plugin.middleware"].ComplianceMiddleware = lambda c, cfg: None
+
+    spec.loader.exec_module(module)
+    return module.CompliancePlugin, db, services
+
+
+def test_initialize_database_failure(monkeypatch, caplog, mock_auth_env):
+    CompliancePlugin, db, services = _load_compliance_plugin(monkeypatch, db_success=False)
+    container = MagicMock()
+    container.get.return_value = "db_conn"
+    container.register = MagicMock()
+    plugin = CompliancePlugin()
+    with caplog.at_level("ERROR"):
+        result = plugin.initialize(container, {})
+
+    assert result is False
+    assert not plugin.is_initialized
+    assert not plugin.is_database_ready
+    assert any(
+        "Failed to initialize compliance database schema" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- fix indentation in `AIClassificationPlugin`
- add tests for AIClassificationPlugin and CompliancePlugin initialization failures
- dynamically stub heavy dependencies for test imports

## Testing
- `pytest tests/plugins/test_ai_classification_plugin.py -q`
- `pytest tests/plugins/test_compliance_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688768b2e35883209c09da41fd70e892