### PR TITLE
Add unified http_error helper

### DIFF
--- a/api/analytics_router.py
+++ b/api/analytics_router.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from error_handling import http_error
 
 from config import get_cache_config
 from core.cache_manager import CacheConfig, InMemoryCacheManager
+from shared.errors.types import ErrorCode
 from services.cached_analytics import CachedAnalyticsService
 from services.security import require_permission
 
@@ -59,4 +61,4 @@ async def get_chart_data(
         return JSONResponse(
             content={"type": "timeline", "data": data.get("hourly_distribution", {})}
         )
-    raise HTTPException(status_code=400, detail="Unknown chart type")
+    raise http_error(ErrorCode.INVALID_INPUT, "Unknown chart type", 400)

--- a/error_handling/__init__.py
+++ b/error_handling/__init__.py
@@ -1,6 +1,7 @@
 """Unified error handling utilities."""
 
 from .api_error_response import api_error_response
+from .api_errors import http_error
 from .core import ErrorContext, ErrorHandler
 from .decorators import handle_errors
 from .exceptions import ErrorCategory, YosaiException
@@ -12,4 +13,5 @@ __all__ = [
     "YosaiException",
     "ErrorCategory",
     "api_error_response",
+    "http_error",
 ]

--- a/error_handling/api_errors.py
+++ b/error_handling/api_errors.py
@@ -1,0 +1,14 @@
+from fastapi import HTTPException
+
+from shared.errors.types import ErrorCode
+
+
+def http_error(code: ErrorCode, message: str, status: int) -> HTTPException:
+    """Return an ``HTTPException`` with a standardized error body."""
+    return HTTPException(
+        status_code=status,
+        detail={"code": code.value, "message": message},
+    )
+
+
+__all__ = ["http_error"]

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -17,7 +17,6 @@ from fastapi import (
     File,
     Form,
     Header,
-    HTTPException,
     Query,
     Request,
     UploadFile,
@@ -46,6 +45,7 @@ from services.common.secrets import get_secret
 from shared.errors.types import ErrorCode
 from yosai_framework import ServiceBuilder
 from yosai_framework.errors import ServiceError
+from error_handling import http_error
 from yosai_framework.service import BaseService
 
 SERVICE_NAME = "analytics-microservice"
@@ -96,28 +96,32 @@ def _jwt_secret() -> str:
 def verify_token(authorization: str = Header("")) -> None:
     """Validate Authorization header using JWT_SECRET."""
     if not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         )
     token = authorization.split(" ", 1)[1]
     try:
         claims = jwt.decode(token, _jwt_secret(), algorithms=["HS256"])
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         ) from exc
     exp = claims.get("exp")
     if exp is not None and exp < time.time():
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         )
     if not claims.get("iss"):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         )
 
 
@@ -204,9 +208,10 @@ async def health_startup() -> dict[str, str]:
     """Startup probe."""
     if app.state.startup_complete:
         return {"status": "complete"}
