### PR TITLE
Add migration docs for deprecations

### DIFF
--- a/docs/migration/legacy-auth.md
+++ b/docs/migration/legacy-auth.md
@@ -1,0 +1,9 @@
+# Legacy Auth Migration
+
+The legacy authentication system relied on a collection of Flask blueprints and custom session handlers. This implementation has been superseded by the unified authentication service located in `services/auth_service.py`.
+
+## Migration Steps
+
+1. Remove any imports of `legacy_auth` modules.
+2. Update your login flows to call methods on `AuthService`.
+3. Ensure tokens are issued via the new service and update configuration files accordingly.

--- a/docs/migration/new-dashboard.md
+++ b/docs/migration/new-dashboard.md
@@ -1,0 +1,9 @@
+# New Dashboard Migration
+
+The original dashboard interface served from `yosai_intel_dashboard` has been replaced with the redesigned React frontend in `ui/`.
+
+## Migration Steps
+
+1. Update deployment pipelines to build the React assets using `npm run build`.
+2. Serve the compiled files from the `ui/dist` directory.
+3. Remove references to the legacy Jinja templates and associated routes.


### PR DESCRIPTION
## Summary
- document how to migrate off the `legacy-auth` module
- add instructions for moving to the new dashboard
- run `generate_deprecation_docs.py`

## Testing
- `pip install PyYAML`
- `python scripts/generate_deprecation_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_6888ae8006dc8320b898e126c05343c8