### PR TITLE
Refactor services to inject config

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -26,8 +26,9 @@ def register_all_application_services(container: ServiceContainer) -> None:
     register_security_services(container)
     register_export_services(container)
     from services.upload.service_registration import register_upload_services
+    from config.dynamic_config import dynamic_config
 
-    register_upload_services(container)
+    register_upload_services(container, config=dynamic_config)
 
 
 def register_all_services(container: ServiceContainer) -> None:
@@ -43,6 +44,8 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigValidator,
         create_config_manager,
     )
+    from core.interfaces import ConfigProviderProtocol
+    from config.dynamic_config import dynamic_config
     from config.database_manager import DatabaseManager, DatabaseSettings
     from core.logging import LoggingService
     from services.configuration_service import (
@@ -58,6 +61,11 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigManager,
         protocol=ConfigurationProtocol,
         factory=lambda c: create_config_manager(container=c),
+    )
+    container.register_singleton(
+        "dynamic_config",
+        dynamic_config,
+        protocol=ConfigProviderProtocol,
     )
     container.register_singleton(
         "configuration_service",
@@ -110,6 +118,7 @@ def register_analytics_services(container: ServiceContainer) -> None:
         ReportGeneratorProtocol,
         PublishingProtocol,
     )
+    from config.dynamic_config import dynamic_config
     from services.analytics_service import create_analytics_service
     from services.data_loading_service import DataLoadingService
     from services.data_processing_service import DataProcessingService
@@ -152,7 +161,7 @@ def register_analytics_services(container: ServiceContainer) -> None:
     )
     container.register_singleton(
         "analytics_service",
-        create_analytics_service(),
+        create_analytics_service(config_provider=dynamic_config),
         protocol=AnalyticsServiceProtocol,
     )
 

--- a/tests/analytics/test_processor_io.py
+++ b/tests/analytics/test_processor_io.py
@@ -136,7 +136,7 @@ async def test_async_file_processor_io(tmp_path):
     df.to_csv(csv_path, index=False)
     content = "data:text/csv;base64," + base64.b64encode(csv_path.read_bytes()).decode()
 
-    processor = AsyncFileProcessor(chunk_size=1)
+    processor = AsyncFileProcessor(chunk_size=1, config=dynamic)
     result = await processor.process_file(content, "input.csv")
 
     json_data = result.to_json(orient="records")

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from core.protocols import ConfigurationProtocol
+from core.interfaces import ConfigProviderProtocol
 
 try:
     from core.protocols import ConfigurationServiceProtocol
@@ -11,7 +12,7 @@ except Exception:  # pragma: no cover - optional deps
         def get_max_upload_size_mb(self) -> int: ...
 
 
-class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol):
+class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, ConfigProviderProtocol):
     """Simple config for unit tests."""
 
     def __init__(self) -> None:

--- a/tests/services/test_async_file_processor.py
+++ b/tests/services/test_async_file_processor.py
@@ -81,6 +81,7 @@ async_mod = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(async_mod)
 AsyncFileProcessor = async_mod.AsyncFileProcessor
+cfg = dyn
 
 
 def test_read_csv_chunks_and_load(tmp_path: Path):
@@ -88,7 +89,7 @@ def test_read_csv_chunks_and_load(tmp_path: Path):
     csv_path = tmp_path / "sample.csv"
     df.to_csv(csv_path, index=False)
 
-    proc = AsyncFileProcessor(chunk_size=2)
+    proc = AsyncFileProcessor(chunk_size=2, config=cfg)
 
     async def gather():
         chunks = []
@@ -113,7 +114,7 @@ def test_process_excel_file(tmp_path: Path):
         + contents
     )
 
