### PR TITLE
Add async processor and mapping tests

### DIFF
--- a/tests/file_processing/test_data_processor_pipeline.py
+++ b/tests/file_processing/test_data_processor_pipeline.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+import importlib.util
+import sys
+import types
+
+import pandas as pd
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "file_processing" / "data_processor.py"
+
+# Provide minimal stubs for core dependencies before loading the module
+callbacks_stub = types.SimpleNamespace(UnifiedCallbackManager=lambda: types.SimpleNamespace(trigger=lambda *a, **k: None))
+truly_stub = types.SimpleNamespace(TrulyUnifiedCallbacks=object)
+cb_events_stub = types.SimpleNamespace(
+    CallbackEvent=types.SimpleNamespace(SYSTEM_WARNING=1, SYSTEM_ERROR=2)
+)
+container_stub = types.ModuleType("core.container")
+container_stub.get_unicode_processor = lambda: types.SimpleNamespace(
+    sanitize_dataframe=lambda df: df
+)
+
+sys.modules.setdefault("core.callbacks", callbacks_stub)
+sys.modules.setdefault("core.truly_unified_callbacks", truly_stub)
+format_stub = types.ModuleType("file_processing.format_detector")
+class FormatDetector:
+    def __init__(self, *a, **k): ...
+    def detect_and_load(self, path, hint=None):
+        return pd.read_csv(path), {}
+class UnsupportedFormatError(Exception):
+    pass
+format_stub.FormatDetector = FormatDetector
+format_stub.UnsupportedFormatError = UnsupportedFormatError
+sys.modules.setdefault("file_processing.format_detector", format_stub)
+
+readers_stub = types.ModuleType("file_processing.readers")
+for name in ["CSVReader", "ExcelReader", "JSONReader", "FWFReader", "ArchiveReader"]:
+    setattr(readers_stub, name, type(name, (), {}))
+sys.modules.setdefault("file_processing.readers", readers_stub)
+sys.modules.setdefault("core.callback_events", cb_events_stub)
+sys.modules.setdefault("core.container", container_stub)
+pkg = types.ModuleType("file_processing")
+pkg.__path__ = [str(MODULE_PATH.parent)]
+sys.modules.setdefault("file_processing", pkg)
+spec = importlib.util.spec_from_file_location("file_processing.data_processor", MODULE_PATH)
+dp_mod = importlib.util.module_from_spec(spec)
+sys.modules["file_processing.data_processor"] = dp_mod
+assert spec.loader is not None
+spec.loader.exec_module(dp_mod)
+DataProcessor = dp_mod.DataProcessor
+
+def test_process_csv_pipeline(tmp_path: Path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01 01:02:03"],
+            "person_id": ["P1"],
+            "badge_id": ["B1"],
+            "device_name": ["Entrance"],
+            "door_id": ["D1"],
+            "access_result": ["granted"],
+        }
+    )
+    csv_path = tmp_path / "d.csv"
+    df.to_csv(csv_path, index=False)
+
+    monkeypatch.setattr(DataProcessor, "_enrich_devices", lambda self, d: d)
+    monkeypatch.setattr(DataProcessor, "load_file", lambda self, p: pd.read_csv(p))
+    monkeypatch.setattr(DataProcessor, "_schema_validate", lambda self, d: d)
+
+    proc = DataProcessor()
+    out = proc.process(str(csv_path))
+
+    required = {
+        "timestamp",
+        "person_id",
+        "badge_id",
+        "device_name",
+        "door_id",
+        "access_result",
+        "date",
+        "hour_of_day",
+        "day_of_week",
+        "person_id_valid",
+        "badge_id_valid",
+        "access_result_code",
+        "event_fingerprint",
+        "is_entry",
+        "is_exit",
+        "pipeline_stage",
+        "schema_version",
+    }
+    assert required.issubset(out.columns)
+    assert str(out.loc[0, "timestamp"].tzinfo) == "UTC"
+    assert out.loc[0, "access_result_code"] == 1
+    assert out.loc[0, "pipeline_stage"] == "normalized"
+    assert out.loc[0, "schema_version"] == "1.0"
+
+
+def test_process_excel_pipeline(tmp_path: Path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "timestamp": ["2024-02-02 10:00:00"],
+            "person_id": ["P2"],
+            "badge_id": ["B2"],
+            "device_name": ["Exit"],
+            "door_id": ["D2"],
+            "access_result": ["denied"],
+        }
+    )
+    xl_path = tmp_path / "d.xlsx"
+    df.to_excel(xl_path, index=False)
+    monkeypatch.setattr(DataProcessor, "load_file", lambda self, p: pd.read_excel(p))
+
+    monkeypatch.setattr(DataProcessor, "_enrich_devices", lambda self, d: d)
+    monkeypatch.setattr(DataProcessor, "_schema_validate", lambda self, d: d)
+
+    proc = DataProcessor()
+    out = proc.process(str(xl_path))
+
+    assert out.loc[0, "access_result_code"] == 0
+    assert out.loc[0, "pipeline_stage"] == "normalized"
+    assert out.loc[0, "schema_version"] == "1.0"

