### PR TITLE
Replace prints with logging

### DIFF
--- a/file_conversion/migrate_existing_files.py
+++ b/file_conversion/migrate_existing_files.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 from .storage_manager import StorageManager
 
@@ -12,13 +15,13 @@ def main() -> None:
     storage = StorageManager()
     pkl_file = Path("Demo3_data_copy.csv.pkl")
     success, message = storage.migrate_pkl_to_parquet(pkl_file)
-    print(message)
+    logger.info(message)
     if success:
         df, err = storage.load_dataframe(pkl_file.with_suffix("").name)
         if err:
-            print(f"Load error: {err}")
+            logger.error("Load error: %s", err)
         else:
-            print(df.head())
+            logger.info("%s", df.head())
 
 
 if __name__ == "__main__":

--- a/test_base_services.py
+++ b/test_base_services.py
@@ -16,35 +16,35 @@ def safe_str(obj):
 
 
 import sys
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).parent
 sys.path.insert(0, safe_str(PROJECT_ROOT))
 
 try:
-    print("🔍 Testing base code imports...")
+    logger.info("🔍 Testing base code imports...")
 
     from config.service_registration import register_upload_services
 
-    print("✅ Service registration imported")
+    logger.info("✅ Service registration imported")
 
     from core.service_container import ServiceContainer
 
-    print("✅ Service container imported")
+    logger.info("✅ Service container imported")
 
     container = ServiceContainer()
-    print("✅ Container created")
+    logger.info("✅ Container created")
 
     register_upload_services(container)
-    print("✅ Services registered")
+    logger.info("✅ Services registered")
 
     upload_service = container.get("upload_processor")
-    print(f"✅ Upload service: {type(upload_service)}")
+    logger.info("✅ Upload service: %s", type(upload_service))
 
-    print("🎉 All base code services loaded successfully!")
+    logger.info("🎉 All base code services loaded successfully!")
 
 except Exception as e:
-    print(f"❌ Base code error: {e}")
-    import traceback
-
-    traceback.print_exc()
+    logger.exception("❌ Base code error: %s", e)

--- a/tests/performance/scenarios/data_generator.py
+++ b/tests/performance/scenarios/data_generator.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import random
 import time
+import logging
 from pathlib import Path
 from typing import Dict, List
 
 import yaml
 
 from ..locust.utils import EVENT_TYPES, random_user_id
+
+logger = logging.getLogger(__name__)
 
 
 def load_pattern(path: str) -> Dict:
@@ -47,4 +50,4 @@ if __name__ == "__main__":
     data = generate_events(args.pattern, args.count)
     with args.output.open("w", encoding="utf-8") as fh:
         json.dump(data, fh)
-    print(f"Generated {args.count} events to {args.output}")
+    logger.info("Generated %d events to %s", args.count, args.output)

--- a/tests/performance/test_event_processing.py
+++ b/tests/performance/test_event_processing.py
@@ -1,7 +1,10 @@
 import random
 import time
 import uuid
+import logging
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 class PerformanceTestRunner:
@@ -28,7 +31,9 @@ class PerformanceTestRunner:
             self.process_event(event)
         end = time.perf_counter()
         total = end - start
-        print(f"Processed {self.num_events} events in {total:.2f} seconds")
+        logger.info(
+            "Processed %d events in %.2f seconds", self.num_events, total
+        )
         return total
 
 

--- a/tests/test_security_display_fix.py
+++ b/tests/test_security_display_fix.py
@@ -1,12 +1,15 @@
 import dash_bootstrap_components as dbc
 import pytest
+import logging
 
 from analytics.core.utils.results_display import create_analysis_results_display
 
 pytestmark = pytest.mark.usefixtures("fake_dbc")
 
+logger = logging.getLogger(__name__)
 
-def test_security_display_fix():
+
+def test_security_display_fix(caplog):
     """Test the security display with corrected data"""
     mock_results = {
         "total_events": 395852,
@@ -17,8 +20,13 @@ def test_security_display_fix():
         "security_score": {"score": 75.5, "threat_level": "medium"},
     }
 
-    display = create_analysis_results_display(mock_results, "security")
+    with caplog.at_level("INFO"):
+        display = create_analysis_results_display(mock_results, "security")
+        logger.info("✅ Header fix validated")
+        logger.info("✅ Statistics extraction validated")
+
     assert isinstance(display, dbc.Card)
     assert "Security Results" in str(display)
-    print("✅ Header fix validated")
-    print("✅ Statistics extraction validated")
+    messages = [r.getMessage() for r in caplog.records]
+    assert "✅ Header fix validated" in messages
+    assert "✅ Statistics extraction validated" in messages


### PR DESCRIPTION
## Summary
- use logging instead of print statements
- log success details when migrating files
- capture log output in security display test

## Testing
- `pip install -q -r requirements-test.txt`
- `PYTHONPATH=. pytest -q tests/test_security_display_fix.py` *(fails: ModuleNotFoundError: No module named 'analytics')*

------
https://chatgpt.com/codex/tasks/task_e_6889e1ce496c8320846b6559b44c0c68