### PR TITLE
Update docs for FileValidator rename

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,9 +17,9 @@ See [React Component Architecture](react_component_architecture.md) for an overv
 ## Latest Changes
 
 - **Unified Validation Package** – Input and file validation are exported from
-  the `security` package. Import `SecurityValidator` from there instead of
-  referencing the modules directly. The deprecated `SecureFileValidator` class
-  has been removed.
+  the `validation` package. Import `SecurityValidator` and `FileValidator` from
+  there instead of referencing the modules directly. The deprecated
+  `UnifiedFileValidator` class has been renamed to `FileValidator`.
 
 - **Separated Analytics Modules** – The previously monolithic
   `AnalyticsService` has been broken into smaller modules under

--- a/docs/service_builder_migration.md
+++ b/docs/service_builder_migration.md
@@ -35,13 +35,14 @@ instance.
 
 ## Replacing Direct Validator Usage
 
-Import validators from the `security` package rather than accessing the
+Import validators from the `validation` package rather than accessing the
 modules directly:
 
 ```python
-from security import SecurityValidator
+from validation import SecurityValidator, FileValidator
 
 validator = SecurityValidator()
+file_validator = FileValidator()
 ```
 
 The package consolidates all validation utilities and keeps the
@@ -80,10 +81,12 @@ def test_health():
 
 ### Validation Rules
 ```python
-from security import SecurityValidator
+from validation import SecurityValidator, FileValidator
 
 def test_validation():
-    v = SecurityValidator()
-    result = v.validate_input("SELECT 1", "query")
+    sv = SecurityValidator()
+    fv = FileValidator()
+    result = sv.validate_input("SELECT 1", "query")
     assert result["valid"]
+    assert fv.validate_file_upload("demo.csv", b"col\n1")["valid"]
 ```

--- a/docs/service_container.md
+++ b/docs/service_container.md
@@ -13,6 +13,7 @@ Create a container and register implementations with the desired lifetime:
 from core.service_container import ServiceContainer
 from services.analytics_service import AnalyticsService
 from services.interfaces import AnalyticsServiceProtocol
+from validation import FileValidator
 
 container = ServiceContainer()
 container.register_singleton(
@@ -20,7 +21,7 @@ container.register_singleton(
     AnalyticsService,
     protocol=AnalyticsServiceProtocol,
 )
-container.register_transient("validator", SecurityValidator)
+container.register_transient("validator", FileValidator)
 container.register_scoped("request_logger", RequestLogger)
 ```
 


### PR DESCRIPTION
## Summary
- document that UnifiedFileValidator was renamed to FileValidator
- use FileValidator in code samples across docs

## Testing
- `pre-commit run --files docs/architecture.md docs/validation_overview.md docs/service_builder_migration.md docs/service_container.md`

------
https://chatgpt.com/codex/tasks/task_e_688940c5fa188320931d74316a0e2bfb