### PR TITLE
Inject configuration service

### DIFF
--- a/services/file_processor_service.py
+++ b/services/file_processor_service.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE, UPLOAD_ALLOWED_EXTENSIONS
+from config.constants import UPLOAD_ALLOWED_EXTENSIONS
 from core.protocols import ConfigurationServiceProtocol
 from core.unicode import UnicodeProcessor as UnicodeHelper
 from core.unicode import process_large_csv_content
@@ -49,10 +49,11 @@ class FileProcessorService(BaseService, BaseFileProcessor):
         decoder: SafeDecoderProtocol = safe_decode_with_unicode_handling,
         validator: FileValidator | None = None,
         *,
-        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        chunk_size: int | None = None,
     ) -> None:
         BaseService.__init__(self, "file-processor", "")
-        BaseFileProcessor.__init__(self, chunk_size=chunk_size, decoder=decoder)
+        chunk = chunk_size or config.get_upload_chunk_size()
+        BaseFileProcessor.__init__(self, chunk_size=chunk, decoder=decoder)
         self.start()
         self.config = config
         self.max_file_size_mb = config.get_max_upload_size_mb()

--- a/tests/test_process_and_analyze.py
+++ b/tests/test_process_and_analyze.py
@@ -1,7 +1,10 @@
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from __future__ import annotations
+
 from services.data_processing.file_processor import FileProcessor
 from services.data_processing.processor import Processor
+from services.upload_processing import UploadAnalyticsProcessor
 from tests.builders import TestDataBuilder
+from tests.fake_configuration import FakeConfiguration
 from validation.security_validator import SecurityValidator
 
 
@@ -14,7 +17,8 @@ def _create_components():
 
     fp = FileProcessor()
     vs = SecurityValidator()
-    processor = Processor(validator=vs)
+    cfg = FakeConfiguration()
+    processor = Processor(validator=vs, config_service=cfg)
 
     ua = UploadAnalyticsProcessor(vs, processor)
     return fp, ua

--- a/tests/test_upload_processing_helpers.py
+++ b/tests/test_upload_processing_helpers.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import pandas as pd
 
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.data_processing.processor import Processor
+from services.upload_processing import UploadAnalyticsProcessor
+from tests.fake_configuration import FakeConfiguration
 from tests.utils.builders import DataFrameBuilder
 from validation.security_validator import SecurityValidator
 
@@ -13,7 +16,8 @@ def _make_processor():
 
     cache.init_app(Flask(__name__))
     vs = SecurityValidator()
-    processor = Processor(validator=vs)
+    cfg = FakeConfiguration()
+    processor = Processor(validator=vs, config_service=cfg)
     return UploadAnalyticsProcessor(vs, processor)
 
 

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -1,5 +1,8 @@
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from __future__ import annotations
+
 from services.data_processing.processor import Processor
+from services.upload_processing import UploadAnalyticsProcessor
+from tests.fake_configuration import FakeConfiguration
 from tests.utils.builders import DataFrameBuilder
 from validation.security_validator import SecurityValidator
 
@@ -12,7 +15,8 @@ def _make_processor():
     cache.init_app(Flask(__name__))
 
     vs = SecurityValidator()
-    processor = Processor(validator=vs)
+    cfg = FakeConfiguration()
+    processor = Processor(validator=vs, config_service=cfg)
 
     return UploadAnalyticsProcessor(vs, processor)
 


### PR DESCRIPTION
## Summary
- support injecting a configuration service into `Processor`
- have `FileProcessorService` use configuration service for chunk size
- update analytics tests to provide a fake configuration

## Testing
- `pre-commit run --files services/data_processing/processor.py services/file_processor_service.py tests/test_upload_processing_module.py tests/test_upload_processing_helpers.py tests/test_process_and_analyze.py`
- `pytest tests/test_upload_processing_module.py tests/test_upload_processing_helpers.py tests/test_process_and_analyze.py -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_688b36db45b88320a977c8ecfb0737ce