### PR TITLE
Refactor file controller callbacks

### DIFF
--- a/tests/test_unified_file_controller.py
+++ b/tests/test_unified_file_controller.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
+import pandas as pd
+import types
+from enum import Enum, auto
+from utils.upload_store import UploadedDataStore
+from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
+
+callback_events_stub = types.ModuleType("core.callback_events")
+
+class CallbackEvent(Enum):
+    FILE_UPLOAD_COMPLETE = auto()
+    DATA_PROCESSED = auto()
+
+callback_events_stub.CallbackEvent = CallbackEvent
+sys.modules.setdefault("core.callback_events", callback_events_stub)
+
+tuc_stub = types.ModuleType("core.truly_unified_callbacks")
+tuc_stub.TrulyUnifiedCallbacks = DummyManager
+sys.modules.setdefault("core.truly_unified_callbacks", tuc_stub)
+
+from yosai_intel_dashboard.src.services.unified_file_controller import register_callbacks
+
+
+class DummyManager:
+    def __init__(self) -> None:
+        self.events = {}
+
+    def register_event(self, event, func, **_):
+        self.events.setdefault(event, []).append(func)
+
+    def trigger(self, event, *args, **kwargs):
+        return [cb(*args, **kwargs) for cb in self.events.get(event, [])]
+
+
+def test_register_callbacks_processes_upload(tmp_path):
+    manager = DummyManager()
+    store = UploadedDataStore(storage_dir=tmp_path)
+    df = DataFrameBuilder().add_column("a", [1, 2]).build()
+    content = UploadFileBuilder().with_dataframe(df).as_base64()
+
+    events = []
+    manager.register_event(
+        CallbackEvent.DATA_PROCESSED,
+        lambda source, data: events.append((source, data)),
+    )
+
+    register_callbacks(manager)
+
+    manager.trigger(CallbackEvent.FILE_UPLOAD_COMPLETE, content, "sample.csv", storage=store)
+
+    saved = store.load_dataframe("sample.csv")
+    assert saved.equals(df)
+    assert events and events[0][1]["rows"] == 2

--- a/yosai_intel_dashboard/src/services/unified_file_controller.py
+++ b/yosai_intel_dashboard/src/services/unified_file_controller.py
@@ -12,7 +12,6 @@ from services.data_processing.file_handler import FileHandler
 from utils.upload_store import UploadedDataStore
 
 _logger = logging.getLogger(__name__)
-callback_manager = TrulyUnifiedCallbacks()
 
 # Simple in-memory metrics
 _metrics = {
@@ -27,6 +26,7 @@ def process_file_upload(
     contents: str,
     filename: str,
     *,
+    callback_manager: TrulyUnifiedCallbacks,
     storage: Optional[UploadedDataStore] = None,
 ) -> dict:
     """Validate ``contents``, sanitize with :class:`UnicodeProcessor` and save.
@@ -78,7 +78,27 @@ def get_processing_metrics() -> dict:
     return dict(_metrics)
 
 
+def register_callbacks(callbacks: TrulyUnifiedCallbacks) -> None:
+    """Register event callbacks for file uploads using *callbacks* manager."""
+
+    def _handle_upload(
+        contents: str,
+        filename: str,
+        *,
+        storage: Optional[UploadedDataStore] = None,
+    ) -> dict:
+        return process_file_upload(
+            contents,
+            filename,
+            callback_manager=callbacks,
+            storage=storage,
+        )
+
+    callbacks.register_event(CallbackEvent.FILE_UPLOAD_COMPLETE, _handle_upload)
+
+
 __all__ = [
     "process_file_upload",
     "get_processing_metrics",
+    "register_callbacks",
 ]


### PR DESCRIPTION
## Summary
- inject `TrulyUnifiedCallbacks` instance into `unified_file_controller`
- hook upload events through a new `register_callbacks` function
- add basic unit test for new registration behaviour

## Testing
- `pytest tests/test_unified_file_controller.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688b97a630bc8320bd135bb25ded93c9