### PR TITLE
Use dynamic secrets in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ from the defaults. For production deployments store these secrets in
 HashiCorp Vault or AWS Secrets Manager as described in
 [docs/secret_management.md](docs/secret_management.md). Vault deployment
 details are provided in [docs/vault_integration.md](docs/vault_integration.md).
+Whenever possible set these values through environment variables or your
+secret management solution rather than hard coding them.
 
 #### Frontend WebSocket URL
 

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -7,6 +7,10 @@ This guide covers how secrets are handled in the Yōsai Intel Dashboard.
 The application expects several secrets to be provided via environment
 variables, Docker secrets, or a cloud secret manager:
 
+Avoid hard coding these values in code or configuration files. Generate
+them dynamically with `os.urandom` during testing or store them securely
+in your secret backend.
+
 - `SECRET_KEY` – Flask and Dash session signing key
 - `DB_PASSWORD` – database account password
 - `AUTH0_CLIENT_ID` – Auth0 application identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
@@ -422,11 +423,15 @@ def sample_doors() -> list[Door]:
 @pytest.fixture(autouse=True)
 def env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """Provide default environment variables for tests."""
+
+    def _rand() -> str:
+        return os.urandom(16).hex()
+
     required = {
-        "SECRET_KEY": "test",
-        "DB_PASSWORD": "pwd",
+        "SECRET_KEY": _rand(),
+        "DB_PASSWORD": _rand(),
         "AUTH0_CLIENT_ID": "cid",
-        "AUTH0_CLIENT_SECRET": "secret",
+        "AUTH0_CLIENT_SECRET": _rand(),
         "AUTH0_DOMAIN": "domain",
         "AUTH0_AUDIENCE": "aud",
     }

--- a/tests/integration/test_analytics_microservice_metrics.py
+++ b/tests/integration/test_analytics_microservice_metrics.py
@@ -13,7 +13,7 @@ services_stub.__path__ = [str(SERVICES_PATH)]
 sys.modules.setdefault("services", services_stub)
 
 # Ensure JWT_SECRET for microservice
-os.environ.setdefault("JWT_SECRET", "test")
+os.environ.setdefault("JWT_SECRET", os.urandom(16).hex())
 
 # Stub metrics and tracing instrumentation
 prom_stub = types.ModuleType("prometheus_fastapi_instrumentator")

--- a/tests/integration/test_api_csrf.py
+++ b/tests/integration/test_api_csrf.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 import types
 
@@ -37,7 +38,7 @@ def _create_app(monkeypatch):
 
 @pytest.mark.integration
 def test_csrf_token_and_protected_endpoint(monkeypatch):
-    monkeypatch.setenv("SECRET_KEY", "test-key")
+    monkeypatch.setenv("SECRET_KEY", os.urandom(16).hex())
     app = _create_app(monkeypatch)
     client = TestClient(app)
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -8,7 +8,8 @@ from config.dynamic_config import DynamicConfigManager
 
 
 def test_yaml_and_env_loading(monkeypatch, tmp_path):
-    yaml_text = """
+    secret = os.urandom(16).hex()
+    yaml_text = f"""
 app:
   title: "Demo ${APP_EXTRA}"
 database:
@@ -21,8 +22,8 @@ security:
 
     monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
     monkeypatch.setenv("APP_EXTRA", "\u0394")
-    monkeypatch.setenv("SECRET_VAR", "secret")
-    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("SECRET_VAR", secret)
+    monkeypatch.setenv("SECRET_KEY", secret)
     # required env vars
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
@@ -44,11 +45,12 @@ def test_json_env_rules_parsed(monkeypatch):
 def test_env_overrides_applied(monkeypatch):
     monkeypatch.setenv("YOSAI_DATABASE_HOST", "db.example.com")
     monkeypatch.setenv("YOSAI_DATABASE_PORT", "1234")
-    monkeypatch.setenv("SECRET_KEY", "s")
-    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", "s")
-    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", "pwd")
+    secret = os.urandom(16).hex()
+    monkeypatch.setenv("SECRET_KEY", secret)
+    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", secret)
+    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", os.urandom(16).hex())
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
-    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", os.urandom(16).hex())
     monkeypatch.setenv("AUTH0_DOMAIN", "dom")
     monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
 
