### PR TITLE
Sanitize uploaded filenames in logs

### DIFF
--- a/services/data_processing/file_processor.py
+++ b/services/data_processing/file_processor.py
@@ -18,6 +18,7 @@ from core.performance import get_performance_monitor
 from core.performance_file_processor import PerformanceFileProcessor
 from core.unicode import UnicodeProcessor as UnicodeHelper
 from core.unicode import safe_format_number, safe_unicode_decode
+from unicode_toolkit import safe_encode_text
 
 from .file_handler import process_file_simple
 
@@ -189,7 +190,11 @@ def process_uploaded_file(
         return {"success": True, "data": df, "filename": filename, "error": None}
 
     except Exception as e:
-        logger.error(f"File processing error for {filename}: {e}")
+        logger.error(
+            "File processing error for %s: %s",
+            safe_encode_text(filename),
+            e,
+        )
         return {"success": False, "error": str(e), "data": None, "filename": filename}
 
 

--- a/services/data_processing/no_limit_processor.py
+++ b/services/data_processing/no_limit_processor.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
+from unicode_toolkit import safe_encode_text
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +34,17 @@ class UnlimitedFileProcessor:
             monitor.throttle_if_needed()
             rows += len(chunk)
             check_memory_limit(self.max_memory_mb, logger)
-            logger.debug("Processed %s rows from %s", rows, path.name)
+            logger.debug(
+                "Processed %s rows from %s",
+                rows,
+                safe_encode_text(path.name),
+            )
             yield chunk
-        logger.info("Finished processing %s rows from %s", rows, path.name)
+        logger.info(
+            "Finished processing %s rows from %s",
+            rows,
+            safe_encode_text(path.name),
+        )
 
     def load_csv(self, file_path: str | Path, encoding: str = "utf-8") -> pd.DataFrame:
         """Return the combined dataframe from all chunks."""
@@ -59,14 +68,18 @@ class UnlimitedFileProcessor:
             if expected != processed_rows:
                 logger.warning(
                     "Possible truncation reading %s: expected %s rows, got %s",
-                    file_path,
+                    safe_encode_text(str(file_path)),
                     expected,
                     processed_rows,
                 )
                 return False
             return True
         except Exception as exc:  # pragma: no cover - validation best effort
-            logger.error("Validation failed for %s: %s", file_path, exc)
+            logger.error(
+                "Validation failed for %s: %s",
+                safe_encode_text(str(file_path)),
+                exc,
+            )
             return False
 
 

--- a/services/data_processing/processor.py
+++ b/services/data_processing/processor.py
@@ -11,6 +11,7 @@ import pandas as pd
 from config.constants import DEFAULT_CHUNK_SIZE
 from config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
+from unicode_toolkit import safe_encode_text
 from monitoring.data_quality_monitor import (
     DataQualityMetrics,
     get_data_quality_monitor,
@@ -138,7 +139,11 @@ class Processor:
                             "device_mappings": {},
                         }
                 except Exception as exc:  # pragma: no cover - best effort
-                    logger.error("Error loading mapping for %s: %s", fname, exc)
+                    logger.error(
+                        "Error loading mapping for %s: %s",
+                        safe_encode_text(fname),
+                        exc,
+                    )
 
             return data
         except Exception as exc:  # pragma: no cover - best effort
@@ -156,7 +161,11 @@ class Processor:
 
             logger.info("Found %d uploaded files", len(data))
             for name, df in data.items():
-                logger.info("%s: %d rows", name, len(df))
+                logger.info(
+                    "%s: %d rows",
+                    safe_encode_text(name),
+                    len(df),
+                )
             return data
         except ImportError:
             logger.error("Could not import uploaded data from file_upload")

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import logging
+from unicode_toolkit import safe_encode_text
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, runtime_checkable
@@ -142,7 +143,9 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
             self.learned_mappings[fingerprint] = learning_data
 
             logger.info(
-                f"✅ Saved {len(device_mappings)} device mappings for {filename}"
+                "✅ Saved %s device mappings for %s",
+                len(device_mappings),
+                safe_encode_text(filename),
             )
             logger.info(f"📁 File: {mapping_file}")
 
@@ -160,12 +163,16 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
         if fingerprint in self.learned_mappings:
             learned_data = self.learned_mappings[fingerprint]
             logger.info(
-                f"🔄 Loaded {len(learned_data.get('mappings', {}))} learned mappings for {filename}"  # noqa: E501
+                "🔄 Loaded %s learned mappings for %s",
+                len(learned_data.get("mappings", {})),
+                safe_encode_text(filename),
             )
             return learned_data.get("mappings", {})
 
         logger.info(
-            f"No learned mappings found for {filename} (fingerprint: {fingerprint})"
+            "No learned mappings found for %s (fingerprint: %s)",
+            safe_encode_text(filename),
+            fingerprint,
         )
         return {}
 
@@ -176,7 +183,7 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
 
         # DETAILED DEBUG
         logger.info("🔍 DEBUG apply_learned_mappings_to_global_store called:")
-        logger.info(f"🔍 DEBUG - filename: {filename}")
+        logger.info("🔍 DEBUG - filename: %s", safe_encode_text(filename))
 
         try:
             from services.ai_mapping_store import ai_mapping_store
@@ -256,7 +263,7 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
     ) -> bool:
         """Save user-confirmed device mappings to database"""
         logger.info("🔍 DEBUG save_user_device_mappings called:")
