### PR TITLE
Move manual test scripts out of pytest

### DIFF
--- a/code_review_report.md
+++ b/code_review_report.md
@@ -39,7 +39,7 @@ Callback distribution:
 
 ## Unicode Handling
 Found 702 potential encoding issues
-  - test_base_services.py:6 - Potential encoding issue: str(PROJECT_ROOT))
+  - scripts/manual_tests/check_base_services.py:6 - Potential encoding issue: str(PROJECT_ROOT))
   - mde.py (removed):12 - Potential encoding issue: str(PROJECT_ROOT))
   - mde.py (removed):262 - Potential encoding issue: str(e)}", color="danger")
   - mde.py (removed):389 - Potential encoding issue: str(e)}", color="warning")

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ testpaths =
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+norecursedirs = scripts/manual_tests
 addopts = 
     --verbose
     --tb=short

--- a/scripts/manual_tests/check_api.py
+++ b/scripts/manual_tests/check_api.py
@@ -1,3 +1,5 @@
+"""Manual script to verify API endpoints are reachable"""
+
 import json
 
 import requests

--- a/scripts/manual_tests/check_base_services.py
+++ b/scripts/manual_tests/check_base_services.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Test base code service loading"""
+"""Manual script to check base code service loading"""
 
 
 def safe_str(obj):

--- a/scripts/manual_tests/check_endpoints.py
+++ b/scripts/manual_tests/check_endpoints.py
@@ -1,3 +1,5 @@
+"""Manual script to exercise selected API endpoints"""
+
 import json
 import os
 


### PR DESCRIPTION
## Summary
- move manual test scripts under `scripts/manual_tests`
- rename them as `check_*` to clarify intent
- exclude manual tests from pytest
- fix documentation reference

## Testing
- `pytest -q` *(fails: 300 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688b96d5b4348320af163ea60412c68b