@@ -69,11 +71,12 @@ security: {}
     path.write_text(yaml_text, encoding="utf-8")
 
     monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
-    monkeypatch.setenv("SECRET_KEY", "secret")
-    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", "secret")
-    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", "envpass")
+    secret = os.urandom(16).hex()
+    monkeypatch.setenv("SECRET_KEY", secret)
+    monkeypatch.setenv("YOSAI_SECURITY_SECRET_KEY", secret)
+    monkeypatch.setenv("YOSAI_DATABASE_PASSWORD", os.urandom(16).hex())
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
-    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", os.urandom(16).hex())
     monkeypatch.setenv("AUTH0_DOMAIN", "domain")
     monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
 

--- a/tests/test_config_production_secrets.py
+++ b/tests/test_config_production_secrets.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from config import create_config_manager
@@ -19,6 +20,6 @@ def set_env(monkeypatch, secret: str) -> None:
 
 
 def test_invalid_secrets_raise(monkeypatch):
-    set_env(monkeypatch, "change-me")
+    set_env(monkeypatch, os.urandom(16).hex())
     with pytest.raises(ValueError):
         create_config_manager()

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
@@ -36,12 +37,13 @@ def test_missing_required_sections(monkeypatch, tmp_path):
 
 
 def test_invalid_section_type(monkeypatch, tmp_path):
-    yaml = """
+    secret = os.urandom(16).hex()
+    yaml = f"""
 app:
   title: Test
 database: []
 security:
-  secret_key: abc
+  secret_key: {secret}
 """
     data = importlib.import_module("yaml").safe_load(yaml)
     with pytest.raises(ConfigurationError):
@@ -49,14 +51,15 @@ security:
 
 
 def test_schema_validation(monkeypatch, tmp_path):
-    yaml = """
+    secret = os.urandom(16).hex()
+    yaml = f"""
 app:
   title: Test
   port: "oops"
 database:
   name: test.db
 security:
-  secret_key: xyz
+  secret_key: {secret}
 """
     data = importlib.import_module("yaml").safe_load(yaml)
     with pytest.raises(ConfigurationError):
@@ -69,13 +72,14 @@ def test_non_mapping_input():
 
 
 def test_valid_config(monkeypatch, tmp_path):
-    yaml_text = """
+    secret = os.urandom(16).hex()
+    yaml_text = f"""
 app:
   title: Test
 database:
   name: test.db
 security:
-  secret_key: xyz
+  secret_key: {secret}
 """
     config_data = importlib.import_module("yaml").safe_load(yaml_text)
     cfg = ConfigValidator.validate(config_data)

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 
 from config import create_config_manager
@@ -13,23 +14,24 @@ def test_dynamic_config_default_display_rows():
 
 
 def test_config_manager_loads_max_display_rows(tmp_path, monkeypatch):
-    yaml = """
+    secret = os.urandom(16).hex()
+    yaml = f"""
 app:
   title: Test
 database:
   name: test.db
 security:
-  secret_key: test
+  secret_key: {secret}
 analytics:
   max_display_rows: 123
 """
     path = tmp_path / "config.yaml"
     path.write_text(yaml)
     envs = {
-        "SECRET_KEY": "x",
-        "DB_PASSWORD": "x",
+        "SECRET_KEY": secret,
+        "DB_PASSWORD": os.urandom(16).hex(),
         "AUTH0_CLIENT_ID": "x",
-        "AUTH0_CLIENT_SECRET": "x",
+        "AUTH0_CLIENT_SECRET": os.urandom(16).hex(),
         "AUTH0_DOMAIN": "x",
         "AUTH0_AUDIENCE": "x",
     }

--- a/tests/test_secret_manager.py
+++ b/tests/test_secret_manager.py
@@ -8,9 +8,10 @@ from core.secret_manager import SecretManager, validate_secrets
 
 
 def test_get_env_secret(monkeypatch):
-    monkeypatch.setenv("MY_SECRET", "value")
+    value = os.urandom(16).hex()
+    monkeypatch.setenv("MY_SECRET", value)
     mgr = SecretManager("env")
