### PR TITLE
Add logging config for CLI

### DIFF
--- a/tools/cli_analytics_fixed.py
+++ b/tools/cli_analytics_fixed.py
@@ -5,6 +5,7 @@ Test Analytics with callback fix applied
 
 import asyncio
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -123,6 +124,7 @@ async def test_analytics_with_fix():
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     result = asyncio.run(test_analytics_with_fix())
     print("\n" + "=" * 50)
     print("FINAL RESULTS:")


### PR DESCRIPTION
## Summary
- set up `logging.basicConfig(level=logging.INFO)` in `cli_analytics_fixed`

`file_conversion/migrate_existing_files.py` could not be located in the repository.

## Testing
- `python -m py_compile tools/cli_analytics_fixed.py`
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 234 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6889e95becb0832081ea13f5d5b40199