--- a/tests/services/test_async_file_processor.py
+++ b/tests/services/test_async_file_processor.py
@@ -1,0 +1,121 @@
+import base64
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import asyncio
+import pytest
+otel = types.ModuleType("opentelemetry");
+context_mod = types.ModuleType("opentelemetry.context");
+otel.context = context_mod;
+config_mod = types.ModuleType("config");
+config_base = types.ModuleType("config.base");
+core_protocols = types.ModuleType("core.protocols");
+core_protocols.FileProcessorProtocol = object;
+sys.modules.setdefault("core.protocols", core_protocols);
+rabbit_stub = types.ModuleType("services.rabbitmq_client");
+rabbit_stub.RabbitMQClient = lambda *a, **k: None;
+sys.modules.setdefault("services.rabbitmq_client", rabbit_stub);
+taskq_stub = types.ModuleType("services.task_queue");
+taskq_stub.create_task = lambda *a, **k: "id";
+taskq_stub.get_status = lambda *a, **k: {"progress": 0};
+sys.modules.setdefault("services.task_queue", taskq_stub);
+mem_stub = types.ModuleType("utils.memory_utils");
+mem_stub.check_memory_limit = lambda *a, **k: None;
+sys.modules.setdefault("utils.memory_utils", mem_stub);
+fp_stub = types.ModuleType("services.data_processing.file_processor");
+fp_stub.UnicodeFileProcessor = types.SimpleNamespace(sanitize_dataframe_unicode=lambda df: df, read_large_csv=lambda path, **k: pd.read_csv(path, **k));
+sys.modules.setdefault("services.data_processing.file_processor", fp_stub)
+prom = types.ModuleType("prometheus_client");
+sys.modules.setdefault("prometheus_client", prom)
+config_base.CacheConfig = object;
+sys.modules.setdefault("config.base", config_base)
+dyn = types.SimpleNamespace(analytics=types.SimpleNamespace(chunk_size=2, max_memory_mb=1024));
+config_mod.dynamic_config = dyn;
+config_mod.DatabaseSettings = lambda *a, **k: None;
+sys.modules.setdefault("config", config_mod);
+sys.modules.setdefault("config.dynamic_config", config_mod)
+sys.modules.setdefault("opentelemetry", otel);
+sys.modules.setdefault("opentelemetry.context", context_mod);
+tracing_stub = types.ModuleType("tracing");
+tracing_stub.propagate_context = lambda *a, **k: None;
+tracing_stub.trace_async_operation = lambda name, coro: coro;
+sys.modules.setdefault("tracing", tracing_stub)
+
+services_root = Path(__file__).resolve().parents[2] / "services"
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(services_root)]
+sys.modules.setdefault("services", services_pkg)
+
+upload_pkg = types.ModuleType("services.upload")
+upload_pkg.__path__ = [str(services_root / "upload")]
+sys.modules.setdefault("services.upload", upload_pkg)
+protocols_mod = types.ModuleType("services.upload.protocols")
+sys.modules.setdefault("services.upload.protocols", protocols_mod)
+data_processing_pkg = types.ModuleType("services.data_processing")
+data_processing_pkg.__path__ = [str(services_root / "data_processing")]
+sys.modules.setdefault("services.data_processing", data_processing_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "services.task_queue", services_root / "task_queue.py"
+)
+tq_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(tq_mod)
+sys.modules.setdefault("services.task_queue", tq_mod)
+clear_task = tq_mod.clear_task
+
+spec = importlib.util.spec_from_file_location(
+    "services.data_processing.async_file_processor",
+    services_root / "data_processing" / "async_file_processor.py",
+)
+async_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(async_mod)
+AsyncFileProcessor = async_mod.AsyncFileProcessor
+
+
+def test_read_csv_chunks_and_load(tmp_path: Path):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": list("xyz")})
+    csv_path = tmp_path / "sample.csv"
+    df.to_csv(csv_path, index=False)
+
+    proc = AsyncFileProcessor(chunk_size=2)
+
+    async def gather():
+        chunks = []
+        async for chunk in proc.read_csv_chunks(csv_path):
+            chunks.append(chunk)
+        return pd.concat(chunks, ignore_index=True)
+
+    loaded_chunks = asyncio.run(gather())
+    assert loaded_chunks.equals(df)
+
+    loaded = asyncio.run(proc.load_csv(csv_path))
+    assert loaded.equals(df)
+
+def test_process_excel_file(tmp_path: Path):
+    df = pd.DataFrame({"a": [5, 6], "b": ["m", "n"]})
+    xl_path = tmp_path / "s.xlsx"
+    df.to_excel(xl_path, index=False)
+    contents = base64.b64encode(xl_path.read_bytes()).decode()
+    data_uri = (
+        "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,"
+        + contents
+    )
+
+    proc = AsyncFileProcessor()
+    progress = []
+    result = asyncio.run(
+        proc.process_file(
+            data_uri,
+            "s.xlsx",
+            progress_callback=lambda _f, p: progress.append(p),
+        )
+    )
+
+    assert result.equals(df)
+    assert progress and progress[-1] == 100
+    clear_task.cache_clear() if hasattr(clear_task, "cache_clear") else None

