### PR TITLE
Refactor long service methods

### DIFF
--- a/services/analytics/helpers.py
+++ b/services/analytics/helpers.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, TYPE_CHECKING
+
+import pandas as pd
+from core.protocols import (
+    ConfigurationProtocol,
+    DatabaseProtocol,
+    EventBusProtocol,
+    StorageProtocol,
+)
+from services.analytics.calculator import Calculator
+from services.analytics.data.loader import DataLoader
+from services.analytics.orchestrator import AnalyticsOrchestrator
+from services.analytics.protocols import DataProcessorProtocol
+from services.analytics.publisher import Publisher
+from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from services.analytics_summary import generate_sample_analytics
+from services.controllers.upload_controller import UploadProcessingController
+from services.data_processing.processor import Processor
+from services.database_retriever import DatabaseAnalyticsRetriever
+from services.interfaces import get_upload_data_service
+from services.summary_report_generator import SummaryReportGenerator
+from services.upload_data_service import UploadDataService
+from validation.security_validator import SecurityValidator
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from yosai_intel_dashboard.models.ml import ModelRegistry
+    from .analytics_service import AnalyticsService
+
+logger = logging.getLogger(__name__)
+
+
+class DataSourceRouter:
+    """Helper to route analytics requests based on source."""
+
+    def __init__(self, orchestrator: AnalyticsOrchestrator) -> None:
+        self.orchestrator = orchestrator
+
+    def get_analytics(self, source: str) -> Dict[str, Any]:
+        """Return analytics data for ``source``."""
+        try:
+            uploaded_data = self.orchestrator.loader.load_uploaded_data()
+            if uploaded_data and source in ["uploaded", "sample"]:
+                logger.info("Forcing uploaded data usage (source was: %s)", source)
+                return self.orchestrator.process_uploaded_data_directly(uploaded_data)
+        except (
+            ImportError,
+            FileNotFoundError,
+            OSError,
+            RuntimeError,
+            ValueError,
+            pd.errors.ParserError,
+        ) as exc:
+            logger.error(
+                "Uploaded data check failed (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+        if source == "sample":
+            return generate_sample_analytics()
+        if source == "uploaded":
+            return {"status": "no_data", "message": "No uploaded files available"}
+        if source == "database":
+            return self.orchestrator.get_database_analytics()
+        return {"status": "error", "message": f"Unknown source: {source}"}
+
+
+def initialize_core_components(
+    service: "AnalyticsService",
+    database: DatabaseProtocol | None,
+    data_processor: DataProcessorProtocol | None,
+    config: ConfigurationProtocol | None,
+    event_bus: EventBusProtocol | None,
+    storage: StorageProtocol | None,
+    upload_data_service: UploadDataService | None,
+    model_registry: ModelRegistry | None,
+    *,
+    upload_controller: UploadProcessingController | None = None,
+    upload_processor: UploadAnalyticsProcessor | None = None,
+    report_generator: SummaryReportGenerator | None = None,
+) -> None:
+    """Initialize basic service dependencies."""
+
+    service.database = database
+    service.data_processor = data_processor or Processor(validator=SecurityValidator())
+    service.config = config
+    service.event_bus = event_bus
+    service.storage = storage
+    service.upload_data_service = upload_data_service or get_upload_data_service()
+    service.model_registry = model_registry
+    service.validation_service = SecurityValidator()
+    if data_processor is None:
+        service.processor = Processor(validator=service.validation_service)
+        service.data_processor = service.processor
+    else:
+        service.processor = data_processor
+        service.data_processor = data_processor
+    service.data_loading_service = service.processor
+    from services.data_processing.file_handler import FileHandler
+
+    service.file_handler = FileHandler()
+
+    if upload_processor is None:
+        upload_processor = UploadAnalyticsProcessor(service.validation_service, service.processor)
+    if upload_controller is None:
+        service.upload_controller = UploadProcessingController(
+            service.validation_service,
+            service.processor,
+            service.upload_data_service,
+            upload_processor,
+        )
+    else:
+        service.upload_controller = upload_controller
+    service.upload_processor = upload_processor
+    service.report_generator = report_generator or SummaryReportGenerator()
+
+
+def initialize_orchestrator_components(
+    service: "AnalyticsService",
+    loader: DataLoader | None = None,
+    calculator: Calculator | None = None,
+    publisher: Publisher | None = None,
+    db_retriever: DatabaseAnalyticsRetriever | None = None,
+) -> None:
+    """Initialize orchestrator helpers for the service."""
+
+    service._setup_database(db_retriever)
+    loader = loader or DataLoader(service.upload_controller, service.processor)
+    calculator = calculator or Calculator(service.report_generator)
+    publisher = publisher or Publisher(service.event_bus)
+    service._create_orchestrator(loader, calculator, publisher)
+    service.router = DataSourceRouter(service.orchestrator)
+
+
+__all__ = [
+    "DataSourceRouter",
+    "initialize_core_components",
+    "initialize_orchestrator_components",
+]

--- a/services/upload/upload_core_helpers.py
+++ b/services/upload/upload_core_helpers.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, List, Tuple
+
+import dash_bootstrap_components as dbc
+from dash import html, no_update
+
+logger = logging.getLogger(__name__)
+
+
+async def process_uploaded_files_helper(core: "UploadCore", contents_list: List[str] | str, filenames_list: List[str] | str) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """Validate and process uploaded files."""
+    if not contents_list:
+        return ([], [], {}, [], {}, no_update, no_update)
+
+    if not isinstance(contents_list, list):
+        contents_list = [contents_list]
+        filenames_list = [filenames_list]
+
+    valid_contents: list[str] = []
+    valid_filenames: list[str] = []
+    alerts: list[Any] = []
+    for content, fname in zip(contents_list, filenames_list):
+        res = core.validator.validate_file_upload(content)
+        ok, msg = res.valid, res.message
+        if not ok:
+            alerts.append(core.processing.build_failure_alert(msg))
+        else:
+            valid_contents.append(content)
+            valid_filenames.append(fname)
+            core.chunked.start_file(fname)
+            core.queue.add_file(fname)
+
+    if not valid_contents:
+        return alerts, [], {}, [], {}, no_update, no_update
+
+    result = await core.processing.process_files(valid_contents, valid_filenames)
+
+    for fname in valid_filenames:
+        core.chunked.finish_file(fname)
+        core.queue.mark_complete(fname)
+
+    result = list(result)
+    result[0] = alerts + result[0]
+    return tuple(result)
+
+
+def finalize_upload_results_helper(core: "UploadCore", _n: int, task_id: str) -> Tuple[Any, Any, Any, Any, Any, Any, Any, bool]:
+    """Return result of async upload task when complete."""
+    if core.rabbitmq:
+        return (no_update,) * 8
+    status = core.task_queue.get_status(task_id)
+    result = status.get("result")
+
+    if status.get("done") and result is not None:
+        core.task_queue.clear_task(task_id)
+        if not isinstance(result, Exception):
+            try:
+                from components.simple_device_mapping import generate_ai_device_defaults
+
+                for fname in core.store.get_filenames():
+                    df = core.store.load_dataframe(fname)
+                    if df is not None and not df.empty:
+                        generate_ai_device_defaults(df, "auto")
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.error("Failed to generate AI defaults: %s", exc)
+        else:
+            result = (
+                [core.processing.build_failure_alert(str(result))],
+                [],
+                {},
+                [],
+                {},
+                no_update,
+                no_update,
+            )
+        return (*result, True)
+
+    return (no_update,) * 8
+
+
+def save_confirmed_device_mappings_helper(core: "UploadCore", confirm_clicks, floors, security, access, special, file_info) -> Tuple[Any, Any, Any]:
+    """Persist user confirmed mappings."""
+    if not confirm_clicks or not file_info:
+        return no_update, no_update, no_update
+    try:
+        devices = file_info.get("devices", [])
+        filename = file_info.get("filename", "")
+
+        user_mappings = {}
+        for i, device in enumerate(devices):
+            user_mappings[device] = {
+                "floor_number": floors[i] if i < len(floors) else 1,
+                "security_level": security[i] if i < len(security) else 5,
+                "is_entry": "entry" in (access[i] if i < len(access) else []),
+                "is_exit": "exit" in (access[i] if i < len(access) else []),
+                "is_restricted": "is_restricted" in (special[i] if i < len(special) else []),
+                "confidence": 1.0,
+                "device_name": device,
+                "source": "user_confirmed",
+                "saved_at": datetime.now().isoformat(),
+            }
+
+        learning_service = core.learning_service
+        if not filename:
+            raise ValueError("No filename provided in file_info")
+        if not devices:
+            raise ValueError("No devices found in file_info")
+
+        core.store.wait_for_pending_saves()
+        df = core.store.load_dataframe(filename)
+        if df is None:
+            raise ValueError(f"Data for '{filename}' could not be loaded")
+        if df.empty:
+            raise ValueError(f"DataFrame for '{filename}' is empty")
+
+        learning_service.save_user_device_mappings(df, filename, user_mappings)
+        from services.ai_mapping_store import ai_mapping_store
+
+        ai_mapping_store.update(user_mappings)
+
+        success_alert = dbc.Toast(
+            "✅ Device mappings saved to database!",
+            header="Confirmed & Saved",
+            is_open=True,
+            dismissable=True,
+            duration=3000,
+        )
+        return success_alert, False, False
+    except Exception as e:  # pragma: no cover - robustness
+        logger.error("Error saving device mappings: %s", e)
+        error_alert = dbc.Toast(
+            f"❌ Error saving mappings: {e}",
+            header="Error",
+            is_open=True,
+            dismissable=True,
+            duration=8000,
+        )
+        return error_alert, no_update, no_update
+
+
+__all__ = [
+    "process_uploaded_files_helper",
+    "finalize_upload_results_helper",
+    "save_confirmed_device_mappings_helper",
+]

--- a/tests/test_analytics_init_helpers.py
+++ b/tests/test_analytics_init_helpers.py
@@ -1,0 +1,56 @@
+import types
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "analytics_helpers", Path("services/analytics/helpers.py")
+)
+helpers = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(helpers)
+initialize_core_components = helpers.initialize_core_components
+initialize_orchestrator_components = helpers.initialize_orchestrator_components
+DataSourceRouter = helpers.DataSourceRouter
+from services.summary_report_generator import SummaryReportGenerator
+from services.data_processing.processor import Processor
+from validation.security_validator import SecurityValidator
+
+
+def test_initialize_core_components_defaults():
+    svc = types.SimpleNamespace()
+    initialize_core_components(
+        svc,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    assert isinstance(svc.validation_service, SecurityValidator)
+    assert isinstance(svc.processor, Processor)
+    assert svc.upload_controller is not None
+    assert svc.upload_processor is not None
+    assert isinstance(svc.report_generator, SummaryReportGenerator)
+
+
+def test_initialize_orchestrator_components(monkeypatch):
+    svc = types.SimpleNamespace()
+    records = {}
+    svc.upload_controller = object()
+    svc.processor = object()
+    svc.report_generator = SummaryReportGenerator()
+    svc.event_bus = None
+
+    def fake_setup(db=None):
+        records['setup'] = True
+    def fake_create(loader, calc, pub):
+        records['create'] = True
+    svc._setup_database = fake_setup
+    svc._create_orchestrator = fake_create
+
+    initialize_orchestrator_components(svc)
+    assert records.get('setup') and records.get('create')
+    assert isinstance(svc.router, DataSourceRouter)
+

--- a/tests/test_upload_core_helpers.py
+++ b/tests/test_upload_core_helpers.py
@@ -1,0 +1,113 @@
+import types
+import base64
+import pandas as pd
+from dash import no_update
+
+from services.upload.upload_core_helpers import (
+    process_uploaded_files_helper,
+    finalize_upload_results_helper,
+    save_confirmed_device_mappings_helper,
+)
+
+
+class DummyProcessing:
+    def __init__(self):
+        self.calls = []
+
+    async def process_files(self, contents, filenames):
+        self.calls.append((contents, filenames))
+        return ([], [], {filenames[0]: {"rows": len(contents)}}, [], {}, no_update, no_update)
+
+    def build_failure_alert(self, msg):
+        return {"alert": msg}
+
+
+class DummyValidator:
+    def validate_file_upload(self, _c):
+        return types.SimpleNamespace(valid=True, message="")
+
+
+class DummyChunked:
+    def __init__(self):
+        self.progress = {}
+
+    def start_file(self, name):
+        self.progress[name] = 0
+
+    def finish_file(self, name):
+        self.progress[name] = 100
+
+    def get_progress(self, name):
+        return self.progress.get(name, 0)
+
+
+class DummyQueue:
+    def __init__(self):
+        self.files = []
+
+    def add_file(self, name):
+        self.files.append(name)
+
+    def mark_complete(self, name):
+        pass
+
+
+class DummyTaskQueue:
+    def __init__(self, status):
+        self.status = status
+        self.cleared = False
+
+    def get_status(self, _tid):
+        return self.status
+
+    def clear_task(self, _tid):
+        self.cleared = True
+
+
+class DummyStore(FakeUploadStore):
+    pass
+
+
+class DummyCore:
+    def __init__(self, status=None):
+        self.validator = DummyValidator()
+        self.processing = DummyProcessing()
+        self.chunked = DummyChunked()
+        self.queue = DummyQueue()
+        self.task_queue = DummyTaskQueue(status or {})
+        self.store = DummyStore()
+        self.learning_service = FakeDeviceLearningService()
+        self.rabbitmq = None
+
+
+def test_process_uploaded_files_helper(async_runner):
+    df = pd.DataFrame({"A": [1, 2]})
+    csv = df.to_csv(index=False).encode()
+    content = "data:text/csv;base64," + base64.b64encode(csv).decode()
+    core = DummyCore()
+    out = async_runner(process_uploaded_files_helper(core, [content], ["sample.csv"]))
+    info = out[2]
+    assert info["sample.csv"]["rows"] == 1
+
+
+def test_finalize_upload_results_helper_done(monkeypatch):
+    core = DummyCore(status={"done": True, "result": (1, 2, 3, 4, 5, 6, 7)})
+    called = {}
+    monkeypatch.setattr(
+        "components.simple_device_mapping.generate_ai_device_defaults",
+        lambda df, profile="auto": called.setdefault("gen", True),
+    )
+    out = finalize_upload_results_helper(core, 1, "tid")
+    assert out[-1] is True
+    assert core.task_queue.cleared
+    assert called.get("gen") is True
+
+
+def test_save_confirmed_device_mappings_helper(monkeypatch):
+    core = DummyCore()
+    df = pd.DataFrame({"A": [1]})
+    core.store.add_file("f.csv", df)
+    monkeypatch.setattr("services.ai_mapping_store.ai_mapping_store.update", lambda m: None)
+    file_info = {"devices": ["d1"], "filename": "f.csv"}
+    res = save_confirmed_device_mappings_helper(core, True, [1], [5], [[]], [[]], file_info)
+    assert res[1] is False

--- a/upload_core.py
+++ b/upload_core.py
@@ -29,6 +29,11 @@ from services.upload.protocols import (
     UploadStorageProtocol,
 )
 from services.upload.upload_queue_manager import UploadQueueManager
+from services.upload.upload_core_helpers import (
+    process_uploaded_files_helper,
+    finalize_upload_results_helper,
+    save_confirmed_device_mappings_helper,
+)
 from validation.security_validator import SecurityValidator
 
 logger = logging.getLogger(__name__)
@@ -77,47 +82,7 @@ class UploadCore:
     async def process_uploaded_files(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
     ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
-        if not contents_list:
-            return (
-                [],
-                [],
-                {},
-                [],
-                {},
-                no_update,
-                no_update,
-            )
-
-        if not isinstance(contents_list, list):
-            contents_list = [contents_list]
-            filenames_list = [filenames_list]
-
-        valid_contents: list[str] = []
-        valid_filenames: list[str] = []
-        alerts: list[Any] = []
-        for content, fname in zip(contents_list, filenames_list):
-            res = self.validator.validate_file_upload(content)
-            ok, msg = res.valid, res.message
-            if not ok:
-                alerts.append(self.processing.build_failure_alert(msg))
-            else:
-                valid_contents.append(content)
-                valid_filenames.append(fname)
-                self.chunked.start_file(fname)
-                self.queue.add_file(fname)
-
-        if not valid_contents:
-            return alerts, [], {}, [], {}, no_update, no_update
-
-        result = await self.processing.process_files(valid_contents, valid_filenames)
-
-        for fname in valid_filenames:
-            self.chunked.finish_file(fname)
-            self.queue.mark_complete(fname)
-
-        result = list(result)
-        result[0] = alerts + result[0]
-        return tuple(result)
+        return await process_uploaded_files_helper(self, contents_list, filenames_list)
 
     def schedule_upload_task(
         self, contents_list: List[str] | str, filenames_list: List[str] | str
@@ -167,117 +132,14 @@ class UploadCore:
     def finalize_upload_results(
         self, _n: int, task_id: str
     ) -> Tuple[Any, Any, Any, Any, Any, Any, Any, bool]:
-        if self.rabbitmq:
-            return (
-                no_update,
-                no_update,
-                no_update,
-                no_update,
-                no_update,
-                no_update,
-                no_update,
-                no_update,
-            )
-        status = self.task_queue.get_status(task_id)
-        result = status.get("result")
-
-        if status.get("done") and result is not None:
-            self.task_queue.clear_task(task_id)
-            if not isinstance(result, Exception):
-                try:
-                    from components.simple_device_mapping import (
-                        generate_ai_device_defaults,
-                    )
-
-                    for fname in self.store.get_filenames():
-                        df = self.store.load_dataframe(fname)
-                        if df is not None and not df.empty:
-                            generate_ai_device_defaults(df, "auto")
-                except Exception as exc:  # pragma: no cover - best effort
-                    logger.error("Failed to generate AI defaults: %s", exc)
-            else:
-                result = (
-                    [self.processing.build_failure_alert(str(result))],
-                    [],
-                    {},
-                    [],
-                    {},
-                    no_update,
-                    no_update,
-                )
-            return (*result, True)
-
-        return (
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-        )
+        return finalize_upload_results_helper(self, _n, task_id)
 
     def save_confirmed_device_mappings(
         self, confirm_clicks, floors, security, access, special, file_info
     ) -> Tuple[Any, Any, Any]:
-        if not confirm_clicks or not file_info:
-            return no_update, no_update, no_update
-        try:
-            devices = file_info.get("devices", [])
-            filename = file_info.get("filename", "")
-
-            user_mappings = {}
-            for i, device in enumerate(devices):
-                user_mappings[device] = {
-                    "floor_number": floors[i] if i < len(floors) else 1,
-                    "security_level": security[i] if i < len(security) else 5,
-                    "is_entry": "entry" in (access[i] if i < len(access) else []),
-                    "is_exit": "exit" in (access[i] if i < len(access) else []),
-                    "is_restricted": "is_restricted"
-                    in (special[i] if i < len(special) else []),
-                    "confidence": 1.0,
-                    "device_name": device,
-                    "source": "user_confirmed",
-                    "saved_at": datetime.now().isoformat(),
-                }
-
-            learning_service = self.learning_service
-            if not filename:
-                raise ValueError("No filename provided in file_info")
-            if not devices:
-                raise ValueError("No devices found in file_info")
-
-            self.store.wait_for_pending_saves()
-            df = self.store.load_dataframe(filename)
-            if df is None:
-                raise ValueError(f"Data for '{filename}' could not be loaded")
-            if df.empty:
-                raise ValueError(f"DataFrame for '{filename}' is empty")
-
-            learning_service.save_user_device_mappings(df, filename, user_mappings)
-            from services.ai_mapping_store import ai_mapping_store
-
-            ai_mapping_store.update(user_mappings)
-
-            success_alert = dbc.Toast(
-                "✅ Device mappings saved to database!",
-                header="Confirmed & Saved",
-                is_open=True,
-                dismissable=True,
-                duration=3000,
-            )
-            return success_alert, False, False
-        except Exception as e:  # pragma: no cover - robustness
-            logger.error("Error saving device mappings: %s", e)
-            error_alert = dbc.Toast(
-                f"❌ Error saving mappings: {e}",
-                header="Error",
-                is_open=True,
-                dismissable=True,
-                duration=8000,
-            )
-            return error_alert, no_update, no_update
+        return save_confirmed_device_mappings_helper(
+            self, confirm_clicks, floors, security, access, special, file_info
+        )
 
 
 __all__ = ["UploadCore"]


### PR DESCRIPTION
## Summary
- extract DataSourceRouter, initialization helpers into `services/analytics/helpers.py`
- move upload processing helpers to `services/upload/upload_core_helpers.py`
- refactor `AnalyticsService.__init__` and `UploadCore` methods to use helpers
- add unit tests for the helper modules

## Testing
- `pip install -r requirements-test.txt`
- `pytest tests/test_analytics_init_helpers.py tests/test_upload_core_helpers.py -q` *(fails: ImportError due to config modules)*

------
https://chatgpt.com/codex/tasks/task_e_6889fb425bd883208e7a39219130ea5e