### PR TITLE
Consolidate analytics service helper

### DIFF
--- a/analytics/controllers/analysis_helpers.py
+++ b/analytics/controllers/analysis_helpers.py
@@ -14,11 +14,11 @@ from analytics.core.utils.results_display import (
 from services.data_processing.analytics_engine import (
     AI_SUGGESTIONS_AVAILABLE,
     analyze_data_with_service,
-    get_analytics_service_safe,
     get_data_source_options_safe,
     process_quality_analysis_safe,
     process_suggests_analysis_safe,
 )
+from services import get_analytics_service
 
 
 # ------------------------------------------------------------
@@ -53,7 +53,7 @@ def run_service_analysis(data_source: str, analysis_type: str):
 def run_unique_patterns_analysis(data_source: str):
     """Run unique patterns analysis using the analytics service."""
     try:
-        analytics_service = get_analytics_service_safe()
+        analytics_service = get_analytics_service()
         if not analytics_service:
             return dbc.Alert("Analytics service not available", color="danger")
         results = analytics_service.get_unique_patterns_analysis(data_source)
@@ -441,7 +441,7 @@ def dispatch_analysis(button_id: str, data_source: str):
 def update_status_alert(_trigger: Any) -> str:
     """Return status alert message based on service health."""
     try:
-        service = get_analytics_service_safe()
+        service = get_analytics_service()
         suggests_available = AI_SUGGESTIONS_AVAILABLE
 
         if service and suggests_available:

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -61,9 +61,20 @@ else:
     FileHandlerService = get_service("FileHandler")
     FILE_HANDLER_AVAILABLE = FileHandlerService is not None
 
-    get_analytics_service = get_service("get_analytics_service")
     create_analytics_service = get_service("create_analytics_service")
     AnalyticsService = get_service("AnalyticsService")
+
+    def get_analytics_service():
+        """Return a shared :class:`AnalyticsService` instance if available."""
+        getter = get_service("get_analytics_service")
+        if getter is None:
+            return None
+        try:
+            return getter()
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.exception("Failed to initialize AnalyticsService: %s", exc)
+            return None
+
     ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 
     __all__ = [

--- a/services/data_processing/__init__.py
+++ b/services/data_processing/__init__.py
@@ -35,7 +35,6 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
         clean_analysis_data_unicode,
         get_ai_suggestions_for_file,
         get_analysis_type_options,
-        get_analytics_service_safe,
         get_data_source_options_safe,
         get_latest_uploaded_source_value,
         process_quality_analysis,
@@ -46,7 +45,6 @@ def load_analytics_helpers() -> None:  # pragma: no cover - optional
 
     globals().update(
         AI_SUGGESTIONS_AVAILABLE=_AI,
-        get_analytics_service_safe=get_analytics_service_safe,
         get_data_source_options_safe=get_data_source_options_safe,
         get_latest_uploaded_source_value=get_latest_uploaded_source_value,
         get_analysis_type_options=get_analysis_type_options,

--- a/services/data_processing/analytics_engine.py
+++ b/services/data_processing/analytics_engine.py
@@ -5,10 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-try:
-    from services import get_analytics_service  # type: ignore
-except Exception:  # pragma: no cover - avoid circular import during tests
-    get_analytics_service = None
+from services import get_analytics_service  # type: ignore
 try:
     from services.ai_suggestions import generate_column_suggestions
 
@@ -34,17 +31,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def get_analytics_service_safe():
-    """Return a shared :class:`AnalyticsService` instance if available."""
-    if get_analytics_service is None:
-        return None
-    try:
-        return get_analytics_service()
-    except Exception as exc:  # pragma: no cover - best effort
-        logger.exception("Failed to initialize AnalyticsService: %s", exc)
-        return None
-
-
 def get_data_source_options_safe() -> List[Dict[str, str]]:
     """Return dropdown options for available data sources."""
     options: List[Dict[str, str]] = []
@@ -59,7 +45,7 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
     except Exception:
         pass
     try:
-        service = get_analytics_service_safe()
+        service = get_analytics_service()
         if service:
             service_sources = service.get_data_source_options()
             for source_dict in service_sources:
@@ -293,7 +279,7 @@ def process_quality_analysis(data_source: str) -> Dict[str, Any]:
 def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str, Any]:
     """Run analysis using the analytics service with chunked processing."""
     try:
-        service = get_analytics_service_safe()
+        service = get_analytics_service()
         if not service:
             return {"error": "Analytics service not available"}
 
@@ -346,7 +332,6 @@ def analyze_data_with_service_safe(
 
 
 __all__ = [
-    "get_analytics_service_safe",
     "get_data_source_options_safe",
     "get_latest_uploaded_source_value",
     "get_analysis_type_options",

--- a/tools/cli_analytics_engine.py
+++ b/tools/cli_analytics_engine.py
@@ -106,11 +106,11 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
                 # Test analytics functions from data_processing.analytics_engine
                 print("\n--- Testing analytics engine functions ---")
                 try:
-                    from services.data_processing.analytics_engine import get_analytics_service_safe
-                    
-                    analytics_func = get_analytics_service_safe()
+                    from services import get_analytics_service
+
+                    analytics_func = get_analytics_service()
                     result["analytics_engine_functions"] = {
-                        "get_analytics_service_safe": str(type(analytics_func)) if analytics_func else None
+                        "get_analytics_service": str(type(analytics_func)) if analytics_func else None
                     }
                     print(f"Analytics engine functions loaded: {analytics_func is not None}")
                     


### PR DESCRIPTION
## Summary
- drop redundant `get_analytics_service_safe`
- expose a safe `get_analytics_service` in `services/__init__`
- update analysis helpers and CLI entry points to use the new helper

## Testing
- `pytest tests/analytics/test_async_api.py::test_generate_report_json -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest tests/test_analytics_service_threadsafe.py::test_get_analytics_service_threadsafe -q` *(fails: ImportError: cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_6889490dc56c8320868f2580ad379481