### PR TITLE
Add service protocols and DI improvements

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -126,6 +126,8 @@ def register_analytics_services(container: ServiceContainer) -> None:
     from services.publishing_service import PublishingService
     from services.controllers.upload_controller import UnifiedUploadController
     from services.data_processing.processor import Processor
+    from services.interfaces import MappingServiceProtocol
+    from mapping.factories.service_factory import create_mapping_service
     from validation.security_validator import SecurityValidator
 
     container.register_singleton(
@@ -139,12 +141,20 @@ def register_analytics_services(container: ServiceContainer) -> None:
         UnifiedUploadController,
     )
     container.register_singleton(
+        "mapping_service",
+        create_mapping_service(container=container),
+        protocol=MappingServiceProtocol,
+    )
+    container.register_singleton(
         "data_loader",
         DataLoadingService,
         protocol=DataLoadingProtocol,
         factory=lambda c: DataLoadingService(
             c.get("upload_controller"),
-            Processor(validator=SecurityValidator()),
+            Processor(
+                validator=SecurityValidator(),
+                mapping_service=c.get("mapping_service", MappingServiceProtocol),
+            ),
         ),
     )
     container.register_singleton(

--- a/yosai_intel_dashboard/src/services/data_processing/processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/processor.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import pandas as pd
 
@@ -16,11 +16,9 @@ from monitoring.data_quality_monitor import (
     get_data_quality_monitor,
 )
 from services.streaming import StreamingService
+from services.interfaces import MappingServiceProtocol, get_mapping_service
 from unicode_toolkit import safe_encode_text
 from validation.security_validator import SecurityValidator
-
-if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from mapping.service import MappingService
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +31,7 @@ class Processor:
         base_data_path: str = "data",
         validator: Optional[SecurityValidator] = None,
         streaming_service: Optional[StreamingService] = None,
-        mapping_service: MappingService | None = None,
+        mapping_service: MappingServiceProtocol | None = None,
         *,
         config: ConfigProviderProtocol | None = None,
     ) -> None:
@@ -42,11 +40,7 @@ class Processor:
         self.session_storage = self.base_path.parent / "session_storage"
         self.validator = validator or SecurityValidator()
         self.streaming_service = streaming_service
-        if mapping_service is None:
-            from mapping.factories.service_factory import create_mapping_service
-
-            mapping_service = create_mapping_service()
-        self.mapping_service = mapping_service
+        self.mapping_service = mapping_service or get_mapping_service()
         self.config = config
 
     # ------------------------------------------------------------------

--- a/yosai_intel_dashboard/src/services/upload_data_service.py
+++ b/yosai_intel_dashboard/src/services/upload_data_service.py
@@ -12,8 +12,10 @@ except ImportError:  # pragma: no cover - for Python <3.12
 import pandas as pd
 
 from core.service_container import ServiceContainer
-from services.interfaces import get_upload_data_service
-from services.protocols.upload_data import UploadDataServiceProtocol
+from services.interfaces import (
+    get_upload_data_service,
+    UploadDataServiceProtocol,
+)
 from utils.upload_store import UploadedDataStore, uploaded_data_store
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- define `MappingServiceProtocol` and `UploadDataServiceProtocol`
- register mapping service with the `ServiceContainer`
- inject mapping and upload services into `Processor` and `SummaryReporter`
- update imports to rely on protocols

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b84d3d94083209d169d9a93007e36