### PR TITLE
Use shared constants across services

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 
 # Default chunk size used across services when reading or uploading large files
 DEFAULT_CHUNK_SIZE: int = 50_000
+# Default chunk size for database migration utilities
+MIGRATION_CHUNK_SIZE: int = 1_000
 # File extensions supported across upload services
 UPLOAD_ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 

--- a/docs/async_db_migration.md
+++ b/docs/async_db_migration.md
@@ -26,6 +26,8 @@ created on application startup.
 3. Use the functions in `async_queries.py` (or your own async SQL
    helpers) with the acquired pool.
 4. Ensure that any cleanup code calls `close_pool()` on shutdown.
+5. Batches default to `MIGRATION_CHUNK_SIZE` rows as defined in
+   `config/constants.py`.
 
 The async pool ensures non‑blocking database access and allows the
 web server to handle more concurrent requests.

--- a/services/analytics_microservice/app.py
+++ b/services/analytics_microservice/app.py
@@ -33,6 +33,7 @@ from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
 from config import get_database_config
+from config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 from config.config_loader import load_service_config
 from core.security import RateLimiter
 from services.analytics_microservice import async_queries
@@ -182,7 +183,10 @@ async def _startup() -> None:
         timeout=cfg.connection_timeout,
     )
 
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    redis_url = os.getenv(
+        "REDIS_URL",
+        f"redis://{DEFAULT_CACHE_HOST}:{DEFAULT_CACHE_PORT}/0",
+    )
     redis = aioredis.from_url(redis_url, decode_responses=True)
     cache_ttl = int(os.getenv("CACHE_TTL", "300"))
 

--- a/services/migration/strategies/analytics_migration.py
+++ b/services/migration/strategies/analytics_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
+from config.constants import MIGRATION_CHUNK_SIZE
 
 from ..framework import MigrationStrategy
 
@@ -11,7 +12,7 @@ class AnalyticsMigration(MigrationStrategy):
     """Migrate analytics related tables."""
 
     TABLE = "analytics_results"
-    CHUNK_SIZE = 1000
+    CHUNK_SIZE = MIGRATION_CHUNK_SIZE
 
     def __init__(self, target_dsn: str) -> None:
         super().__init__(self.TABLE, target_dsn)

--- a/services/migration/strategies/events_migration.py
+++ b/services/migration/strategies/events_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
+from config.constants import DataProcessingLimits
 
 from ..framework import MigrationStrategy
 
@@ -11,7 +12,7 @@ class EventsMigration(MigrationStrategy):
     """Migrate access events table. Supports TimescaleDB targets."""
 
     TABLE = "access_events"
-    CHUNK_SIZE = 10000
+    CHUNK_SIZE = DataProcessingLimits.DEFAULT_QUERY_LIMIT
 
     def __init__(self, target_dsn: str) -> None:
         super().__init__(self.TABLE, target_dsn)

--- a/services/migration/strategies/gateway_migration.py
+++ b/services/migration/strategies/gateway_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
+from config.constants import MIGRATION_CHUNK_SIZE
 
 from ..framework import MigrationStrategy
 
@@ -11,7 +12,7 @@ class GatewayMigration(MigrationStrategy):
     """Migrate gateway related tables."""
 
     TABLE = "gateway_logs"
-    CHUNK_SIZE = 1000
+    CHUNK_SIZE = MIGRATION_CHUNK_SIZE
 
     def __init__(self, target_dsn: str) -> None:
         super().__init__(self.TABLE, target_dsn)

--- a/services/stream_processor.py
+++ b/services/stream_processor.py
@@ -2,6 +2,7 @@ import logging
 from typing import IO, Any, List, Tuple, Union
 
 import pandas as pd
+from config.constants import DataProcessingLimits
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ class StreamProcessor:
     def process_large_csv(
         file_like: Union[str, IO[str]],
         *,
-        chunk_size: int = 10000,
+        chunk_size: int = DataProcessingLimits.SMALL_DATA_CHUNK_ROWS,
         **read_kwargs: Any,
     ) -> Tuple[pd.DataFrame, List[str]]:
         """Read ``file_like`` CSV in ``chunk_size`` pieces.

--- a/services/upload/chunked_upload_manager.py
+++ b/services/upload/chunked_upload_manager.py
@@ -8,7 +8,7 @@ from typing import Optional
 import pandas as pd
 
 from config.connection_retry import ConnectionRetryManager, RetryConfig
-from config.constants import DEFAULT_CHUNK_SIZE
+from config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
 from config.protocols import ConnectionRetryManagerProtocol, RetryConfigProtocol
 from utils.upload_store import UploadedDataStore
 
@@ -43,7 +43,7 @@ class ChunkedUploadManager:
         self.metadata_dir.mkdir(parents=True, exist_ok=True)
         self.initial_chunk_size = initial_chunk_size
         self.min_chunk_size = 1000
-        self.max_chunk_size = 100_000
+        self.max_chunk_size = DataProcessingLimits.MAX_CHUNK_SIZE
         self.retry_config = RetryConfig(max_attempts=3, base_delay=0.2, jitter=False)
         self._retry_manager_cls = retry_manager_cls
 

--- a/services/upload/chunked_upload_manager_async.py
+++ b/services/upload/chunked_upload_manager_async.py
@@ -10,7 +10,7 @@ from typing import Awaitable, Callable, Optional, TypeVar
 import pandas as pd
 
 from config.connection_retry import RetryConfig
-from config.constants import DEFAULT_CHUNK_SIZE
+from config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
 from config.database_exceptions import ConnectionRetryExhausted
 from utils.upload_store import UploadedDataStore
 
@@ -48,7 +48,7 @@ class ChunkedUploadManager:
         self.initial_chunk_size = initial_chunk_size
         self.bandwidth_limit = bandwidth_limit  # bytes per second
         self.min_chunk_size = 1000
-        self.max_chunk_size = 100_000
+        self.max_chunk_size = DataProcessingLimits.MAX_CHUNK_SIZE
         self.retry_config = RetryConfig(max_attempts=3, base_delay=0.2, jitter=False)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- deduplicate service defaults by using `config.constants`
- document new `MIGRATION_CHUNK_SIZE` constant

## Testing
- `pytest tests/test_default_constants.py::test_default_cache_port -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_688b1098dec08320889f45f5d007ff30