### PR TITLE
Update security validation and tests

### DIFF
--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -56,12 +56,14 @@ class ValidationMiddleware:
         if request.content_length and request.content_length > self.max_body_size:
             return Response("Request Entity Too Large", status=413)
 
-        # Validate query string parameters
-        for value in request.args.values():
+        # Validate query string parameters and store sanitized versions
+        sanitized_args = {}
+        for key, value in request.args.items():
             try:
-                self.orchestrator.validate(value)
+                sanitized_args[key] = self.orchestrator.validate(value)
             except ValidationError:
                 return Response("Bad Request", status=400)
+        request.sanitized_args = sanitized_args
 
         # Validate body content
         if request.data:

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -19,3 +19,9 @@ def test_oversized_upload_is_invalid():
     result = validator.validate_file_meta("big.csv", too_big)
     assert result["valid"] is False
     assert any("File too large" in issue for issue in result["issues"])
+
+
+def test_sanitize_filename_strips_path_components():
+    validator = SecurityValidator()
+    sanitized = validator.sanitize_filename("../foo/bar.csv")
+    assert sanitized == "bar.csv"


### PR DESCRIPTION
## Summary
- sanitize filename input in `SecurityValidator`
- store sanitized query parameters on incoming requests
- validate uploaded file metadata and filenames
- cover filename sanitization in tests

## Testing
- `pytest -k sanitize_filename_strips_path_components tests/test_security_service.py -q` *(fails: ImportError: cannot import name 'dynamic_config')*

------
https://chatgpt.com/codex/tasks/task_e_688a0bd064b08320b5a89c25a7bb23a9