### PR TITLE
Refactor validator imports

### DIFF
--- a/services/registry.py
+++ b/services/registry.py
@@ -94,8 +94,8 @@ register_service(
     "services.data_processing.file_handler:FileHandler",
 )
 register_service(
-    "UnifiedFileValidator",
-    "services.data_processing.file_handler:FileHandler",
+    "SecurityValidator",
+    "validation.security_validator:SecurityValidator",
 )
 register_service(
     "UploadAnalyticsProcessor",

--- a/services/upload/__init__.py
+++ b/services/upload/__init__.py
@@ -11,7 +11,7 @@ from utils.upload_store import UploadedDataStore as UploadStorage
 from .ai import AISuggestionService, analyze_device_name_with_ai
 from .controllers.upload_controller import UnifiedUploadController as UploadController
 from .core.processor import UploadProcessingService
-from .core.validator import ClientSideValidator as UploadValidator
+from validation.security_validator import SecurityValidator
 from .helpers import save_ai_training_data
 from .protocols import (
     DeviceLearningServiceProtocol,
@@ -32,7 +32,7 @@ __all__ = [
     "DeviceLearningServiceProtocol",
     "get_device_learning_service",
     "UploadProcessingService",
-    "UploadValidator",
+    "SecurityValidator",
     "UploadStorage",
     "UploadController",
     "safe_encode_text",

--- a/tests/stubs/upload_validator.py
+++ b/tests/stubs/upload_validator.py
@@ -1,3 +1,3 @@
-class UploadValidator:
+class SecurityValidator:
     def validate_file_upload(self, content):
         return type("Result", (), {"valid": True, "message": ""})

--- a/tests/test_upload_validator.py
+++ b/tests/test_upload_validator.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
-from validation.security_validator import SecurityValidator as UploadValidator
+from validation.security_validator import SecurityValidator
 
 
 def test_validate_file_upload_dataframe():
     df = DataFrameBuilder().add_column("a", [1]).build()
-    v = UploadValidator(max_size_mb=1)
+    v = SecurityValidator(max_size_mb=1)
     res = v.validate_file_upload(df)
     assert res.valid
 
@@ -15,7 +15,7 @@ def test_validate_file_upload_dataframe():
 def test_validate_file_upload_base64(tmp_path):
     df = DataFrameBuilder().add_column("a", [1]).add_column("b", [2]).build()
     uri = UploadFileBuilder().with_dataframe(df).as_base64()
-    v = UploadValidator(max_size_mb=1)
+    v = SecurityValidator(max_size_mb=1)
     res = v.validate_file_upload(uri)
     assert res.valid
 
@@ -23,6 +23,6 @@ def test_validate_file_upload_base64(tmp_path):
 def test_validate_file_upload_path(tmp_path):
     df = DataFrameBuilder().add_column("a", [1]).add_column("b", [2]).build()
     path = UploadFileBuilder().with_dataframe(df).write_csv(tmp_path / "file.csv")
-    v = UploadValidator(max_size_mb=1)
+    v = SecurityValidator(max_size_mb=1)
     res = v.validate_file_upload(path)
     assert res.valid


### PR DESCRIPTION
## Summary
- update references to use SecurityValidator class
- remove outdated UploadValidator alias
- register SecurityValidator service correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_688940c43fbc8320b135216112c51530