-    raise HTTPException(
-        status_code=503,
-        detail=ServiceError(ErrorCode.UNAVAILABLE, "starting").to_dict(),
+    raise http_error(
+        ErrorCode.UNAVAILABLE,
+        "starting",
+        503,
     )
 
 
@@ -215,9 +220,10 @@ async def health_ready() -> dict[str, str]:
     """Readiness probe."""
     if app.state.ready:
         return {"status": "ready"}
-    raise HTTPException(
-        status_code=503,
-        detail=ServiceError(ErrorCode.UNAVAILABLE, "not ready").to_dict(),
+    raise http_error(
+        ErrorCode.UNAVAILABLE,
+        "not ready",
+        503,
     )
 
 
@@ -272,7 +278,7 @@ async def threat_assessment(
         else:
             payload = await request.json()
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=400, detail="invalid payload") from exc
+        raise http_error(ErrorCode.INVALID_INPUT, "invalid payload", 400) from exc
 
     if isinstance(payload, list):
         df = pd.DataFrame(payload)
@@ -333,7 +339,7 @@ async def register_model(
         except Exception:  # pragma: no cover - invalid model file
             pass
     except Exception as exc:  # pragma: no cover - registry failure
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise http_error(ErrorCode.INTERNAL, str(exc), 500) from exc
     return {"name": name, "version": record.version}
 
 
@@ -342,7 +348,7 @@ async def register_model(
 async def list_versions(name: str, _: None = Depends(verify_token)):
     records = app.state.model_registry.list_models(name)
     if not records:
-        raise HTTPException(status_code=404, detail="model not found")
+        raise http_error(ErrorCode.NOT_FOUND, "model not found", 404)
     return {
         "name": name,
         "versions": [r.version for r in records],
@@ -356,11 +362,11 @@ async def rollback(
 ):
     records = app.state.model_registry.list_models(name)
     if not records or version not in [r.version for r in records]:
-        raise HTTPException(status_code=404, detail="version not found")
+        raise http_error(ErrorCode.NOT_FOUND, "version not found", 404)
     try:
         app.state.model_registry.set_active_version(name, version)
     except Exception as exc:  # pragma: no cover - registry failure
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise http_error(ErrorCode.INTERNAL, str(exc), 500) from exc
 
     preload_active_models()
     return {"name": name, "active_version": version}
@@ -375,7 +381,7 @@ async def predict(
 ):
     record = app.state.model_registry.get_model(name, active_only=True)
     if record is None:
-        raise HTTPException(status_code=404, detail="no active version")
+        raise http_error(ErrorCode.NOT_FOUND, "no active version", 404)
     local_dir = app.state.model_dir / name / record.version
     local_dir.mkdir(parents=True, exist_ok=True)
     local_path = local_dir / os.path.basename(record.storage_uri)
@@ -385,7 +391,7 @@ async def predict(
                 record.storage_uri, str(local_path)
             )
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+            raise http_error(ErrorCode.INTERNAL, str(exc), 500) from exc
 
     model_obj = app.state.models.get(name)
     if model_obj is None:
@@ -393,11 +399,11 @@ async def predict(
             model_obj = joblib.load(local_path)
             app.state.models[name] = model_obj
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+            raise http_error(ErrorCode.INTERNAL, str(exc), 500) from exc
     try:
         result = model_obj.predict(req.data)
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise http_error(ErrorCode.INTERNAL, str(exc), 500) from exc
     try:
         df = pd.DataFrame(req.data)
         app.state.model_registry.log_features(name, df)
@@ -411,7 +417,7 @@ async def predict(
 async def get_drift(name: str, _: None = Depends(verify_token)):
     metrics = app.state.model_registry.get_drift_metrics(name)
     if not metrics:
-        raise HTTPException(status_code=404, detail="no drift data")
+        raise http_error(ErrorCode.NOT_FOUND, "no drift data", 404)
     return metrics
 
 

--- a/services/event-ingestion/app.py
+++ b/services/event-ingestion/app.py
@@ -5,7 +5,7 @@ import json
 import os
 import pathlib
 
-from fastapi import Header, HTTPException, Request, status
+from fastapi import Header, Request, status
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -18,6 +18,7 @@ from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
 from core.security import RateLimiter
 from error_handling.middleware import ErrorHandlingMiddleware
 from services.security import verify_service_jwt
+from error_handling import http_error
 from services.streaming.service import StreamingService
 from shared.errors.types import ErrorCode
 from tracing import trace_async_operation
@@ -62,15 +63,17 @@ async def rate_limit(request: Request, call_next):
 
 def verify_token(authorization: str = Header("")) -> None:
     if not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         )
     token = authorization.split(" ", 1)[1]
     if not verify_service_jwt(token):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ServiceError(ErrorCode.UNAUTHORIZED, "unauthorized").to_dict(),
+        raise http_error(
+            ErrorCode.UNAUTHORIZED,
+            "unauthorized",
+            status.HTTP_401_UNAUTHORIZED,
         )
 
 

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,8 @@
+from error_handling.api_errors import http_error
+from shared.errors.types import ErrorCode
+
+
+def test_http_error_returns_exception():
+    exc = http_error(ErrorCode.INVALID_INPUT, "bad request", 400)
+    assert exc.status_code == 400
+    assert exc.detail == {"code": "invalid_input", "message": "bad request"}

--- a/yosai_framework/service.py
+++ b/yosai_framework/service.py
@@ -3,7 +3,7 @@ import signal
 from typing import Any
 
 import structlog
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from opentelemetry import trace
 from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.sdk.resources import Resource
@@ -18,6 +18,8 @@ from prometheus_client import (
 )
 
 from .config import ServiceConfig, load_config
+from error_handling import http_error
+from shared.errors.types import ErrorCode
 
 
 class BaseService:
@@ -156,10 +158,10 @@ class BaseService:
         async def _health_ready() -> dict[str, str]:
             if self.app.state.ready:
                 return {"status": "ready"}
-            raise HTTPException(status_code=503, detail="not ready")
+            raise http_error(ErrorCode.UNAVAILABLE, "not ready", 503)
 
         @self.app.get("/health/startup")
         async def _health_startup() -> dict[str, str]:
             if self.app.state.startup_complete:
                 return {"status": "complete"}
-            raise HTTPException(status_code=503, detail="starting")
+            raise http_error(ErrorCode.UNAVAILABLE, "starting", 503)


### PR DESCRIPTION
## Summary
- add `http_error` factory in `error_handling`
- use `http_error` across services instead of building `HTTPException`
- export helper in package init
- test helper behaviour

## Testing
- `pytest tests/test_api_errors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa8fa9b4c8320930880b90819934f