### PR TITLE
Remove PostgreSQL manager

### DIFF
--- a/core/plugins/config/database_manager.py
+++ b/core/plugins/config/database_manager.py
@@ -44,33 +44,6 @@ class MockDatabaseManager(IDatabaseManager):
         return f"Mock result for: {query}"
 
 
-class PostgreSQLDatabaseManager(IDatabaseManager):
-    """Deprecated synchronous PostgreSQL manager."""
-
-    def __init__(self, database_config) -> None:
-        self.config = database_config
-
-    def get_connection(self) -> ConnectionResult:  # pragma: no cover - legacy
-        raise NotImplementedError(
-            "PostgreSQLDatabaseManager is deprecated. "
-            "Use AsyncPostgreSQLManager instead."
-        )
-
-    def test_connection(self) -> bool:  # pragma: no cover - legacy
-        return False
-
-    def close_connection(self) -> None:  # pragma: no cover - legacy
-        pass
-
-    def execute_query(
-        self, query: str, params: Optional[Dict] = None
-    ) -> Any:  # pragma: no cover - legacy
-        raise NotImplementedError(
-            "PostgreSQLDatabaseManager is deprecated. "
-            "Use AsyncPostgreSQLManager instead."
-        )
-
-
 class SQLiteDatabaseManager(IDatabaseManager):
     """SQLite database manager"""
 
@@ -151,7 +124,6 @@ class SQLiteDatabaseManager(IDatabaseManager):
 
 __all__ = [
     "MockDatabaseManager",
-    "PostgreSQLDatabaseManager",
     "SQLiteDatabaseManager",
     "AsyncPostgreSQLManager",
 ]

--- a/core/plugins/config/factories.py
+++ b/core/plugins/config/factories.py
@@ -27,8 +27,7 @@ class DatabaseManagerFactory:
         """Create database manager based on configuration"""
         # Import here to avoid circular imports
         from .database_manager import (
-            MockDatabaseManager,
-            PostgreSQLDatabaseManager,
+            AsyncPostgreSQLManager,
             SQLiteDatabaseManager,
         )
 
@@ -36,17 +35,16 @@ class DatabaseManagerFactory:
         if not cls._managers:
             cls._managers.update(
                 {
-                    "mock": MockDatabaseManager,
-                    "postgresql": PostgreSQLDatabaseManager,
+                    "postgresql": AsyncPostgreSQLManager,
                     "sqlite": SQLiteDatabaseManager,
                 }
             )
 
-        db_type = getattr(database_config, "type", "mock")
+        db_type = getattr(database_config, "type", "sqlite")
 
         if db_type not in cls._managers:
-            logger.warning(f"Unknown database type: {db_type}, using mock")
-            db_type = "mock"
+            logger.warning(f"Unknown database type: {db_type}, using sqlite")
+            db_type = "sqlite"
 
         manager_class = cls._managers[db_type]
         return manager_class(database_config)


### PR DESCRIPTION
## Summary
- drop deprecated `PostgreSQLDatabaseManager`
- register only `AsyncPostgreSQLManager` and `SQLiteDatabaseManager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.base')*

------
https://chatgpt.com/codex/tasks/task_e_68889dff45e0832086f2e28b2bf19339