### PR TITLE
Fix SQL parameterization and add injection test

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,13 @@
+# Secure Database Queries
+
+To reduce the risk of SQL injection vulnerabilities:
+
+- Always use parameterized queries with placeholders like `%s` or `?` rather than
+  formatting values into query strings.
+- Prefer the `execute_query` and `execute_command` helpers which enforce
+  parameter validation.
+- Never concatenate untrusted input with SQL keywords or table names.
+- Validate user-supplied data types before executing a query.
+
+Following these practices ensures that user input is passed separately from the
+SQL statement, preventing malicious injections.

--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -63,10 +63,8 @@ def ensure_checkpoint(cur: DictCursor) -> None:
     )
     execute_command(
         cur,
-        (
-            f"INSERT INTO {CHECKPOINT_TABLE} (last_ts) VALUES ('1970-01-01') "
-            "ON CONFLICT DO NOTHING"
-        ),
+        f"INSERT INTO {CHECKPOINT_TABLE} (last_ts) VALUES (%s) ON CONFLICT DO NOTHING",
+        ("1970-01-01",),
     )
 
 


### PR DESCRIPTION
## Summary
- use parameter placeholders in `replicate_to_timescale.py`
- record executed queries in DummyCursor
- test that malicious input is passed as parameters
- document secure query guidelines

## Testing
- `pre-commit run --files scripts/replicate_to_timescale.py tests/migration/test_migrate_to_timescale.py docs/security.md`
- `pytest tests/migration/test_migrate_to_timescale.py -k update_checkpoint_uses_parameters -vv`

------
https://chatgpt.com/codex/tasks/task_e_6889bf227f948320a4261f24c2a944f9