### PR TITLE
Add architecture summary and module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,17 @@ make deprecation-docs
 make clean
 ```
 
+### Running tests, linting and Docker builds
+
+Use the Makefile targets (or `tools/ops_cli.py`) to execute the test suite,
+run style checks and build Docker images.
+
+```bash
+make test        # run pytest
+make lint        # run flake8
+make build       # docker compose build
+```
+
 Updates to component lifecycle should be recorded in `deprecation.yml`. Run
 `make deprecation-docs` whenever this file changes.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# High-Level Architecture
+
+The dashboard follows a microservice style design. A Flask & Dash front end
+communicates with several background services using REST and message queues.
+A lightweight dependency injection container wires these pieces together and
+allows tests to replace implementations easily.
+
+Key elements:
+
+- **Service Container** – central registry that provides shared services and
+  resolves dependencies on demand.
+- **Plugins** – optional packages discovered at startup to extend the system
+  without modifying core modules.
+- **Analytics Service** – background worker that performs heavy data processing
+  and exposes an async API.
+- **Gateway** – small Go proxy that exposes the API to the network and
+  orchestrates authentication and rate limiting.
+
+All interactions go through well defined protocols located under
+`services/interfaces.py`.  The container provides default implementations but
+alternate ones can be registered for testing or custom deployments.
+
+See `docs/architecture.md` and related diagrams for a more detailed breakdown.

--- a/services/upload/async_processor.py
+++ b/services/upload/async_processor.py
@@ -1,3 +1,5 @@
+"""Async helpers for reading uploaded files."""
+
 import asyncio
 from pathlib import Path
 from typing import Any

--- a/services/upload/chunked_upload_manager.py
+++ b/services/upload/chunked_upload_manager.py
@@ -1,3 +1,5 @@
+"""Manage chunked file uploads with retry logic."""
+
 import json
 import logging
 import time
@@ -9,7 +11,6 @@ import pandas as pd
 
 from config.connection_retry import ConnectionRetryManager, RetryConfig
 from config.constants import DEFAULT_CHUNK_SIZE
-from config.protocols import ConnectionRetryManagerProtocol, RetryConfigProtocol
 from utils.upload_store import UploadedDataStore
 
 logger = logging.getLogger(__name__)

--- a/services/upload/chunked_upload_manager_async.py
+++ b/services/upload/chunked_upload_manager_async.py
@@ -1,3 +1,5 @@
+"""Asynchronous chunked upload handling."""
+
 import asyncio
 import json
 import logging

--- a/services/upload/controllers/upload_controller.py
+++ b/services/upload/controllers/upload_controller.py
@@ -1,12 +1,13 @@
+"""Dash controller for the unified upload page."""
+
 import base64
 import io
 import json
 import logging
 from typing import Any, List, Tuple
 
-import dash_bootstrap_components as dbc
 import pandas as pd
-from dash import Input, Output, State, dash_table, html
+from dash import Input, Output, dash_table
 from dash.exceptions import PreventUpdate
 
 logger = logging.getLogger(__name__)

--- a/services/upload/file_processor_service.py
+++ b/services/upload/file_processor_service.py
@@ -1,7 +1,8 @@
+"""Handle parsing and storage of uploaded files."""
+
 import logging
 from typing import Any, Callable, Dict, List
 
-import pandas as pd
 
 from core.protocols import FileProcessorProtocol
 from services.upload.protocols import UploadDataServiceProtocol, UploadStorageProtocol

--- a/services/upload/helpers.py
+++ b/services/upload/helpers.py
@@ -1,3 +1,5 @@
+"""Utility functions for upload related callbacks."""
+
 import json
 import logging
 from datetime import datetime

--- a/services/upload/learning_coordinator.py
+++ b/services/upload/learning_coordinator.py
@@ -1,3 +1,5 @@
+"""Coordinate device learning requests triggered by uploads."""
+
 import logging
 from typing import Dict
 

--- a/services/upload/managers.py
+++ b/services/upload/managers.py
@@ -1,3 +1,6 @@
+"""Lightweight progress trackers for file uploads."""
+
+
 class ChunkedUploadManager:
     """Track progress for chunked file uploads."""
 

--- a/services/upload/modal.py
+++ b/services/upload/modal.py
@@ -1,3 +1,5 @@
+"""Modal dialog helpers for the upload page."""
+
 import logging
 from typing import Any, Tuple
 

--- a/services/upload/orchestrator.py
+++ b/services/upload/orchestrator.py
@@ -1,3 +1,5 @@
+"""High-level coordination for handling uploaded files."""
+
 from __future__ import annotations
 
 import logging

--- a/services/upload/upload_queue_manager.py
+++ b/services/upload/upload_queue_manager.py
@@ -1,3 +1,5 @@
+"""Priority queue for background upload processing."""
+
 import asyncio
 import heapq
 import logging

--- a/services/upload/upload_types.py
+++ b/services/upload/upload_types.py
@@ -1,3 +1,5 @@
+"""Typed containers describing upload results."""
+
 from dataclasses import dataclass
 from typing import Any, Dict, List
 

--- a/services/upload/validator.py
+++ b/services/upload/validator.py
@@ -1,3 +1,5 @@
+"""Client-side style validations for uploads."""
+
 import base64
 import json
 from typing import Any, Callable, Iterable, List, Mapping

--- a/services/uploader.py
+++ b/services/uploader.py
@@ -1,3 +1,5 @@
+"""Utility class wrapping :class:`UploadedDataStore`."""
+
 from __future__ import annotations
 
 from typing import Dict


### PR DESCRIPTION
## Summary
- document how to run checks in `README`
- create a high level `ARCHITECTURE.md`
- add module docstrings to upload service modules
- fix unused import warnings in upload modules

## Testing
- `flake8 services/upload/async_processor.py services/upload/orchestrator.py services/upload/helpers.py services/upload/modal.py services/upload/validator.py services/upload/chunked_upload_manager.py services/upload/chunked_upload_manager_async.py services/upload/file_processor_service.py services/upload/learning_coordinator.py services/upload/managers.py services/upload/controllers/upload_controller.py services/upload/upload_queue_manager.py services/upload/upload_types.py services/uploader.py | head -n 20`
- `pytest tests/test_upload_store_filename_validation.py -k test_unsafe_filenames_rejected -q` *(fails: ImportError - cannot import 'Config' due to circular import)*

------
https://chatgpt.com/codex/tasks/task_e_688a190157348320976f873ef1fe83a8