### PR TITLE
Add uploader service registration

### DIFF
--- a/config/service_registration.py
+++ b/config/service_registration.py
@@ -23,9 +23,11 @@ def register_upload_services(container: ServiceContainer) -> None:
     from services.interfaces import DoorMappingServiceProtocol
     from services.upload.core.processor import UploadProcessingService
     from services.upload.core.validator import ClientSideValidator
+    from services.uploader import Uploader
     from utils.upload_store import UploadedDataStore
 
     upload_store = UploadedDataStore(dynamic_config.upload.folder)
+    container.register_singleton("uploader", Uploader(upload_store))
     door_mapping_service = DoorMappingService(DynamicConfigurationService())
     container.register_singleton(
         "door_mapping_service",

--- a/services/uploader.py
+++ b/services/uploader.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from utils.upload_store import UploadedDataStore
+
+
+class Uploader:
+    """Simple wrapper to save dataframes using :class:`UploadedDataStore`."""
+
+    def __init__(self, store: UploadedDataStore) -> None:
+        self.store = store
+
+    def add_file(self, filename: str, df: pd.DataFrame) -> None:
+        """Save ``df`` to ``filename`` using the underlying store."""
+        self.store.add_file(filename, df)
+
+    def get_all_data(self) -> Dict[str, pd.DataFrame]:
+        """Return all uploaded data from the store."""
+        return self.store.get_all_data()
+
+
+__all__ = ["Uploader"]

--- a/tests/test_device_endpoint_utils.py
+++ b/tests/test_device_endpoint_utils.py
@@ -8,9 +8,12 @@ core_container_stub = types.ModuleType("core.container")
 core_container_stub.container = types.SimpleNamespace(
     has=lambda name: True,
     get=lambda name: None,
+    register_singleton=lambda *args, **kwargs: None,
 )
 service_reg_stub = types.ModuleType("config.service_registration")
-service_reg_stub.register_upload_services = lambda c: None
+service_reg_stub.register_upload_services = lambda c: c.register_singleton(
+    "uploader", object()
+)
 sys.modules.setdefault("core.container", core_container_stub)
 sys.modules.setdefault("config.service_registration", service_reg_stub)
 

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -33,7 +33,9 @@ class DummyUploadService:
 def _create_app(monkeypatch):
     # Provide minimal stubs to avoid heavy imports during module load
     fake_reg = types.ModuleType("config.service_registration")
-    fake_reg.register_upload_services = lambda c: None
+    fake_reg.register_upload_services = lambda c: c.register_singleton(
+        "uploader", object()
+    )
     monkeypatch.setitem(sys.modules, "config.service_registration", fake_reg)
 
     cont = ServiceContainer()
@@ -86,7 +88,9 @@ class FailingUploadService:
 
 def test_upload_returns_error_on_exception(monkeypatch):
     fake_reg = types.ModuleType("config.service_registration")
-    fake_reg.register_upload_services = lambda c: None
+    fake_reg.register_upload_services = lambda c: c.register_singleton(
+        "uploader", object()
+    )
     monkeypatch.setitem(sys.modules, "config.service_registration", fake_reg)
 
     cont = ServiceContainer()
@@ -136,7 +140,9 @@ class DummyFileProcessor:
 
 def _create_validator_app(monkeypatch):
     fake_reg = types.ModuleType("config.service_registration")
-    fake_reg.register_upload_services = lambda c: None
+    fake_reg.register_upload_services = lambda c: c.register_singleton(
+        "uploader", object()
+    )
     monkeypatch.setitem(sys.modules, "config.service_registration", fake_reg)
 
     cont = ServiceContainer()


### PR DESCRIPTION
## Summary
- add simple `Uploader` helper around `UploadedDataStore`
- register `uploader` singleton in `register_upload_services`
- update test stubs to provide the new service

## Testing
- `pytest tests/test_upload_endpoint.py tests/test_device_endpoint_utils.py -q` *(fails: ModuleNotFoundError: No module named 'flask_apispec')*

------
https://chatgpt.com/codex/tasks/task_e_688a0bbe89c883209ab4449259457007