-    proc = AsyncFileProcessor()
+    proc = AsyncFileProcessor(config=cfg)
     progress = []
     result = asyncio.run(
         proc.process_file(
@@ -135,6 +136,6 @@ def test_read_uploaded_file_csv(tmp_path: Path):
     contents = base64.b64encode(csv_path.read_bytes()).decode()
     data_uri = "data:text/csv;base64," + contents
 
-    proc = AsyncFileProcessor()
+    proc = AsyncFileProcessor(config=cfg)
     loaded, _ = asyncio.run(proc.read_uploaded_file(data_uri, "t.csv"))
     assert loaded.equals(df)

--- a/tests/services/test_async_file_processor_nodisk.py
+++ b/tests/services/test_async_file_processor_nodisk.py
@@ -52,6 +52,7 @@ async_mod = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(async_mod)
 AsyncFileProcessor = async_mod.AsyncFileProcessor
+cfg = config_mod.dynamic_config
 
 
 def _setup_temp_patches(monkeypatch, stored_data):
@@ -96,7 +97,7 @@ def test_process_file_csv_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
 
-    proc = AsyncFileProcessor()
+    proc = AsyncFileProcessor(config=cfg)
     progress = []
     result = asyncio.run(
         proc.process_file(
@@ -127,7 +128,7 @@ def test_process_file_excel_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_excel", fake_read_excel)
 
-    proc = AsyncFileProcessor()
+    proc = AsyncFileProcessor(config=cfg)
     progress = []
     result = asyncio.run(
         proc.process_file(
@@ -155,7 +156,7 @@ def test_process_file_json_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_json", fake_read_json)
 
-    proc = AsyncFileProcessor()
+    proc = AsyncFileProcessor(config=cfg)
     progress = []
     result = asyncio.run(
         proc.process_file(

--- a/yosai_intel_dashboard/src/core/interfaces.py
+++ b/yosai_intel_dashboard/src/core/interfaces.py
@@ -36,3 +36,22 @@ class AnalyticsProviderProtocol(Protocol):
     def get_metrics(self) -> Dict[str, Any]:
         """Return computed analytics metrics."""
         ...
+
+
+class ConfigProviderProtocol(Protocol):
+    """Provide direct access to configuration objects."""
+
+    @property
+    @abstractmethod
+    def analytics(self) -> Any:
+        """Return analytics configuration object."""
+
+    @property
+    @abstractmethod
+    def database(self) -> Any:
+        """Return database configuration object."""
+
+    @property
+    @abstractmethod
+    def security(self) -> Any:
+        """Return security configuration object."""

--- a/yosai_intel_dashboard/src/services/streaming/service.py
+++ b/yosai_intel_dashboard/src/services/streaming/service.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Generator, Optional
 
-from config.dynamic_config import dynamic_config
+from core.interfaces import ConfigProviderProtocol
 from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ class StreamingService(BaseService):
 
     def __init__(self, config: Optional[Any] = None) -> None:
         super().__init__("streaming", "")
-        self.config = config or getattr(dynamic_config, "streaming", None)
+        self.config = getattr(config, "streaming", config)
         self.producer = None
         self.consumer = None
         self._client = None

--- a/yosai_intel_dashboard/src/services/upload/service_registration.py
+++ b/yosai_intel_dashboard/src/services/upload/service_registration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from components.ui_builder import UploadUIBuilder
-from config.dynamic_config import dynamic_config
+from core.interfaces import ConfigProviderProtocol
 from core.protocols import FileProcessorProtocol
 from core.service_container import (
     CircularDependencyError,
@@ -33,10 +33,14 @@ from utils.upload_store import UploadedDataStore
 from validation.file_validator import FileValidator
 
 
-def register_upload_services(container: ServiceContainer) -> None:
+def register_upload_services(
+    container: ServiceContainer, *, config: ConfigProviderProtocol | None = None
+) -> None:
     """Register upload related services with the container."""
 
-    upload_store = UploadedDataStore(dynamic_config.upload.folder)
+    upload_cfg = getattr(config, "upload", None) if config else None
+    folder = getattr(upload_cfg, "folder", "uploads")
+    upload_store = UploadedDataStore(folder)
     container.register_singleton(
         "upload_storage",
         upload_store,


### PR DESCRIPTION
## Summary
- define a new `ConfigProviderProtocol`
- inject configuration objects into analytics and processing services
- register `dynamic_config` with `ServiceContainer`
- pass config objects to upload service registration
- update async file processor tests to provide config

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688b726b050083209a143dc41dd4ea28