### PR TITLE
Introduce AnalyticsService for microservice

### DIFF
--- a/services/analytics_microservice/analytics_service.py
+++ b/services/analytics_microservice/analytics_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import redis.asyncio as aioredis
+
+from yosai_intel_dashboard.models.ml import ModelRegistry
+from services.common.async_db import close_pool
+
+
+class AnalyticsService:
+    """Manage shared resources for the analytics microservice."""
+
+    def __init__(
+        self,
+        redis: aioredis.Redis,
+        pool: asyncpg.pool.Pool,
+        model_registry: ModelRegistry,
+        *,
+        cache_ttl: int = 300,
+        model_dir: Path | None = None,
+    ) -> None:
+        self.redis = redis
+        self.pool = pool
+        self.model_registry = model_registry
+        self.cache_ttl = cache_ttl
+        self.model_dir = model_dir or Path("model_store")
+        self.models: dict[str, Any] = {}
+
+    async def close(self) -> None:
+        await close_pool()
+        if self.redis is not None:
+            await self.redis.close()
+
+    def preload_active_models(self) -> None:
+        """Load active models into memory from the registry."""
+        self.models = {}
+        registry = self.model_registry
+        try:
+            records = registry.list_models()
+        except Exception:  # pragma: no cover - registry unavailable
+            return
+        names = {r.name for r in records}
+        for name in names:
+            record = registry.get_model(name, active_only=True)
+            if record is None:
+                continue
+            local_dir = self.model_dir / name / record.version
+            local_dir.mkdir(parents=True, exist_ok=True)
+            filename = record.storage_uri.split("/")[-1]
+            local_path = local_dir / filename
+            if not local_path.exists():
+                try:
+                    registry.download_artifact(record.storage_uri, str(local_path))
+                except Exception:  # pragma: no cover - best effort
+                    continue
+            try:
+                import joblib
+
+                model_obj = joblib.load(local_path)
+                self.models[name] = model_obj
+            except Exception:  # pragma: no cover - invalid model
+                continue
+
+
+async def get_analytics_service(request) -> AnalyticsService:
+    return request.app.state.analytics_service
+

--- a/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/services/analytics_microservice/tests/test_endpoints_async.py
@@ -126,6 +126,33 @@ def load_app(jwt_secret: str = "secret") -> tuple:
     sys.modules.setdefault("redis", redis_stub)
     sys.modules.setdefault("redis.asyncio", redis_async)
 
+    analytics_stub = types.ModuleType(
+        "services.analytics_microservice.analytics_service"
+    )
+
+    class DummyAnalyticsService:
+        def __init__(self, *a, **k):
+            self.redis = types.SimpleNamespace(get=AsyncMock(), set=AsyncMock())
+            self.pool = object()
+            self.model_registry = None
+            self.cache_ttl = 300
+            self.model_dir = pathlib.Path("/tmp")
+            self.models = {}
+
+        async def close(self):
+            pass
+
+        def preload_active_models(self):
+            pass
+
+    dummy_service = DummyAnalyticsService()
+
+    analytics_stub.AnalyticsService = DummyAnalyticsService
+    analytics_stub.get_analytics_service = lambda *a, **k: dummy_service
+    sys.modules[
+        "services.analytics_microservice.analytics_service"
+    ] = analytics_stub
+
     queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
     queries_stub.fetch_dashboard_summary = AsyncMock(return_value={"status": "ok"})
     queries_stub.fetch_access_patterns = AsyncMock(return_value={"days": 7})
@@ -362,10 +389,11 @@ def load_app(jwt_secret: str = "secret") -> tuple:
     # Mark application as ready without running full startup
     module.app.state.ready = True
     module.app.state.startup_complete = True
+    module.app.state.analytics_service = dummy_service
 
     # base service already registers health routes
 
-    return module, queries_stub, db_stub
+    return module, queries_stub, dummy_service
 
 
 @pytest.mark.asyncio
@@ -384,7 +412,7 @@ async def test_health_endpoints():
 
 @pytest.mark.asyncio
 async def test_dashboard_summary_endpoint():
-    module, queries_stub, db_stub = load_app()
+    module, queries_stub, dummy_service = load_app()
     token = jwt.encode(
         {"sub": "svc", "iss": "gateway", "exp": int(time.time()) + 60},
         "secret",
@@ -400,7 +428,6 @@ async def test_dashboard_summary_endpoint():
         assert resp.json() == {"status": "ok"}
 
     queries_stub.fetch_dashboard_summary.assert_awaited_once()
-    db_stub.get_pool.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -438,11 +465,10 @@ async def test_internal_error_response():
 
 @pytest.mark.asyncio
 async def test_model_registry_endpoints(tmp_path):
-    module, _, _ = load_app()
-    module.app.state.model_dir = tmp_path
+    module, _, svc = load_app()
+    svc.model_dir = tmp_path
     from yosai_intel_dashboard.models.ml import ModelRegistry
-
-    module.app.state.model_registry = ModelRegistry()
+    svc.model_registry = ModelRegistry()
     token = jwt.encode(
         {"sub": "svc", "iss": "gateway", "exp": int(time.time()) + 60},
         "secret",
@@ -475,8 +501,8 @@ async def test_model_registry_endpoints(tmp_path):
 
 @pytest.mark.asyncio
 async def test_predict_endpoint(tmp_path):
-    module, _, _ = load_app()
-    module.app.state.model_dir = tmp_path
+    module, _, svc = load_app()
+    svc.model_dir = tmp_path
 
     model = Dummy()
     path = tmp_path / "demo" / "1" / "model.joblib"
@@ -487,8 +513,8 @@ async def test_predict_endpoint(tmp_path):
     registry = ModelRegistry()
     registry.register_model("demo", str(path), {}, "", version="1")
     registry.set_active_version("demo", "1")
-    module.app.state.model_registry = registry
-    module.preload_active_models()
+    svc.model_registry = registry
+    module.preload_active_models(svc)
 
     token = jwt.encode(
         {"sub": "svc", "iss": "gateway", "exp": int(time.time()) + 60},


### PR DESCRIPTION
## Summary
- encapsulate DB pool, redis and model registry in `AnalyticsService`
- use dependency injection via `get_analytics_service`
- update startup/shutdown and endpoints to use the service
- adjust microservice tests for the new dependency

## Testing
- `pip install pandas asyncpg redis fastapi jose prometheus-fastapi-instrumentator uvicorn pytest -q`
- `pytest -k analytics_microservice -q` *(fails: ModuleNotFoundError: dash._callback_context)*

------
https://chatgpt.com/codex/tasks/task_e_688aa8f92ed483209c79b2727f4d87ca