### PR TITLE
Set up ESLint for JS and TS

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,31 @@
 export default [
   {
+    files: ["**/*.{js,jsx}"],
+    ignores: ["node_modules/**"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    plugins: {
+      prettier: (await import("eslint-plugin-prettier")).default,
+      react: (await import("eslint-plugin-react")).default,
+    },
+    rules: {
+      "prettier/prettier": "error",
+      "react/no-danger": "error",
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
+  {
     files: ["**/*.{ts,tsx}"],
     ignores: ["node_modules/**"],
     languageOptions: {
@@ -13,8 +39,7 @@ export default [
       },
     },
     plugins: {
-      "@typescript-eslint": (await import("@typescript-eslint/eslint-plugin"))
-        .default,
+      "@typescript-eslint": (await import("@typescript-eslint/eslint-plugin")).default,
       prettier: (await import("eslint-plugin-prettier")).default,
       react: (await import("eslint-plugin-react")).default,
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "build-css": "sh scripts/build_css.sh",
-    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:a11y": "pa11y http://localhost:8050",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",


### PR DESCRIPTION
## Summary
- install ESLint plugins
- support JS/TS linting via eslint.config.js
- update `lint` script

## Testing
- `npm run lint` *(fails: 1225 errors due to prettier rules)*

------
https://chatgpt.com/codex/tasks/task_e_6889d707a5848320a92eefea3042ad8e