-        logger.info(f"🔍 DEBUG - filename: {filename}")
+        logger.info("🔍 DEBUG - filename: %s", safe_encode_text(filename))
         logger.info(f"🔍 DEBUG - user_mappings type: {type(user_mappings)}")
         logger.info(
             f"🔍 DEBUG - user_mappings length: {len(user_mappings) if user_mappings else 'None'}"  # noqa: E501
@@ -288,7 +295,9 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
             self._persist_learned_mappings()
 
             logger.info(
-                f"✅ Saved user device mappings for {filename}: {len(user_mappings)} devices"  # noqa: E501
+                "✅ Saved user device mappings for %s: %s devices",
+                safe_encode_text(filename),
+                len(user_mappings),
             )
             return True
 
@@ -310,7 +319,10 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
                 ):
                     return data.get("device_mappings") or data.get("mappings", {})
 
-            logger.info(f"No user device mappings found for {filename}")
+            logger.info(
+                "No user device mappings found for %s",
+                safe_encode_text(filename),
+            )
             return {}
 
         except Exception as e:

--- a/services/learning/src/api/consolidated_service.py
+++ b/services/learning/src/api/consolidated_service.py
@@ -7,6 +7,7 @@ import asyncio
 import hashlib
 import json
 import logging
+from unicode_toolkit import safe_encode_text
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -58,7 +59,11 @@ class ConsolidatedLearningService:
             asyncio.run(_cache_manager.clear())
         except Exception:
             pass
-        self.logger.info(f"Saved mapping {fingerprint[:8]} for {filename}")
+        self.logger.info(
+            "Saved mapping %s for %s",
+            fingerprint[:8],
+            safe_encode_text(filename),
+        )
         return fingerprint
 
     def get_learned_mappings(self, df: pd.DataFrame, filename: str) -> Dict[str, Any]:
@@ -67,7 +72,10 @@ class ConsolidatedLearningService:
 
         if fingerprint in self.learned_data:
             learned = self.learned_data[fingerprint]
-            self.logger.info(f"Found exact match for {filename}")
+            self.logger.info(
+                "Found exact match for %s",
+                safe_encode_text(filename),
+            )
             return {
                 "device_mappings": learned["device_mappings"],
                 "column_mappings": learned["column_mappings"],
@@ -78,7 +86,10 @@ class ConsolidatedLearningService:
 
         similar = self._find_similar_mapping(df)
         if similar:
-            self.logger.info(f"Found similar mapping for {filename}")
+            self.logger.info(
+                "Found similar mapping for %s",
+                safe_encode_text(filename),
+            )
             return {
                 "device_mappings": similar["device_mappings"],
                 "column_mappings": similar["column_mappings"],

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -6,6 +6,7 @@ Handles Unicode surrogate characters safely
 import io
 import json
 import logging
+from unicode_toolkit import safe_encode_text
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -126,7 +127,11 @@ def process_uploaded_file(
         return {"status": "success", "data": df, "filename": filename, "error": None}
 
     except Exception as e:
-        logger.error(f"File processing error for {filename}: {e}")
+        logger.error(
+            "File processing error for %s: %s",
+            safe_encode_text(filename),
+            e,
+        )
         return {"status": "error", "error": str(e), "data": None, "filename": filename}
 
 

--- a/tests/integration/test_log_sanitization.py
+++ b/tests/integration/test_log_sanitization.py
@@ -1,0 +1,14 @@
+import pytest
+
+try:
+    from unicode_toolkit import safe_encode_text  # type: ignore
+except Exception as exc:  # pragma: no cover - environment missing deps
+    pytest.skip(f"unicode_toolkit unavailable: {exc}", allow_module_level=True)
+
+
+def test_safe_encode_strips_newlines():
+    assert safe_encode_text("bad\nname.csv") == "badname.csv"
+
+
+def test_safe_encode_drops_prefix():
+    assert safe_encode_text("=formula.csv") == "formula.csv"

--- a/utils/upload_store.py
+++ b/utils/upload_store.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+from unicode_toolkit import safe_encode_text
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
@@ -196,7 +197,11 @@ class UploadedDataStore(UploadStorageProtocol):
                 with open(path, "r", encoding="utf-8", errors="replace") as fh:
                     return json.load(fh)
             except Exception as exc:  # pragma: no cover - best effort
-                logger.error(f"Error loading mapping {filename}: {exc}")
+                logger.error(
+                    "Error loading mapping %s: %s",
+                    safe_encode_text(filename),
+                    exc,
+                )
         return {}
 
     def save_mapping(self, filename: str, mapping: Dict[str, Any]) -> None:
@@ -206,7 +211,11 @@ class UploadedDataStore(UploadStorageProtocol):
             with open(path, "w", encoding="utf-8") as fh:
                 json.dump(mapping, fh, indent=2)
         except Exception as exc:  # pragma: no cover - best effort
-            logger.error(f"Error saving mapping {filename}: {exc}")
+            logger.error(
+                "Error saving mapping %s: %s",
+                safe_encode_text(filename),
+                exc,
+            )
 
     def get_all_data(self) -> Dict[str, pd.DataFrame]:
         return {fname: self.load_dataframe(fname) for fname in self.get_filenames()}


### PR DESCRIPTION
## Summary
- sanitize filenames before logging by using `unicode_toolkit.safe_encode_text`
- include tests covering the sanitization helper

## Testing
- `pytest tests/integration/test_log_sanitization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a18fa6b108320825dd0aaef879450