### PR TITLE
Replace prints with logging

### DIFF
--- a/tests/test_event_service_logging.py
+++ b/tests/test_event_service_logging.py
@@ -1,0 +1,105 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import logging
+import pytest
+
+# Setup minimal environment to load EventServiceAdapter
+services_path = pathlib.Path(__file__).resolve().parents[1] / "yosai_intel_dashboard" / "src" / "services"
+
+core_pkg = types.ModuleType("core")
+core_pkg.__path__ = []
+service_container_mod = types.ModuleType("core.service_container")
+class ServiceContainer: pass
+service_container_mod.ServiceContainer = ServiceContainer
+sys.modules.setdefault("core", core_pkg)
+sys.modules.setdefault("core.service_container", service_container_mod)
+
+stub_services = types.ModuleType("services")
+stub_services.__path__ = [str(services_path)]
+sys.modules.setdefault("services", stub_services)
+
+interfaces_mod = types.ModuleType("services.interfaces")
+class AnalyticsServiceProtocol: pass
+interfaces_mod.AnalyticsServiceProtocol = AnalyticsServiceProtocol
+sys.modules.setdefault("services.interfaces", interfaces_mod)
+
+feat_mod = types.ModuleType("services.feature_flags")
+class FeatureFlags:
+    def __init__(self):
+        self._flags = {}
+    def is_enabled(self, name):
+        return self._flags.get(name, False)
+feat_mod.feature_flags = FeatureFlags()
+stub_services.feature_flags = feat_mod
+sys.modules.setdefault("services.feature_flags", feat_mod)
+
+cb_mod = types.ModuleType("services.resilience.circuit_breaker")
+class CircuitBreakerOpen(Exception):
+    pass
+class DummyBreaker:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+cb_mod.CircuitBreaker = DummyBreaker
+cb_mod.CircuitBreakerOpen = CircuitBreakerOpen
+sys.modules.setdefault("services.resilience.circuit_breaker", cb_mod)
+
+sys.modules.setdefault("kafka", types.ModuleType("kafka"))
+setattr(sys.modules["kafka"], "KafkaProducer", object)
+
+spec = importlib.util.spec_from_file_location(
+    "migration_adapter",
+    services_path / "migration" / "adapter.py",
+)
+migration_adapter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration_adapter)
+EventServiceAdapter = migration_adapter.EventServiceAdapter
+
+@pytest.mark.asyncio
+async def test_init_logs(monkeypatch, caplog):
+    def fail(*a, **k):
+        raise RuntimeError("fail")
+    monkeypatch.setattr(migration_adapter, "KafkaProducer", fail)
+    with caplog.at_level(logging.WARNING):
+        EventServiceAdapter(base_url="http://localhost")
+    assert any("Kafka initialization failed" in r.getMessage() for r in caplog.records)
+
+@pytest.mark.asyncio
+async def test_kafka_send_failure_logs(monkeypatch, caplog):
+    class FailingProducer:
+        def send(self, *a, **k):
+            class F:
+                def get(self, timeout=None):
+                    raise RuntimeError("boom")
+            return F()
+    monkeypatch.setattr(migration_adapter, "KafkaProducer", lambda *a, **k: FailingProducer())
+    adapter = EventServiceAdapter(base_url="http://localhost")
+    adapter.circuit_breaker = DummyBreaker()
+
+    class DummyResp:
+        async def json(self):
+            return {"ok": True}
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def post(self, *a, **k):
+            return DummyResp()
+
+    monkeypatch.setattr(migration_adapter.aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    monkeypatch.setattr(migration_adapter.aiohttp, "ClientTimeout", lambda *a, **k: None)
+
+    with caplog.at_level(logging.WARNING):
+        await adapter._process_event({"event_id": "E1"})
+    assert any("Kafka send failed" in r.getMessage() for r in caplog.records)

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -327,26 +327,25 @@ class ConfigHelper:
         return dynamic_config.get_upload_chunk_size()
 
 
-def diagnose_upload_config():
+def diagnose_upload_config() -> None:
     """Diagnostic function to check upload configuration"""
     import os
 
-    print("=== Upload Configuration Diagnosis ===")
-    print(f"Environment MAX_UPLOAD_MB: {os.getenv('MAX_UPLOAD_MB', 'Not Set')}")
-    print(f"Dynamic Config max_upload_mb: {dynamic_config.security.max_upload_mb}MB")
-    print(f"Upload folder: {dynamic_config.upload.folder}")
-    print(f"Max file size: {dynamic_config.upload.max_file_size_mb}MB")
-    print(f"Calculated max bytes: {dynamic_config.get_max_upload_size_bytes():,}")
-    print(f"Supports 50MB+ files: {dynamic_config.validate_large_file_support()}")
+    logger.info("=== Upload Configuration Diagnosis ===")
+    logger.info("Environment MAX_UPLOAD_MB: %s", os.getenv("MAX_UPLOAD_MB", "Not Set"))
+    logger.info("Dynamic Config max_upload_mb: %sMB", dynamic_config.security.max_upload_mb)
+    logger.info("Upload folder: %s", dynamic_config.upload.folder)
+    logger.info("Max file size: %sMB", dynamic_config.upload.max_file_size_mb)
+    logger.info("Calculated max bytes: %s", f"{dynamic_config.get_max_upload_size_bytes():,}")
+    logger.info("Supports 50MB+ files: %s", dynamic_config.validate_large_file_support())
 
-    # Check if environment is overriding to small value
     env_value = os.getenv("MAX_UPLOAD_MB")
     if env_value and int(env_value) < 50:
-        print(
-            "\u26a0\ufe0f  WARNING: Environment variable MAX_UPLOAD_MB="
-            f"{env_value} is too small!"
+        logger.warning(
+            "\u26a0\ufe0f  WARNING: Environment variable MAX_UPLOAD_MB=%s is too small!",
+            env_value,
         )
-        print("   Run: unset MAX_UPLOAD_MB")
+        logger.info("   Run: unset MAX_UPLOAD_MB")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log upload config diagnostics instead of printing
- log EventServiceAdapter messages with logger
- test logging behaviour for EventServiceAdapter

## Testing
- `pytest tests/test_event_service_logging.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688b96cf86548320b25312da582bdad4