### PR TITLE
Add database tests

### DIFF
--- a/tests/database/test_database_manager_retry.py
+++ b/tests/database/test_database_manager_retry.py
@@ -1,0 +1,145 @@
+import sys
+import types
+import dataclasses
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def load_database_manager():
+    """Import config.database_manager with stubbed dependencies."""
+    if 'core.unicode' not in sys.modules:
+        unicode_mod = types.ModuleType('core.unicode')
+        class UnicodeSQLProcessor:
+            @staticmethod
+            def encode_query(query):
+                return str(query)
+        unicode_mod.UnicodeSQLProcessor = UnicodeSQLProcessor
+        sys.modules['core.unicode'] = unicode_mod
+
+    pkg = types.ModuleType('config')
+    pkg.__path__ = []
+    sys.modules['config'] = pkg
+
+    sys.modules['config.dynamic_config'] = types.ModuleType('config.dynamic_config')
+    sys.modules['config.dynamic_config'].dynamic_config = types.SimpleNamespace(
+        get_db_connection_timeout=lambda: 1,
+        get_db_pool_size=lambda: 1,
+    )
+
+    @dataclasses.dataclass
+    class DatabaseSettings:
+        type: str = 'mock'
+        host: str = 'localhost'
+        port: int = 5432
+        name: str = 'db'
+        user: str = 'user'
+        password: str = ''
+        connection_timeout: int = 1
+        initial_pool_size: int = 1
+        max_pool_size: int = 1
+        shrink_timeout: int = 0
+
+    schema_mod = types.ModuleType('config.schema')
+    schema_mod.DatabaseSettings = DatabaseSettings
+    sys.modules['config.schema'] = schema_mod
+
+    ex_mod = types.ModuleType('config.database_exceptions')
+    class ConnectionRetryExhausted(Exception):
+        pass
+    class ConnectionValidationFailed(Exception):
+        pass
+    class DatabaseError(Exception):
+        pass
+    ex_mod.ConnectionRetryExhausted = ConnectionRetryExhausted
+    ex_mod.ConnectionValidationFailed = ConnectionValidationFailed
+    ex_mod.DatabaseError = DatabaseError
+    sys.modules['config.database_exceptions'] = ex_mod
+
+    prot_mod = types.ModuleType('config.protocols')
+    class RetryConfigProtocol: ...
+    class ConnectionRetryManagerProtocol: ...
+    prot_mod.RetryConfigProtocol = RetryConfigProtocol
+    prot_mod.ConnectionRetryManagerProtocol = ConnectionRetryManagerProtocol
+    sys.modules['config.protocols'] = prot_mod
+
+    retry_path = Path(__file__).resolve().parents[2] / 'config' / 'connection_retry.py'
+    spec = importlib.util.spec_from_file_location('config.connection_retry', retry_path)
+    conn_retry_mod = importlib.util.module_from_spec(spec)
+    sys.modules['config.connection_retry'] = conn_retry_mod
+    spec.loader.exec_module(conn_retry_mod)
+
+    dm_path = Path(__file__).resolve().parents[2] / 'config' / 'database_manager.py'
+    spec = importlib.util.spec_from_file_location('config.database_manager', dm_path)
+    dbm = importlib.util.module_from_spec(spec)
+    sys.modules['config.database_manager'] = dbm
+    spec.loader.exec_module(dbm)
+    return dbm
+
+
+def make_manager(conn, attempts=3):
+    dbm = load_database_manager()
+    retry_mod = sys.modules['config.connection_retry']
+    cfg = dbm.DatabaseSettings()
+    manager = dbm.EnhancedPostgreSQLManager(cfg)
+    manager.pool = types.SimpleNamespace(get_connection=lambda: conn, release_connection=lambda c: None)
+    manager.retry_manager = retry_mod.ConnectionRetryManager(
+        retry_mod.RetryConfig(max_attempts=attempts, base_delay=0, jitter=False)
+    )
+    return manager, dbm
+
+
+class FailingConnection:
+    def __init__(self, query_failures=0, health_failures=0):
+        self.query_failures = query_failures
+        self.health_failures = health_failures
+        self.query_calls = 0
+        self.health_calls = 0
+
+    def execute_query(self, query, params=None):
+        self.query_calls += 1
+        if self.query_calls <= self.query_failures:
+            raise RuntimeError('boom')
+        return [{'ok': True}]
+
+    def execute_command(self, cmd, params=None):
+        pass
+
+    def health_check(self):
+        self.health_calls += 1
+        return self.health_calls > self.health_failures
+
+    def close(self):
+        pass
+
+
+def test_execute_query_retries_until_success():
+    conn = FailingConnection(query_failures=2)
+    manager, dbm = make_manager(conn, attempts=3)
+    result = manager.execute_query_with_retry('SELECT 1')
+    assert result == [{'ok': True}]
+    assert conn.query_calls == 3
+
+
+def test_execute_query_retry_exhausted():
+    conn = FailingConnection(query_failures=3)
+    manager, dbm = make_manager(conn, attempts=2)
+    exc = sys.modules['config.database_exceptions'].ConnectionRetryExhausted
+    with pytest.raises(exc):
+        manager.execute_query_with_retry('SELECT 1')
+
+
+def test_health_check_retries_until_success():
+    conn = FailingConnection(health_failures=1)
+    manager, _ = make_manager(conn, attempts=3)
+    assert manager.health_check_with_retry() is True
+    assert conn.health_calls == 2
+
+
+def test_health_check_retry_exhausted():
+    conn = FailingConnection(health_failures=5)
+    manager, dbm = make_manager(conn, attempts=2)
+    exc = sys.modules['config.database_exceptions'].ConnectionRetryExhausted
+    with pytest.raises(exc):
+        manager.health_check_with_retry()

