### PR TITLE
Update callbacks registration example

### DIFF
--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -14,6 +14,10 @@ from core.callback_events import CallbackEvent
 
 callbacks = TrulyUnifiedCallbacks(app)
 
+``callbacks`` should be created once during application startup and
+shared with all modules and plugins for registration. Avoid instantiating
+``TrulyUnifiedCallbacks`` in individual modules.
+
 @callbacks.callback(Output('output', 'children'), Input('btn', 'n_clicks'))
 def handle_click(n):
     return f"Clicked {n} times"

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -73,7 +73,12 @@ You can change the search location by passing a different package name to `Plugi
        def register_callbacks(self, manager, container) -> bool:
            svc: GreetingService = container.get("greeting_service")
 
-           @manager.app.callback(Output("greet-output", "children"), Input("name-input", "value"))
+           @manager.unified_callback(
+               Output("greet-output", "children"),
+               Input("name-input", "value"),
+               callback_id="example_greet",
+               component_name="example_plugin",
+           )
            def _greet(name):
                if not name:
                    raise PreventUpdate

--- a/plugins/example/plugin.py
+++ b/plugins/example/plugin.py
@@ -59,8 +59,11 @@ class ExamplePlugin(CallbackPluginProtocol):
         """Example callback using the registered service."""
         svc: GreetingService = container.get("greeting_service")
 
-        @manager.app.callback(
-            Output("greet-output", "children"), Input("name-input", "value")
+        @manager.unified_callback(
+            Output("greet-output", "children"),
+            Input("name-input", "value"),
+            callback_id="example_greet",
+            component_name="example_plugin",
         )
         def _greet(name: str | None) -> str:
             if not name:


### PR DESCRIPTION
## Summary
- use `TrulyUnifiedCallbacks.unified_callback` in example plugin
- explain single global callback instance in architecture docs
- update plugin docs with new registration pattern

## Testing
- `pre-commit run --files plugins/example/plugin.py docs/callback_architecture.md docs/plugins.md` *(with mypy and bandit skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6889c77cc68c8320be1b8b9979f30dfa