### PR TITLE
Remove default SECRET_KEY in debug tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,9 +769,9 @@ defined in `gunicorn.conf.py`.
 
 
 The secret key is not included in the default YAML files. **You must**
-set `SECRET_KEY` in your environment or a `.env` file before starting
-the application. The API now raises a `RuntimeError` if the variable is
-missing.
+provide `SECRET_KEY` via an environment variable, Docker secret or your
+secret manager (e.g. Vault) before starting the application. The API
+raises a `RuntimeError` if the variable is missing.
 
 When `YOSAI_ENV=production` the application will refuse to start unless both
 `DB_PASSWORD` and `SECRET_KEY` are provided via environment variables or Docker

--- a/docs/debug_helpers.md
+++ b/docs/debug_helpers.md
@@ -14,4 +14,8 @@ removed. Use the following tools for diagnostics:
 - Run `python -m tools.debug` for a unified CLI covering asset and callback diagnostics.
 - The old `debug_cache_error.py` and `debug_mde.py` helpers have been removed.
 
+These helpers use your configured environment for secrets. Set `SECRET_KEY` in
+your shell or secret manager before running them. The utilities no longer
+inject a default value.
+
 Test stubs under `tests/utils/` and `tests/stubs/utils/` also provide simplified assets for debugging in the test suite.

--- a/tools/debug/assets.py
+++ b/tools/debug/assets.py
@@ -8,6 +8,7 @@ from typing import Iterable
 from core.app_factory import create_app
 from utils.assets_debug import check_navbar_assets, debug_dash_asset_serving
 from utils.assets_utils import get_nav_icon
+from core.env_validation import validate_env
 
 DEFAULT_ICONS = [
     "analytics",
@@ -25,7 +26,7 @@ def debug_navbar_icons(icon_names: Iterable[str] | None = None) -> None:
     icons = list(icon_names or DEFAULT_ICONS)
 
     os.environ.setdefault("YOSAI_ENV", "development")
-    os.environ.setdefault("SECRET_KEY", "debug")
+    validate_env(["SECRET_KEY"])
 
     app = create_app(mode="simple")
     results = check_navbar_assets(icons, warn=False)


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY in tools/debug/assets.py rather than defaulting to 'debug'
- document providing secrets for debug helpers
- note SECRET_KEY should come from env, Docker secrets or Vault

## Testing
- `pip install -r requirements-test.txt` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `pytest -k secret_manager --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `python start_api.py` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.models')*

------
https://chatgpt.com/codex/tasks/task_e_6889c77869d88320ba29c181586b7189