--- a/tests/database/test_database_service_error.py
+++ b/tests/database/test_database_service_error.py
@@ -1,0 +1,173 @@
+import sys
+import types
+import dataclasses
+import importlib.util
+from pathlib import Path
+
+
+def stub_config_and_core():
+    pkg = types.ModuleType('config')
+    pkg.__path__ = []
+    sys.modules['config'] = pkg
+    sys.modules['config.dynamic_config'] = types.ModuleType('config.dynamic_config')
+    sys.modules['config.dynamic_config'].dynamic_config = types.SimpleNamespace(
+        get_db_connection_timeout=lambda: 1,
+        get_db_pool_size=lambda: 1,
+    )
+    @dataclasses.dataclass
+    class DatabaseSettings:
+        type: str = 'mock'
+        host: str = 'localhost'
+        port: int = 0
+        name: str = 'db'
+        user: str = 'user'
+        password: str = ''
+        connection_timeout: int = 1
+    pkg.DatabaseSettings = DatabaseSettings
+
+    cache_mod = types.ModuleType('core.cache_manager')
+    class InMemoryCacheManager:
+        def __init__(self, config=None):
+            self.store = {}
+        async def start(self):
+            pass
+        async def stop(self):
+            self.store.clear()
+        async def get(self, key):
+            return self.store.get(key)
+        async def set(self, key, value, ttl=None):
+            self.store[key] = value
+        async def delete(self, key):
+            return self.store.pop(key, None) is not None
+        async def clear(self):
+            self.store.clear()
+        def get_lock(self, key, timeout=10):
+            class _Lock:
+                async def __aenter__(self):
+                    pass
+                async def __aexit__(self, exc_type, exc, tb):
+                    pass
+            return _Lock()
+    class CacheConfig:
+        pass
+    def cache_with_lock(manager, ttl=None, key_func=None, name=None):
+        def decorator(func):
+            cache = {}
+            def wrapper(*args, **kwargs):
+                key = key_func(*args, **kwargs) if key_func else 'k'
+                if key in cache:
+                    return cache[key]
+                result = func(*args, **kwargs)
+                cache[key] = result
+                return result
+            return wrapper
+        return decorator
+    cache_mod.InMemoryCacheManager = InMemoryCacheManager
+    cache_mod.CacheConfig = CacheConfig
+    cache_mod.cache_with_lock = cache_with_lock
+    sys.modules['core.cache_manager'] = cache_mod
+
+
+stub_config_and_core()
+
+from services.database_retriever import DatabaseAnalyticsRetriever
+from services.db_analytics_helper import DatabaseAnalyticsHelper
+
+module_path = Path(__file__).resolve().parents[2] / 'services' / 'database_analytics_service.py'
+spec = importlib.util.spec_from_file_location('services.database_analytics_service', module_path)
+db_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(db_module)
+DatabaseAnalyticsService = db_module.DatabaseAnalyticsService
+
+
+class ErrorManager:
+    def get_connection(self):
+        raise RuntimeError('fail')
+
+    def release_connection(self, conn):
+        pass
+
+
+class BadQueryConnection:
+    def execute_query(self, query, params=None):
+        raise RuntimeError('bad query')
+
+    def execute_command(self, cmd, params=None):
+        pass
+
+    def health_check(self):
+        return True
+
+    def close(self):
+        pass
+
+
+class SimpleManager:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def get_connection(self):
+        return self._conn
+
+    def release_connection(self, conn):
+        pass
+
+
+def test_service_returns_error_when_connection_fails():
+    service = DatabaseAnalyticsService(ErrorManager())
+    result = service.get_analytics()
+    assert result['status'] == 'error'
+
+
+def test_service_returns_error_on_query_failure():
+    service = DatabaseAnalyticsService(SimpleManager(BadQueryConnection()))
+    result = service.get_analytics()
+    assert result['status'] == 'error'
+
+
+def test_retriever_caches_results():
+    class Helper(DatabaseAnalyticsHelper):
+        def __init__(self):
+            self.calls = 0
+        def get_analytics(self):
+            self.calls += 1
+            return {'value': self.calls}
+
+    helper = Helper()
+    retriever = DatabaseAnalyticsRetriever(helper)
+    first = retriever.get_analytics()
+    second = retriever.get_analytics()
+    assert first == second
+    assert helper.calls == 1
+
+
+def test_service_success_with_sqlite(tmp_path):
+    db_file = tmp_path / 'test.db'
+    @dataclasses.dataclass
+    class DS:
+        type: str = 'sqlite'
+        host: str = 'localhost'
+        port: int = 0
+        name: str = str(db_file)
+        user: str = ''
+        password: str = ''
+        connection_timeout: int = 1
+        initial_pool_size: int = 1
+        max_pool_size: int = 1
+        shrink_timeout: int = 0
+
+    dm_path = Path(__file__).resolve().parents[2] / 'config' / 'database_manager.py'
+    spec = importlib.util.spec_from_file_location('config.database_manager', dm_path)
+    dm_mod = importlib.util.module_from_spec(spec)
+    sys.modules['config.database_manager'] = dm_mod
+    spec.loader.exec_module(dm_mod)
+    conn = dm_mod.SQLiteConnection(DS())
+    conn.execute_command('CREATE TABLE access_events(event_type TEXT, status TEXT, timestamp TEXT, location TEXT)')
+    conn.execute_command('INSERT INTO access_events(event_type, status, timestamp, location) VALUES("access","success","2021-01-01","A")')
+    class Manager(SimpleManager):
+        pass
+    manager = Manager(conn)
+    service = DatabaseAnalyticsService(manager)
+    result = service.get_analytics()
+    assert result['status'] == 'success'
+    conn.close()


### PR DESCRIPTION
## Summary
- add retry tests for EnhancedPostgreSQLManager
- add DatabaseAnalyticsService error handling and caching tests

## Testing
- `pytest tests/database/test_database_manager_retry.py tests/database/test_database_service_error.py -q --cov=config.database_manager --cov=services.database_analytics_service --cov=services.database_retriever --cov=services.db_analytics_helper --cov=services.base_database_service --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6889c77f2f08832080ac70c484e9cdc6