### PR TITLE
Add shared upload validation helper

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -5,7 +5,6 @@ All deprecated individual validators have been removed and consolidated.
 """
 
 from core.exceptions import ValidationError
-from validation import UnicodeValidator
 
 from .attack_detection import AttackDetection
 from .secrets_validator import SecretsValidator, register_health_endpoint

--- a/services/upload/utils/file_parser.py
+++ b/services/upload/utils/file_parser.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
-"""
-File processing service - Core data processing without UI dependencies
-Handles Unicode surrogate characters safely
-"""
+from __future__ import annotations
+
+"""File processing service - Core data processing without UI dependencies
+Handles Unicode surrogate characters safely"""
 import io
-import json
 import logging
-from unicode_toolkit import safe_encode_text
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Tuple
 
 import chardet
 import pandas as pd
@@ -21,6 +18,9 @@ from core.protocols import ConfigurationProtocol
 
 # Core processing imports only - NO UI COMPONENTS
 from core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
+from unicode_toolkit import safe_encode_text
+from validation.security_validator import SecurityValidator
+from validation.upload_utils import decode_and_validate_upload
 
 logger = logging.getLogger(__name__)
 
@@ -60,23 +60,6 @@ class UnicodeFileProcessor:
         return result["data"], result["error"]
 
 
-def _safe_b64decode(contents: str) -> Tuple[Optional[bytes], Optional[str]]:
-    """Return decoded bytes or an error message."""
-    import base64
-
-    if "," not in contents:
-        return None, "Invalid data URI"
-
-    try:
-        _, content_string = contents.split(",", 1)
-        decoded = base64.b64decode(content_string, validate=True)
-        if not decoded:
-            return None, "Empty file contents"
-        return decoded, None
-    except (base64.binascii.Error, ValueError) as exc:
-        return None, f"Invalid base64 data: {exc}"
-
-
 def process_uploaded_file(
     contents: str,
     filename: str,
@@ -88,15 +71,22 @@ def process_uploaded_file(
     Returns: Dict with 'data', 'filename', 'status', 'error'
     """
     try:
-        decoded, decode_err = _safe_b64decode(contents)
-        if decoded is None:
-            logger.error("Base64 decode failed for %s: %s", filename, decode_err)
+        validator = SecurityValidator()
+        info = decode_and_validate_upload(contents, filename, validator)
+        if not info["valid"]:
+            logger.error(
+                "Base64 validation failed for %s: %s",
+                filename,
+                ", ".join(info.get("issues", [])),
+            )
             return {
                 "status": "error",
-                "error": decode_err,
+                "error": "; ".join(info.get("issues", [])),
                 "data": None,
-                "filename": filename,
+                "filename": info.get("filename", filename),
             }
+        decoded = info["decoded"]
+        filename = info["filename"]
         # Safe Unicode processing
         text_content = UnicodeFileProcessor.safe_decode_content(decoded)
 

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Unified validation package."""
 
 from .core import ValidationResult, Validator

--- a/validation/file_validator.py
+++ b/validation/file_validator.py
@@ -103,7 +103,7 @@ class FileValidator(CompositeValidator):
             return b""
 
     def validate_file_upload(self, filename: str, content: bytes) -> dict:
-        result = self.validate((filename, content))
+        result = super().validate((filename, content))
         if not result.valid:
             return {"valid": False, "issues": result.issues or []}
         size_mb = len(content) / (1024 * 1024)

--- a/validation/upload_utils.py
+++ b/validation/upload_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import base64
+import os
+from typing import Dict, List
+
+from core.exceptions import ValidationError
+
+from .security_validator import SecurityValidator
+
+
+def decode_and_validate_upload(
+    contents: str,
+    filename: str,
+    validator: SecurityValidator | None = None,
+) -> Dict[str, any]:
+    """Decode base64 ``contents`` and validate upload metadata.
+
+    Returns a dict with keys ``valid``, ``filename``, ``decoded`` (bytes or ``None``),
+    ``size_mb`` when valid and ``issues`` listing any problems.
+    """
+    validator = validator or SecurityValidator()
+    issues: List[str] = []
+    try:
+        sanitized = validator.sanitize_filename(filename)
+    except ValidationError:
+        sanitized = os.path.basename(filename)
+        issues.append("Invalid filename")
+
+    if "," not in contents:
+        issues.append("Invalid data URI")
+        return {
+            "valid": False,
+            "filename": sanitized,
+            "decoded": None,
+            "issues": issues,
+        }
+
+    try:
+        _, data = contents.split(",", 1)
+        decoded = base64.b64decode(data, validate=True)
+    except (base64.binascii.Error, ValueError) as exc:
+        issues.append(f"Invalid base64 data: {exc}")
+        return {
+            "valid": False,
+            "filename": sanitized,
+            "decoded": None,
+            "issues": issues,
+        }
+
+    res = validator.file_validator.validate_file_upload(sanitized, decoded)
+    res.setdefault("issues", [])
+    res["issues"] = issues + res["issues"]
+    if res["valid"]:
+        res["decoded"] = decoded
+    else:
+        res["decoded"] = None
+    res["filename"] = sanitized
+    return res


### PR DESCRIPTION
## Summary
- add `decode_and_validate_upload` utility for uploads
- reuse the helper in file processor modules
- update upload validator tests
- fix `FileValidator.validate_file_upload` usage
- drop eager dependency on validation in `security/__init__`

## Testing
- `pre-commit run --files validation/upload_utils.py validation/__init__.py services/data_processing/file_processor.py services/upload/utils/file_parser.py tests/test_upload_validator.py security/__init__.py validation/file_validator.py` *(fails: mypy, bandit)*
- `pytest -q tests/test_upload_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_688b1089113c832094bf7fa055cc67e9