### PR TITLE
Add file upload validation and tests

### DIFF
--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import io
 import sys
 import types
 import pandas as pd
@@ -111,3 +112,58 @@ def test_upload_returns_error_on_exception(monkeypatch):
     assert resp.status_code == 500
     body = resp.get_json()
     assert body == {"code": "internal", "message": "boom"}
+
+
+class DummyValidator:
+    def validate_file_upload(self, filename, content):
+        if filename.endswith(".exe"):
+            raise ValueError("unsupported")
+        if len(content) > 5:
+            raise ValueError("too_large")
+
+
+class DummyFileProcessor:
+    def __init__(self):
+        self.validator = DummyValidator()
+
+    def process_file_async(self, contents, filename):
+        return "job123"
+
+    def get_job_status(self, job_id):
+        return {}
+
+
+def _create_validator_app(monkeypatch):
+    fake_reg = types.ModuleType("config.service_registration")
+    fake_reg.register_upload_services = lambda c: None
+    monkeypatch.setitem(sys.modules, "config.service_registration", fake_reg)
+
+    cont = ServiceContainer()
+    cont.register_singleton("file_processor", DummyFileProcessor())
+
+    container_mod = types.ModuleType("core.container")
+    container_mod.container = cont
+    monkeypatch.setitem(sys.modules, "core.container", container_mod)
+
+    upload_ep = importlib.import_module("upload_endpoint")
+
+    app = Flask(__name__)
+    app.register_blueprint(upload_ep.upload_bp)
+    monkeypatch.setattr(upload_ep, "container", cont, raising=False)
+    return app
+
+
+def test_upload_rejects_oversized_file(monkeypatch):
+    app = _create_validator_app(monkeypatch)
+    client = app.test_client()
+    data = {"file": (io.BytesIO(b"123456"), "big.csv")}
+    resp = client.post("/v1/upload", data=data)
+    assert resp.status_code == 400
+
+
+def test_upload_rejects_unsupported_file(monkeypatch):
+    app = _create_validator_app(monkeypatch)
+    client = app.test_client()
+    data = {"file": (io.BytesIO(b"abc"), "bad.exe")}
+    resp = client.post("/v1/upload", data=data)
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate uploaded bytes using existing file validator before encoding
- return INVALID_INPUT errors when validation fails
- test error handling for oversized and unsupported files

## Testing
- `pytest -q tests/test_upload_endpoint.py::test_upload_files_uses_asyncio_run` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_6889490dc0788320a90909de1311d7a8