### PR TITLE
Refactor reader utilities

### DIFF
--- a/file_processing/readers/csv_reader.py
+++ b/file_processing/readers/csv_reader.py
@@ -6,7 +6,7 @@ from core.callback_events import CallbackEvent
 from core.callbacks import UnifiedCallbackManager
 from core.protocols import UnicodeProcessorProtocol
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from services.data_processing.file_processor import FileProcessor
+from utils.pandas_readers import read_csv
 
 from .base import BaseReader
 
@@ -27,7 +27,7 @@ class CSVReader(BaseReader):
         if not str(file_path).lower().endswith(".csv"):
             raise CSVReader.CannotParse("extension mismatch")
         try:
-            df = FileProcessor.read_large_csv(file_path, **hint)
+            df = read_csv(file_path, **hint)
         except Exception as exc:
             raise CSVReader.CannotParse(str(exc)) from exc
 

--- a/file_processing/readers/excel_reader.py
+++ b/file_processing/readers/excel_reader.py
@@ -6,6 +6,7 @@ from core.callback_events import CallbackEvent
 from core.callbacks import UnifiedCallbackManager
 from core.protocols import UnicodeProcessorProtocol
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from utils.pandas_readers import read_excel
 
 from .base import BaseReader
 
@@ -25,7 +26,7 @@ class ExcelReader(BaseReader):
         if not str(file_path).lower().endswith((".xls", ".xlsx")):
             raise ExcelReader.CannotParse("extension mismatch")
         try:
-            df = pd.read_excel(file_path, **(hint or {}))
+            df = read_excel(file_path, **(hint or {}))
         except Exception as exc:
             raise ExcelReader.CannotParse(str(exc)) from exc
 

--- a/file_processing/readers/fwf_reader.py
+++ b/file_processing/readers/fwf_reader.py
@@ -6,6 +6,7 @@ from core.callback_events import CallbackEvent
 from core.callbacks import UnifiedCallbackManager
 from core.protocols import UnicodeProcessorProtocol
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from utils.pandas_readers import read_fwf
 
 from .base import BaseReader
 
@@ -26,7 +27,7 @@ class FWFReader(BaseReader):
         if not str(file_path).lower().endswith(".fwf"):
             raise FWFReader.CannotParse("extension mismatch")
         try:
-            df = pd.read_fwf(file_path, **hint)
+            df = read_fwf(file_path, **hint)
         except Exception as exc:
             raise FWFReader.CannotParse(str(exc)) from exc
 

--- a/file_processing/readers/json_reader.py
+++ b/file_processing/readers/json_reader.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import pandas as pd
 
 from core.callback_events import CallbackEvent
@@ -10,6 +8,7 @@ from core.protocols import UnicodeProcessorProtocol
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 
 from .base import BaseReader
+from utils.pandas_readers import read_json as util_read_json
 
 
 class JSONReader(BaseReader):
@@ -28,13 +27,7 @@ class JSONReader(BaseReader):
         if not str(file_path).lower().endswith(".json"):
             raise JSONReader.CannotParse("extension mismatch")
         try:
-            with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
-                text = fh.read()
-            try:
-                data = json.loads(text)
-                df = pd.json_normalize(data)
-            except json.JSONDecodeError:
-                df = pd.read_json(text, lines=True)
+            df = util_read_json(file_path)
         except Exception as exc:
             raise JSONReader.CannotParse(str(exc)) from exc
 

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from core.config import get_max_display_rows
 from services.upload.utils.file_parser import UnicodeFileProcessor
+from utils.pandas_readers import read_csv, read_excel, read_json, read_parquet
 
 
 class AsyncUploadProcessor:
@@ -15,20 +16,24 @@ class AsyncUploadProcessor:
         self.unicode_processor = UnicodeFileProcessor()
 
     async def read_csv(self, path: str | Path, **kwargs: Any) -> pd.DataFrame:
-        df = await asyncio.to_thread(pd.read_csv, path, **kwargs)
-        return self.unicode_processor.sanitize_dataframe_unicode(df)
+        return await asyncio.to_thread(
+            read_csv, path, processor=self.unicode_processor, **kwargs
+        )
 
     async def read_excel(self, path: str | Path, **kwargs: Any) -> pd.DataFrame:
-        df = await asyncio.to_thread(pd.read_excel, path, **kwargs)
-        return self.unicode_processor.sanitize_dataframe_unicode(df)
+        return await asyncio.to_thread(
+            read_excel, path, processor=self.unicode_processor, **kwargs
+        )
 
     async def read_json(self, path: str | Path, **kwargs: Any) -> pd.DataFrame:
-        df = await asyncio.to_thread(pd.read_json, path, **kwargs)
-        return self.unicode_processor.sanitize_dataframe_unicode(df)
+        return await asyncio.to_thread(
+            read_json, path, processor=self.unicode_processor, **kwargs
+        )
 
     async def read_parquet(self, path: str | Path, **kwargs: Any) -> pd.DataFrame:
-        df = await asyncio.to_thread(pd.read_parquet, path, **kwargs)
-        return self.unicode_processor.sanitize_dataframe_unicode(df)
+        return await asyncio.to_thread(
+            read_parquet, path, processor=self.unicode_processor, **kwargs
+        )
 
     async def preview_from_parquet(
         self, path: str | Path, *, rows: int | None = None

--- a/utils/pandas_readers.py
+++ b/utils/pandas_readers.py
@@ -1,0 +1,68 @@
+"""Shared pandas file reader helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import json
+import pandas as pd
+
+from services.upload.utils.file_parser import UnicodeFileProcessor
+
+
+def _sanitize(df: pd.DataFrame, processor: UnicodeFileProcessor | None) -> pd.DataFrame:
+    proc = processor or UnicodeFileProcessor()
+    return proc.sanitize_dataframe_unicode(df)
+
+
+def read_csv(
+    path: str | Path, *, processor: UnicodeFileProcessor | None = None, **kwargs: Any
+) -> pd.DataFrame:
+    """Read a CSV file and sanitize Unicode."""
+    df = pd.read_csv(path, **kwargs)
+    return _sanitize(df, processor)
+
+
+def read_excel(
+    path: str | Path, *, processor: UnicodeFileProcessor | None = None, **kwargs: Any
+) -> pd.DataFrame:
+    """Read an Excel file and sanitize Unicode."""
+    df = pd.read_excel(path, **kwargs)
+    return _sanitize(df, processor)
+
+
+def read_json(
+    path: str | Path,
+    *,
+    processor: UnicodeFileProcessor | None = None,
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Read a JSON file and sanitize Unicode."""
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    try:
+        data = json.loads(text)
+        df = pd.json_normalize(data)
+    except json.JSONDecodeError:
+        df = pd.read_json(text, lines=True)
+    return _sanitize(df, processor)
+
+
+def read_parquet(
+    path: str | Path, *, processor: UnicodeFileProcessor | None = None, **kwargs: Any
+) -> pd.DataFrame:
+    """Read a parquet file and sanitize Unicode."""
+    df = pd.read_parquet(path, **kwargs)
+    return _sanitize(df, processor)
+
+
+def read_fwf(
+    path: str | Path, *, processor: UnicodeFileProcessor | None = None, **kwargs: Any
+) -> pd.DataFrame:
+    """Read a fixed-width file and sanitize Unicode."""
+    df = pd.read_fwf(path, **kwargs)
+    return _sanitize(df, processor)
+
+
+__all__ = ["read_csv", "read_excel", "read_json", "read_parquet", "read_fwf"]


### PR DESCRIPTION
## Summary
- factor out pandas reading helpers
- reuse helpers across csv/excel/json/fwf readers
- update AsyncUploadProcessor to use shared helpers

## Testing
- `black utils/pandas_readers.py services/upload/async_processor.py file_processing/readers/*.py`
- `pytest -q` *(fails: ModuleNotFoundError for test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a1194aeec8320a36f937bd2c127cc