### PR TITLE
Add lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           set -xe
           pip install -r requirements.lock
           pip install -r requirements-test.txt
+      - name: Run pre-commit
+        run: |
+          set -xe
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
       - name: Upload OpenAPI
         uses: actions/upload-artifact@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,22 @@ repos:
     hooks:
       - id: black
         args: ["--line-length=88"]
+        language_version: python3
+        types: [python]
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile=black", "--line-length=88"]
+        language_version: python3
+        types: [python]
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:
       - id: flake8
         args: ["--max-line-length=88"]
+        language_version: python3
+        types: [python]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.1
     hooks:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,8 @@ export default [
     rules: {
       semi: "error",
       quotes: ["error", "single"],
+      eqeqeq: "error",
+      "no-console": "warn",
     },
   },
   {


### PR DESCRIPTION
## Summary
- include black, isort and flake8 in pre-commit with explicit config
- enforce global lint rules via eslint.config.js
- run pre-commit in CI so lint failures break the build

## Testing
- `pre-commit run --files eslint.config.js .pre-commit-config.yaml .github/workflows/ci.yml`
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eslint-plugin-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_688a18fbfb2c8320a484eb093a2c19a8