### PR TITLE
Add prod Dockerfile and GitHub workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,46 +1,27 @@
-# Yosai Dashboard Environment Variables
+# Example production environment configuration for Yosai Intel Dashboard
+# Copy this file to `.env` and fill in values for your deployment.
 
-# Required variables
+# Required secrets
 SECRET_KEY=
 DB_PASSWORD=
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
 AUTH0_DOMAIN=
 AUTH0_AUDIENCE=
+JWT_SECRET=
 
-# Flask Configuration
-FLASK_ENV=development
-FLASK_DEBUG=1
-# Provide a strong 32+ character value for production
-
-# Yosai Configuration
-YOSAI_ENV=development
+# General configuration
+YOSAI_ENV=production
+FLASK_ENV=production
+FLASK_DEBUG=0
 YOSAI_CONFIG_FILE=config/config.yaml
 
-# Database Configuration
+# Database connection
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=yosai_db
 DB_USER=yosai_user
-# Password for the database user
 
-# Auth0 Configuration (Development example values)
-AUTH0_CLIENT_ID=<client-id>
-AUTH0_CLIENT_SECRET=<client-secret>
-AUTH0_DOMAIN=example.auth0.com
-AUTH0_AUDIENCE=<audience>
-# Identifier for the Auth0 API
-
-# Security
-WTF_CSRF_ENABLED=True
-# Shared secret used for service tokens
-JWT_SECRET=
-
-# Additional
-DEBUG=1
-
-# Frontend Configuration
+# Frontend configuration
 REACT_APP_API_BASE=/v1
-# Base path for frontend API requests
 REACT_APP_WS_URL=localhost:5001
-# WebSocket base URL for the frontend

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.lock
+          pip install -r requirements-test.txt
+      - name: Run unit tests
+        run: pytest -q
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: docker build -t yosai-dashboard .

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f .env ]; then
+  # shellcheck disable=SC1091
+  source .env
+fi
+
+exec gunicorn -c gunicorn.conf.py wsgi:server


### PR DESCRIPTION
## Summary
- provide a production `Dockerfile`
- document required environment variables in `.env.example`
- add `start.sh` helper for running gunicorn
- set up basic GitHub Actions workflow for building the image and running unit tests

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: 232 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889fb50efcc8320bf8d73614dd4fc33