### PR TITLE
Remove legacy migrator reference

### DIFF
--- a/core/performance.py
+++ b/core/performance.py
@@ -11,7 +11,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING
 
 import pandas as pd
 import psutil

--- a/docs/migration_callback_system.md
+++ b/docs/migration_callback_system.md
@@ -24,19 +24,12 @@ on `TrulyUnifiedCallbacks`,
 All modules must migrate to this API before upgrading. The legacy wrappers are
 no longer shipped with the project.
 
-## Cleanup Utility Example
+## Cleaning Up Old Imports
 
-The repository provides `legacy_callback_migrator.py` which rewrites any
-remaining references to `callback_controller` and verifies that the unified
-callback system works correctly. Run it from the project root:
-
-```bash
-python legacy_callback_migrator.py --dry-run
-```
-
-Omit `--dry-run` to apply the changes. The script scans for deprecated imports,
-adds the required `TrulyUnifiedCallbacks` import if missing and performs a
-simple runtime validation of the new system.
+Search the codebase for `callback_controller` and update any remaining
+references to use the unified API. Make sure to import `TrulyUnifiedCallbacks`
+where required and remove any deprecated wrappers. Running the tests after
+each change helps ensure the callbacks behave as expected.
 
 ## Best Practices for Migration
 
@@ -50,5 +43,5 @@ simple runtime validation of the new system.
 - **Enable Unicode safety** with `unicode_safe=True` or by using
   `UnicodeAwareTrulyUnifiedCallbacks`. Surrogate pairs and non‑printable
   characters are sanitized automatically to avoid UTF‑8 errors.
-- **Remove legacy imports** after migration and verify that tests pass. The
-  `legacy_callback_migrator.py` script can assist with large refactors.
+- **Remove legacy imports** after migration and verify that tests pass. Use a
+  search-and-replace workflow to update modules in bulk when refactoring.

--- a/scripts/generate_fastapi_openapi.py
+++ b/scripts/generate_fastapi_openapi.py
@@ -47,8 +47,27 @@ def _stub_analytics_deps() -> None:
         max_pool_size = 1
         connection_timeout = 1
 
+    class DatabaseSettings:
+        def __init__(self):
+            self.initial_pool_size = 1
+            self.max_pool_size = 1
+            self.connection_timeout = 1
+
+        def get_connection_string(self) -> str:  # pragma: no cover - stub
+            return "postgresql://"
+
     config_stub.get_database_config = lambda: _Cfg()
+    dynamic_config_stub = types.ModuleType("config.dynamic_config")
+    dynamic_config_stub.get_db_pool_size = lambda: 1
+    dynamic_config_stub.get_db_connection_timeout = lambda: 1
+    dynamic_config_stub.dynamic_config = types.SimpleNamespace(
+        get_db_pool_size=lambda: 1,
+        get_db_connection_timeout=lambda: 1,
+    )
+    config_stub.dynamic_config = dynamic_config_stub.dynamic_config
+    config_stub.DatabaseSettings = DatabaseSettings
     sys.modules["config"] = config_stub
+    sys.modules["config.dynamic_config"] = dynamic_config_stub
 
     validate_stub = types.ModuleType("config.validate")
     validate_stub.validate_required_env = lambda vars: None
@@ -123,6 +142,7 @@ def _stub_ingestion_deps() -> None:
 
     tracing_stub = types.ModuleType("tracing")
     tracing_stub.trace_async_operation = lambda *a, **k: a[2] if len(a) > 2 else None
+    tracing_stub.propagate_context = lambda headers: None
     sys.modules["tracing"] = tracing_stub
 
 

--- a/yosai_intel_dashboard/__init__.py
+++ b/yosai_intel_dashboard/__init__.py
@@ -1,0 +1,9 @@
+import sys
+import types
+
+# Provide backward compatibility for old import paths
+import models as _models
+sys.modules.setdefault(__name__ + '.models', _models)
+
+import src as _src
+sys.modules.setdefault(__name__ + '.src', _src)


### PR DESCRIPTION
## Summary
- update callback migration docs and drop legacy script reference
- provide backward-compatibility package for old `yosai_intel_dashboard` imports
- relax FastAPI OpenAPI generator stubs for docs build
- fix missing `TYPE_CHECKING` import in performance module

## Testing
- `make docs` *(fails: ModuleNotFoundError: No module named 'config.base'; 'config' is not a package)*
- `make lint-docs` *(fails: No rule to make target 'lint-docs')*

------
https://chatgpt.com/codex/tasks/task_e_6889dfb4ad4c8320a432f8655189954f