### PR TITLE
Add model drift detection

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -162,6 +162,24 @@ ui.record_frame_time(16.7)
 ui.record_callback_duration("update_chart", 0.05)
 ```
 
+## Model Monitoring
+
+`PerformanceMonitor` keeps a running list of `model.accuracy`,
+`model.precision` and `model.recall` values recorded by
+`ModelPerformanceMonitor`. The helper method `detect_model_drift()`
+compares the averaged metrics against a baseline and returns ``True`` when the
+relative difference exceeds the configured threshold.
+
+```python
+from monitoring.model_performance_monitor import ModelMetrics
+from core.performance import get_performance_monitor
+
+baseline = ModelMetrics(accuracy=0.92, precision=0.88, recall=0.90)
+monitor = get_performance_monitor()
+if monitor.detect_model_drift(baseline, threshold=0.05):
+    print("Model drift detected")
+```
+
 ## Caching Strategy
 
 Several analytics methods use `advanced_cache.cache_with_lock` to store results.

--- a/tests/test_performance_monitor_model_drift.py
+++ b/tests/test_performance_monitor_model_drift.py
@@ -1,0 +1,61 @@
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+# stub config.dynamic_config for PerformanceMonitor
+cfg = ModuleType("config")
+cfg.dynamic_config = SimpleNamespace(performance=SimpleNamespace(memory_usage_threshold_mb=1024))
+sys.modules["config"] = cfg
+sys.modules["config.dynamic_config"] = cfg
+
+# minimal ModelMetrics stub used by detect_model_drift
+mpm_stub = ModuleType("monitoring.model_performance_monitor")
+@dataclass
+class ModelMetrics:
+    accuracy: float
+    precision: float
+    recall: float
+mpm_stub.ModelMetrics = ModelMetrics
+sys.modules["monitoring.model_performance_monitor"] = mpm_stub
+
+# create minimal package structure for core
+core_pkg = ModuleType("core")
+core_pkg.__path__ = []  # mark as package
+sys.modules["core"] = core_pkg
+
+# load dependencies used by performance.py
+for name in ["base_model", "cpu_optimizer", "memory_manager"]:
+    spec = importlib.util.spec_from_file_location(
+        f"core.{name}", Path("core") / f"{name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "core"
+    sys.modules[f"core.{name}"] = mod
+    spec.loader.exec_module(mod)
+
+spec = importlib.util.spec_from_file_location("core.performance", Path("core/performance.py"))
+perf = importlib.util.module_from_spec(spec)
+perf.__package__ = "core"
+sys.modules["core.performance"] = perf
+spec.loader.exec_module(perf)
+
+PerformanceMonitor = perf.PerformanceMonitor
+
+
+def test_detect_model_drift():
+    monitor = PerformanceMonitor(max_metrics=10)
+    monitor.aggregated_metrics = {
+        "model.accuracy": [0.8],
+        "model.precision": [0.9],
+        "model.recall": [0.95],
+    }
+    baseline = ModelMetrics(1.0, 1.0, 1.0)
+    assert monitor.detect_model_drift(baseline, threshold=0.1)
+    monitor.aggregated_metrics = {
+        "model.accuracy": [0.98],
+        "model.precision": [0.99],
+        "model.recall": [1.0],
+    }
+    assert not monitor.detect_model_drift(baseline, threshold=0.1)


### PR DESCRIPTION
## Summary
- extend `PerformanceMonitor` with `get_average_model_metrics` and `detect_model_drift`
- document new model monitoring workflow
- add unit test for drift detection

## Testing
- `pytest tests/test_model_performance_monitor.py::test_detect_drift tests/test_performance_monitor_model_drift.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fc62bccc83208407dd06b0fa8899