### PR TITLE
Refactor page callbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from dash import Dash, html
 
 from simple_di import ServiceContainer
 from services.greeting import GreetingService
+from pages import greetings, register_callbacks
 
 
 def create_app() -> Dash:
@@ -11,23 +12,11 @@ def create_app() -> Dash:
     container = ServiceContainer()
     container.register("greeting_service", GreetingService())
 
-    from pages import greetings
-
     app = Dash(__name__)
     app.layout = html.Div([greetings.layout()])
 
-    # Always register greeting callbacks
-    greetings.register_callbacks(app, container)
-
-    # Optionally register other feature callbacks
-    for name in ("upload", "device_learning", "data_enhancer"):
-        try:
-            module = __import__(f"pages.{name}", fromlist=["register_callbacks"])
-            if hasattr(module, "register_callbacks"):
-                module.register_callbacks(app, container)
-        except Exception:
-            # Feature optional in minimal environment
-            continue
+    # Register callbacks for all pages
+    register_callbacks(app, container)
 
     # Expose container for testing/usage
     app._container = container

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -1,3 +1,22 @@
-"""Page callback registry."""
+"""Page callback registry and helper for registering all callbacks."""
 
-__all__ = ["greetings", "upload", "device_learning", "data_enhancer"]
+from importlib import import_module
+from typing import Iterable
+
+
+FEATURES: Iterable[str] = ["greetings", "upload", "device_learning", "data_enhancer"]
+
+
+def register_callbacks(app, container) -> None:
+    """Import each page package and register its callbacks."""
+    for name in FEATURES:
+        try:
+            module = import_module(f"{__name__}.{name}")
+        except Exception:  # pragma: no cover - optional pages
+            continue
+
+        if hasattr(module, "register_callbacks"):
+            module.register_callbacks(app, container)
+
+
+__all__ = [*FEATURES, "register_callbacks"]

--- a/pages/data_enhancer/callbacks.py
+++ b/pages/data_enhancer/callbacks.py
@@ -11,7 +11,7 @@ from core.truly_unified_callbacks import TrulyUnifiedCallbacks
 from services.data_enhancer.processor import DataEnhancerProcessor
 
 
-def register_callbacks(app, ICON_PATHS=None) -> None:
+def register_callbacks(app, container) -> None:
     """Register data enhancer callbacks."""
     callbacks = TrulyUnifiedCallbacks(app)
     _register(callbacks)
@@ -112,4 +112,3 @@ def _register(cb: TrulyUnifiedCallbacks) -> None:
             raise PreventUpdate
         df = pd.read_json(data, orient="split")
         return dcc.send_data_frame(df.to_csv, "enhanced.csv", index=False)
-

--- a/pages/upload/callbacks.py
+++ b/pages/upload/callbacks.py
@@ -2,10 +2,26 @@ from __future__ import annotations
 
 """Upload feature callbacks."""
 
+from dash import Input, Output
+from dash.exceptions import PreventUpdate
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from services.upload.controllers.upload_controller import UnifiedUploadController
 
 
 def register_callbacks(app, container) -> None:
     """Register upload callbacks using the provided Dash *app*."""
     callbacks = TrulyUnifiedCallbacks(app)
-    callbacks.register_upload_callbacks()
+    controller = UnifiedUploadController()
+
+    @callbacks.register_handler(
+        [Output("to-column-map-btn", "disabled"), Output("uploaded-df-store", "data")],
+        [Input("drag-drop-upload", "contents"), Input("drag-drop-upload", "filename")],
+        callback_id="file_upload_handle",
+        component_name="file_upload",
+        prevent_initial_call=True,
+    )
+    def handle_upload(contents, filename):
+        df = controller.parse_upload(contents, filename)
+        if df is None:
+            raise PreventUpdate
+        return False, df.to_json(date_format="iso", orient="split")

--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -2,61 +2,35 @@ import base64
 import io
 import json
 import logging
-from typing import Any, List, Tuple
+from typing import List, Optional
 
-import dash_bootstrap_components as dbc
 import pandas as pd
-from dash import Input, Output, State, dash_table, html
-from dash.exceptions import PreventUpdate
 
 logger = logging.getLogger(__name__)
 
 
 class UnifiedUploadController:
-    """Fixed upload controller with proper callback objects."""
+    """Handle core upload parsing logic independent of Dash."""
 
-    def __init__(self, callbacks: Any | None = None) -> None:
-        self.callbacks = callbacks
+    def __init__(self) -> None:
         self._progress = 0
         self._files: List[str] = []
 
-    def upload_callbacks(self) -> List[Tuple[Any, Any, Any, Any, str, dict]]:
-        def handle_upload(contents, filename):
-            if not contents or not filename:
-                raise PreventUpdate
+    def parse_upload(self, contents: str, filename: str) -> Optional[pd.DataFrame]:
+        """Return parsed DataFrame from uploaded *contents*."""
+        if not contents or not filename:
+            return None
 
-            try:
-                content_type, content_string = contents.split(",", 1)
-                decoded = base64.b64decode(content_string)
-                if filename.lower().endswith(".json"):
-                    data = json.loads(decoded.decode("utf-8"))
-                    df = pd.DataFrame(data)
-                else:
-                    df = pd.read_csv(io.StringIO(decoded.decode("utf-8")))
-            except Exception as exc:
-                logger.error("Failed to parse uploaded file: %s", exc)
-                return False, {}
+        try:
+            _type, content_string = contents.split(",", 1)
+            decoded = base64.b64decode(content_string)
+            if filename.lower().endswith(".json"):
+                data = json.loads(decoded.decode("utf-8"))
+                df = pd.DataFrame(data)
+            else:
+                df = pd.read_csv(io.StringIO(decoded.decode("utf-8")))
+        except Exception as exc:  # pragma: no cover - parsing errors
+            logger.error("Failed to parse uploaded file: %s", exc)
+            return None
 
-            dash_table.DataTable(
-                data=df.head().to_dict("records"),
-                columns=[{"name": c, "id": c} for c in df.columns],
-                page_size=5,
-            )
-            return False, df.to_json(date_format="iso", orient="split")
-
-        return [
-            (
-                handle_upload,
-                [
-                    Output("to-column-map-btn", "disabled"),
-                    Output("uploaded-df-store", "data"),
-                ],
-                [
-                    Input("drag-drop-upload", "contents"),
-                    Input("drag-drop-upload", "filename"),
-                ],
-                [],  # No states
-                "file_upload_handle",
-                {"prevent_initial_call": True},
-            ),
-        ]
+        return df

--- a/tests/stubs/services/upload/controllers/upload_controller.py
+++ b/tests/stubs/services/upload/controllers/upload_controller.py
@@ -1,12 +1,3 @@
 class UnifiedUploadController:
-    def __init__(self, callbacks=None):
-        self.callbacks = callbacks
-
-    def upload_callbacks(self):
-        return []
-
-    def progress_callbacks(self):
-        return []
-
-    def validation_callbacks(self):
-        return []
+    def parse_upload(self, contents: str, filename: str):
+        return None


### PR DESCRIPTION
## Summary
- centralize page callback registration
- align data enhancer and upload page callbacks
- decouple upload controller from Dash

## Testing
- `pytest -q tests/test_new_page_callbacks.py`

------
https://chatgpt.com/codex/tasks/task_e_688a18f507fc83208582701ca319291c