### PR TITLE
Improve test setup

### DIFF
--- a/config/base_loader.py
+++ b/config/base_loader.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 
 import yaml
 
-from core.unicode import UnicodeSQLProcessor
 
 
 class BaseConfigLoader:
@@ -64,6 +63,8 @@ class BaseConfigLoader:
     def _sanitize(self, obj: Any) -> Any:
         if isinstance(obj, str):
             try:
+                from core.unicode import UnicodeSQLProcessor
+
                 return UnicodeSQLProcessor.encode_query(obj)
             except Exception:
                 return obj

--- a/config/dynamic_config.py
+++ b/config/dynamic_config.py
@@ -4,8 +4,6 @@ import logging
 import os
 from typing import Any, Dict
 
-from utils.config_resolvers import resolve_max_upload_size_mb
-
 from .app_config import UploadConfig
 from .base_loader import BaseConfigLoader
 from .constants import (
@@ -19,8 +17,6 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
-from .utils import get_ai_confidence_threshold as _get_ai_confidence_threshold
-from .utils import get_upload_chunk_size as _get_upload_chunk_size
 
 logger = logging.getLogger(__name__)
 
@@ -262,10 +258,14 @@ class DynamicConfigManager(BaseConfigLoader):
         }
 
     def get_ai_confidence_threshold(self) -> int:
-        return _get_ai_confidence_threshold(self)
+        from utils.config_resolvers import resolve_ai_confidence_threshold
+
+        return resolve_ai_confidence_threshold(self)
 
     def get_max_upload_size_mb(self) -> int:
         """Get maximum upload size in MB."""
+        from utils.config_resolvers import resolve_max_upload_size_mb
+
         return resolve_max_upload_size_mb(self)
 
     def get_max_upload_size_bytes(self) -> int:
@@ -277,7 +277,9 @@ class DynamicConfigManager(BaseConfigLoader):
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        return _get_upload_chunk_size(self)
+        from utils.config_resolvers import resolve_upload_chunk_size
+
+        return resolve_upload_chunk_size(self)
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)

--- a/utils/config_resolvers.py
+++ b/utils/config_resolvers.py
@@ -4,9 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.config import get_ai_confidence_threshold as default_ai_confidence_threshold
-from core.config import get_max_upload_size_mb as default_max_upload_size_mb
-from core.config import get_upload_chunk_size as default_upload_chunk_size
+def _default_ai_confidence_threshold() -> float:
+    try:
+        from core.config import get_ai_confidence_threshold
+
+        return get_ai_confidence_threshold()
+    except Exception:
+        return 0.0
+
+
+def _default_max_upload_size_mb() -> int:
+    try:
+        from core.config import get_max_upload_size_mb
+
+        return get_max_upload_size_mb()
+    except Exception:
+        return 0
+
+
+def _default_upload_chunk_size() -> int:
+    try:
+        from core.config import get_upload_chunk_size
+
+        return get_upload_chunk_size()
+    except Exception:
+        return 0
 
 
 def resolve_ai_confidence_threshold(cfg: Any | None = None) -> float:
@@ -18,7 +40,7 @@ def resolve_ai_confidence_threshold(cfg: Any | None = None) -> float:
             return cfg.performance.ai_confidence_threshold
         if hasattr(cfg, "ai_threshold"):
             return cfg.ai_threshold
-    return default_ai_confidence_threshold()
+    return _default_ai_confidence_threshold()
 
 
 def resolve_max_upload_size_mb(cfg: Any | None = None) -> int:
@@ -30,7 +52,7 @@ def resolve_max_upload_size_mb(cfg: Any | None = None) -> int:
             return cfg.max_size_mb
         if hasattr(cfg, "security") and hasattr(cfg.security, "max_upload_mb"):
             return cfg.security.max_upload_mb
-    return default_max_upload_size_mb()
+    return _default_max_upload_size_mb()
 
 
 def resolve_upload_chunk_size(cfg: Any | None = None) -> int:
@@ -40,7 +62,7 @@ def resolve_upload_chunk_size(cfg: Any | None = None) -> int:
             return cfg.uploads.DEFAULT_CHUNK_SIZE
         if hasattr(cfg, "chunk_size"):
             return cfg.chunk_size
-    return default_upload_chunk_size()
+    return _default_upload_chunk_size()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- avoid failing when optional test packages are missing
- stub out extra optional packages in `tests/conftest.py`
- lazily import utilities in `config.dynamic_config`
- break circular import in `utils.config_resolvers`
- move heavy import in `config.base_loader` into function

## Testing
- `pytest -q` *(fails: 157 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a3b54ad5c8320ae2a7ff489fe0d23