### PR TITLE
Ensure uploaded values sanitized in logs

### DIFF
--- a/plugins/ai_classification/services/csv_processor.py
+++ b/plugins/ai_classification/services/csv_processor.py
@@ -1,6 +1,8 @@
 """Enhanced CSV processing service with optional Polars optimization"""
 
 import logging
+
+from unicode_toolkit import safe_encode_text
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -50,7 +52,11 @@ class CSVProcessorService:
                 return self._process_with_polars(csv_data, filename, session_id)
             return self._process_with_pandas(csv_data, filename, session_id)
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("CSV processing failed for %s: %s", filename, exc)
+            logger.error(
+                "CSV processing failed for %s: %s",
+                safe_encode_text(filename),
+                safe_encode_text(exc),
+            )
             return {
                 "success": False,
                 "error": f"Failed to process CSV: {exc}",

--- a/plugins/example/plugin.py
+++ b/plugins/example/plugin.py
@@ -8,6 +8,7 @@ from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
 from core.protocols.plugin import CallbackPluginProtocol, PluginMetadata
+from unicode_toolkit import safe_encode_text
 
 
 @dataclass
@@ -15,7 +16,7 @@ class GreetingService:
     greeting: str = "Hello"
 
     def greet(self, name: str) -> str:
-        return f"{self.greeting}, {name}!"
+        return f"{self.greeting}, {safe_encode_text(name)}!"
 
 
 class ExamplePlugin(CallbackPluginProtocol):

--- a/services/analytics/data/loader.py
+++ b/services/analytics/data/loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from unicode_toolkit import safe_encode_text
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
@@ -74,7 +75,11 @@ class DataLoader:
         for filename, df in uploaded_data.items():
             original_rows = len(df)
             total_original_rows += original_rows
-            logger.info("   %s: %s rows", filename, f"{original_rows:,}")
+            logger.info(
+                "   %s: %s rows",
+                safe_encode_text(filename),
+                f"{original_rows:,}",
+            )
 
             cleaned_df = self.upload_processor.clean_uploaded_dataframe(df)
             all_dfs.append(cleaned_df)

--- a/services/data_processing/processor.py
+++ b/services/data_processing/processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from unicode_toolkit import safe_encode_text
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple
@@ -216,7 +217,11 @@ class Processor:
                                 meta["date_range"]["end"], dates.max()
                             )
             except Exception as exc:  # pragma: no cover - best effort
-                logger.error("Error processing %s: %s", filename, exc)
+                logger.error(
+                    "Error processing %s: %s",
+                    safe_encode_text(filename),
+                    safe_encode_text(exc),
+                )
 
         if combined:
             final_df = pd.concat(combined, ignore_index=True)

--- a/services/greeting/__init__.py
+++ b/services/greeting/__init__.py
@@ -1,5 +1,8 @@
+from unicode_toolkit import safe_encode_text
+
+
 class GreetingService:
     """Simple greeting service."""
 
     def greet(self, name: str) -> str:
-        return f"Hello, {name}!"
+        return f"Hello, {safe_encode_text(name)}!"

--- a/services/upload/core/file_processor_service.py
+++ b/services/upload/core/file_processor_service.py
@@ -1,4 +1,6 @@
 import logging
+
+from unicode_toolkit import safe_encode_text
 from typing import Any, Callable, Dict, List
 
 import pandas as pd
