### PR TITLE
Add model drift detection helper

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -15,6 +15,18 @@ metrics = ModelMetrics(accuracy=0.95, precision=0.92, recall=0.90)
 monitor.log_metrics(metrics)
 if monitor.detect_drift(metrics):
     print("Model drift detected")
+
+# Alternatively, compare metrics directly using
+# :meth:`PerformanceMonitor.detect_model_drift`:
+
+```python
+from core.performance import get_performance_monitor
+
+pm = get_performance_monitor()
+baseline = {"accuracy": 0.95, "precision": 0.92, "recall": 0.90}
+if pm.detect_model_drift(metrics.__dict__, baseline):
+    print("Model drift detected")
+```
 ```
 
 To expose the metrics for Prometheus scraping start the server:

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -162,6 +162,22 @@ ui.record_frame_time(16.7)
 ui.record_callback_duration("update_chart", 0.05)
 ```
 
+### Model Drift Detection
+
+`PerformanceMonitor` includes a helper for simple model drift checks. Pass the
+current metrics and the training baseline to `detect_model_drift` to see if any
+metric deviates by more than a threshold (default 5%):
+
+```python
+from core.performance import get_performance_monitor
+
+pm = get_performance_monitor()
+baseline = {"accuracy": 0.95, "precision": 0.92, "recall": 0.90}
+live = {"accuracy": 0.80, "precision": 0.91, "recall": 0.88}
+if pm.detect_model_drift(live, baseline):
+    print("Drift detected")
+```
+
 ## Caching Strategy
 
 Several analytics methods use `advanced_cache.cache_with_lock` to store results.

--- a/tests/test_performance_monitor_drift.py
+++ b/tests/test_performance_monitor_drift.py
@@ -1,0 +1,36 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+# minimal config stub
+cfg_mod = ModuleType("config")
+class DatabaseSettings:
+    def __init__(self, type: str = "sqlite", **_: object) -> None:
+        self.type = type
+cfg_mod.DatabaseSettings = DatabaseSettings
+cfg_mod.dynamic_config = SimpleNamespace(performance=SimpleNamespace(memory_usage_threshold_mb=1024))
+sys.modules["config"] = cfg_mod
+sys.modules["config.dynamic_config"] = cfg_mod
+
+import importlib.util
+from pathlib import Path
+
+core_pkg = ModuleType("core")
+core_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "core")]
+sys.modules.setdefault("core", core_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "core.performance", Path(__file__).resolve().parents[1] / "core" / "performance.py"
+)
+perf_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perf_module
+spec.loader.exec_module(perf_module)  # type: ignore
+PerformanceMonitor = perf_module.PerformanceMonitor
+
+
+def test_detect_model_drift():
+    monitor = PerformanceMonitor()
+    baseline = {"accuracy": 1.0, "precision": 0.5, "recall": 0.5}
+    metrics = {"accuracy": 0.85, "precision": 0.55, "recall": 0.5}
+    assert monitor.detect_model_drift(metrics, baseline, drift_threshold=0.1)
+    metrics_ok = {"accuracy": 0.95, "precision": 0.55, "recall": 0.5}
+    assert not monitor.detect_model_drift(metrics_ok, baseline, drift_threshold=0.1)


### PR DESCRIPTION
## Summary
- extend `PerformanceMonitor` with `detect_model_drift`
- document drift detection support
- describe usage in monitoring docs
- add unit test for the helper

## Testing
- `pytest tests/test_performance_monitor_drift.py tests/test_model_performance_monitor.py tests/monitoring/test_model_performance_monitor_drift.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fc398624832097476ad4cf145f9e