### PR TITLE
Update Docker builds and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,5 @@ DB_EVENTS_NAME=yosai_events_db
 REACT_APP_API_BASE=/v1
 REACT_APP_WS_URL=localhost:5001
 PERMISSION_SERVICE_URL=http://rbac-service:8081
+SERVICE_REGISTRY_URL=http://service-registry:8500
+

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
 
 jobs:
@@ -133,6 +134,32 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}-${{ matrix.name }}:latest
             ghcr.io/${{ github.repository }}-${{ matrix.name }}:${{ steps.vars.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release-image:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [container-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push release image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -27,5 +27,9 @@ EXPOSE 8050
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8050/ || exit 1
 
-# Run application with Gunicorn
-CMD ["gunicorn", "wsgi:server", "--bind", "0.0.0.0:8050"]
+# Copy start script
+COPY start.sh ./start.sh
+RUN chmod +x start.sh
+
+# Run application via start.sh so environment variables from `.env` are loaded
+CMD ["./start.sh"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -34,4 +34,8 @@ EXPOSE 8050
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 CMD curl -f http://localhost:8050/ || exit 1
 
-CMD ["gunicorn", "-c", "gunicorn.conf.py", "wsgi:server"]
+COPY start.sh ./start.sh
+RUN chmod +x start.sh
+
+# Run application via start.sh so `.env` variables are loaded
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ docker-compose \
 
 `start.sh` reads variables from `.env` before launching the server. Ensure the
 file exists or pass the required values via `--env-file` when running the
-container.
+container. If you override the default command in Docker Compose, invoke
+`./start.sh` so the variables are loaded correctly.
 
 web UI on `http://localhost:8080`, pgAdmin on `http://localhost:5050`, and the API gateway on `http://localhost:8081`.
 
@@ -407,6 +408,8 @@ docker-compose -f docker-compose.prod.yml up -d
 The container entrypoint runs `start.sh`, which sources the `.env` file before
 launching Gunicorn. Make sure the file exists or supply one via Docker's
 `--env-file` option.
+When deploying manually or via Kubernetes, execute `start.sh` to ensure
+environment variables from `.env` are available to the app.
 Whenever you modify the code, rebuild the Docker image with `docker-compose build` (or `docker-compose up --build`) so the running container picks up your changes.
 Docker Compose expects the database password and Flask secret key to be
 provided via Docker secrets or environment variables. Create


### PR DESCRIPTION
## Summary
- load variables from `.env` using `start.sh` in all Dockerfiles
- note using `start.sh` with Docker Compose and manual deployments
- provide `SERVICE_REGISTRY_URL` in `.env.example`
- publish Docker image on tag push via CI workflow

## Testing
- `pip install -q -r requirements-test.txt`
- `pip install -q requests httpx`
- `pytest -k 'nomatch' -q` *(fails: ModuleNotFoundError: asyncpg, structlog, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688a18fe0784832097ee7a7fe45661d6