### PR TITLE
Add type hints to services and utils

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+from .analytics.protocols import AnalyticsServiceProtocol
+
 if os.getenv("LIGHTWEIGHT_SERVICES"):
     __all__ = []
 else:
@@ -68,7 +70,7 @@ else:
     create_analytics_service = get_service("create_analytics_service")
     AnalyticsService = get_service("AnalyticsService")
 
-    def get_analytics_service():
+    def get_analytics_service() -> AnalyticsServiceProtocol | None:
         """Return a shared :class:`AnalyticsService` instance if available."""
         getter = get_service("get_analytics_service")
         if getter is None:

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -77,7 +77,7 @@ class AnalyticsProviderProtocol(Protocol):
         ...
 
 
-def ensure_analytics_config():
+def ensure_analytics_config() -> None:
     """Emergency fix to ensure analytics configuration exists."""
     try:
         from config.dynamic_config import dynamic_config

--- a/services/device_endpoint.py
+++ b/services/device_endpoint.py
@@ -6,6 +6,7 @@ from flask_apispec import doc
 from pydantic import BaseModel
 
 from config.service_registration import register_upload_services
+from typing import Any, Tuple, Dict
 
 # Use the shared DI container for dependency resolution
 from core.container import container
@@ -91,9 +92,9 @@ def build_ai_device_mappings(df: pd.DataFrame, filename: str, upload_service) ->
 def build_device_mappings(
     filename: str,
     df: pd.DataFrame,
-    device_service,
-    upload_service,
-) -> dict:
+    device_service: Any,
+    upload_service: Any,
+) -> dict[str, dict]:
     """Construct the device mapping dictionary for *df* and *filename*."""
     user_mappings = device_service.get_user_device_mappings(filename)
     if user_mappings:
@@ -110,7 +111,7 @@ def build_device_mappings(
 )
 @validate_input(DeviceSuggestSchema)
 @validate_output(DeviceResponseSchema)
-def suggest_devices(payload: DeviceSuggestSchema):
+def suggest_devices(payload: DeviceSuggestSchema) -> Tuple[Dict[str, Any], int]:
     """Get device suggestions using DeviceLearningService"""
     try:
         filename = payload.filename

--- a/services/rabbitmq_client.py
+++ b/services/rabbitmq_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 import pika
 
@@ -22,11 +22,11 @@ class RabbitMQClient:
     def declare_queue(
         self,
         name: str,
-        """Declare a durable queue, optionally with DLQ and priority."""
         *,
         dead_letter: str | None = None,
         max_priority: int | None = None,
     ) -> None:
+        """Declare a durable queue, optionally with DLQ and priority."""
         args: dict[str, Any] = {}
         if dead_letter:
             args["x-dead-letter-exchange"] = ""
@@ -40,12 +40,12 @@ class RabbitMQClient:
         queue: str,
         task_type: str,
         payload: Any,
-        """Publish a task message and return its generated id."""
         *,
         priority: int = 0,
         delay_ms: int = 0,
         max_retries: int = 3,
     ) -> str:
+        """Publish a task message and return its generated id."""
         task = {
             "id": str(uuid.uuid4()),
             "type": task_type,

--- a/services/task_queue.py
+++ b/services/task_queue.py
@@ -26,8 +26,8 @@ class TaskQueue(TaskQueueProtocol):
     def create_task(
         self,
         func: Callable[[Callable[[int], None]], Awaitable[Any]] | Awaitable[Any],
-        """Schedule an async task and return its identifier."""
     ) -> str:
+        """Schedule an async task and return its identifier."""
         task_id = str(uuid.uuid4())
         ctx = ot_context.get_current()
         with self._lock:
@@ -78,9 +78,9 @@ _default_queue = TaskQueue()
 
 
 def create_task(
-    """Add a task to the default queue."""
     func: Callable[[Callable[[int], None]], Awaitable[Any]] | Awaitable[Any],
 ) -> str:
+    """Add a task to the default queue."""
     return _default_queue.create_task(func)
 
 

--- a/utils/assets_debug.py
+++ b/utils/assets_debug.py
@@ -76,7 +76,9 @@ def log_asset_info(icon: str) -> None:
     logger.info(f"Icon path {path} exists={path.is_file()}")
 
 
-def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = True):
+def navbar_icon(
+    filename: str, alt: str, fallback_text: str, *, warn: bool = True
+) -> html.Img | html.Span:
     """Return an ``Img`` component or fallback text for missing icons.
 
     Set ``warn=False`` to suppress the warning log when the icon is missing.

--- a/utils/assets_utils.py
+++ b/utils/assets_utils.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+from dash import Dash
 from flask import request, url_for
 
 from utils.assets_debug import check_navbar_assets
@@ -13,7 +14,7 @@ def get_nav_icon(app, name: str) -> str | None:
     return None
 
 
-def ensure_icon_cache_headers(app):
+def ensure_icon_cache_headers(app: Dash) -> Dash:
     """Add cache headers for icon assets to prevent loading issues.
 
     This registers an ``after_request`` hook on ``app.server`` that sets
@@ -177,7 +178,7 @@ def ensure_all_navbar_assets(app=None) -> None:
     logging.getLogger(__name__).info("Asset directory ensured")
 
 
-def fix_flask_mime_types(app):
+def fix_flask_mime_types(app: Dash) -> Dash:
     """Fix CSS MIME type issues"""
 
     @app.server.after_request

--- a/utils/sample_data_generator.py
+++ b/utils/sample_data_generator.py
@@ -10,7 +10,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def generate_sample_access_data(num_records=1000):
+def generate_sample_access_data(num_records: int = 1000) -> pd.DataFrame:
     """Generate sample access control data for testing"""
 
     # Sample data parameters
@@ -111,7 +111,7 @@ def generate_sample_access_data(num_records=1000):
     return df
 
 
-def save_sample_data():
+def save_sample_data() -> None:
     # Generate different sized datasets
     datasets = {
         "sample_small.csv": 100,
@@ -159,7 +159,7 @@ Run this after setting up the project structure
 """
 
 
-def test_file_upload():
+def test_file_upload() -> bool:
     """Test file upload functionality"""
 
     # Generate test data using function defined above


### PR DESCRIPTION
## Summary
- fix malformed docstrings in RabbitMQ and task queue services
- annotate service helper to return protocol type
- update device endpoint signatures
- annotate utilities for Dash asset helpers
- add type hints for pydantic decorators and sample data generator

## Testing
- `mypy --strict -p services -p utils` *(fails: many existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b108bb71c83208a0e5bd17366d65f