### PR TITLE
Document architecture and add module docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ docker-compose \
   -f docker-compose.dev.yml up --build
 ```
 
+To build individual images without starting the stack run:
+```bash
+docker build -t yosai-dashboard -f Dockerfile .
+docker build -t yosai-gateway -f Dockerfile.gateway .
+```
+
 web UI on `http://localhost:8080`, pgAdmin on `http://localhost:5050`, and the API gateway on `http://localhost:8081`.
 
 ### Go API Gateway
@@ -492,6 +498,12 @@ mypy .
 # Check code quality
 black . --check
 flake8 .
+```
+
+You can also use the Makefile shortcuts:
+```bash
+make test  # run pytest and coverage
+make lint  # run flake8 and type checks
 ```
 
 The `tests/` directory contains the integration and unit tests for the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# High Level Design
+
+The dashboard follows a modular, service‑oriented architecture built around a
+`ServiceContainer`. Each page composes small services obtained from the
+container to keep dependencies loosely coupled.  Background workers, the API
+gateway and the UI all share the same contracts defined under
+`services/interfaces.py`.
+
+```
+request -> gateway -> service container -> service -> repository -> database
+```
+
+The core layers include:
+
+- **Service Container** – Registers implementations and injects them on demand.
+- **Services** – Encapsulate business logic and orchestrate repositories.
+- **Repositories** – Handle persistence and external APIs.
+- **Plugins** – Optional extensions discovered at runtime.
+
+This layout allows tests to swap in lightweight mocks for any dependency. The
+same container setup is reused by the CLI tools and unit tests so behaviour is
+consistent across environments.
+
+See `docs/architecture.md` for a detailed breakdown and diagrams of individual
+components.

--- a/services/upload/ai.py
+++ b/services/upload/ai.py
@@ -1,3 +1,7 @@
+"""Helper functions powered by the AI mapping store."""
+
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, List
 

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -1,3 +1,7 @@
+"""Async utilities for reading uploaded files without blocking."""
+
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 from typing import Any

--- a/services/upload/chunked_upload_manager.py
+++ b/services/upload/chunked_upload_manager.py
@@ -1,3 +1,7 @@
+"""Manage progress for chunked file uploads."""
+
+from __future__ import annotations
+
 import json
 import logging
 import time

--- a/services/upload/chunked_upload_manager_async.py
+++ b/services/upload/chunked_upload_manager_async.py
@@ -1,3 +1,7 @@
+"""Asynchronous manager for streaming large uploads in chunks."""
+
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -1,3 +1,7 @@
+"""Dash callbacks powering the interactive upload page."""
+
+from __future__ import annotations
+
 import base64
 import io
 import json

--- a/services/upload/core/file_processor_service.py
+++ b/services/upload/core/file_processor_service.py
@@ -1,3 +1,7 @@
+"""Process uploaded files and persist results to storage."""
+
+from __future__ import annotations
+
 import logging
 from typing import Any, Callable, Dict, List
 

--- a/services/upload/core/learning_coordinator.py
+++ b/services/upload/core/learning_coordinator.py
@@ -1,3 +1,7 @@
+"""High level interface around the device learning service."""
+
+from __future__ import annotations
+
 import logging
 from typing import Dict
 

--- a/services/upload/core/orchestrator.py
+++ b/services/upload/core/orchestrator.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+"""Coordinate upload processing, validation and storage steps."""
+
 import logging
 from typing import Any, Callable, Dict, List, Tuple
 
 import pandas as pd
 
+from components.upload.ui_builder import UploadUIBuilder
 from core.protocols import FileProcessorProtocol
 from services.async_file_processor import AsyncFileProcessor
 from services.data_enhancer.mapping_utils import get_ai_column_suggestions
 from services.upload.core.file_processor_service import FileProcessor
 from services.upload.core.file_validator import FileValidator
 from services.upload.core.learning_coordinator import LearningCoordinator
-from components.upload.ui_builder import UploadUIBuilder
 from services.upload.protocols import (
     DeviceLearningServiceProtocol,
     UploadProcessingServiceProtocol,

--- a/services/upload/core/validator.py
+++ b/services/upload/core/validator.py
@@ -1,3 +1,7 @@
+"""Client-side validation rules executed on the server."""
+
+from __future__ import annotations
+
 import base64
 import json
 from typing import Any, Callable, Iterable, List, Mapping

--- a/services/upload/helpers.py
+++ b/services/upload/helpers.py
@@ -1,3 +1,7 @@
+"""Helper utilities for upload callbacks and AI training data."""
+
+from __future__ import annotations
+
 import json
 import logging
 from datetime import datetime

--- a/services/upload/managers.py
+++ b/services/upload/managers.py
@@ -1,3 +1,8 @@
+"""Simple progress and queue managers used by the upload page."""
+
+from __future__ import annotations
+
+
 class ChunkedUploadManager:
     """Track progress for chunked file uploads."""
 

--- a/services/upload/modal.py
+++ b/services/upload/modal.py
@@ -1,3 +1,7 @@
+"""Control modal dialogs triggered during file uploads."""
+
+from __future__ import annotations
+
 import logging
 from typing import Any, Tuple
 

--- a/services/upload/upload_queue_manager.py
+++ b/services/upload/upload_queue_manager.py
@@ -1,3 +1,7 @@
+"""Background task queue for file uploads."""
+
+from __future__ import annotations
+
 import asyncio
 import heapq
 import logging

--- a/services/upload/upload_types.py
+++ b/services/upload/upload_types.py
@@ -1,3 +1,7 @@
+"""Simple dataclasses representing results of the upload workflow."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Dict, List
 


### PR DESCRIPTION
## Summary
- add missing module docstrings in `services/upload`
- include high level architecture summary
- document testing, linting and docker build commands

## Testing
- `pre-commit run --files services/upload/ai.py services/upload/async_processor.py services/upload/chunked_upload_manager.py services/upload/chunked_upload_manager_async.py services/upload/helpers.py services/upload/managers.py services/upload/modal.py services/upload/upload_queue_manager.py services/upload/upload_types.py services/upload/controllers/upload_controller.py services/upload/core/file_processor_service.py services/upload/core/learning_coordinator.py services/upload/core/orchestrator.py services/upload/core/validator.py docs/ARCHITECTURE.md README.md`
- `pytest -k "none" -q` *(fails: Missing required test dependencies: psutil)*

------
https://chatgpt.com/codex/tasks/task_e_688a11a1ee688320b1fd89ec80587b1c