### PR TITLE
Decouple service_integration from registry

### DIFF
--- a/config/complete_service_registration.py
+++ b/config/complete_service_registration.py
@@ -42,8 +42,18 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigValidator,
         create_config_manager,
     )
-    from config.database_manager import DatabaseManager, DatabaseSettings
+    from config.database_manager import (
+        DatabaseManager,
+        DatabaseSettings,
+        MockConnection,
+        EnhancedPostgreSQLManager,
+    )
     from core.logging import LoggingService
+    from config.protocols import (
+        DatabaseManagerProtocol,
+        EnhancedPostgreSQLManagerProtocol,
+    )
+    from database.types import DatabaseConnection
     from services.configuration_service import (
         ConfigurationServiceProtocol,
         DynamicConfigurationService,
@@ -71,8 +81,26 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
     container.register_singleton(
         "database_manager",
         DatabaseManager,
-        protocol=DatabaseProtocol,
+        protocol=DatabaseManagerProtocol,
         factory=lambda c: DatabaseManager(DatabaseSettings()),
+    )
+    container.register_transient(
+        "database_connection",
+        object,
+        protocol=DatabaseConnection,
+        factory=lambda c: c.get("database_manager").get_connection(),
+    )
+    container.register_transient(
+        "mock_connection",
+        MockConnection,
+        protocol=DatabaseConnection,
+        factory=lambda c: MockConnection(),
+    )
+    container.register_singleton(
+        "enhanced_postgresql_manager",
+        EnhancedPostgreSQLManager,
+        protocol=EnhancedPostgreSQLManagerProtocol,
+        factory=lambda c: EnhancedPostgreSQLManager(DatabaseSettings()),
     )
 
     from core.events import EventBus

--- a/config/protocols.py
+++ b/config/protocols.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Protocol, TypeVar
 
+from database.types import DatabaseConnection
+
 T = TypeVar("T")
 
 
@@ -45,10 +47,32 @@ class ConfigTransformerProtocol(Protocol):
         ...
 
 
+class DatabaseManagerProtocol(Protocol):
+    """Minimal interface for database manager services."""
+
+    def get_connection(self) -> DatabaseConnection: ...
+
+    def health_check(self) -> bool: ...
+
+    def close(self) -> None: ...
+
+
+class EnhancedPostgreSQLManagerProtocol(DatabaseManagerProtocol, Protocol):
+    """Specialized interface for enhanced PostgreSQL managers."""
+
+    def execute_query_with_retry(
+        self, query: str, params: Optional[Dict] | None = None
+    ) -> Any: ...
+
+    def health_check_with_retry(self) -> bool: ...
+
+
 __all__ = [
     "RetryConfigProtocol",
     "ConnectionRetryManagerProtocol",
     "ConfigLoaderProtocol",
     "ConfigValidatorProtocol",
     "ConfigTransformerProtocol",
+    "DatabaseManagerProtocol",
+    "EnhancedPostgreSQLManagerProtocol",
 ]

--- a/config/service_integration.py
+++ b/config/service_integration.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from services.registry import get_service
+from core.service_container import ServiceContainer
+from database.types import DatabaseConnection
+from .protocols import (
+    DatabaseManagerProtocol,
+    EnhancedPostgreSQLManagerProtocol,
+)
 
 __all__ = [
     "get_database_manager",
@@ -12,26 +17,56 @@ __all__ = [
 ]
 
 
-def _get_service(name: str):
-    """Safely retrieve optional services from registry."""
-    return get_service(name)
+def _get_container(
+    container: ServiceContainer | None = None,
+) -> ServiceContainer | None:
+    if container is not None:
+        return container
+    try:  # pragma: no cover - dash may be missing in tests
+        from dash import get_app
+
+        app = get_app()
+        return getattr(app, "_service_container", None)
+    except Exception:
+        return None
 
 
-def get_database_manager():
+def get_database_manager(
+    container: ServiceContainer | None = None,
+) -> DatabaseManagerProtocol | None:
     """Return the optional ``DatabaseManager`` service."""
-    return _get_service("DatabaseManager")
+    c = _get_container(container)
+    if c and c.has("database_manager"):
+        return c.get("database_manager")
+    return None
 
 
-def get_database_connection():
+def get_database_connection(
+    container: ServiceContainer | None = None,
+) -> DatabaseConnection | None:
     """Return the optional ``DatabaseConnection`` service."""
-    return _get_service("DatabaseConnection")
+    c = _get_container(container)
+    if c and c.has("database_connection"):
+        return c.get("database_connection")
+    manager = get_database_manager(c)
+    return manager.get_connection() if manager else None
 
 
-def get_mock_connection():
+def get_mock_connection(
+    container: ServiceContainer | None = None,
+) -> DatabaseConnection | None:
     """Return the optional ``MockConnection`` service."""
-    return _get_service("MockConnection")
+    c = _get_container(container)
+    if c and c.has("mock_connection"):
+        return c.get("mock_connection")
+    return None
 
 
-def get_enhanced_postgresql_manager():
+def get_enhanced_postgresql_manager(
+    container: ServiceContainer | None = None,
+) -> EnhancedPostgreSQLManagerProtocol | None:
     """Return the optional ``EnhancedPostgreSQLManager`` service."""
-    return _get_service("EnhancedPostgreSQLManager")
+    c = _get_container(container)
+    if c and c.has("enhanced_postgresql_manager"):
+        return c.get("enhanced_postgresql_manager")
+    return None

--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -43,8 +43,18 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigValidator,
         create_config_manager,
     )
-    from config.database_manager import DatabaseManager, DatabaseSettings
+    from config.database_manager import (
+        DatabaseManager,
+        DatabaseSettings,
+        MockConnection,
+        EnhancedPostgreSQLManager,
+    )
     from core.logging import LoggingService
+    from config.protocols import (
+        DatabaseManagerProtocol,
+        EnhancedPostgreSQLManagerProtocol,
+    )
+    from database.types import DatabaseConnection
     from services.configuration_service import (
         ConfigurationServiceProtocol,
         DynamicConfigurationService,
@@ -72,8 +82,26 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
     container.register_singleton(
         "database_manager",
         DatabaseManager,
-        protocol=DatabaseProtocol,
+        protocol=DatabaseManagerProtocol,
         factory=lambda c: DatabaseManager(DatabaseSettings()),
+    )
+    container.register_transient(
+        "database_connection",
+        object,
+        protocol=DatabaseConnection,
+        factory=lambda c: c.get("database_manager").get_connection(),
+    )
+    container.register_transient(
+        "mock_connection",
+        MockConnection,
+        protocol=DatabaseConnection,
+        factory=lambda c: MockConnection(),
+    )
+    container.register_singleton(
+        "enhanced_postgresql_manager",
+        EnhancedPostgreSQLManager,
+        protocol=EnhancedPostgreSQLManagerProtocol,
+        factory=lambda c: EnhancedPostgreSQLManager(DatabaseSettings()),
     )
 
     from core.events import EventBus


### PR DESCRIPTION
## Summary
- add database manager protocols
- register optional database services with the DI container
- resolve optional DB helpers from the container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.database_exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_688b36ce78d08320b5a49a1d381dc8ab