### PR TITLE
Expose database manager protocols

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -130,6 +130,8 @@ __all__ = [
     "CSSConstants",
     "execute_secure_query",
     "UnicodeHandler",
+    "DatabaseManagerProtocol",
+    "EnhancedPostgreSQLManagerProtocol",
 ]
 
 


### PR DESCRIPTION
## Summary
- expose `DatabaseManagerProtocol` and `EnhancedPostgreSQLManagerProtocol` through `config`

## Testing
- `pytest tests/test_enhanced_database_manager.py -q` *(fails: KeyError 'yosai_intel_dashboard')*

------
https://chatgpt.com/codex/tasks/task_e_688b3d07a09c8320b2e505f8ae01947d