### PR TITLE
Standardize API error responses

### DIFF
--- a/api/settings_endpoint.py
+++ b/api/settings_endpoint.py
@@ -4,9 +4,8 @@ import os
 from filelock import FileLock
 from flask import Blueprint, jsonify, request
 from flask_apispec import doc
-from error_handling import ErrorCategory, ErrorHandler
-from yosai_framework.errors import CODE_TO_STATUS
-from shared.errors.types import ErrorCode
+from error_handling import ErrorCategory, ErrorHandler, api_error_response
+
 from pydantic import BaseModel
 
 from utils.pydantic_decorators import validate_input, validate_output
@@ -72,6 +71,5 @@ def update_settings(payload: SettingsSchema):
     try:
         _save_settings(settings)
     except Exception as exc:
-        err = handler.handle(exc, ErrorCategory.INTERNAL)
-        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
+        return api_error_response(exc, ErrorCategory.INTERNAL, handler=handler)
     return {"status": "success", "settings": settings}, 200

--- a/error_handling/__init__.py
+++ b/error_handling/__init__.py
@@ -3,6 +3,7 @@
 from .core import ErrorContext, ErrorHandler
 from .decorators import handle_errors
 from .exceptions import ErrorCategory, YosaiException
+from .api_error_response import api_error_response
 
 __all__ = [
     "ErrorHandler",
@@ -10,4 +11,5 @@ __all__ = [
     "handle_errors",
     "YosaiException",
     "ErrorCategory",
+    "api_error_response",
 ]

--- a/error_handling/api_error_response.py
+++ b/error_handling/api_error_response.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+from flask import jsonify, Response
+
+from shared.errors.types import ErrorCode
+
+CODE_TO_STATUS: dict[ErrorCode, int] = {
+    ErrorCode.INVALID_INPUT: 400,
+    ErrorCode.UNAUTHORIZED: 401,
+    ErrorCode.NOT_FOUND: 404,
+    ErrorCode.INTERNAL: 500,
+    ErrorCode.UNAVAILABLE: 503,
+}
+
+from .core import ErrorHandler
+from .exceptions import ErrorCategory
+
+
+def api_error_response(
+    exc: Exception,
+    category: ErrorCategory = ErrorCategory.INTERNAL,
+    *,
+    handler: ErrorHandler | None = None,
+    details: Any | None = None,
+) -> tuple[Response, int]:
+    """Return a JSON error response for *exc* using ``ErrorHandler``."""
+    h = handler or ErrorHandler()
+    err = h.handle(exc, category, details)
+    status = CODE_TO_STATUS.get(ErrorCode(err.category.value), 500)
+    return jsonify(err.to_dict()), status
+

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -92,6 +92,43 @@ components:
         itemsPerPage:
           type: integer
           nullable: true
+  responses:
+    BadRequest:
+      description: Invalid input
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: invalid_input
+            message: Invalid request
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: not_found
+            message: Item not found
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: unauthorized
+            message: Unauthorized
+    ServerError:
+      description: Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: internal
+            message: Server error
 paths:
   /events:
     get:

--- a/plugins/compliance_plugin/api.py
+++ b/plugins/compliance_plugin/api.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 from flask import Blueprint, request, jsonify
-from error_handling import ErrorCategory, ErrorHandler
-from yosai_framework.errors import CODE_TO_STATUS
-from shared.errors.types import ErrorCode
+from error_handling import ErrorCategory, ErrorHandler, api_error_response
 from flask_apispec import doc
 
 logger = logging.getLogger(__name__)
@@ -53,8 +51,7 @@ class ComplianceAPI:
                 }), 200
             except Exception as e:
                 logger.error(f"Health check failed: {e}")
-                err = self.handler.handle(e, ErrorCategory.INTERNAL)
-                return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
+                return api_error_response(e, ErrorCategory.INTERNAL, handler=self.handler)
         
         @self.blueprint.route('/consent', methods=['POST'])
         @doc(tags=['compliance'], responses={200: 'Success', 400: 'Bad Request', 503: 'Service Unavailable', 500: 'Server Error'})
@@ -78,8 +75,7 @@ class ComplianceAPI:
 
             except Exception as e:
                 logger.error(f"Error granting consent: {e}")
-                err = self.handler.handle(e, ErrorCategory.INTERNAL)
-                return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.INTERNAL]
+                return api_error_response(e, ErrorCategory.INTERNAL, handler=self.handler)
     
     def register_routes(self, app) -> bool:
         """

--- a/tests/test_api_error_response.py
+++ b/tests/test_api_error_response.py
@@ -1,0 +1,13 @@
+import pytest
+from flask import Flask
+
+from error_handling import api_error_response, ErrorCategory
+
+
+def test_api_error_response_generates_json_and_status():
+    app = Flask(__name__)
+    with app.app_context():
+        resp, status = api_error_response(ValueError("bad"), ErrorCategory.INVALID_INPUT)
+        assert status == 400
+        assert resp.get_json() == {"code": "invalid_input", "message": "bad"}
+

--- a/token_endpoint.py
+++ b/token_endpoint.py
@@ -1,7 +1,5 @@
 from flask import Blueprint, jsonify
-from error_handling import ErrorCategory, ErrorHandler
-from yosai_framework.errors import CODE_TO_STATUS
-from shared.errors.types import ErrorCode
+from error_handling import ErrorCategory, ErrorHandler, api_error_response
 from pydantic import BaseModel
 from utils.pydantic_decorators import validate_input, validate_output
 from services.security import refresh_access_token
@@ -27,8 +25,9 @@ class AccessTokenResponse(BaseModel):
 def refresh_token_endpoint(payload: RefreshRequest):
     new_token = refresh_access_token(payload.refresh_token)
     if not new_token:
-        err = handler.handle(
-            PermissionError("invalid refresh token"), ErrorCategory.UNAUTHORIZED
+        return api_error_response(
+            PermissionError("invalid refresh token"),
+            ErrorCategory.UNAUTHORIZED,
+            handler=handler,
         )
-        return jsonify(err.to_dict()), CODE_TO_STATUS[ErrorCode.UNAUTHORIZED]
     return {"access_token": new_token}


### PR DESCRIPTION
## Summary
- centralize API error formatting via `api_error_response`
- refactor endpoints to use the new helper
- document error responses in OpenAPI spec
- test new helper

## Testing
- `pytest tests/test_api_error_response.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889bf27e2908320bde6e6611e417467