### PR TITLE
Inject resolvers into DynamicConfigManager

### DIFF
--- a/yosai_intel_dashboard/src/core/config.py
+++ b/yosai_intel_dashboard/src/core/config.py
@@ -2,63 +2,75 @@ from __future__ import annotations
 
 """Simple configuration helpers used across the project."""
 
-from typing import Any
-
 from config.config import get_analytics_config
-from config.dynamic_config import dynamic_config
-from config.utils import get_ai_confidence_threshold as _get_ai_confidence_threshold
-from config.utils import get_upload_chunk_size as _get_upload_chunk_size
+from typing import TYPE_CHECKING
+
+from config.utils import (
+    get_ai_confidence_threshold as _get_ai_confidence_threshold,
+    get_upload_chunk_size as _get_upload_chunk_size,
+)
+from core.container import container
 from core.protocols import ConfigurationProtocol
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from config.dynamic_config import DynamicConfigManager
+
+
+def _dynamic_config() -> "DynamicConfigManager":
+    """Return the :class:`DynamicConfigManager` from the DI container."""
+    return container.get("dynamic_config")
 
 
 def get_ai_confidence_threshold() -> float:
     """Return the AI confidence threshold from the dynamic configuration."""
-    return _get_ai_confidence_threshold(dynamic_config)
+    return _get_ai_confidence_threshold(_dynamic_config())
 
 
 def get_upload_chunk_size() -> int:
     """Return the upload chunk size from the dynamic configuration."""
-    return _get_upload_chunk_size(dynamic_config)
+    return _get_upload_chunk_size(_dynamic_config())
 
 
 def get_max_parallel_uploads() -> int:
     """Return the maximum number of parallel uploads from the dynamic configuration."""
-    return dynamic_config.get_max_parallel_uploads()
+    return _dynamic_config().get_max_parallel_uploads()
 
 
 def get_validator_rules() -> dict:
     """Return validator rules for uploads from the dynamic configuration."""
-    return dynamic_config.get_validator_rules()
+    return _dynamic_config().get_validator_rules()
 
 
 def get_max_upload_size_mb() -> int:
     """Return the maximum upload size in megabytes from the dynamic configuration."""
-    return dynamic_config.get_max_upload_size_mb()
+    return _dynamic_config().get_max_upload_size_mb()
 
 
 def get_max_upload_size_bytes() -> int:
     """Return the maximum upload size in bytes from the dynamic configuration."""
-    return dynamic_config.get_max_upload_size_bytes()
+    return _dynamic_config().get_max_upload_size_bytes()
 
 
 def validate_large_file_support() -> bool:
     """Return ``True`` if large file uploads are supported."""
-    return dynamic_config.validate_large_file_support()
+    return _dynamic_config().validate_large_file_support()
 
 
 def get_db_pool_size() -> int:
     """Return the configured database pool size."""
-    return dynamic_config.get_db_pool_size()
+    return _dynamic_config().get_db_pool_size()
 
 
-def get_max_display_rows(config: ConfigurationProtocol = dynamic_config) -> int:
+def get_max_display_rows(
+    config: ConfigurationProtocol | None = None,
+) -> int:
     """Return maximum number of rows to show in previews."""
     try:
-        return (
-            get_analytics_config().max_display_rows or config.analytics.max_display_rows
-        )
+        cfg = config or _dynamic_config()
+        return get_analytics_config().max_display_rows or cfg.analytics.max_display_rows
     except Exception:
-        return config.analytics.max_display_rows
+        cfg = config or _dynamic_config()
+        return cfg.analytics.max_display_rows
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- allow `DynamicConfigManager` to receive resolver callables
- use the DI container inside `core.config` instead of importing `dynamic_config`

## Testing
- `flake8 yosai_intel_dashboard/src/core/config.py yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py`
- `pytest tests/test_dynamic_config_validation.py::test_invalid_yaml_types -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_688b84d120848320925142abdaea73fe