### PR TITLE
Harden SQL usage and add injection tests

### DIFF
--- a/docs/security_guidelines.md
+++ b/docs/security_guidelines.md
@@ -1,0 +1,8 @@
+# Security Guidelines
+
+## Safe Database Queries
+
+- Use parameterized queries whenever inserting values into SQL statements.
+- For asyncpg, prefer `$1`, `$2`, etc. placeholders or SQLAlchemy bind parameters.
+- Avoid formatting user input directly into query strings.
+- Quote identifiers like table names using `asyncpg.utils._quote_ident` when dynamic.

--- a/services/migration/strategies/analytics_migration.py
+++ b/services/migration/strategies/analytics_migration.py
@@ -21,7 +21,9 @@ class AnalyticsMigration(MigrationStrategy):
         assert self.target_pool is not None
         while True:
             rows: List[asyncpg.Record] = await source_pool.fetch(
-                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+                f"SELECT * FROM {self.TABLE} OFFSET $1 LIMIT $2",
+                start,
+                self.CHUNK_SIZE,
             )
             if not rows:
                 break

--- a/services/migration/strategies/events_migration.py
+++ b/services/migration/strategies/events_migration.py
@@ -21,7 +21,9 @@ class EventsMigration(MigrationStrategy):
         assert self.target_pool is not None
         while True:
             rows: List[asyncpg.Record] = await source_pool.fetch(
-                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+                f"SELECT * FROM {self.TABLE} OFFSET $1 LIMIT $2",
+                start,
+                self.CHUNK_SIZE,
             )
             if not rows:
                 break

--- a/services/migration/strategies/gateway_migration.py
+++ b/services/migration/strategies/gateway_migration.py
@@ -21,7 +21,9 @@ class GatewayMigration(MigrationStrategy):
         assert self.target_pool is not None
         while True:
             rows: List[asyncpg.Record] = await source_pool.fetch(
-                f"SELECT * FROM {self.TABLE} OFFSET {start} LIMIT {self.CHUNK_SIZE}"
+                f"SELECT * FROM {self.TABLE} OFFSET $1 LIMIT $2",
+                start,
+                self.CHUNK_SIZE,
             )
             if not rows:
                 break

--- a/services/migration/validators/integrity_checker.py
+++ b/services/migration/validators/integrity_checker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncpg
+from asyncpg.utils import _quote_ident
 
 
 class IntegrityChecker:
@@ -9,8 +10,10 @@ class IntegrityChecker:
     async def rowcount_equal(
         self, source: asyncpg.Pool, target: asyncpg.Pool, table: str
     ) -> bool:
-        src = await source.fetchval(f"SELECT COUNT(*) FROM {table}")
-        tgt = await target.fetchval(f"SELECT COUNT(*) FROM {table}")
+        safe_table = _quote_ident(table)
+        query = f"SELECT COUNT(*) FROM {safe_table}"
+        src = await source.fetchval(query)
+        tgt = await target.fetchval(query)
         return src == tgt
 
 

--- a/services/optimized_queries.py
+++ b/services/optimized_queries.py
@@ -40,7 +40,9 @@ class OptimizedQueryService:
         try:
             rows = execute_secure_query(self.db, query, params)
         except Exception:  # Fallback for databases without ANY()
-            placeholders = ",".join(["%s"] * len(user_ids))
+            placeholders = ", ".join(
+                f"${i + 1}" for i in range(len(user_ids))
+            )
             query = f"SELECT * FROM people WHERE person_id IN ({placeholders})"
             params = tuple(user_ids)
             rows = execute_secure_query(self.db, query, params)

--- a/services/timescale/manager.py
+++ b/services/timescale/manager.py
@@ -119,12 +119,12 @@ class TimescaleDBManager:
         compression_days = int(os.getenv("TIMESCALE_COMPRESSION_DAYS", "30"))
         retention_days = int(os.getenv("TIMESCALE_RETENTION_DAYS", "365"))
         await conn.execute(
-            "SELECT add_compression_policy('access_events',"
-            f" INTERVAL '{compression_days} days', if_not_exists => TRUE)"
+            "SELECT add_compression_policy('access_events', INTERVAL $1 || ' days', if_not_exists => TRUE)",
+            compression_days,
         )
         await conn.execute(
-            "SELECT add_retention_policy('access_events',"
-            f" INTERVAL '{retention_days} days', if_not_exists => TRUE)"
+            "SELECT add_retention_policy('access_events', INTERVAL $1 || ' days', if_not_exists => TRUE)",
+            retention_days,
         )
 
     # ------------------------------------------------------------------

--- a/services/timescale/models.py
+++ b/services/timescale/models.py
@@ -88,15 +88,13 @@ def apply_policies(conn: Connection, table: str = "access_events") -> None:
     )
     conn.execute(
         text(
-            f"SELECT add_compression_policy('{table}', INTERVAL '{hot}', "
-            "if_not_exists => TRUE)"
-        )
+            "SELECT add_compression_policy(:table, INTERVAL :hot, if_not_exists => TRUE)"
+        ).bindparams(table=table, hot=hot)
     )
     conn.execute(
         text(
-            f"SELECT add_retention_policy('{table}', INTERVAL '{retention}', "
-            "if_not_exists => TRUE)"
-        )
+            "SELECT add_retention_policy(:table, INTERVAL :retention, if_not_exists => TRUE)"
+        ).bindparams(table=table, retention=retention)
     )
 
 

--- a/tests/database/test_sql_injection.py
+++ b/tests/database/test_sql_injection.py
@@ -1,0 +1,42 @@
+import pytest
+from services.optimized_queries import OptimizedQueryService
+from services.migration.validators.integrity_checker import IntegrityChecker
+
+
+class RecordingConn:
+    def __init__(self):
+        self.last_query = None
+        self.last_params = None
+
+    def execute_query(self, query, params=None):
+        self.last_query = query
+        self.last_params = params
+        return []
+
+
+class RecordingPool:
+    def __init__(self):
+        self.last_query = None
+
+    async def fetchval(self, query, *params):
+        self.last_query = query
+        return 0
+
+
+def test_batch_get_users_injection():
+    conn = RecordingConn()
+    service = OptimizedQueryService(conn)
+    malicious = "1; DROP TABLE people;"
+    service.batch_get_users([malicious])
+    assert malicious in conn.last_params[0]
+    assert malicious not in conn.last_query
+
+
+@pytest.mark.asyncio
+async def test_rowcount_equal_injection():
+    pool = RecordingPool()
+    checker = IntegrityChecker()
+    malicious = "danger; DROP TABLE x;"
+    await checker.rowcount_equal(pool, pool, malicious)
+    assert malicious in pool.last_query
+    assert pool.last_query.startswith("SELECT COUNT(*) FROM \"")


### PR DESCRIPTION
## Summary
- sanitize table name in integrity checker
- parameterize fetch queries in migration strategies
- drop f-string interpolation for optimized queries
- parameterize retention policies in TimescaleDB manager
- document safe DB query patterns
- test SQL injection handling

## Testing
- `pytest tests/database/test_sql_injection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c779ff8c83209e238b6665263cfd