--- a/tests/services/test_mapping_utils.py
+++ b/tests/services/test_mapping_utils.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+import pandas as pd
+import pytest
+
+SPEC_PATH = Path(__file__).resolve().parents[2] / "services" / "data_enhancer" / "mapping_utils.py"
+spec = importlib.util.spec_from_file_location("mapping_utils", SPEC_PATH)
+mapping_utils = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mapping_utils)
+apply_fuzzy_column_matching = mapping_utils.apply_fuzzy_column_matching
+apply_manual_mapping = mapping_utils.apply_manual_mapping
+get_mapping_suggestions = mapping_utils.get_mapping_suggestions
+
+
+def test_apply_fuzzy_column_matching():
+    df = pd.DataFrame(
+        {
+            "Person ID": ["p1"],
+            "Door Name": ["d1"],
+            "Result": ["granted"],
+            "Time": ["2024-01-01"],
+        }
+    )
+    renamed, mapping = apply_fuzzy_column_matching(
+        df, ["person_id", "door_id", "access_result", "timestamp"]
+    )
+    assert list(renamed.columns) == [
+        "person_id",
+        "door_id",
+        "access_result",
+        "timestamp",
+    ]
+    assert mapping == {
+        "person_id": "Person ID",
+        "door_id": "Door Name",
+        "access_result": "Result",
+        "timestamp": "Time",
+    }
+
+
+def test_apply_manual_mapping_error():
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(ValueError):
+        apply_manual_mapping(df, {"person_id": "B"})
+
+
+def test_get_mapping_suggestions():
+    df = pd.DataFrame({"UserID": ["u1"], "Door": ["d"], "Status": ["ok"], "Date": ["2023"]})
+    info = get_mapping_suggestions(df)
+    assert set(info["required_columns"]) == {"person_id", "door_id", "access_result", "timestamp"}
+    assert info["missing_mappings"] == []


### PR DESCRIPTION
## Summary
- add service-level async file processor tests
- cover DataProcessor pipeline behavior
- test data enhancer mapping utilities

## Testing
- `pytest tests/services/test_async_file_processor.py tests/file_processing/test_data_processor_pipeline.py tests/services/test_mapping_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a11967dc48320a4c83cb2161a1b22