### PR TITLE
Refactor callbacks into pages with DI container

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+"""Sample Dash application wiring pages and services."""
+
+from dash import Dash, html
+
+from simple_di import ServiceContainer
+from services.greeting import GreetingService
+from pages.greetings import layout as greetings_layout
+from pages.greetings.callbacks import register_callbacks
+
+
+def create_app() -> Dash:
+    """Build the DI container, create the Dash app and register callbacks."""
+    container = ServiceContainer()
+    container.register("greeting_service", GreetingService())
+
+    app = Dash(__name__)
+    app.layout = html.Div([greetings_layout()])
+
+    register_callbacks(app, container)
+
+    # Expose container for testing/usage
+    app._container = container
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/pages/greetings/__init__.py
+++ b/pages/greetings/__init__.py
@@ -1,0 +1,4 @@
+from .layout import layout
+from .callbacks import register_callbacks
+
+__all__ = ["layout", "register_callbacks"]

--- a/pages/greetings/callbacks.py
+++ b/pages/greetings/callbacks.py
@@ -1,0 +1,18 @@
+from dash import Input, Output
+from dash.exceptions import PreventUpdate
+
+from simple_di import inject
+from services.greeting import GreetingService
+
+
+def register_callbacks(app, container) -> None:
+    """Register page callbacks."""
+
+    @app.callback(Output("greet-output", "children"), Input("name-input", "value"))
+    @inject(container=container)
+    def _update_greeting(name: str, svc: GreetingService):
+        if not name:
+            raise PreventUpdate
+        return svc.greet(name)
+
+    return None

--- a/pages/greetings/layout.py
+++ b/pages/greetings/layout.py
@@ -1,0 +1,9 @@
+from dash import html
+
+
+def layout():
+    """Return the page layout."""
+    return html.Div([
+        html.Div(id="name-input"),
+        html.Div(id="greet-output"),
+    ])

--- a/services/greeting/__init__.py
+++ b/services/greeting/__init__.py
@@ -1,0 +1,5 @@
+class GreetingService:
+    """Simple greeting service."""
+
+    def greet(self, name: str) -> str:
+        return f"Hello, {name}!"

--- a/simple_di.py
+++ b/simple_di.py
@@ -1,0 +1,50 @@
+"""Minimal dependency injection utilities used in tests."""
+
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Any, Callable, Type
+
+
+class ServiceContainer:
+    """Very small service registry."""
+
+    def __init__(self) -> None:
+        self._services: dict[str, Any] = {}
+        self._type_map: dict[Type, str] = {}
+
+    def register(self, key: str, instance: Any) -> None:
+        self._services[key] = instance
+        self._type_map[type(instance)] = key
+
+    def get(self, key: str, typ: Type | None = None) -> Any:
+        return self._services[key]
+
+    def _find_service_for_type(self, typ: Type) -> str | None:
+        return self._type_map.get(typ)
+
+
+def inject(container: ServiceContainer) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator injecting arguments resolved from *container* by type."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        sig = inspect.signature(func)
+        params = sig.parameters
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            bound = sig.bind_partial(*args, **kwargs)
+            for name, param in params.items():
+                if name in bound.arguments:
+                    continue
+                if param.annotation is inspect.Parameter.empty:
+                    continue
+                service_key = container._find_service_for_type(param.annotation)
+                if service_key and service_key not in bound.arguments:
+                    kwargs[name] = container.get(service_key)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_new_page_callbacks.py
+++ b/tests/test_new_page_callbacks.py
@@ -1,0 +1,50 @@
+import pytest
+from simple_di import ServiceContainer
+from services.greeting import GreetingService
+from pages.greetings.callbacks import register_callbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
+
+
+def test_register_callbacks_injects_service(monkeypatch):
+    import dash
+
+    app = dash.Dash(__name__)
+    container = ServiceContainer()
+    svc = GreetingService()
+    container.register("greeting_service", svc)
+
+    captured = {}
+
+    def fake_callback(*args, **kwargs):
+        def decorator(func):
+            captured["func"] = func
+            return func
+        return decorator
+
+    monkeypatch.setattr(app, "callback", fake_callback)
+
+    register_callbacks(app, container)
+
+    assert "func" in captured
+    cb = captured["func"]
+    assert cb("Bob") == "Hello, Bob!"
+
+
+def test_app_factory_builds_container(monkeypatch):
+    import app as app_module
+
+    captured = {}
+
+    def fake_callback(*args, **kwargs):
+        def decorator(func):
+            captured["func"] = func
+            return func
+        return decorator
+
+    monkeypatch.setattr(app_module.Dash, "callback", fake_callback, raising=False)
+
+    dash_app = app_module.create_app()
+    assert isinstance(dash_app._container.get("greeting_service"), GreetingService)
+    cb = captured["func"]
+    assert cb("Alice") == "Hello, Alice!"


### PR DESCRIPTION
## Summary
- create simple `ServiceContainer` and `inject` decorator
- add greeting service under `services/`
- register Dash callbacks from `pages/greetings/callbacks.py`
- build container and register callbacks in `app.py`
- test new DI callback setup

## Testing
- `pytest tests/test_new_page_callbacks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889fb3d90a88320beccee8cd34470eb