### PR TITLE
Add service configuration loader

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -7,10 +7,38 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional
+from dataclasses import dataclass
 
 from .base_loader import BaseConfigLoader
 from .environment import select_config_file
 from .protocols import ConfigLoaderProtocol
+
+
+@dataclass
+class ServiceSettings:
+    """Settings specific to microservices."""
+
+    redis_url: str = "redis://localhost:6379/0"
+    cache_ttl: int = 300
+    model_dir: Path = Path("model_store")
+    registry_db: str = "sqlite:///model_registry.db"
+    registry_bucket: str = "local-models"
+    mlflow_uri: Optional[str] = None
+
+
+def load_service_config() -> ServiceSettings:
+    """Return service settings from environment with defaults."""
+
+    return ServiceSettings(
+        redis_url=os.getenv("REDIS_URL", ServiceSettings.redis_url),
+        cache_ttl=int(os.getenv("CACHE_TTL", str(ServiceSettings.cache_ttl))),
+        model_dir=Path(os.getenv("MODEL_DIR", str(ServiceSettings.model_dir))),
+        registry_db=os.getenv("MODEL_REGISTRY_DB", ServiceSettings.registry_db),
+        registry_bucket=os.getenv(
+            "MODEL_REGISTRY_BUCKET", ServiceSettings.registry_bucket
+        ),
+        mlflow_uri=os.getenv("MLFLOW_URI"),
+    )
 
 
 def validate_uploads_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -68,4 +96,10 @@ class ConfigLoader(BaseConfigLoader, ConfigLoaderProtocol):
         return validate_uploads_config(data)
 
 
-__all__ = ["ConfigLoader", "ConfigLoaderProtocol", "validate_uploads_config"]
+__all__ = [
+    "ConfigLoader",
+    "ConfigLoaderProtocol",
+    "validate_uploads_config",
+    "ServiceSettings",
+    "load_service_config",
+]

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -35,6 +35,7 @@ from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
 from config import get_database_config
+from config.config_loader import load_service_config
 from core.security import RateLimiter
 from services.analytics_microservice import async_queries
 from services.analytics_microservice.unicode_middleware import (
@@ -171,17 +172,16 @@ async def _startup() -> None:
         timeout=cfg.connection_timeout,
     )
 
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-    app.state.redis = aioredis.from_url(redis_url, decode_responses=True)
-    app.state.cache_ttl = int(os.getenv("CACHE_TTL", "300"))
+    svc_cfg = load_service_config()
+    app.state.redis = aioredis.from_url(svc_cfg.redis_url, decode_responses=True)
+    app.state.cache_ttl = svc_cfg.cache_ttl
 
-    app.state.model_dir = Path(os.environ.get("MODEL_DIR", "model_store"))
+    app.state.model_dir = svc_cfg.model_dir
     app.state.model_dir.mkdir(parents=True, exist_ok=True)
 
-    db_url = os.getenv("MODEL_REGISTRY_DB", "sqlite:///model_registry.db")
-    bucket = os.getenv("MODEL_REGISTRY_BUCKET", "local-models")
-    mlflow_uri = os.getenv("MLFLOW_URI")
-    app.state.model_registry = ModelRegistry(db_url, bucket, mlflow_uri=mlflow_uri)
+    app.state.model_registry = ModelRegistry(
+        svc_cfg.registry_db, svc_cfg.registry_bucket, mlflow_uri=svc_cfg.mlflow_uri
+    )
     preload_active_models()
     app.state.ready = True
     app.state.startup_complete = True

--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -19,6 +19,7 @@ from core.security import RateLimiter
 from error_handling.middleware import ErrorHandlingMiddleware
 from services.security import verify_service_jwt
 from services.streaming.service import StreamingService
+from config.config_loader import load_service_config
 from shared.errors.types import ErrorCode
 from tracing import trace_async_operation
 from yosai_framework.errors import ServiceError
@@ -83,6 +84,8 @@ async def _consume_loop() -> None:
 
 @app.on_event("startup")
 async def startup() -> None:
+    # Load environment driven settings
+    load_service_config()
     service.initialize()
     asyncio.create_task(
         trace_async_operation("consume_loop", "ingest", _consume_loop())

--- a/tests/test_service_config_loader.py
+++ b/tests/test_service_config_loader.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from config.config_loader import load_service_config, ServiceSettings
+
+
+def test_load_service_config_defaults(monkeypatch):
+    for var in [
+        "REDIS_URL",
+        "CACHE_TTL",
+        "MODEL_DIR",
+        "MODEL_REGISTRY_DB",
+        "MODEL_REGISTRY_BUCKET",
+        "MLFLOW_URI",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = load_service_config()
+    assert cfg.redis_url == ServiceSettings.redis_url
+    assert cfg.cache_ttl == ServiceSettings.cache_ttl
+    assert cfg.model_dir == ServiceSettings.model_dir
+    assert cfg.registry_db == ServiceSettings.registry_db
+    assert cfg.registry_bucket == ServiceSettings.registry_bucket
+    assert cfg.mlflow_uri is None
+
+
+def test_load_service_config_overrides(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://example:6380/1")
+    monkeypatch.setenv("CACHE_TTL", "123")
+    monkeypatch.setenv("MODEL_DIR", "/tmp/models")
+    monkeypatch.setenv("MODEL_REGISTRY_DB", "sqlite:///test.db")
+    monkeypatch.setenv("MODEL_REGISTRY_BUCKET", "bucket")
+    monkeypatch.setenv("MLFLOW_URI", "http://mlflow")
+
+    cfg = load_service_config()
+    assert cfg.redis_url == "redis://example:6380/1"
+    assert cfg.cache_ttl == 123
+    assert cfg.model_dir == Path("/tmp/models")
+    assert cfg.registry_db == "sqlite:///test.db"
+    assert cfg.registry_bucket == "bucket"
+    assert cfg.mlflow_uri == "http://mlflow"


### PR DESCRIPTION
## Summary
- add `ServiceSettings` and `load_service_config` helper
- wire analytics microservice startup to use new config loader
- call loader during event ingestion startup
- test service config loading

## Testing
- `pytest tests/test_service_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa8f76ba883209f1db8b0622ed61d