### PR TITLE
Remove secret prints from rotation scripts

### DIFF
--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -45,6 +45,20 @@ cluster, the updated manifest is applied automatically. After the pods
 restart, remove the previous credentials from your secret store or
 database to prevent reuse.
 
+### Retrieving Rotated Secrets
+
+`scripts/vault_rotate.py` updates the values stored in Vault without
+printing them to the terminal. Fetch the new credentials using the Vault
+CLI or another authenticated client:
+
+```bash
+vault kv get -field=password secret/data/db
+vault kv get -field=secret secret/data/jwt
+```
+
+Share the retrieved secrets only over secure channels and update any
+dependent services accordingly.
+
 ## Docker and Cloud Secret Usage
 
 Secrets can be supplied as Docker secrets when running with Docker

--- a/scripts/generate_dev_secrets.py
+++ b/scripts/generate_dev_secrets.py
@@ -1,14 +1,29 @@
 #!/usr/bin/env python3
 """Generate strong random secret values for development.
 
-Outputs SECRET_KEY and DB_PASSWORD lines using `secrets.token_urlsafe`.
+Writes the values to an env file rather than printing them to stdout.
 """
+from __future__ import annotations
+
+import argparse
+import logging
 import secrets
 
 
 def main() -> None:
-    print(f"SECRET_KEY={secrets.token_urlsafe(32)}")
-    print(f"DB_PASSWORD={secrets.token_urlsafe(32)}")
+    parser = argparse.ArgumentParser(description="Generate development secrets")
+    parser.add_argument(
+        "--output", default="dev_secrets.env", help="file to write secrets"
+    )
+    args = parser.parse_args()
+
+    secret_key = secrets.token_urlsafe(32)
+    db_password = secrets.token_urlsafe(32)
+    with open(args.output, "w") as fh:
+        fh.write(f"SECRET_KEY={secret_key}\n")
+        fh.write(f"DB_PASSWORD={db_password}\n")
+    logging.basicConfig(level=logging.INFO)
+    logging.info("generated secrets written to %s", args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/rotate_secrets.py
+++ b/scripts/rotate_secrets.py
@@ -7,6 +7,7 @@ the manifest with ``kubectl`` if the cluster is reachable.
 """
 from __future__ import annotations
 
+import logging
 import secrets
 import subprocess
 from pathlib import Path
@@ -55,7 +56,7 @@ def cluster_reachable() -> bool:
 def apply_config(file_path: Path = SECRETS_FILE) -> None:
     """Apply the secret manifest using kubectl if possible."""
     if not cluster_reachable():
-        print("kubectl not configured or cluster unreachable; skipping apply")
+        logging.warning("kubectl not configured or cluster unreachable; skipping apply")
         return
     subprocess.run(["kubectl", "apply", "-f", str(file_path)], check=True)
 
@@ -73,10 +74,11 @@ def restart_deployment(
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     updates = update_secrets()
-    print("Secrets rotated:")
-    for key, value in updates.items():
-        print(f"- {key}: {value}")
+    logging.info("Secrets rotated and written to %s", SECRETS_FILE)
+    for key in updates:
+        logging.info("rotated %s", key)
     apply_config()
     restart_deployment()
 


### PR DESCRIPTION
## Summary
- avoid printing secrets in vault_rotate.py, rotate_secrets.py and generate_dev_secrets.py
- log sanitized messages instead
- write development secrets to `dev_secrets.env`
- document how to fetch rotated secrets from Vault

## Testing
- `pre-commit run --files scripts/vault_rotate.py scripts/rotate_secrets.py scripts/generate_dev_secrets.py docs/secret_management.md`

------
https://chatgpt.com/codex/tasks/task_e_6889bf23c0b083208574fc0eeaac41cc