@@ -44,7 +46,11 @@ class FileProcessor:
             if mapping:
                 df = df.rename(columns=mapping)
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Failed to load mappings for %s: %s", filename, exc)
+            logger.error(
+                "Failed to load mappings for %s: %s",
+                safe_encode_text(filename),
+                safe_encode_text(exc),
+            )
         self.store.add_file(filename, df)
         return {
             "df": df,

--- a/services/upload/core/learning_coordinator.py
+++ b/services/upload/core/learning_coordinator.py
@@ -1,4 +1,6 @@
 import logging
+
+from unicode_toolkit import safe_encode_text
 from typing import Dict
 
 import pandas as pd
@@ -18,7 +20,11 @@ class LearningCoordinator:
         try:
             return self.service.get_user_device_mappings(filename) or {}
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Failed to load user mappings for %s: %s", filename, exc)
+            logger.error(
+                "Failed to load user mappings for %s: %s",
+                safe_encode_text(filename),
+                safe_encode_text(exc),
+            )
             return {}
 
     def auto_apply(self, df: pd.DataFrame, filename: str) -> bool:
@@ -30,5 +36,8 @@ class LearningCoordinator:
                 return True
             return False
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error("Failed to auto-apply learned mappings: %s", exc)
+            logger.error(
+                "Failed to auto-apply learned mappings: %s",
+                safe_encode_text(exc),
+            )
             return False

--- a/services/upload/helpers.py
+++ b/services/upload/helpers.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 from dash._callback_context import callback_context
 
+from unicode_toolkit import safe_encode_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +19,7 @@ def get_trigger_id() -> str:
 def save_ai_training_data(filename: str, mappings: Dict[str, str], file_info: Dict):
     """Save confirmed mappings for AI training."""
     try:
-        logger.info("🤖 Saving AI training data for %s", filename)
+        logger.info("🤖 Saving AI training data for %s", safe_encode_text(filename))
         training_data = {
             "filename": filename,
             "timestamp": datetime.now().isoformat(),

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -20,6 +20,7 @@ from core.protocols import ConfigurationProtocol
 
 # Core processing imports only - NO UI COMPONENTS
 from core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
+from unicode_toolkit import safe_encode_text
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,11 @@ def process_uploaded_file(
     try:
         decoded, decode_err = _safe_b64decode(contents)
         if decoded is None:
-            logger.error("Base64 decode failed for %s: %s", filename, decode_err)
+            logger.error(
+                "Base64 decode failed for %s: %s",
+                safe_encode_text(filename),
+                safe_encode_text(decode_err),
+            )
             return {
                 "status": "error",
                 "error": decode_err,
@@ -126,8 +131,17 @@ def process_uploaded_file(
         return {"status": "success", "data": df, "filename": filename, "error": None}
 
     except Exception as e:
-        logger.error(f"File processing error for {filename}: {e}")
-        return {"status": "error", "error": str(e), "data": None, "filename": filename}
+        logger.error(
+            "File processing error for %s: %s",
+            safe_encode_text(filename),
+            safe_encode_text(e),
+        )
+        return {
+            "status": "error",
+            "error": str(e),
+            "data": None,
+            "filename": filename,
+        }
 
 
 def create_file_preview(

--- a/tests/integration/test_sanitization.py
+++ b/tests/integration/test_sanitization.py
@@ -1,0 +1,21 @@
+import importlib
+import types
+import sys
+
+
+def test_greeting_service_uses_safe_encode():
+    fake = types.ModuleType("unicode_toolkit")
+    captured = {}
+
+    def sanitize(val):
+        captured['val'] = val
+        return 'clean'
+
+    fake.safe_encode_text = sanitize
+    sys.modules['unicode_toolkit'] = fake
+    import services.greeting as greeting
+    importlib.reload(greeting)
+
+    svc = greeting.GreetingService()
+    assert svc.greet('<bad>') == 'Hello, clean!'
+    assert captured['val'] == '<bad>'

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 import logging
+
+from unicode_toolkit import safe_encode_text
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
@@ -128,7 +130,11 @@ class UploadedDataStore(UploadStorageProtocol):
                         }
                         modified = True
                     except Exception as exc:  # pragma: no cover - best effort
-                        logger.error(f"Error converting {pkl_path}: {exc}")
+                        logger.error(
+                            "Error converting %s: %s",
+                            safe_encode_text(str(pkl_path)),
+                            safe_encode_text(exc),
+                        )
                         continue
                 else:
                     # Ensure path metadata exists for already-converted files
@@ -138,7 +144,10 @@ class UploadedDataStore(UploadStorageProtocol):
                 with open(self._info_path(), "w", encoding="utf-8") as f:
                     json.dump(self._file_info_store, f, indent=2)
         except Exception as e:  # pragma: no cover - best effort
-            logger.error(f"Error loading uploaded data info: {e}")
+            logger.error(
+                "Error loading uploaded data info: %s",
+                safe_encode_text(e),
+            )
 
     def _save_to_disk(self, filename: str, df: pd.DataFrame) -> None:
         try:
@@ -156,7 +165,10 @@ class UploadedDataStore(UploadStorageProtocol):
                 with open(self._info_path(), "w", encoding="utf-8") as f:
                     json.dump(self._file_info_store, f, indent=2)
         except Exception as e:  # pragma: no cover - best effort
-            logger.error(f"Error saving uploaded data: {e}")
+            logger.error(
+                "Error saving uploaded data: %s",
+                safe_encode_text(e),
+            )
 
     # -- Public API ---------------------------------------------------------
     def add_file(self, filename: str, df: pd.DataFrame) -> None:
@@ -196,7 +208,11 @@ class UploadedDataStore(UploadStorageProtocol):
                 with open(path, "r", encoding="utf-8", errors="replace") as fh:
                     return json.load(fh)
             except Exception as exc:  # pragma: no cover - best effort
-                logger.error(f"Error loading mapping {filename}: {exc}")
+                logger.error(
+                    "Error loading mapping %s: %s",
+                    safe_encode_text(filename),
+                    safe_encode_text(exc),
+                )
         return {}
 
     def save_mapping(self, filename: str, mapping: Dict[str, Any]) -> None:
@@ -206,7 +222,11 @@ class UploadedDataStore(UploadStorageProtocol):
             with open(path, "w", encoding="utf-8") as fh:
                 json.dump(mapping, fh, indent=2)
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error(f"Error saving mapping {filename}: {exc}")
+            logger.error(
+                "Error saving mapping %s: %s",
+                safe_encode_text(filename),
+                safe_encode_text(exc),
+            )
 
     def get_all_data(self) -> Dict[str, pd.DataFrame]:
         return {fname: self.load_dataframe(fname) for fname in self.get_filenames()}
@@ -245,7 +265,10 @@ class UploadedDataStore(UploadStorageProtocol):
                 if self._info_path().exists():
                     self._info_path().unlink()
             except Exception as e:  # pragma: no cover - best effort
-                logger.error(f"Error clearing uploaded data: {e}")
+                logger.error(
+                    "Error clearing uploaded data: %s",
+                    safe_encode_text(e),
+                )
         try:
 
             try:

--- a/validation/file_validator.py
+++ b/validation/file_validator.py
@@ -4,6 +4,8 @@ import base64
 import csv
 import io
 import logging
+
+from unicode_toolkit import safe_encode_text
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Tuple
 
@@ -119,7 +121,11 @@ class FileValidator(CompositeValidator):
             try:
                 return self.validator.validate(filename, content)
             except Exception as exc:  # pragma: no cover - delegate errors
-                logger.error("Validation failed for %s: %s", filename, exc)
+                logger.error(
+                    "Validation failed for %s: %s",
+                    safe_encode_text(filename),
+                    safe_encode_text(exc),
+                )
                 return False, str(exc)
         return True, ""
 


### PR DESCRIPTION
## Summary
- sanitize greeting message output using `safe_encode_text`
- encode filenames before logging throughout upload pipeline
- add test demonstrating sanitation

## Testing
- `pytest tests/integration/test_sanitization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a119897a88320928fd78421d2403d