### PR TITLE
Deduplicate config helpers

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -6,17 +6,21 @@ from typing import Any
 
 from config.config import get_analytics_config
 from config.dynamic_config import dynamic_config
+from config.utils import (
+    get_ai_confidence_threshold as _get_ai_confidence_threshold,
+    get_upload_chunk_size as _get_upload_chunk_size,
+)
 from core.protocols import ConfigurationProtocol
 
 
 def get_ai_confidence_threshold() -> float:
     """Return the AI confidence threshold from the dynamic configuration."""
-    return dynamic_config.get_ai_confidence_threshold()
+    return _get_ai_confidence_threshold(dynamic_config)
 
 
 def get_upload_chunk_size() -> int:
     """Return the upload chunk size from the dynamic configuration."""
-    return dynamic_config.get_upload_chunk_size()
+    return _get_upload_chunk_size(dynamic_config)
 
 
 def get_max_parallel_uploads() -> int:

--- a/services/configuration_service.py
+++ b/services/configuration_service.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from config.dynamic_config import DynamicConfigManager, dynamic_config
+from config.utils import (
+    get_ai_confidence_threshold as _get_ai_confidence_threshold,
+    get_upload_chunk_size as _get_upload_chunk_size,
+)
 from core.protocols import ConfigurationServiceProtocol
 
 
@@ -23,7 +27,7 @@ class DynamicConfigurationService(ConfigurationServiceProtocol):
         return self._cfg.validate_large_file_support()
 
     def get_upload_chunk_size(self) -> int:
-        return self._cfg.get_upload_chunk_size()
+        return _get_upload_chunk_size(self._cfg)
 
     def get_max_parallel_uploads(self) -> int:
         return self._cfg.get_max_parallel_uploads()
@@ -32,7 +36,7 @@ class DynamicConfigurationService(ConfigurationServiceProtocol):
         return self._cfg.get_validator_rules()
 
     def get_ai_confidence_threshold(self) -> int:
-        return self._cfg.get_ai_confidence_threshold()
+        return _get_ai_confidence_threshold(self._cfg)
 
     def get_db_pool_size(self) -> int:
         return self._cfg.get_db_pool_size()

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -72,7 +72,7 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        from core.config import get_upload_chunk_size
+        from config.utils import get_upload_chunk_size
 
         return get_upload_chunk_size()
 
@@ -87,7 +87,7 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):
         return get_validator_rules()
 
     def get_ai_confidence_threshold(self) -> int:
-        from core.config import get_ai_confidence_threshold
+        from config.utils import get_ai_confidence_threshold
 
         return get_ai_confidence_threshold()
 

--- a/tests/stubs/config/dynamic_config.py
+++ b/tests/stubs/config/dynamic_config.py
@@ -8,12 +8,8 @@ class Analytics:
     max_memory_mb = 1024
 
 
-from core.config import (
-    get_ai_confidence_threshold,
-    get_max_parallel_uploads,
-    get_upload_chunk_size,
-    get_validator_rules,
-)
+from config.utils import get_ai_confidence_threshold, get_upload_chunk_size
+from core.config import get_max_parallel_uploads, get_validator_rules
 
 
 class DynamicConfigManager:


### PR DESCRIPTION
## Summary
- import unified config helpers from `config.utils`
- use centralized helpers in configuration service and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.callback_events')*

------
https://chatgpt.com/codex/tasks/task_e_6889e1cd7dec83209ac153dbc3a8547a