-    assert mgr.get("MY_SECRET") == "value"
+    assert mgr.get("MY_SECRET") == value
 
 
 def test_get_missing_secret_raises(monkeypatch):
@@ -21,18 +22,18 @@ def test_get_missing_secret_raises(monkeypatch):
 
 
 def test_generate_and_validate_secret_key(monkeypatch):
-    key = SecretManager.generate_secret_key(32)
-    monkeypatch.setenv("SECRET_KEY", key)
-    assert SecretManager.get_secret_key() == key
+    mgr = SecretManager()
+    key = mgr.rotate_secret("SECRET_KEY", 32)
+    assert mgr.get("SECRET_KEY") == key
 
 
 def test_validate_secrets_summary(monkeypatch):
-    monkeypatch.setenv("SECRET_KEY", "s" * 32)
+    monkeypatch.setenv("SECRET_KEY", os.urandom(32).hex())
     monkeypatch.setenv("AUTH0_CLIENT_ID", "id")
-    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("AUTH0_CLIENT_SECRET", os.urandom(16).hex())
     monkeypatch.setenv("AUTH0_DOMAIN", "domain")
     monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
-    monkeypatch.setenv("DB_PASSWORD", "p" * 32)
+    monkeypatch.setenv("DB_PASSWORD", os.urandom(32).hex())
     summary = validate_secrets()
     assert summary["checks"]["SECRET_KEY"]
     assert summary["valid"]

--- a/tests/test_secrets_integration.py
+++ b/tests/test_secrets_integration.py
@@ -1,10 +1,11 @@
+import os
 from core.secret_manager import SecretsManager
 
 
 def test_env_overrides_docker(tmp_path, monkeypatch):
     secret_file = tmp_path / "SECRET_KEY"
-    secret_file.write_text("file-secret")
-    monkeypatch.setenv("SECRET_KEY", "env-secret")
+    secret_file.write_text(os.urandom(16).hex())
+    monkeypatch.setenv("SECRET_KEY", os.urandom(16).hex())
 
     manager = SecretsManager(docker_dir=tmp_path)
     assert manager.get("SECRET_KEY") == "env-secret"
@@ -12,7 +13,7 @@ def test_env_overrides_docker(tmp_path, monkeypatch):
 
 def test_docker_fallback(tmp_path, monkeypatch):
     secret_file = tmp_path / "DB_PASSWORD"
-    secret_file.write_text("file-pass")
+    secret_file.write_text(os.urandom(16).hex())
     monkeypatch.delenv("DB_PASSWORD", raising=False)
 
     manager = SecretsManager(docker_dir=tmp_path)

--- a/tests/test_unified_loader.py
+++ b/tests/test_unified_loader.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 
@@ -11,21 +12,23 @@ def _stub_optional_modules():
 
 
 def test_environment_processor_applied(monkeypatch, tmp_path):
-    cfg_text = """
+    secret = os.urandom(16).hex()
+    cfg_text = f"""
 app:
   host: localhost
   port: 8000
 database:
   host: db.local
 security:
-  secret_key: default
+  secret_key: {secret}
 """
     path = tmp_path / "config.yaml"
     path.write_text(cfg_text, encoding="utf-8")
 
     monkeypatch.setenv("YOSAI_DATABASE_HOST", "db.example.com")
     monkeypatch.setenv("YOSAI_PORT", "9000")
-    monkeypatch.setenv("SECRET_KEY", "envsecret")
+    env_secret = os.urandom(16).hex()
+    monkeypatch.setenv("SECRET_KEY", env_secret)
 
     _stub_optional_modules()
     from config.unified_loader import UnifiedLoader
@@ -35,4 +38,4 @@ security:
 
     assert cfg.database.host == "db.example.com"
     assert cfg.app.port == 9000
-    assert cfg.app.secret_key == "envsecret"
+    assert cfg.app.secret_key == env_secret


### PR DESCRIPTION
## Summary
- generate secrets dynamically in pytest fixtures and tests
- update docs to discourage hardcoded secrets

## Testing
- `pytest tests/test_secret_manager.py::test_generate_and_validate_secret_key -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e1d1ed148320a813aff7af081149