### PR TITLE
Add callback middleware for secure Dash handlers

### DIFF
--- a/core/dash_callback_middleware.py
+++ b/core/dash_callback_middleware.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Utilities to wrap Dash callbacks with validation and error handling."""
+
+import asyncio
+from typing import Any, Callable, Iterable, Tuple
+
+from dash import Output, no_update
+
+from validation.security_validator import SecurityValidator
+
+from .error_handling import ErrorSeverity, error_handler
+
+SafeReturn = Any
+
+
+def _sanitize_value(value: Any, name: str, validator: SecurityValidator) -> Any:
+    if isinstance(value, str):
+        result = validator.validate_input(value, name)
+        return result.get("sanitized", value)
+    return value
+
+
+def _sanitize_args(
+    args: Iterable[Any], validator: SecurityValidator
+) -> tuple[Any, ...]:
+    sanitized = []
+    for i, val in enumerate(args):
+        sanitized.append(_sanitize_value(val, f"arg{i}", validator))
+    return tuple(sanitized)
+
+
+def _sanitize_kwargs(
+    kwargs: dict[str, Any], validator: SecurityValidator
+) -> dict[str, Any]:
+    return {k: _sanitize_value(v, k, validator) for k, v in kwargs.items()}
+
+
+def wrap_callback(
+    func: Callable[..., Any],
+    outputs: Tuple[Output, ...],
+    validator: SecurityValidator,
+) -> Callable[..., SafeReturn]:
+    """Wrap a Dash callback with validation and error logging."""
+
+    safe_default: SafeReturn
+    default_tuple = tuple(no_update for _ in outputs)
+    safe_default = default_tuple[0] if len(default_tuple) == 1 else default_tuple
+
+    async def _async_wrapper(*args: Any, **kwargs: Any) -> SafeReturn:
+        try:
+            s_args = _sanitize_args(args, validator)
+            s_kwargs = _sanitize_kwargs(kwargs, validator)
+            return await func(*s_args, **s_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            error_handler.handle_error(
+                exc,
+                severity=ErrorSeverity.HIGH,
+                context={"callback": getattr(func, "__name__", "<anonymous>")},
+            )
+            return safe_default
+
+    def _sync_wrapper(*args: Any, **kwargs: Any) -> SafeReturn:
+        try:
+            s_args = _sanitize_args(args, validator)
+            s_kwargs = _sanitize_kwargs(kwargs, validator)
+            return func(*s_args, **s_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            error_handler.handle_error(
+                exc,
+                severity=ErrorSeverity.HIGH,
+                context={"callback": getattr(func, "__name__", "<anonymous>")},
+            )
+            return safe_default
+
+    return _async_wrapper if asyncio.iscoroutinefunction(func) else _sync_wrapper
+
+
+__all__ = ["wrap_callback"]

--- a/tests/test_dash_callback_middleware.py
+++ b/tests/test_dash_callback_middleware.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import dash
+from dash import Output
+
+from core.dash_callback_middleware import wrap_callback
+from core.error_handling import error_handler
+from validation.security_validator import SecurityValidator
+
+
+def test_wrap_callback_validation(monkeypatch):
+    outputs = (Output("o", "children"),)
+    called = {}
+
+    def cb(value):
+        called["v"] = value
+        return value
+
+    wrapper = wrap_callback(cb, outputs, SecurityValidator())
+    # valid input
+    assert wrapper("ok") == "ok"
+    assert called["v"] == "ok"
+
+    called.clear()
+    result = wrapper("<script>")
+    assert result is dash.no_update
+    assert called == {}
+
+
+def test_wrap_callback_error_logged(monkeypatch):
+    outputs = (Output("o", "children"),)
+
+    def cb(value):
+        raise RuntimeError("boom")
+
+    recorded = {}
+
+    def fake_handle_error(exc, *, severity, context):
+        recorded["exc"] = exc
+        recorded["ctx"] = context
+
+    monkeypatch.setattr(error_handler, "handle_error", fake_handle_error)
+    wrapper = wrap_callback(cb, outputs, SecurityValidator())
+    out = wrapper("ok")
+    assert out is dash.no_update
+    assert isinstance(recorded.get("exc"), RuntimeError)
+    assert "callback" in recorded.get("ctx", {})


### PR DESCRIPTION
## Summary
- create `wrap_callback` middleware to sanitize Dash callback inputs
- log exceptions through `error_handler` and return safe defaults
- integrate new middleware into `TrulyUnifiedCallbacks`
- add tests for the callback wrapper

## Testing
- `pre-commit run --files core/truly_unified_callbacks.py core/dash_callback_middleware.py tests/test_dash_callback_middleware.py`
- `pytest tests/test_dash_callback_middleware.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688b10799be88320934852581b116766