### PR TITLE
Update layout test import

### DIFF
--- a/independent_tests/test_page_container_layout.py
+++ b/independent_tests/test_page_container_layout.py
@@ -1,25 +1,13 @@
 import re
+from importlib import import_module
 
 from dash import dcc, html, page_container
 
-# Dynamically load the _create_main_layout function without importing the whole module
-with open("core/app_factory/__init__.py") as f:
-    src = f.read()
-
-start_idx = src.find("def _create_main_layout")
-end_idx = src.find("def _create_navbar")
-func_code = src[start_idx:end_idx]
-
-namespace = {
-    "html": html,
-    "dcc": dcc,
-    "page_container": page_container,
-    "_create_navbar": lambda: html.Div("nav"),
-    "DEFAULT_THEME": "dark",
-}
-exec(func_code, namespace)
+# Import _create_main_layout directly from the app factory module
+layout_module = import_module("core.app_factory")
+create_main_layout = layout_module._create_main_layout
 
 
 def test_page_container_in_layout():
-    layout = namespace["_create_main_layout"]()
+    layout = create_main_layout()
     assert "page_container" in str(layout)


### PR DESCRIPTION
## Summary
- drop exec-based import in test
- load `_create_main_layout` using `importlib`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=tests/stubs:. pytest -q independent_tests/test_page_container_layout.py` *(fails: cannot import name 'jsonify' from 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6889e1d042208320a5002e83d0308474