### PR TITLE
Refactor repeated config getters

### DIFF
--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import logging
 import os
 from typing import Any, Dict
+
+from utils.config_resolvers import resolve_max_upload_size_mb
 
 from .app_config import UploadConfig
 from .base_loader import BaseConfigLoader
@@ -15,11 +19,8 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
-from utils.config_resolvers import (
-    resolve_ai_confidence_threshold,
-    resolve_max_upload_size_mb,
-    resolve_upload_chunk_size,
-)
+from .utils import get_ai_confidence_threshold as _get_ai_confidence_threshold
+from .utils import get_upload_chunk_size as _get_upload_chunk_size
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +262,7 @@ class DynamicConfigManager(BaseConfigLoader):
         }
 
     def get_ai_confidence_threshold(self) -> int:
-        return resolve_ai_confidence_threshold(self)
+        return _get_ai_confidence_threshold(self)
 
     def get_max_upload_size_mb(self) -> int:
         """Get maximum upload size in MB."""
@@ -276,7 +277,7 @@ class DynamicConfigManager(BaseConfigLoader):
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        return resolve_upload_chunk_size(self)
+        return _get_upload_chunk_size(self)
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)

--- a/config/utils.py
+++ b/config/utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Shared configuration helper functions."""
+
+from typing import Any
+
+from utils.config_resolvers import (
+    resolve_ai_confidence_threshold,
+    resolve_upload_chunk_size,
+)
+
+
+def get_ai_confidence_threshold(cfg: Any | None = None) -> float:
+    """Return the AI confidence threshold for *cfg* or the global config."""
+    if cfg is None:
+        from config.dynamic_config import dynamic_config
+
+        cfg = dynamic_config
+    return resolve_ai_confidence_threshold(cfg)
+
+
+def get_upload_chunk_size(cfg: Any | None = None) -> int:
+    """Return the upload chunk size for *cfg* or the global config."""
+    if cfg is None:
+        from config.dynamic_config import dynamic_config
+
+        cfg = dynamic_config
+    return resolve_upload_chunk_size(cfg)
+
+
+__all__ = ["get_ai_confidence_threshold", "get_upload_chunk_size"]

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+stub_utils = ModuleType("utils")
+stub_utils.__path__ = []
+
+stub_core = ModuleType("core.config")
+stub_core.get_ai_confidence_threshold = lambda: 0.75
+stub_core.get_max_upload_size_mb = lambda: 10
+stub_core.get_upload_chunk_size = lambda: 128
+stub_core_pkg = ModuleType("core")
+stub_core_pkg.__path__ = []
+stub_core_pkg.config = stub_core
+sys.modules["core"] = stub_core_pkg
+sys.modules["core.config"] = stub_core
+
+stub_config_pkg = ModuleType("config")
+stub_config_pkg.__path__ = []
+sys.modules["config"] = stub_config_pkg
+
+spec_resolvers = importlib.util.spec_from_file_location(
+    "utils.config_resolvers",
+    Path(__file__).resolve().parents[1] / "utils" / "config_resolvers.py",
+)
+config_resolvers = importlib.util.module_from_spec(spec_resolvers)
+spec_resolvers.loader.exec_module(config_resolvers)
+stub_utils.config_resolvers = config_resolvers
+sys.modules["utils"] = stub_utils
+sys.modules["utils.config_resolvers"] = config_resolvers
+
+spec_utils = importlib.util.spec_from_file_location(
+    "config.utils", Path(__file__).resolve().parents[1] / "config" / "utils.py"
+)
+config_utils = importlib.util.module_from_spec(spec_utils)
+spec_utils.loader.exec_module(config_utils)
+
+
+def test_get_ai_confidence_threshold_from_cfg():
+    cfg = SimpleNamespace(ai_threshold=0.55)
+    assert config_utils.get_ai_confidence_threshold(cfg) == 0.55
+
+
+def test_get_upload_chunk_size_from_cfg():
+    cfg = SimpleNamespace(chunk_size=256)
+    assert config_utils.get_upload_chunk_size(cfg) == 256


### PR DESCRIPTION
## Summary
- add helper functions for common config getters
- use helpers in `dynamic_config`
- test utility functions

## Testing
- `pre-commit run --files config/utils.py config/dynamic_config.py tests/test_config_utils.py`
- `pytest tests/test_config_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c7774094832087cdb69057213c9e