### PR TITLE
Remove unused Flask-Compress

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -26,7 +26,7 @@ needed in production.
 `requirements.txt` lists all core dependencies. The most important packages are:
 
 - `Flask` and extensions (`Flask-Babel`, `Flask-Login`, `Flask-WTF`,
-  `Flask-Compress`, `Flask-Talisman`, `Flask-Caching`)
+  `Flask-Talisman`, `Flask-Caching`)
 - `dash`, `dash-bootstrap-components`, `dash-extensions`, `dash-leaflet`
 - `plotly`
 - `pandas`, `numpy`

--- a/requirements.lock
+++ b/requirements.lock
@@ -56,7 +56,6 @@ flasgger==0.9.7.1
 Flask==2.3.3
 flask-babel==4.0.0
 Flask-Caching==2.0.2
-Flask-Compress==1.18
 flask-cors==6.0.1
 Flask-Login==0.6.2
 flask-talisman==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Werkzeug==2.3.7
 flask-babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
-Flask-Compress==1.18
 flask-talisman==1.1.0
 Flask-Caching==2.0.2
 dash==2.18.2


### PR DESCRIPTION
## Summary
- drop Flask-Compress from the dependency lists
- clean up docs

## Testing
- `pip-audit -r requirements.txt --no-deps` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: Missing required test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688887bc9f108320b8ca51e98dd4375a