### PR TITLE
Use container for upload controller

### DIFF
--- a/config/service_registration.py
+++ b/config/service_registration.py
@@ -10,6 +10,7 @@ from services.upload.protocols import (
     UploadStorageProtocol,
     UploadValidatorProtocol,
 )
+from services.upload.controllers.upload_controller import UnifiedUploadController
 
 
 def register_upload_services(container: ServiceContainer) -> None:
@@ -74,4 +75,10 @@ def register_upload_services(container: ServiceContainer) -> None:
         "upload_processor",
         upload_processor,
         protocol=UploadProcessingServiceProtocol,
+    )
+
+    container.register_transient(
+        "upload_controller",
+        UnifiedUploadController,
+        protocol=UploadControllerProtocol,
     )

--- a/pages/upload/callbacks.py
+++ b/pages/upload/callbacks.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from dash import Input, Output
 from dash.exceptions import PreventUpdate
 from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from services.upload.controllers.upload_controller import UnifiedUploadController
+from services.upload.protocols import UploadControllerProtocol
 
 
 def register_callbacks(app, container) -> None:
     """Register upload callbacks using the provided Dash *app*."""
     callbacks = TrulyUnifiedCallbacks(app)
-    controller = UnifiedUploadController()
+    controller: UploadControllerProtocol = container.get("upload_controller")
 
     @callbacks.register_handler(
         [Output("to-column-map-btn", "disabled"), Output("uploaded-df-store", "data")],

--- a/tests/test_upload_page_callbacks.py
+++ b/tests/test_upload_page_callbacks.py
@@ -1,0 +1,45 @@
+import pytest
+from simple_di import ServiceContainer
+from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from pages.upload.callbacks import register_callbacks
+
+pytestmark = pytest.mark.usefixtures("fake_dash")
+
+
+def test_register_callbacks_uses_container(monkeypatch):
+    import dash
+
+    app = dash.Dash(__name__)
+    container = ServiceContainer()
+
+    class DummyDF:
+        def to_json(self, **kwargs):
+            return "dummy"
+
+    class DummyController:
+        def __init__(self):
+            self.called = None
+
+        def parse_upload(self, contents, filename):
+            self.called = (contents, filename)
+            return DummyDF()
+
+    controller = DummyController()
+    container.register("upload_controller", controller)
+
+    captured = {}
+
+    def fake_handler(self, *args, **kwargs):
+        def decorator(func):
+            captured["func"] = func
+            return func
+        return decorator
+
+    monkeypatch.setattr(TrulyUnifiedCallbacks, "register_handler", fake_handler)
+
+    register_callbacks(app, container)
+
+    cb = captured["func"]
+    result = cb("data", "name.csv")
+    assert controller.called == ("data", "name.csv")
+    assert result == (False, "dummy")


### PR DESCRIPTION
## Summary
- resolve `UnifiedUploadController` from DI container in upload callbacks
- register `UnifiedUploadController` in the service container
- test upload page callbacks use container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.unicode')*

------
https://chatgpt.com/codex/tasks/task_e_688b107a0ee08320906f830439b9177f