### PR TITLE
Refactor analytics component registration

### DIFF
--- a/config/complete_service_registration.py
+++ b/config/complete_service_registration.py
@@ -102,39 +102,15 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
 
 
 def register_analytics_services(container: ServiceContainer) -> None:
-    class SimpleAnalyticsService:
-        def get_dashboard_summary(self, time_range: str = "30d") -> Dict[str, Any]:
-            return {"status": "stub", "message": "Analytics not configured"}
+    """Register analytics components and service."""
 
-        def analyze_access_patterns(
-            self, days: int, user_id: str | None = None
-        ) -> Dict[str, Any]:
-            return {"status": "stub"}
-
-        def detect_anomalies(self, data, sensitivity: float = 0.5):
-            return []
-
-        def generate_report(
-            self, report_type: str, params: Dict[str, Any]
-        ) -> Dict[str, Any]:
-            return {"status": "stub"}
-
-        def get_user_activity_summary(
-            self, user_id: str, days: int = 30
-        ) -> Dict[str, Any]:
-            return {"status": "stub"}
-
-        def get_facility_statistics(
-            self, facility_id: str | None = None
-        ) -> Dict[str, Any]:
-            return {"status": "stub"}
-
-        def health_check(self) -> Dict[str, Any]:
-            return {"status": "healthy", "service": "analytics_stub"}
+    from core.protocols import AnalyticsServiceProtocol
+    from services.analytics_service import create_analytics_service
 
     container.register_singleton(
         "analytics_service",
-        SimpleAnalyticsService(),
+        create_analytics_service(),
+        protocol=AnalyticsServiceProtocol,
     )
 
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.processing.calculator import Calculator  # noqa: E402
+from services.analytics.calculator import Calculator  # noqa: E402
 
 
 def _make_df():

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.data.loader import DataLoader  # noqa: E402
+from services.analytics.data_loader import DataLoader  # noqa: E402
 
 
 class DummyUploadProc:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -34,7 +34,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.events.publisher import Publisher  # noqa: E402
+from services.analytics.publisher import Publisher  # noqa: E402
 
 
 class DummyBus:


### PR DESCRIPTION
## Summary
- register analytics_service in the service container
- update imports for new analytics modules in tests

## Testing
- `pytest tests/test_data_loader.py tests/test_calculator.py tests/test_publisher.py tests/test_transformer.py tests/test_validator.py tests/test_sample_paths.py -q` *(fails: cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_6889bf25f46c83209c74170c32a030e5