### PR TITLE
Fix legacy import paths

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -4,7 +4,7 @@ import logging
 
 from api.adapter import create_api_app
 
-from config.constants import API_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from core.di.bootstrap import bootstrap_container
 from core.env_validation import validate_required_env
 

--- a/scripts/callback_graph.py
+++ b/scripts/callback_graph.py
@@ -8,8 +8,8 @@ import os
 from dash import Dash
 from graphviz import Digraph
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from services.upload.callbacks import UploadCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.services.upload.callbacks import UploadCallbacks
 
 
 def load_callbacks() -> TrulyUnifiedCallbacks:

--- a/scripts/manual_tests/check_base_services.py
+++ b/scripts/manual_tests/check_base_services.py
@@ -24,11 +24,11 @@ sys.path.insert(0, safe_str(PROJECT_ROOT))
 try:
     print("🔍 Testing base code imports...")
 
-    from services.upload.service_registration import register_upload_services
+    from yosai_intel_dashboard.src.services.upload.service_registration import register_upload_services
 
     print("✅ Service registration imported")
 
-    from core.service_container import ServiceContainer
+    from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
     print("✅ Service container imported")
 

--- a/scripts/test_large_file_processing.py
+++ b/scripts/test_large_file_processing.py
@@ -1,7 +1,7 @@
 def test_large_file_processing():
     import pandas as pd
 
-    from services.analytics_service import AnalyticsService
+    from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
     # Create a test dataframe similar to your data
     test_df = pd.DataFrame(

--- a/scripts/update_imports.py
+++ b/scripts/update_imports.py
@@ -14,8 +14,34 @@ ROOT = Path(__file__).resolve().parents[1]
 # repository root, so rewriting them would break imports.  As new
 # packages are migrated they can be added back to this mapping.
 PATTERNS = {
-    r"\bfrom\s+models(\.|\s)": "from models\\1",
-    r"\bimport\s+models(\.|$)": "import models\\1",
+    # Core domain imports
+    r"\bfrom\s+models\.base\s+import": "from yosai_intel_dashboard.src.core.domain.entities.base import",
+    r"\bfrom\s+models\.entities\s+import": "from yosai_intel_dashboard.src.core.domain.entities.entities import",
+    r"\bfrom\s+models\.events\s+import": "from yosai_intel_dashboard.src.core.domain.entities.events import",
+    r"\bfrom\s+models\.enums\s+import": "from yosai_intel_dashboard.src.core.domain.value_objects.enums import",
+
+    # Callback system imports
+    r"\bfrom\s+core\.callbacks\s+import\s+UnifiedCallbackManager": "from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks",
+    r"\bfrom\s+core\.callback_controller\s+import\s+CallbackController": "from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks",
+    r"\bfrom\s+core\.truly_unified_callbacks\s+import\s+TrulyUnifiedCallbacks": "from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks",
+    r"\bfrom\s+core\.callback_events\s+import\s+CallbackEvent": "from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent",
+    r"\bfrom\s+services\.security_callback_controller\s+import": "from yosai_intel_dashboard.src.infrastructure.callbacks.security_controller import",
+
+    # Service imports
+    r"\bfrom\s+services\.analytics_service\s+import": "from yosai_intel_dashboard.src.services.analytics.analytics_service import",
+    r"\bfrom\s+services\.analytics\.": "from yosai_intel_dashboard.src.services.analytics.",
+    r"\bfrom\s+services\.upload\.": "from yosai_intel_dashboard.src.services.upload.",
+    r"\bfrom\s+services\.data_processing\.": "from yosai_intel_dashboard.src.services.data_processing.",
+
+    # Infrastructure imports
+    r"\bfrom\s+config\.": "from yosai_intel_dashboard.src.infrastructure.config.",
+    r"\bfrom\s+core\.service_container\s+import": "from yosai_intel_dashboard.src.infrastructure.di.service_container import",
+    r"\bfrom\s+core\.protocols\s+import": "from yosai_intel_dashboard.src.core.interfaces.protocols import",
+    r"\bfrom\s+services\.interfaces\s+import": "from yosai_intel_dashboard.src.core.interfaces.service_protocols import",
+
+    # UI imports
+    r"\bfrom\s+components\.": "from yosai_intel_dashboard.src.adapters.ui.components.",
+    r"\bfrom\s+pages\.": "from yosai_intel_dashboard.src.adapters.ui.pages.",
 }
 
 

--- a/start_api.py
+++ b/start_api.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Import Flask app directly from adapter
 from api.adapter import create_api_app
 
-from config.constants import API_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from core.di.bootstrap import bootstrap_container
 
 

--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from core.protocols import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import (
     ConfigurationProtocol,
     DatabaseProtocol,
     EventBusProtocol,
@@ -11,7 +11,7 @@ from core.protocols import (
     SecurityServiceProtocol,
     StorageProtocol,
 )
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.metadata_enhancement_engine import register_metadata_services
 
 
@@ -24,8 +24,8 @@ def register_all_application_services(container: ServiceContainer) -> None:
     register_metadata_services(container)
     register_security_services(container)
     register_export_services(container)
-    from config.dynamic_config import dynamic_config
-    from services.upload.service_registration import register_upload_services
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
+    from yosai_intel_dashboard.src.services.upload.service_registration import register_upload_services
 
     register_upload_services(container, config=dynamic_config)
 
@@ -43,8 +43,8 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigValidator,
         create_config_manager,
     )
-    from config.database_manager import DatabaseManager, DatabaseSettings
-    from config.dynamic_config import dynamic_config
+    from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, DatabaseSettings
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
     from core.interfaces import ConfigProviderProtocol
     from core.logging import LoggingService
     from services.configuration_service import (
@@ -102,7 +102,7 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=StorageProtocol,
     )
 
-    from config.cache_manager import get_cache_manager
+    from yosai_intel_dashboard.src.infrastructure.config.cache_manager import get_cache_manager
 
     container.register_singleton(
         "cache_manager",
@@ -112,7 +112,7 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
 
 def register_analytics_services(container: ServiceContainer) -> None:
     """Register analytics components and service."""
-    from core.protocols import (
+    from yosai_intel_dashboard.src.core.interfaces.protocols import (
         AnalyticsServiceProtocol,
         ConfigProviderProtocol,
         DatabaseProtocol,
@@ -120,8 +120,8 @@ def register_analytics_services(container: ServiceContainer) -> None:
         StorageProtocol,
     )
     from mapping.factories.service_factory import create_mapping_service
-    from services.analytics.calculator import create_calculator
-    from services.analytics.protocols import (
+    from yosai_intel_dashboard.src.services.analytics.calculator import create_calculator
+    from yosai_intel_dashboard.src.services.analytics.protocols import (
         CalculatorProtocol,
         DataLoadingProtocol,
         DataProcessorProtocol,
@@ -129,14 +129,14 @@ def register_analytics_services(container: ServiceContainer) -> None:
         ReportGeneratorProtocol,
         UploadAnalyticsProtocol,
     )
-    from services.analytics.upload_analytics import UploadAnalyticsProcessor
-    from services.analytics_service import AnalyticsService
+    from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+    from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
     from services.controllers.upload_controller import UploadProcessingController
     from services.controllers.protocols import UploadProcessingControllerProtocol
     from services.data_loading_service import DataLoadingService
-    from services.data_processing.processor import Processor
+    from yosai_intel_dashboard.src.services.data_processing.processor import Processor
     from services.data_processing_service import DataProcessingService
-    from services.interfaces import (
+    from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
         MappingServiceProtocol,
         UploadDataServiceProtocol,
         get_database_analytics_retriever,
@@ -248,7 +248,7 @@ def register_security_services(container: ServiceContainer) -> None:
 
 
 def register_export_services(container: ServiceContainer) -> None:
-    from core.protocols import ExportServiceProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import ExportServiceProtocol
     from services.export_service import ExportService
 
     container.register_transient(

--- a/tests/analytics/test_async_api.py
+++ b/tests/analytics/test_async_api.py
@@ -2,7 +2,7 @@ import json
 
 from fastapi.testclient import TestClient
 
-from services.analytics.async_api import app, event_bus
+from yosai_intel_dashboard.src.services.analytics.async_api import app, event_bus
 
 
 def test_health_endpoint():

--- a/tests/analytics/test_async_repository.py
+++ b/tests/analytics/test_async_repository.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from services.analytics.async_repository import AsyncEventRepository
+from yosai_intel_dashboard.src.services.analytics.async_repository import AsyncEventRepository
 
 
 class DummySession:

--- a/tests/analytics/test_async_service.py
+++ b/tests/analytics/test_async_service.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from services.analytics.async_service import AsyncAnalyticsService
+from yosai_intel_dashboard.src.services.analytics.async_service import AsyncAnalyticsService
 
 
 class _DummyContext:

--- a/tests/builders.py
+++ b/tests/builders.py
@@ -5,12 +5,12 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from core.protocols import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import (
     ConfigurationProtocol,
     UnicodeProcessorProtocol,
 )
-from core.service_container import ServiceContainer
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.upload.protocols import (
     FileProcessorProtocol,
     UploadStorageProtocol,
 )

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -3,8 +3,8 @@ import types
 import pytest
 from dash import no_update
 
-from services.upload.processor import UploadProcessingService
-from services.upload.upload_core import UploadCore
+from yosai_intel_dashboard.src.services.upload.processor import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload.upload_core import UploadCore
 from tests.fakes import (
     FakeDeviceLearningService,
     FakeUploadDataService,

--- a/tests/cli_file_processor.py
+++ b/tests/cli_file_processor.py
@@ -17,8 +17,8 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from config import create_config_manager
-from services.upload.service_registration import register_upload_services
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.upload.service_registration import register_upload_services
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.file_processor_service import FileProcessorService
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,7 +296,7 @@ class FakeUnicodeProcessor:
 
 
 try:
-    from services.upload.protocols import UploadStorageProtocol
+    from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 except Exception:  # pragma: no cover - optional dep fallback
     from typing import Protocol
 
@@ -307,7 +307,7 @@ except Exception:  # pragma: no cover - optional dep fallback
 
 
 try:
-    from core.protocols import ConfigurationProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 except Exception:  # pragma: no cover - optional dep fallback
 
     class ConfigurationProtocol(Protocol):

--- a/tests/custom/test_upload_queue_manager.py
+++ b/tests/custom/test_upload_queue_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
 
 
 async def _handler(item: str) -> str:

--- a/tests/database/test_intelligent_pool.py
+++ b/tests/database/test_intelligent_pool.py
@@ -1,4 +1,4 @@
-from config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 from database.intelligent_connection_pool import IntelligentConnectionPool
 
 

--- a/tests/database/test_performance_analyzer.py
+++ b/tests/database/test_performance_analyzer.py
@@ -1,4 +1,4 @@
-from config.database_manager import DatabaseSettings, EnhancedPostgreSQLManager
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseSettings, EnhancedPostgreSQLManager
 
 
 def test_query_metrics_collected_for_multiple_queries():

--- a/tests/di/test_container_core.py
+++ b/tests/di/test_container_core.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from core.container import Container
-from core.service_container import DependencyInjectionError
+from yosai_intel_dashboard.src.infrastructure.di.service_container import DependencyInjectionError
 
 
 def test_container_initialization():

--- a/tests/di/test_dependency_discovery.py
+++ b/tests/di/test_dependency_discovery.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class Foo:

--- a/tests/di/test_di_container_integration.py
+++ b/tests/di/test_di_container_integration.py
@@ -1,6 +1,6 @@
 from config import create_config_manager
 from core.container import Container
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
 
 def test_container_initializes_without_circular_dependencies():

--- a/tests/di/test_performance_monitor.py
+++ b/tests/di/test_performance_monitor.py
@@ -1,7 +1,7 @@
 import time
 
 from core.performance_monitor import DIPerformanceMonitor
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def test_container_records_resolution_time():

--- a/tests/di/test_service_container.py
+++ b/tests/di/test_service_container.py
@@ -1,6 +1,6 @@
 import pytest
 
-from core.service_container import (
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
     CircularDependencyError,
     DependencyInjectionError,
     ServiceContainer,

--- a/tests/docs/test_documentation_examples.py
+++ b/tests/docs/test_documentation_examples.py
@@ -1,5 +1,5 @@
 from analytics.core import create_manager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class DatabaseManager:

--- a/tests/doubles/test_configuration.py
+++ b/tests/doubles/test_configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 
 class TestConfiguration(ConfigurationProtocol):

--- a/tests/doubles/test_file_processor_service.py
+++ b/tests/doubles/test_file_processor_service.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Tuple
 
 import pandas as pd
 
-from core.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 
 
 class FileProcessorServiceStub(FileProcessorProtocol):

--- a/tests/doubles/test_unicode_processor.py
+++ b/tests/doubles/test_unicode_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 
 class TestUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
 
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from core.interfaces import ConfigProviderProtocol
 
 try:
-    from core.protocols import ConfigurationServiceProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 except Exception:  # pragma: no cover - optional deps
     from typing import Protocol
 
@@ -73,7 +73,7 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, Con
         return self.get_max_upload_size_mb() >= 50
 
     def get_upload_chunk_size(self) -> int:
-        from config.utils import get_upload_chunk_size
+        from yosai_intel_dashboard.src.infrastructure.config.utils import get_upload_chunk_size
 
         return get_upload_chunk_size()
 
@@ -88,7 +88,7 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, Con
         return get_validator_rules()
 
     def get_ai_confidence_threshold(self) -> int:
-        from config.utils import get_ai_confidence_threshold
+        from yosai_intel_dashboard.src.infrastructure.config.utils import get_ai_confidence_threshold
 
         return get_ai_confidence_threshold()
 

--- a/tests/fake_unicode_processor.py
+++ b/tests/fake_unicode_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional, Union
 
 import pandas as pd
 
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 
 class FakeUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, List
 import pandas as pd
 
 try:
-    from core.protocols import FileProcessorProtocol
-    from services.upload.protocols import UploadStorageProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+    from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 except Exception:  # pragma: no cover - fallback stubs for optional deps
     from typing import Protocol
 
@@ -33,7 +33,7 @@ except Exception:  # pragma: no cover - fallback stubs for optional deps
 
 
 try:
-    from services.interfaces import (
+    from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
         DeviceLearningServiceProtocol,
         UploadDataServiceProtocol,
     )
@@ -64,7 +64,7 @@ except Exception:  # pragma: no cover - fallback stubs
 
 
 try:
-    from core.protocols import ConfigurationServiceProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 except Exception:  # pragma: no cover - fallback stub
     from typing import Protocol
 
@@ -74,7 +74,7 @@ except Exception:  # pragma: no cover - fallback stub
 
 
 try:
-    from core.protocols import UnicodeProcessorProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 except Exception:  # pragma: no cover - fallback stub
     from typing import Protocol
 

--- a/tests/file_processing/test_column_mapper.py
+++ b/tests/file_processing/test_column_mapper.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.file_processing.column_mapper import map_columns
 
 

--- a/tests/file_processing/test_common_dataframe.py
+++ b/tests/file_processing/test_common_dataframe.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.data_processing.common import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.common import process_dataframe
 
 
 def test_process_dataframe_csv(tmp_path):

--- a/tests/integration/test_plugin_consolidation_integration.py
+++ b/tests/integration/test_plugin_consolidation_integration.py
@@ -5,7 +5,7 @@ from dash import Dash, html
 
 from config import create_config_manager
 from core.plugins.auto_config import setup_plugins
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from tests.test_auto_configuration import _set_env
 from tests.utils.plugin_package_builder import PluginPackageBuilder
 

--- a/tests/integration/test_plugin_health_endpoint.py
+++ b/tests/integration/test_plugin_health_endpoint.py
@@ -38,7 +38,7 @@ from flask import Flask
 from config import create_config_manager
 from core.plugins.manager import PluginManager
 from core.protocols.plugin import PluginMetadata
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class EnumJSONProvider(DefaultJSONProvider):

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -32,8 +32,8 @@ sys.modules["scipy"].stats = sys.modules["scipy.stats"]
 from config import create_config_manager
 from core.events import EventBus
 from core.plugins.auto_config import setup_plugins
-from core.service_container import ServiceContainer
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")

--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from config.connection_retry import ConnectionRetryManager, RetryConfig
+from yosai_intel_dashboard.src.infrastructure.config.connection_retry import ConnectionRetryManager, RetryConfig
 import importlib.util
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from pathlib import Path as _Path

--- a/tests/integration/test_upload_progress_sse.py
+++ b/tests/integration/test_upload_progress_sse.py
@@ -5,7 +5,7 @@ import dash_bootstrap_components as dbc
 import pytest
 from dash import dcc, html
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 pytestmark = pytest.mark.usefixtures("fake_dash", "fake_dbc")

--- a/tests/plugins/test_performance_monitoring.py
+++ b/tests/plugins/test_performance_monitoring.py
@@ -1,7 +1,7 @@
 import time
 import types
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from tests.plugins.test_plugin_manager import _install_protocol_stubs
 
 

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Protocol
 import pytest
 
 from config import create_config_manager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:

--- a/tests/plugins/test_plugin_manager_load_all.py
+++ b/tests/plugins/test_plugin_manager_load_all.py
@@ -2,7 +2,7 @@ import sys
 
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class MyPlugin:

--- a/tests/session_tests/test_session_lifetime.py
+++ b/tests/session_tests/test_session_lifetime.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from flask import Flask, session
 
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[2]))

--- a/tests/stubs/config/complete_service_registration.py
+++ b/tests/stubs/config/complete_service_registration.py
@@ -1,4 +1,4 @@
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def register_all_application_services(container: ServiceContainer) -> None:

--- a/tests/stubs/config/dynamic_config.py
+++ b/tests/stubs/config/dynamic_config.py
@@ -8,7 +8,7 @@ class Analytics:
     max_memory_mb = 1024
 
 
-from config.utils import get_ai_confidence_threshold, get_upload_chunk_size
+from yosai_intel_dashboard.src.infrastructure.config.utils import get_ai_confidence_threshold, get_upload_chunk_size
 from core.config import get_max_parallel_uploads, get_validator_rules
 
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -14,7 +14,7 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
 sys.modules["services"] = services_stub
 
-from services.analytics.processing.aggregator import Aggregator  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.processing.aggregator import Aggregator  # noqa: E402
 
 
 def test_aggregate():

--- a/tests/test_ai_processor_model_integration.py
+++ b/tests/test_ai_processor_model_integration.py
@@ -4,7 +4,7 @@ import sys
 
 import pandas as pd
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from mapping.models import RuleBasedModel
 
 # Insert stub before importing the adapter

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -22,7 +22,7 @@ if "chardet" not in sys.modules:
     sys.modules["chardet"] = types.ModuleType("chardet")
 import pandas as pd
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 from tests.fake_configuration import FakeConfiguration
 
 

--- a/tests/test_analyze_with_chunking.py
+++ b/tests/test_analyze_with_chunking.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
 
 def test_analyze_with_chunking_large_df():

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -14,7 +14,7 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
 sys.modules["services"] = services_stub
 
-from services.analytics.processing.analyzer import Analyzer  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.processing.analyzer import Analyzer  # noqa: E402
 
 
 def test_analyze():

--- a/tests/test_async_upload_processor.py
+++ b/tests/test_async_upload_processor.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from services.upload.async_processor import AsyncUploadProcessor
+from yosai_intel_dashboard.src.services.upload.async_processor import AsyncUploadProcessor
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 

--- a/tests/test_auto_configuration.py
+++ b/tests/test_auto_configuration.py
@@ -12,7 +12,7 @@ from core.plugins.auto_config import setup_plugins
 from core.plugins.callback_unifier import CallbackUnifier
 from core.plugins.decorators import safe_callback
 from core.protocols.plugin import PluginMetadata
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_cache_service.py
+++ b/tests/test_cache_service.py
@@ -1,4 +1,4 @@
-from services.analytics.storage.cache import _cache_manager, cached
+from yosai_intel_dashboard.src.services.analytics.storage.cache import _cache_manager, cached
 
 
 @cached(ttl=1)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.calculator import Calculator  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.calculator import Calculator  # noqa: E402
 
 
 def _make_df():

--- a/tests/test_callback_manager.py
+++ b/tests/test_callback_manager.py
@@ -1,7 +1,7 @@
 import threading
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 
 def test_thread_safe_registration_and_trigger():

--- a/tests/test_callback_manager_events.py
+++ b/tests/test_callback_manager_events.py
@@ -1,5 +1,5 @@
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 
 def test_priority_and_async_trigger():

--- a/tests/test_callback_unifier.py
+++ b/tests/test_callback_unifier.py
@@ -4,7 +4,7 @@ from dash import Input, Output
 
 from core.callback_registry import CallbackRegistry
 from core.plugins.decorators import unified_callback
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_chunked_upload_manager.py
+++ b/tests/test_chunked_upload_manager.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from services.upload.chunked_upload_manager import ChunkedUploadManager
+from yosai_intel_dashboard.src.services.upload.chunked_upload_manager import ChunkedUploadManager
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
@@ -47,7 +47,7 @@ def test_chunked_upload_manager_resume(tmp_path, monkeypatch):
         original_add_file(name, chunk_df)
 
     monkeypatch.setattr(store, "add_file", fail_second)
-    from config.connection_retry import ConnectionRetryExhausted
+    from yosai_intel_dashboard.src.infrastructure.config.connection_retry import ConnectionRetryExhausted
 
     with pytest.raises(ConnectionRetryExhausted):
         mgr.upload_file(data_file)

--- a/tests/test_chunked_upload_manager_async.py
+++ b/tests/test_chunked_upload_manager_async.py
@@ -3,7 +3,7 @@ import asyncio
 import pandas as pd
 import pytest
 
-from services.upload.chunked_upload_manager_async import ChunkedUploadManager
+from yosai_intel_dashboard.src.services.upload.chunked_upload_manager_async import ChunkedUploadManager
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
@@ -50,7 +50,7 @@ def test_async_chunked_upload_manager_resume(tmp_path, monkeypatch, async_runner
         original_add_file(name, chunk_df)
 
     monkeypatch.setattr(store, "add_file", fail_second)
-    from config.connection_retry import ConnectionRetryExhausted
+    from yosai_intel_dashboard.src.infrastructure.config.connection_retry import ConnectionRetryExhausted
 
     with pytest.raises(ConnectionRetryExhausted):
         async_runner(mgr.upload_file(data_file))

--- a/tests/test_complete_dataset_analysis.py
+++ b/tests/test_complete_dataset_analysis.py
@@ -7,7 +7,7 @@ import tempfile
 import pandas as pd
 import pytest
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
 
 def test_complete_dataset_analysis():

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from config import create_config_manager
-from config.dynamic_config import DynamicConfigManager
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager
 
 
 def test_yaml_and_env_loading(monkeypatch, tmp_path):

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -18,7 +18,7 @@ sys.modules["config.config_manager"] = _cfg_module
 spec.loader.exec_module(_cfg_module)  # type: ignore
 create_config_manager = _cfg_module.create_config_manager
 
-from config.config_validator import ConfigValidator
+from yosai_intel_dashboard.src.infrastructure.config.config_validator import ConfigValidator
 from core.exceptions import ConfigurationError
 
 
@@ -87,7 +87,7 @@ security:
 
 
 def test_upload_limit_error():
-    from config.base import Config
+    from yosai_intel_dashboard.src.infrastructure.config.base import Config
 
     cfg = Config()
     cfg.security.max_upload_mb = 0
@@ -97,7 +97,7 @@ def test_upload_limit_error():
 
 
 def test_upload_limit_warning():
-    from config.base import Config
+    from yosai_intel_dashboard.src.infrastructure.config.base import Config
 
     cfg = Config()
     cfg.security.max_upload_mb = 2000

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,7 +1,7 @@
 import time
 
-from config.connection_pool import DatabaseConnectionPool
-from config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 
 
 def factory():

--- a/tests/test_connection_pool_threadsafe.py
+++ b/tests/test_connection_pool_threadsafe.py
@@ -1,7 +1,7 @@
 import threading
 
-from config.connection_pool import DatabaseConnectionPool
-from config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 
 
 def factory():

--- a/tests/test_connection_retry.py
+++ b/tests/test_connection_retry.py
@@ -2,8 +2,8 @@ import time
 
 import pytest
 
-from config.connection_retry import ConnectionRetryManager, RetryConfig
-from config.database_exceptions import ConnectionRetryExhausted
+from yosai_intel_dashboard.src.infrastructure.config.connection_retry import ConnectionRetryManager, RetryConfig
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionRetryExhausted
 
 
 def test_retry_success(monkeypatch):

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -36,7 +36,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.data.loader import DataLoader  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.data.loader import DataLoader  # noqa: E402
 
 
 class DummyUploadProc:

--- a/tests/test_data_quality_monitor.py
+++ b/tests/test_data_quality_monitor.py
@@ -55,7 +55,7 @@ def test_processor_evaluates_quality(monkeypatch):
         module.Processor = Processor
         sys.modules["services.data_processing.processor"] = module
 
-    from services.data_processing.processor import Processor
+    from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 
     proc = Processor()
     df = pd.DataFrame(

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,8 +1,8 @@
 import pytest
 
 from config import DatabaseSettings
-from config.connection_pool import DatabaseConnectionPool
-from config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 from tests.fake_configuration import FakeConfiguration
 
 

--- a/tests/test_datetime_fix.py
+++ b/tests/test_datetime_fix.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 from services.result_formatting import ensure_datetime_columns
 
 

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -8,7 +8,7 @@ from config import create_config_manager
 from core.plugins.dependency_resolver import PluginDependencyResolver
 from core.plugins.manager import PluginManager
 from core.protocols.plugin import PluginMetadata
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class DummyPlugin:

--- a/tests/test_display_rows_limit.py
+++ b/tests/test_display_rows_limit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from yosai_intel_dashboard.src.file_processing import create_file_preview
 
 

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from config.secrets_validator import DockerSecretSource, SecretsValidator
+from yosai_intel_dashboard.src.infrastructure.config.secrets_validator import DockerSecretSource, SecretsValidator
 
 
 def test_docker_secret_source(tmp_path):

--- a/tests/test_doubles.py
+++ b/tests/test_doubles.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from core.protocols import UnicodeProcessorProtocol
-from services.upload.protocols import UploadStorageProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 
 
 class SimpleUnicodeProcessor(UnicodeProcessorProtocol):

--- a/tests/test_dynamic_config_validation.py
+++ b/tests/test_dynamic_config_validation.py
@@ -1,4 +1,4 @@
-from config.dynamic_config import DynamicConfigManager
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager
 
 
 def test_invalid_yaml_types(tmp_path, monkeypatch):

--- a/tests/test_enhanced_connection_pool.py
+++ b/tests/test_enhanced_connection_pool.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 
-from config.database_exceptions import ConnectionValidationFailed
-from config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionValidationFailed
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 from database.intelligent_connection_pool import (
     CircuitBreaker,
     IntelligentConnectionPool,

--- a/tests/test_enhanced_database_manager.py
+++ b/tests/test_enhanced_database_manager.py
@@ -1,4 +1,4 @@
-from config.database_manager import DatabaseSettings, EnhancedPostgreSQLManager
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseSettings, EnhancedPostgreSQLManager
 
 
 def test_execute_query_with_retry(monkeypatch):

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 
 
 def test_process_csv(tmp_path):

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from yosai_intel_dashboard.src.file_processing import create_file_preview
-from services.data_processing.file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     UnicodeFileProcessor,
     process_uploaded_file,
 )

--- a/tests/test_file_processor_component.py
+++ b/tests/test_file_processor_component.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services.upload.file_processor_service import FileProcessor
+from yosai_intel_dashboard.src.services.upload.file_processor_service import FileProcessor
 from tests.fakes import FakeFileProcessor, FakeUploadDataService, FakeUploadStore
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -10,7 +10,7 @@ from services.data_enhancer.mapping_utils import (
     apply_fuzzy_column_matching,
     get_mapping_suggestions,
 )
-from services.data_processing.file_processor import process_uploaded_file
+from yosai_intel_dashboard.src.services.data_processing.file_processor import process_uploaded_file
 from validation.security_validator import SecurityValidator
 
 

--- a/tests/test_file_validator_component.py
+++ b/tests/test_file_validator_component.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from services.upload.protocols import UploadValidatorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadValidatorProtocol
 from validation.file_validator import FileValidator
 
 

--- a/tests/test_file_validator_errors.py
+++ b/tests/test_file_validator_errors.py
@@ -1,6 +1,6 @@
 import base64
 
-from services.data_processing.common import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.common import process_dataframe
 
 
 def safe_decode_file(contents: str):

--- a/tests/test_intelligent_multilevel_cache.py
+++ b/tests/test_intelligent_multilevel_cache.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from config.base import CacheConfig
+from yosai_intel_dashboard.src.infrastructure.config.base import CacheConfig
 from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 
 

--- a/tests/test_json_serialization_plugin.py
+++ b/tests/test_json_serialization_plugin.py
@@ -19,7 +19,7 @@ from core.json_serialization_plugin import (
     JsonSerializationService,
 )
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 # Legacy DI tests were skipped previously. Run them now.
 # pytest.skip("legacy DI tests skipped", allow_module_level=True)

--- a/tests/test_lazystring_fix.py
+++ b/tests/test_lazystring_fix.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.constants import SecurityLimits
+from yosai_intel_dashboard.src.infrastructure.config.constants import SecurityLimits
 from core.serialization import SafeJSONSerializer
 
 serializer = SafeJSONSerializer()

--- a/tests/test_learning_coordinator_component.py
+++ b/tests/test_learning_coordinator_component.py
@@ -1,4 +1,4 @@
-from services.upload.learning_coordinator import LearningCoordinator
+from yosai_intel_dashboard.src.services.upload.learning_coordinator import LearningCoordinator
 from tests.fakes import FakeDeviceLearningService
 from tests.utils.builders import DataFrameBuilder
 

--- a/tests/test_mapping_modular.py
+++ b/tests/test_mapping_modular.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from mapping.models import MappingModel
 from mapping.processors.ai_processor import AIColumnMapperAdapter
 from mapping.processors.column_processor import ColumnProcessor

--- a/tests/test_mappings_endpoint.py
+++ b/tests/test_mappings_endpoint.py
@@ -87,7 +87,7 @@ if "flask_apispec" not in sys.modules:
     )
 
 from error_handling import ErrorHandler
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from yosai_intel_dashboard.src.services import mappings_endpoint
 
 # Ensure dash stubs are available for service imports

--- a/tests/test_master_callback_system.py
+++ b/tests/test_master_callback_system.py
@@ -2,7 +2,7 @@ import pytest
 from dash import Dash
 from dash.dependencies import Input, Output
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -8,7 +8,7 @@ from config import create_config_manager
 from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
-from config.constants import MAX_DISPLAY_ROWS
+from yosai_intel_dashboard.src.infrastructure.config.constants import MAX_DISPLAY_ROWS
 from yosai_intel_dashboard.src.file_processing import create_file_preview
 
 

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -5,8 +5,8 @@ from tests.fake_configuration import FakeConfiguration
 
 fake_cfg = FakeConfiguration()
 from core.performance import get_performance_monitor
-from services.data_processing.common import process_dataframe
-from services.data_processing.file_handler import process_file_simple
+from yosai_intel_dashboard.src.services.data_processing.common import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.file_handler import process_file_simple
 
 
 def test_memory_limit_abort_csv(monkeypatch, tmp_path):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,4 +1,4 @@
-from services.analytics.storage.persistence import PersistenceManager
+from yosai_intel_dashboard.src.services.analytics.storage.persistence import PersistenceManager
 
 
 class DummyDB:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.protocols.plugin import PluginMetadata
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class SimplePlugin:

--- a/tests/test_plugin_manager_callbacks_health.py
+++ b/tests/test_plugin_manager_callbacks_health.py
@@ -22,8 +22,8 @@ finally:
 
 from config import create_config_manager
 from core.plugins.manager import PluginManager
-from core.service_container import ServiceContainer
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from tests.utils.plugin_package_builder import PluginPackageBuilder
 
 

--- a/tests/test_plugin_manager_core.py
+++ b/tests/test_plugin_manager_core.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.protocols.plugin import PluginMetadata, PluginStatus
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class DummyPlugin:

--- a/tests/test_plugin_manager_cycle_logging.py
+++ b/tests/test_plugin_manager_cycle_logging.py
@@ -4,7 +4,7 @@ import sys
 import types
 
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class DummyConfigManager:

--- a/tests/test_plugin_manager_thread.py
+++ b/tests/test_plugin_manager_thread.py
@@ -2,7 +2,7 @@ import time
 
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def test_health_thread_stops_on_exit():

--- a/tests/test_plugin_priority.py
+++ b/tests/test_plugin_priority.py
@@ -5,7 +5,7 @@ import sys
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager as PluginManager
 from core.protocols.plugin import PluginPriority
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def test_priority_order(tmp_path):

--- a/tests/test_process_and_analyze.py
+++ b/tests/test_process_and_analyze.py
@@ -1,6 +1,6 @@
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.file_processor import FileProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from tests.builders import TestDataBuilder
 from validation.security_validator import SecurityValidator
 

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -2,7 +2,7 @@ import asyncio
 
 from services.device_learning_service import DeviceLearningService
 from services.upload import UploadProcessingService
-from services.upload.upload_core import UploadCore
+from yosai_intel_dashboard.src.services.upload.upload_core import UploadCore
 from tests.fakes import FakeUploadDataService
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Protocol, assert_type, runtime_che
 import pandas as pd
 import pytest
 
-from core.protocols import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import (
     AnalyticsServiceProtocol,
     ConfigurationProtocol,
     DatabaseProtocol,
@@ -13,8 +13,8 @@ from core.protocols import (
     SecurityServiceProtocol,
     StorageProtocol,
 )
-from core.service_container import ServiceContainer
-from services.analytics_service import AnalyticsService
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
 
 @runtime_checkable
@@ -175,7 +175,7 @@ class TestProtocolCompliance:
         assert_type(cfg, ConfigurationProtocol)
 
     def test_analytics_service_compliance(self):
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
         class ConcreteAnalyticsService(AnalyticsService):
             def analyze_access_patterns(self, days: int) -> Dict[str, Any]:
@@ -246,7 +246,7 @@ class TestProtocolCompliance:
             container.get("security_validator", SecurityServiceProtocol),
             SecurityServiceProtocol,
         )
-        from services.analytics.protocols import (
+        from yosai_intel_dashboard.src.services.analytics.protocols import (
             DataLoadingProtocol,
             DataProcessorProtocol,
             PublishingProtocol,

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -34,7 +34,7 @@ sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
 sys.modules.setdefault("structlog", types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
-from services.analytics.publisher import Publisher  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.publisher import Publisher  # noqa: E402
 
 
 class DummyBus:

--- a/tests/test_read_uploaded_file.py
+++ b/tests/test_read_uploaded_file.py
@@ -1,4 +1,4 @@
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,4 +1,4 @@
-from services.analytics.storage.repository import AnalyticsRepository
+from yosai_intel_dashboard.src.services.analytics.storage.repository import AnalyticsRepository
 
 
 class DummyHelper:

--- a/tests/test_sanitize_dataframe_memory.py
+++ b/tests/test_sanitize_dataframe_memory.py
@@ -2,7 +2,7 @@ import pandas as pd
 import psutil
 import pytest
 
-from services.data_processing.file_processor import UnicodeFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import UnicodeFileProcessor
 
 
 @pytest.mark.slow

--- a/tests/test_secure_config_manager.py
+++ b/tests/test_secure_config_manager.py
@@ -4,7 +4,7 @@ import types
 import pytest
 from cryptography.fernet import Fernet
 
-from config.secure_config_manager import SecureConfigManager
+from yosai_intel_dashboard.src.infrastructure.config.secure_config_manager import SecureConfigManager
 from core.exceptions import ConfigurationError
 
 

--- a/tests/test_secure_db.py
+++ b/tests/test_secure_db.py
@@ -1,7 +1,7 @@
 import pytest
 
-from config.database_exceptions import UnicodeEncodingError
-from config.secure_db import execute_secure_query
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.secure_db import execute_secure_query
 
 
 class DummyConn:

--- a/tests/test_secure_query_wrapper.py
+++ b/tests/test_secure_query_wrapper.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
 from security.secure_query_wrapper import (
     execute_secure_command,
     execute_secure_sql,

--- a/tests/test_service_config_loader.py
+++ b/tests/test_service_config_loader.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from config.config_loader import ServiceSettings, load_service_config
+from yosai_intel_dashboard.src.infrastructure.config.config_loader import ServiceSettings, load_service_config
 
 
 def test_load_service_config_defaults(monkeypatch):

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -1,4 +1,4 @@
-from services.analytics.events.subscriber import Subscriber
+from yosai_intel_dashboard.src.services.analytics.events.subscriber import Subscriber
 
 
 class DummyBus:

--- a/tests/test_surrogate_handling.py
+++ b/tests/test_surrogate_handling.py
@@ -2,7 +2,7 @@ import json
 
 import pandas as pd
 
-from services.data_processing.common import process_dataframe
+from yosai_intel_dashboard.src.services.data_processing.common import process_dataframe
 
 
 def test_process_dataframe_csv_with_surrogate(tmp_path):

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -12,7 +12,7 @@ def create_theme_app():
     app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 
     # Import and create unified callback coordinator
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
     coordinator = TrulyUnifiedCallbacks(app)
 

--- a/tests/test_thread_safe_plugin_manager.py
+++ b/tests/test_thread_safe_plugin_manager.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from config import create_config_manager
 from core.plugins.manager import ThreadSafePluginManager
 from core.protocols.plugin import PluginMetadata
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 class ConcurrencyPlugin:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -14,7 +14,7 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
 sys.modules["services"] = services_stub
 
-from services.analytics.data.transformer import DataTransformer  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.data.transformer import DataTransformer  # noqa: E402
 
 
 def test_transformer_basic():

--- a/tests/test_unicode_handler.py
+++ b/tests/test_unicode_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
 from core.unicode import UnicodeSQLProcessor
 
 

--- a/tests/test_unicode_handler_class.py
+++ b/tests/test_unicode_handler_class.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.unicode_handler import UnicodeHandler
+from yosai_intel_dashboard.src.infrastructure.config.unicode_handler import UnicodeHandler
 
 
 def test_handler_encodes_query_surrogates():

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.unicode import (
     ChunkedUnicodeProcessor,
     UnicodeProcessor,
@@ -46,8 +46,8 @@ def callback_handler(event: CallbackEvent):
 
 _GLOBAL = CallbackController()
 fire_event = _GLOBAL.fire_event
-from services.data_processing.file_processor import FileProcessor as RobustFileProcessor
-from services.data_processing.file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor as RobustFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     process_file_simple,
 )
 

--- a/tests/test_unicode_handling.py
+++ b/tests/test_unicode_handling.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
 from core.unicode import UnicodeSQLProcessor
 
 

--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -3,7 +3,7 @@ import time
 import pandas as pd
 import pytest
 
-from config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
 from core.unicode import UnicodeProcessor as UtilsProcessor  # Alias check
 from core.unicode import (
     UnicodeSQLProcessor,

--- a/tests/test_unified_callback_coordinator.py
+++ b/tests/test_unified_callback_coordinator.py
@@ -1,8 +1,8 @@
 import pytest
 from dash import Dash, Input, Output
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 

--- a/tests/test_unified_loader.py
+++ b/tests/test_unified_loader.py
@@ -31,7 +31,7 @@ security:
     monkeypatch.setenv("SECRET_KEY", env_secret)
 
     _stub_optional_modules()
-    from config.unified_loader import UnifiedLoader
+    from yosai_intel_dashboard.src.infrastructure.config.unified_loader import UnifiedLoader
 
     loader = UnifiedLoader(str(path))
     cfg = loader.load()

--- a/tests/test_unified_plugin_registry.py
+++ b/tests/test_unified_plugin_registry.py
@@ -19,7 +19,7 @@ import sys
 from config import create_config_manager
 from core.plugins.auto_config import PluginAutoConfiguration
 from core.plugins.unified_registry import UnifiedPluginRegistry
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 pytestmark = pytest.mark.usefixtures("fake_dash")
 from core.protocols.plugin import PluginMetadata

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -13,7 +13,7 @@ sys.modules.setdefault("yosai_intel_dashboard", types.ModuleType("yosai_intel_da
 sys.modules["yosai_intel_dashboard"].__path__ = [str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard")]
 
 from error_handling import ErrorHandler
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 

--- a/tests/test_upload_processing_helpers.py
+++ b/tests/test_upload_processing_helpers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from tests.utils.builders import DataFrameBuilder
 from validation.security_validator import SecurityValidator
 

--- a/tests/test_upload_processing_module.py
+++ b/tests/test_upload_processing_module.py
@@ -1,5 +1,5 @@
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from tests.utils.builders import DataFrameBuilder
 from validation.security_validator import SecurityValidator
 

--- a/tests/test_upload_protocols.py
+++ b/tests/test_upload_protocols.py
@@ -1,14 +1,14 @@
 import inspect
 
-from core.protocols import FileProcessorProtocol
-from services.data_processing.async_file_processor import AsyncFileProcessor
-from services.upload.processor import UploadProcessingService
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
+from yosai_intel_dashboard.src.services.upload.processor import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadProcessingServiceProtocol,
     UploadStorageProtocol,
     UploadValidatorProtocol,
 )
-from services.upload.validator import ClientSideValidator
+from yosai_intel_dashboard.src.services.upload.validator import ClientSideValidator
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
 

--- a/tests/test_upload_queue_manager.py
+++ b/tests/test_upload_queue_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
 
 
 async def _dummy_handler(item):

--- a/tests/test_upload_validator.py
+++ b/tests/test_upload_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from validation.upload_utils import decode_and_validate_upload
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -15,7 +15,7 @@ sys.modules["services"] = services_stub
 
 import pandas as pd
 
-from services.analytics.data.validator import Validator  # noqa: E402
+from yosai_intel_dashboard.src.services.analytics.data.validator import Validator  # noqa: E402
 
 
 def test_validate_methods():

--- a/tools/apply_callback_patch.py
+++ b/tools/apply_callback_patch.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(project_root))
 
 # Apply the fix globally when this module is imported
 try:
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
 
     # Add register_handler as an alias to handle_register if it doesn't exist
     if hasattr(CallbackManager, "handle_register") and not hasattr(
@@ -26,7 +26,7 @@ except ImportError:
 
 def ensure_callback_compatibility():
     """Ensure callback manager has both method names"""
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
 
     if not hasattr(CallbackManager, "register_handler"):
         CallbackManager.register_handler = CallbackManager.handle_register

--- a/tools/cli_analytics_engine.py
+++ b/tools/cli_analytics_engine.py
@@ -8,7 +8,7 @@ import json
 import sys
 from pathlib import Path
 
-from config.app_config import UploadConfig
+from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadConfig
 
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
@@ -22,8 +22,8 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
         # Process the parquet file using pandas directly
         import pandas as pd
 
-        from services.analytics.upload_analytics import UploadAnalyticsProcessor
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
         from services.device_learning_service import DeviceLearningService
 
         parquet_path = (

--- a/tools/cli_analytics_fixed.py
+++ b/tools/cli_analytics_fixed.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(project_root))
 
 # Apply callback patch first
 try:
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
 
     if hasattr(CallbackManager, "handle_register") and not hasattr(
         CallbackManager, "register_handler"
@@ -31,7 +31,7 @@ async def test_analytics_with_fix():
 
         import pandas as pd
 
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
         # Load the Enhanced Security Demo data
         parquet_path = Path("temp/uploaded_data/Enhanced_Security_Demo.csv.parquet")

--- a/tools/cli_async_processor.py
+++ b/tools/cli_async_processor.py
@@ -47,7 +47,7 @@ async def process_file_with_service(
         logger.info(f"Processing file with AsyncFileProcessor: {file_path}")
 
         # Import and create AsyncFileProcessor
-        from services.data_processing.async_file_processor import AsyncFileProcessor
+        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
 
         processor = AsyncFileProcessor()
 

--- a/tools/cli_mapping_explorer.py
+++ b/tools/cli_mapping_explorer.py
@@ -31,7 +31,7 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
         # Process file first
         import base64
 
-        from services.data_processing.async_file_processor import AsyncFileProcessor
+        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
 
         path = Path(file_path)
         filename = path.name

--- a/tools/cli_mapping_tester.py
+++ b/tools/cli_mapping_tester.py
@@ -42,7 +42,7 @@ async def test_mapping_service(
 
         # Step 1: Process file with AsyncFileProcessor
         logger.info("=== STEP 1: File Processing ===")
-        from services.data_processing.async_file_processor import AsyncFileProcessor
+        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
 
         processor = AsyncFileProcessor()
 

--- a/tools/cli_run_analytics.py
+++ b/tools/cli_run_analytics.py
@@ -8,7 +8,7 @@ import json
 import sys
 from pathlib import Path
 
-from config.app_config import UploadConfig
+from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadConfig
 
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
@@ -20,7 +20,7 @@ async def run_real_analytics():
 
         import pandas as pd
 
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
         # Load the Enhanced Security Demo data
         parquet_path = (

--- a/tools/diagnose_upload_config.py
+++ b/tools/diagnose_upload_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
-from config.dynamic_config import diagnose_upload_config, dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import diagnose_upload_config, dynamic_config
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/test_analytics_both_fixes.py
+++ b/tools/test_analytics_both_fixes.py
@@ -18,7 +18,7 @@ def apply_both_fixes():
 
     # Step 1: Callback fix
     try:
-        from core.truly_unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
 
         if hasattr(CallbackManager, "handle_register") and not hasattr(
             CallbackManager, "register_handler"
@@ -80,7 +80,7 @@ async def test_analytics_comprehensive():
 
         import pandas as pd
 
-        from services.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
 
         # Load the Enhanced Security Demo data
         parquet_path = Path("temp/uploaded_data/Enhanced_Security_Demo.csv.parquet")

--- a/validation/factory.py
+++ b/validation/factory.py
@@ -12,7 +12,7 @@ def create_security_validator(
     config: Mapping[str, bool] | None = None,
 ) -> SecurityValidator:
     if config is None:
-        from config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
         cfg = dynamic_config.uploads.VALIDATOR_RULES
     else:

--- a/validation/file_validator.py
+++ b/validation/file_validator.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover - optional dependency
-    from services.upload.protocols import UploadValidatorProtocol
+    from yosai_intel_dashboard.src.services.upload.protocols import UploadValidatorProtocol
 else:
     UploadValidatorProtocol = Any
 
@@ -71,13 +71,13 @@ class FileValidator(CompositeValidator):
         validator: UploadValidatorProtocol | None = None,
     ) -> None:
         if max_size_mb is None:
-            from config.dynamic_config import dynamic_config
+            from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
             size_mb = getattr(dynamic_config.security, "max_upload_mb", 10)
         else:
             size_mb = max_size_mb
         size = size_mb * 1024 * 1024
-        from config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
         default_types = getattr(dynamic_config, "upload", None)
         if default_types and hasattr(default_types, "allowed_file_types"):

--- a/validation/security_validator.py
+++ b/validation/security_validator.py
@@ -5,7 +5,7 @@ import os
 import re
 from typing import Iterable
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.exceptions import ValidationError
 
 from .core import ValidationResult

--- a/yosai_framework/config.py
+++ b/yosai_framework/config.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import jsonschema
 import yaml
 
-from config.validator import YosaiConfig, validate_config
+from yosai_intel_dashboard.src.infrastructure.config.validator import YosaiConfig, validate_config
 
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "config" / "service.schema.yaml"
 

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -20,7 +20,7 @@ from api.analytics_router import (
 from api.analytics_router import router as analytics_router
 from settings_endpoint import settings_bp
 
-from config.constants import API_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from middleware.performance import TimingMiddleware
 from core.container import container
 from services.device_endpoint import create_device_blueprint

--- a/yosai_intel_dashboard/src/adapters/api/api_app.py
+++ b/yosai_intel_dashboard/src/adapters/api/api_app.py
@@ -1,6 +1,6 @@
 from api.adapter import create_api_app
 
-from config.constants import API_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 
 app = create_api_app()
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/csv_processor.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/csv_processor.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 
 # Optional Polars import with pandas fallback
 try:

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_dashboard.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_dashboard.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Protocol
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_query
 from services.compliance.consent_service import ConsentService
 from services.compliance.data_retention_service import DataRetentionService

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
@@ -10,7 +10,7 @@ from controllers.compliance_controller import register_compliance_routes
 
 from core.audit_logger import create_audit_logger
 from core.container import Container
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 from services.compliance.consent_service import create_consent_service
 from services.compliance.dsar_service import create_dsar_service

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/audit_logger.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/audit_logger.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from flask import g, request
 from flask_login import current_user
 
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/breach_notification_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/breach_notification_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command, execute_query
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
@@ -11,11 +11,11 @@ from uuid import uuid4
 import pandas as pd
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_query
 from services.compliance.consent_service import ConsentService
 from services.compliance.data_retention_service import DataRetentionService
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 from yosai_intel_dashboard.models.compliance import ConsentType, DataSensitivityLevel
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import (
     ConsentLog,

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/cross_border_transfer_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/cross_border_transfer_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/data_retention_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/data_retention_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import DataSensitivityLevel
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dpia_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dpia_service.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
 from core.audit_logger import ComplianceAuditLogger
-from core.protocols import DatabaseProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import (

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/toggle_manager.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/toggle_manager.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Set
 from core.rbac import require_role
 from database.secure_exec import execute_command, execute_query
 from plugins.common_callbacks import csv_pre_process_callback
-from services.data_processing.file_processor import FileProcessor
+from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
+++ b/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
@@ -9,7 +9,7 @@ from marshmallow import Schema, fields
 
 from app import app
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler
-from services.analytics_service import calculate_risk_score
+from yosai_intel_dashboard.src.services.analytics.analytics_service import calculate_risk_score
 from shared.errors.types import ErrorCode
 from validation.security_validator import SecurityValidator
 from yosai_framework.errors import CODE_TO_STATUS

--- a/yosai_intel_dashboard/src/adapters/ui/pages/data_enhancer/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/data_enhancer/callbacks.py
@@ -7,7 +7,7 @@ import pandas as pd
 from dash import Input, Output, State, dash_table, dcc, html
 from dash.exceptions import PreventUpdate
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from services.data_enhancer.processor import DataEnhancerProcessor
 
 

--- a/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
@@ -7,8 +7,8 @@ from dash import html
 from dash._callback_context import callback_context
 from dash.dependencies import Input, Output
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from services.interfaces import get_device_learning_service
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_device_learning_service
 
 
 def register_callbacks(app, container) -> None:

--- a/yosai_intel_dashboard/src/adapters/ui/pages/greetings/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/greetings/callbacks.py
@@ -2,7 +2,7 @@ from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
 try:  # pragma: no cover - allow tests without full core package
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 except Exception:  # pragma: no cover - lightweight fallback
     class TrulyUnifiedCallbacks:  # type: ignore[too-few-public-methods]
         """Minimal stub used when core package isn't available."""

--- a/yosai_intel_dashboard/src/adapters/ui/pages/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/upload/callbacks.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from services.upload.controllers.upload_controller import UnifiedUploadController
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.services.upload.controllers.upload_controller import UnifiedUploadController
 
 
 def register_callbacks(app, container) -> None:

--- a/yosai_intel_dashboard/src/core/advanced_cache.py
+++ b/yosai_intel_dashboard/src/core/advanced_cache.py
@@ -11,8 +11,8 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import redis.asyncio as redis
 
-# from config.config import get_cache_config  # Moved to lazy import
-from config.cache_config import CacheConfig
+# from yosai_intel_dashboard.src.infrastructure.config.config import get_cache_config  # Moved to lazy import
+from yosai_intel_dashboard.src.infrastructure.config.cache_config import CacheConfig
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +165,7 @@ def cache_with_lock(
 
 async def create_advanced_cache_manager() -> AdvancedCacheManager:
     """Initialize :class:`AdvancedCacheManager` using application config."""
-    from config.config import get_cache_config  # Lazy import
+    from yosai_intel_dashboard.src.infrastructure.config.config import get_cache_config  # Lazy import
 
     cfg = get_cache_config()
     manager = AdvancedCacheManager(cfg)

--- a/yosai_intel_dashboard/src/core/app_factory/plugins.py
+++ b/yosai_intel_dashboard/src/core/app_factory/plugins.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from dash import Dash
 
 from core.plugins.auto_config import PluginAutoConfiguration
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def _initialize_plugins(

--- a/yosai_intel_dashboard/src/core/config.py
+++ b/yosai_intel_dashboard/src/core/config.py
@@ -2,25 +2,25 @@ from __future__ import annotations
 
 """Simple configuration helpers used across the project."""
 
-from config.config import get_analytics_config
+from yosai_intel_dashboard.src.infrastructure.config.config import get_analytics_config
 from typing import TYPE_CHECKING
 
-from config.utils import (
+from yosai_intel_dashboard.src.infrastructure.config.utils import (
     get_ai_confidence_threshold as _get_ai_confidence_threshold,
     get_upload_chunk_size as _get_upload_chunk_size,
 )
 from core.container import container
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
-    from config.dynamic_config import DynamicConfigManager
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager
 
 
 def _dynamic_config() -> "DynamicConfigManager":
     """Return the :class:`DynamicConfigManager` from the DI container."""
     if container.has("dynamic_config"):
         return container.get("dynamic_config")
-    from config.dynamic_config import dynamic_config
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
     return dynamic_config
 

--- a/yosai_intel_dashboard/src/core/di/bootstrap.py
+++ b/yosai_intel_dashboard/src/core/di/bootstrap.py
@@ -1,7 +1,7 @@
 """Container bootstrap utilities."""
 from __future__ import annotations
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from startup.service_registration import register_all_application_services
 from startup.registry_startup import register_optional_services
 

--- a/yosai_intel_dashboard/src/core/di/decorators.py
+++ b/yosai_intel_dashboard/src/core/di/decorators.py
@@ -5,7 +5,7 @@ from functools import wraps
 from typing import Any, Callable, Optional, Type
 
 from core.container import container as _global_container
-from core.service_container import ServiceContainer, ServiceLifetime
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer, ServiceLifetime
 
 # ---------------------------------------------------------------------------
 

--- a/yosai_intel_dashboard/src/core/domain/entities/access_events.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/access_events.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Union
 
 import pandas as pd
 
-from config.constants import DataProcessingLimits
+from yosai_intel_dashboard.src.infrastructure.config.constants import DataProcessingLimits
 from core.query_optimizer import monitor_query_performance
 from database.secure_exec import execute_command, execute_query
 from validation.security_validator import SecurityValidator
@@ -339,7 +339,7 @@ class AccessEventModel(BaseModel):
 def create_access_event_model(db_connection=None) -> AccessEventModel:
     """Factory function to create AccessEventModel instance"""
     if db_connection is None:
-        from config.database_manager import get_database
+        from yosai_intel_dashboard.src.infrastructure.config.database_manager import get_database
 
         db_connection = get_database()
 

--- a/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
+++ b/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
@@ -13,7 +13,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import redis.asyncio as redis
 
-from config.base import CacheConfig
+from yosai_intel_dashboard.src.infrastructure.config.base import CacheConfig
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,7 @@ class IntelligentMultiLevelCache:
 
 async def create_intelligent_cache_manager() -> IntelligentMultiLevelCache:
     """Initialize cache manager from configuration."""
-    from config.config import get_cache_config
+    from yosai_intel_dashboard.src.infrastructure.config.config import get_cache_config
 
     cfg = get_cache_config()
     manager = IntelligentMultiLevelCache(cfg)

--- a/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
@@ -7,7 +7,7 @@ from mapping.core.models import MappingData
 
 import pandas as pd
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 @runtime_checkable
@@ -92,7 +92,7 @@ def get_upload_validator(
     c = _get_container(container)
     if c and c.has("upload_validator"):
         return c.get("upload_validator")
-    from services.upload.validator import ClientSideValidator
+    from yosai_intel_dashboard.src.services.upload.validator import ClientSideValidator
 
     return ClientSideValidator()
 
@@ -266,7 +266,7 @@ def get_analytics_data_loader(
     c = _get_container(container)
     if c and c.has("data_loader"):
         return c.get("data_loader")
-    from services.analytics.data.loader import DataLoader
+    from yosai_intel_dashboard.src.services.analytics.data.loader import DataLoader
 
     return DataLoader(controller, processor)
 

--- a/yosai_intel_dashboard/src/core/performance.py
+++ b/yosai_intel_dashboard/src/core/performance.py
@@ -26,7 +26,7 @@ from typing import (
 import pandas as pd
 import psutil
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from monitoring.model_performance_monitor import ModelMetrics

--- a/yosai_intel_dashboard/src/core/performance_file_processor.py
+++ b/yosai_intel_dashboard/src/core/performance_file_processor.py
@@ -9,7 +9,7 @@ from typing import IO, Callable, Iterable, List, Optional, Union
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 
 try:
     import psutil
@@ -23,7 +23,7 @@ class PerformanceFileProcessor:
     def __init__(
         self, chunk_size: int = DEFAULT_CHUNK_SIZE, *, max_memory_mb: int | None = None
     ) -> None:
-        from config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
         self.chunk_size = chunk_size
         self.logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/core/plugins/auto_config.py
+++ b/yosai_intel_dashboard/src/core/plugins/auto_config.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 from dash import Dash
 
 from config import ConfigManager, create_config_manager
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 from .unified_registry import UnifiedPluginRegistry
 

--- a/yosai_intel_dashboard/src/core/plugins/config/__init__.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/__init__.py
@@ -2,7 +2,7 @@
 
 # Re-export from unified configuration for compatibility
 from config import ConfigManager, get_config
-from config.database_manager import DatabaseManager
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager
 
 
 def get_service_locator() -> ConfigManager:

--- a/yosai_intel_dashboard/src/core/plugins/config/async_database_manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/async_database_manager.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 
 import asyncpg
 
-from config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/core/plugins/config/cache_manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/cache_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 import dill
 import redis
 
-from config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 
 from .interfaces import ICacheManager
 

--- a/yosai_intel_dashboard/src/core/plugins/config/database_manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/database_manager.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
-from config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
 
 from .async_database_manager import AsyncPostgreSQLManager
 from .interfaces import ConnectionResult, IDatabaseManager

--- a/yosai_intel_dashboard/src/core/plugins/manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/manager.py
@@ -9,14 +9,14 @@ import time
 from typing import Any, Dict, List
 
 from config import ConfigManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.protocols.plugin import (
     CallbackPluginProtocol,
     PluginPriority,
     PluginProtocol,
     PluginStatus,
 )
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 from .dependency_resolver import PluginDependencyResolver
 

--- a/yosai_intel_dashboard/src/core/plugins/unified_registry.py
+++ b/yosai_intel_dashboard/src/core/plugins/unified_registry.py
@@ -6,14 +6,14 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from dash import Dash
 
 from config import ConfigManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.plugins.manager import ThreadSafePluginManager
 from core.protocols.plugin import PluginProtocol
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.registry import registry as service_registry
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class UnifiedPluginRegistry:
         self.callback_manager = callback_manager or TrulyUnifiedCallbacks()
 
         # Import lazily to avoid circular dependency during module import
-        from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
         self.coordinator = TrulyUnifiedCallbacks(app)
         self.plugin_manager = ThreadSafePluginManager(

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -20,7 +20,7 @@ from typing import (
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 
 
 @runtime_checkable
@@ -464,7 +464,7 @@ class UnicodeProcessorProtocol(Protocol):
         ...
 
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 def _get_container(

--- a/yosai_intel_dashboard/src/core/security.py
+++ b/yosai_intel_dashboard/src/core/security.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.base_model import BaseModel
 
 # Import the high-level ``SecurityValidator`` used across the application.
@@ -331,7 +331,7 @@ def rate_limit_decorator(max_requests: int = 100, window_minutes: int = 1):
 def initialize_validation_callbacks() -> None:
     """Set up request validation callbacks on import."""
     try:
-        from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
         from security.validation_middleware import ValidationMiddleware
     except Exception:
         # Optional components may be missing in minimal environments

--- a/yosai_intel_dashboard/src/core/unicode.py
+++ b/yosai_intel_dashboard/src/core/unicode.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Iterable, Optional, Union
 
 import pandas as pd  # type: ignore[import]
 
-from config.database_exceptions import UnicodeEncodingError
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import UnicodeEncodingError
 from security.unicode_security_validator import (
     UnicodeSecurityConfig,
     UnicodeSecurityValidator,

--- a/yosai_intel_dashboard/src/database/__init__.py
+++ b/yosai_intel_dashboard/src/database/__init__.py
@@ -5,7 +5,7 @@ __all__ = ["DatabaseManager", "MockConnection"]
 
 def __getattr__(name: str):
     if name in __all__:
-        from config.database_manager import DatabaseManager, MockConnection
+        from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, MockConnection
 
         return {"DatabaseManager": DatabaseManager, "MockConnection": MockConnection}[
             name

--- a/yosai_intel_dashboard/src/database/connection.py
+++ b/yosai_intel_dashboard/src/database/connection.py
@@ -5,7 +5,7 @@ from typing import Optional, Protocol
 import pandas as pd
 from opentelemetry import trace
 
-from config.database_manager import DatabaseManager, MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, MockConnection
 from database.metrics import queries_total, query_errors_total
 
 

--- a/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
+++ b/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
@@ -6,7 +6,7 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Tuple
 
-from config.database_exceptions import ConnectionValidationFailed
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionValidationFailed
 from database.types import DatabaseConnection
 
 

--- a/yosai_intel_dashboard/src/file_processing/column_mapper.py
+++ b/yosai_intel_dashboard/src/file_processing/column_mapper.py
@@ -5,8 +5,8 @@ from typing import Dict, Iterable, List, Optional
 import pandas as pd
 from rapidfuzz import process
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 REQUIRED_COLUMNS = ["person_id", "door_id", "access_result", "timestamp"]
 OPTIONAL_COLUMNS = ["device_name", "location"]

--- a/yosai_intel_dashboard/src/file_processing/data_processor.py
+++ b/yosai_intel_dashboard/src/file_processing/data_processor.py
@@ -6,14 +6,14 @@ from typing import Dict, Optional
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.error_handling import (
     ErrorCategory,
     ErrorSeverity,
     with_error_handling,
 )
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 from .format_detector import FormatDetector, UnsupportedFormatError
 from .readers import ArchiveReader, CSVReader, ExcelReader, FWFReader, JSONReader
@@ -79,7 +79,7 @@ class DataProcessor:
 
     def _standardize_ids(self, df: pd.DataFrame) -> pd.DataFrame:
         """
-        Validate and standardize 'person_id' and 'badge_id' using regex from config.
+        Validate and standardize 'person_id' and 'badge_id' using regex from yosai_intel_dashboard.src.infrastructure.config.
         Flags invalid entries and sets them to None.
         """
         df = df.copy()

--- a/yosai_intel_dashboard/src/file_processing/exporter.py
+++ b/yosai_intel_dashboard/src/file_processing/exporter.py
@@ -7,10 +7,10 @@ from typing import Dict
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.container import get_unicode_processor
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 from .column_mapper import REQUIRED_COLUMNS
 

--- a/yosai_intel_dashboard/src/file_processing/format_detector.py
+++ b/yosai_intel_dashboard/src/file_processing/format_detector.py
@@ -5,11 +5,11 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.container import get_unicode_processor
-from core.protocols import UnicodeProcessorProtocol
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 
 class UnsupportedFormatError(Exception):

--- a/yosai_intel_dashboard/src/file_processing/readers/archive_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/archive_reader.py
@@ -8,9 +8,9 @@ from typing import List
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 from ..format_detector import FormatDetector
 
 from .base import BaseReader

--- a/yosai_intel_dashboard/src/file_processing/readers/base.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/base.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 import pandas as pd
 
 from core.container import get_unicode_processor
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 
 class BaseReader:

--- a/yosai_intel_dashboard/src/file_processing/readers/csv_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/csv_reader.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols import UnicodeProcessorProtocol
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_csv
 
 from .base import BaseReader

--- a/yosai_intel_dashboard/src/file_processing/readers/excel_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/excel_reader.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols import UnicodeProcessorProtocol
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_excel
 
 from .base import BaseReader

--- a/yosai_intel_dashboard/src/file_processing/readers/fwf_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/fwf_reader.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols import UnicodeProcessorProtocol
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_fwf
 
 from .base import BaseReader

--- a/yosai_intel_dashboard/src/file_processing/readers/json_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/json_reader.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols import UnicodeProcessorProtocol
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_json as util_read_json
 
 from .base import BaseReader

--- a/yosai_intel_dashboard/src/file_processing/utils.py
+++ b/yosai_intel_dashboard/src/file_processing/utils.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Iterable
 import chardet
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.config import get_max_display_rows
 from core.performance_file_processor import PerformanceFileProcessor
 from core.unicode import (

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -484,7 +484,7 @@ class TrulyUnifiedCallbacks:
 
         if controller is None:
             try:
-                from services.upload.controllers.upload_controller import (
+                from yosai_intel_dashboard.src.services.upload.controllers.upload_controller import (
                     UnifiedUploadController,
                 )
             except Exception as exc:  # pragma: no cover - import errors logged

--- a/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from startup import service_registration
 
 

--- a/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 from pydantic import ValidationError
 
 from core.exceptions import ConfigurationError
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 from .base import CacheConfig, Config
 from .config_transformer import ConfigTransformer

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from core.container import get_unicode_processor
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 from .unicode_processor import (
     FileUnicodeHandler,

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from core.container import get_unicode_processor
-from core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 from core.unicode import UnicodeProcessor as UnicodeHelper
 from core.unicode import contains_surrogates
 from security.events import SecurityEvent, emit_security_event

--- a/yosai_intel_dashboard/src/infrastructure/config/utils.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/utils.py
@@ -13,7 +13,7 @@ from yosai_intel_dashboard.src.utils.config_resolvers import (
 def get_ai_confidence_threshold(cfg: Any | None = None) -> float:
     """Return the AI confidence threshold for *cfg* or the global config."""
     if cfg is None:
-        from config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
         cfg = dynamic_config
     return resolve_ai_confidence_threshold(cfg)
@@ -22,7 +22,7 @@ def get_ai_confidence_threshold(cfg: Any | None = None) -> float:
 def get_upload_chunk_size(cfg: Any | None = None) -> int:
     """Return the upload chunk size for *cfg* or the global config."""
     if cfg is None:
-        from config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
         cfg = dynamic_config
     return resolve_upload_chunk_size(cfg)

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/data_quality_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/data_quality_monitor.py
@@ -26,11 +26,11 @@ except Exception:  # pragma: no cover - metrics optional for tests
     compatibility_failures = _DummyCounter()
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from config.base import DataQualityThresholds
+    from yosai_intel_dashboard.src.infrastructure.config.base import DataQualityThresholds
 
 else:  # pragma: no cover - runtime import for tests
     try:
-        from config.base import DataQualityThresholds
+        from yosai_intel_dashboard.src.infrastructure.config.base import DataQualityThresholds
     except Exception:  # pragma: no cover - minimal fallback
 
         class DataQualityThresholds:
@@ -75,13 +75,13 @@ class DataQualityMonitor:
         cfg = get_monitoring_config()
         dq_cfg = getattr(cfg, "data_quality", None)
         if isinstance(dq_cfg, dict):
-            from config.base import DataQualityThresholds
+            from yosai_intel_dashboard.src.infrastructure.config.base import DataQualityThresholds
 
             self.thresholds = DataQualityThresholds(**dq_cfg)
         elif dq_cfg is not None:
             self.thresholds = dq_cfg
         else:
-            from config.base import DataQualityThresholds
+            from yosai_intel_dashboard.src.infrastructure.config.base import DataQualityThresholds
 
             self.thresholds = thresholds or DataQualityThresholds()
 

--- a/yosai_intel_dashboard/src/infrastructure/security/events.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/events.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 SecurityEvent = CallbackEvent
 

--- a/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
@@ -4,9 +4,9 @@ from typing import Callable, Optional, Protocol
 
 from flask import Response, request
 
-from config.dynamic_config import dynamic_config
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.exceptions import ValidationError
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import pandas as pd
 
 from core.container import container as default_container
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from mapping.models import HeuristicMappingModel, MappingModel
 
 

--- a/yosai_intel_dashboard/src/models/css_build_optimizer.py
+++ b/yosai_intel_dashboard/src/models/css_build_optimizer.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/models/ml/data_processor.py
+++ b/yosai_intel_dashboard/src/models/ml/data_processor.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.utils.memory_utils import check_memory_limit
 
 try:
@@ -168,7 +168,7 @@ class DataProcessor:
     # ------------------------------------------------------------------
     def _cleanse(self, df: pd.DataFrame) -> pd.DataFrame:
         # Unicode sanitization via existing helper
-        from services.data_processing.file_processor import UnicodeFileProcessor as _UFP
+        from yosai_intel_dashboard.src.services.data_processing.file_processor import UnicodeFileProcessor as _UFP
 
         cleaned = _UFP.sanitize_dataframe_unicode(df, chunk_size=self.config.chunk_size)
         return (

--- a/yosai_intel_dashboard/src/services/analytics/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_service.py
@@ -34,29 +34,29 @@ import pandas as pd
 from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
 from core.di_decorators import inject, injectable
 from core.interfaces import ConfigProviderProtocol
-from core.protocols import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import (
     AnalyticsServiceProtocol,
     DatabaseProtocol,
     EventBusProtocol,
     StorageProtocol,
 )
-from services.analytics.calculator import Calculator
-from services.analytics.orchestrator import AnalyticsOrchestrator
-from services.analytics.protocols import (
+from yosai_intel_dashboard.src.services.analytics.calculator import Calculator
+from yosai_intel_dashboard.src.services.analytics.orchestrator import AnalyticsOrchestrator
+from yosai_intel_dashboard.src.services.analytics.protocols import (
     CalculatorProtocol,
     DataProcessorProtocol,
     PublishingProtocol,
     ReportGeneratorProtocol,
     UploadAnalyticsProtocol,
 )
-from services.analytics.publisher import Publisher
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.analytics.publisher import Publisher
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.analytics_summary import generate_sample_analytics
 from services.controllers.protocols import UploadProcessingControllerProtocol
 from services.controllers.upload_controller import UploadProcessingController
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from services.helpers.database_initializer import initialize_database
-from services.interfaces import (
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     AnalyticsDataLoaderProtocol,
     DatabaseAnalyticsRetrieverProtocol,
     get_analytics_data_loader,
@@ -148,7 +148,7 @@ class AnalyticsService(AnalyticsServiceProtocol):
         self.processor = data_processor
         # Legacy attribute aliases
         self.data_loading_service = self.processor
-        from services.data_processing.file_handler import FileHandler
+        from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 
         self.file_handler = FileHandler()
 

--- a/yosai_intel_dashboard/src/services/analytics/async_api.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_api.py
@@ -23,7 +23,7 @@ from starlette.types import ASGIApp
 from core.cache_manager import CacheConfig, InMemoryCacheManager
 from core.events import EventBus
 from yosai_intel_dashboard.src.error_handling import http_error
-from services.analytics_service import get_analytics_service
+from yosai_intel_dashboard.src.services.analytics.analytics_service import get_analytics_service
 from services.cached_analytics import CachedAnalyticsService
 from services.common.async_db import get_pool
 from services.security import require_permission

--- a/yosai_intel_dashboard/src/services/analytics/cached_analytics.py
+++ b/yosai_intel_dashboard/src/services/analytics/cached_analytics.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Any, Dict
 
 from core.cache_manager import CacheManager
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from services.analytics_summary import generate_sample_analytics
 
 

--- a/yosai_intel_dashboard/src/services/analytics/data/loader.py
+++ b/yosai_intel_dashboard/src/services/analytics/data/loader.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Tuple
 import pandas as pd
 
 from services.controllers.upload_controller import UploadProcessingController
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 from core.interfaces import ConfigProviderProtocol
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/analytics/events/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/events/publisher.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from services.event_publisher import publish_event
 
 

--- a/yosai_intel_dashboard/src/services/analytics/events/subscriber.py
+++ b/yosai_intel_dashboard/src/services/analytics/events/subscriber.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 
 
 class Subscriber:

--- a/yosai_intel_dashboard/src/services/analytics/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/publisher.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from services.event_publisher import publish_event
 
 

--- a/yosai_intel_dashboard/src/services/analytics/storage/persistence.py
+++ b/yosai_intel_dashboard/src/services/analytics/storage/persistence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Tuple
 
-from config.database_manager import DatabaseSettings
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseSettings
 
 from services.helpers.database_initializer import initialize_database
 

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -27,8 +27,8 @@ from pydantic import BaseModel
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
 from config import get_database_config
-from config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
-from config.config_loader import load_service_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
+from yosai_intel_dashboard.src.infrastructure.config.config_loader import load_service_config
 from core.security import RateLimiter
 from yosai_intel_dashboard.src.error_handling import http_error
 from services.analytics_microservice import async_queries

--- a/yosai_intel_dashboard/src/services/analytics_microservice/async_queries.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/async_queries.py
@@ -6,10 +6,10 @@ from typing import Any, Dict
 
 import asyncpg
 
-from services.analytics.common_queries import (
+from yosai_intel_dashboard.src.services.analytics.common_queries import (
     fetch_access_patterns as _fetch_access_patterns,
 )
-from services.analytics.common_queries import (
+from yosai_intel_dashboard.src.services.analytics.common_queries import (
     fetch_dashboard_summary as _fetch_dashboard_summary,
 )
 

--- a/yosai_intel_dashboard/src/services/async_file_processor.py
+++ b/yosai_intel_dashboard/src/services/async_file_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Convenience wrapper for the async file processor."""
 
-from services.data_processing.async_file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.async_file_processor import (
     AsyncFileProcessor as _AsyncFileProcessor,
 )
 

--- a/yosai_intel_dashboard/src/services/chunked_analysis.py
+++ b/yosai_intel_dashboard/src/services/chunked_analysis.py
@@ -9,7 +9,7 @@ import dask
 import pandas as pd
 from dask.distributed import Client, LocalCluster
 
-from config.config import get_analytics_config
+from yosai_intel_dashboard.src.infrastructure.config.config import get_analytics_config
 from validation.data_validator import DataValidator
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/services/common/secrets.py
+++ b/yosai_intel_dashboard/src/services/common/secrets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from config.environment import get_environment
+from yosai_intel_dashboard.src.infrastructure.config.environment import get_environment
 
 from .vault_client import VaultClient
 

--- a/yosai_intel_dashboard/src/services/configuration_service.py
+++ b/yosai_intel_dashboard/src/services/configuration_service.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from config.dynamic_config import DynamicConfigManager, dynamic_config
-from config.utils import get_ai_confidence_threshold as _get_ai_confidence_threshold
-from config.utils import get_upload_chunk_size as _get_upload_chunk_size
-from core.protocols import ConfigurationServiceProtocol
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager, dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.utils import get_ai_confidence_threshold as _get_ai_confidence_threshold
+from yosai_intel_dashboard.src.infrastructure.config.utils import get_upload_chunk_size as _get_upload_chunk_size
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 
 
 class DynamicConfigurationService(ConfigurationServiceProtocol):

--- a/yosai_intel_dashboard/src/services/controllers/upload_controller.py
+++ b/yosai_intel_dashboard/src/services/controllers/upload_controller.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from core.di_decorators import inject, injectable
-from services.analytics.upload_analytics import UploadAnalyticsProcessor
+from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
 from services.protocols.processor import ProcessorProtocol
-from services.upload.protocols import UploadAnalyticsProtocol
-from services.interfaces import UploadDataServiceProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadAnalyticsProtocol
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import UploadDataServiceProtocol
 from validation.security_validator import SecurityValidator
 
 

--- a/yosai_intel_dashboard/src/services/data_enhancer/app.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/app.py
@@ -19,7 +19,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import dcc, html
 
-from config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from core.unicode import clean_unicode_surrogates
 
 from .config import (
@@ -32,7 +32,7 @@ from .config import (
 )
 
 if CONTAINER_AVAILABLE:
-    from core.service_container import ServiceContainer
+    from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/yosai_intel_dashboard/src/services/data_enhancer/callbacks.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/callbacks.py
@@ -9,7 +9,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import Input, Output, State, callback_context, dash_table, dcc, html
 
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 from .app import EnhancedFileProcessor, MultiBuildingDataEnhancer
 from .config import (

--- a/yosai_intel_dashboard/src/services/data_enhancer/config.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/config.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:
     from services.door_mapping_service import DoorMappingService
-    from services.interfaces import get_door_mapping_service
+    from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_door_mapping_service
 
     AI_DOOR_SERVICE_AVAILABLE = True
     logger.info("✅ AI Door Service loaded successfully")
@@ -25,7 +25,7 @@ except Exception as e:  # pragma: no cover - optional dependency
     logger.warning(f"⚠️ AI Door Service not available - using fallback: {e}")
 
 try:
-    from core.service_container import ServiceContainer
+    from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
     CONTAINER_AVAILABLE = True
     logger.info("✅ Service Container available")

--- a/yosai_intel_dashboard/src/services/data_loading_service.py
+++ b/yosai_intel_dashboard/src/services/data_loading_service.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
-from services.analytics.data.loader import DataLoader
-from services.analytics.protocols import DataLoadingProtocol
-from services.interfaces import AnalyticsDataLoaderProtocol
+from yosai_intel_dashboard.src.services.analytics.data.loader import DataLoader
+from yosai_intel_dashboard.src.services.analytics.protocols import DataLoadingProtocol
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import AnalyticsDataLoaderProtocol
 from services.controllers.upload_controller import UploadProcessingController
-from services.data_processing.processor import Processor
+from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 
 
 class DataLoadingService(DataLoadingProtocol, AnalyticsDataLoaderProtocol):

--- a/yosai_intel_dashboard/src/services/data_processing/analytics_engine.py
+++ b/yosai_intel_dashboard/src/services/data_processing/analytics_engine.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - optional AI suggestions
         return {}
 
 
-from services.interfaces import get_upload_data_service
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
 from yosai_intel_dashboard.src.utils.preview_utils import serialize_dataframe_preview
 from validation.unicode_validator import UnicodeValidator
 

--- a/yosai_intel_dashboard/src/services/data_processing/async_file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/async_file_processor.py
@@ -14,7 +14,7 @@ from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 
-from core.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 from core.interfaces import ConfigProviderProtocol
 from services.rabbitmq_client import RabbitMQClient
 from services.task_queue import create_task, get_status

--- a/yosai_intel_dashboard/src/services/data_processing/base_file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/base_file_processor.py
@@ -5,7 +5,7 @@ from typing import IO, Callable, Iterable, List, Union
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from core.unicode import UnicodeProcessor as UnicodeHelper
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 from yosai_intel_dashboard.src.utils.memory_utils import check_memory_limit

--- a/yosai_intel_dashboard/src/services/data_processing/common.py
+++ b/yosai_intel_dashboard/src/services/data_processing/common.py
@@ -6,8 +6,8 @@ from typing import Optional, Tuple
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 from .dataframe_utils import process_dataframe as _process_dataframe
 

--- a/yosai_intel_dashboard/src/services/data_processing/data_processing_service.py
+++ b/yosai_intel_dashboard/src/services/data_processing/data_processing_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pandas as pd
 
-from services.analytics.data_processor import DataProcessor
-from services.analytics.protocols import DataProcessorProtocol
+from yosai_intel_dashboard.src.services.analytics.data_processor import DataProcessor
+from yosai_intel_dashboard.src.services.analytics.protocols import DataProcessorProtocol
 
 
 class DataProcessingService(DataProcessorProtocol):

--- a/yosai_intel_dashboard/src/services/data_processing/dataframe_utils.py
+++ b/yosai_intel_dashboard/src/services/data_processing/dataframe_utils.py
@@ -9,10 +9,10 @@ from typing import Optional, Tuple
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/data_processing/file_handler.py
+++ b/yosai_intel_dashboard/src/services/data_processing/file_handler.py
@@ -8,21 +8,21 @@ from typing import Any, Optional, Tuple
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from core.unicode import (
     process_large_csv_content,
     sanitize_dataframe,
     sanitize_for_utf8,
 )
 from services.common.config_utils import common_init, create_config_methods
-from services.data_processing.core.exceptions import (
+from yosai_intel_dashboard.src.services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,
 )
-from services.upload.upload_types import ValidationResult
+from yosai_intel_dashboard.src.services.upload.upload_types import ValidationResult
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/services/data_processing/file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/file_processor.py
@@ -11,8 +11,8 @@ from typing import Any, Dict, Iterable, Tuple
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.file_processing import (
     create_file_preview as _create_preview,

--- a/yosai_intel_dashboard/src/services/data_processing/no_limit_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/no_limit_processor.py
@@ -9,7 +9,7 @@ from typing import Iterable, List
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
 from unicode_toolkit import safe_encode_text
 

--- a/yosai_intel_dashboard/src/services/data_processing/processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/processor.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from core.interfaces import ConfigProviderProtocol
 from core.performance import get_performance_monitor
 from monitoring.data_quality_monitor import (
@@ -16,7 +16,7 @@ from monitoring.data_quality_monitor import (
     get_data_quality_monitor,
 )
 from services.streaming import StreamingService
-from services.interfaces import MappingServiceProtocol, get_mapping_service
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import MappingServiceProtocol, get_mapping_service
 from unicode_toolkit import safe_encode_text
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/services/database_retriever.py
+++ b/yosai_intel_dashboard/src/services/database_retriever.py
@@ -7,7 +7,7 @@ from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_loc
 _cache_manager = InMemoryCacheManager(CacheConfig())
 
 from .db_analytics_helper import DatabaseAnalyticsHelper
-from services.interfaces import DatabaseAnalyticsRetrieverProtocol
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import DatabaseAnalyticsRetrieverProtocol
 
 
 class DatabaseAnalyticsRetriever(DatabaseAnalyticsRetrieverProtocol):

--- a/yosai_intel_dashboard/src/services/device_learning_service.py
+++ b/yosai_intel_dashboard/src/services/device_learning_service.py
@@ -34,7 +34,7 @@ class DeviceServiceProtocol(Protocol):
 
 
 if TYPE_CHECKING:
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/door_mapping_service.py
+++ b/yosai_intel_dashboard/src/services/door_mapping_service.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from core.protocols import ConfigurationServiceProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 
 # ADD after existing imports
 from services.ai_device_generator import AIDeviceGenerator

--- a/yosai_intel_dashboard/src/services/event-ingestion/app.py
+++ b/yosai_intel_dashboard/src/services/event-ingestion/app.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from config.config_loader import load_service_config
+from yosai_intel_dashboard.src.infrastructure.config.config_loader import load_service_config
 from core.security import RateLimiter
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.error_handling.middleware import ErrorHandlingMiddleware

--- a/yosai_intel_dashboard/src/services/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/event_publisher.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/event_streaming_service.py
+++ b/yosai_intel_dashboard/src/services/event_streaming_service.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 from kafka import KafkaConsumer, KafkaProducer
 
-from config.kafka_config import KafkaConfig, from_environment
+from yosai_intel_dashboard.src.infrastructure.config.kafka_config import KafkaConfig, from_environment
 from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/export_service.py
+++ b/yosai_intel_dashboard/src/services/export_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from core.protocols import ExportServiceProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ExportServiceProtocol
 
 
 class ExportService(ExportServiceProtocol):

--- a/yosai_intel_dashboard/src/services/file_processor_service.py
+++ b/yosai_intel_dashboard/src/services/file_processor_service.py
@@ -13,11 +13,11 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE, UPLOAD_ALLOWED_EXTENSIONS
-from core.protocols import ConfigurationServiceProtocol
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE, UPLOAD_ALLOWED_EXTENSIONS
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 from core.unicode import UnicodeProcessor as UnicodeHelper
 from core.unicode import process_large_csv_content
-from services.data_processing.base_file_processor import BaseFileProcessor
+from yosai_intel_dashboard.src.services.data_processing.base_file_processor import BaseFileProcessor
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 from yosai_intel_dashboard.src.utils.memory_utils import memory_safe
 from yosai_intel_dashboard.src.utils.protocols import SafeDecoderProtocol

--- a/yosai_intel_dashboard/src/services/helpers/database_initializer.py
+++ b/yosai_intel_dashboard/src/services/helpers/database_initializer.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any, Optional, Tuple
 
-from config.database_exceptions import DatabaseError
-from config.database_manager import DatabaseManager, DatabaseSettings
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import DatabaseError
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, DatabaseSettings
 from services.db_analytics_helper import DatabaseAnalyticsHelper
 from services.summary_reporter import SummaryReporter
 

--- a/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
+++ b/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
@@ -39,9 +39,9 @@ except ImportError:  # pragma: no cover - for Python <3.12
 import pandas as pd
 
 from core.di_decorators import inject, injectable
-from core.service_container import ServiceContainer
-from services.analytics.protocols import AnalyticsServiceProtocol
-from services.upload.protocols import UploadDataServiceProtocol
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.services.analytics.protocols import AnalyticsServiceProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadDataServiceProtocol
 
 
 @runtime_checkable

--- a/yosai_intel_dashboard/src/services/migration/adapter.py
+++ b/yosai_intel_dashboard/src/services/migration/adapter.py
@@ -15,9 +15,9 @@ from kafka import KafkaProducer
 
 logger = logging.getLogger(__name__)
 
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.feature_flags import feature_flags
-from services.interfaces import AnalyticsServiceProtocol
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import AnalyticsServiceProtocol
 from services.resilience.circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
@@ -234,7 +234,7 @@ def register_migration_services(container: MigrationContainer) -> None:
     event_adapter = EventServiceAdapter(base_url=k8s_service_url("events"))
     container.register_with_adapter("event_processor", None, event_adapter)
 
-    from services.analytics_service import create_analytics_service
+    from yosai_intel_dashboard.src.services.analytics.analytics_service import create_analytics_service
 
     python_analytics = create_analytics_service()
     analytics_adapter = AnalyticsServiceAdapter(

--- a/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
-from config.constants import MIGRATION_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import MIGRATION_CHUNK_SIZE
 
 from ..framework import MigrationStrategy
 

--- a/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
-from config.constants import DataProcessingLimits
+from yosai_intel_dashboard.src.infrastructure.config.constants import DataProcessingLimits
 
 from ..framework import MigrationStrategy
 

--- a/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import AsyncIterator, List
 
 import asyncpg
-from config.constants import MIGRATION_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.constants import MIGRATION_CHUNK_SIZE
 
 from ..framework import MigrationStrategy
 

--- a/yosai_intel_dashboard/src/services/publishing_service.py
+++ b/yosai_intel_dashboard/src/services/publishing_service.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
-from services.analytics.protocols import PublishingProtocol
-from services.analytics.publisher import Publisher
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.services.analytics.protocols import PublishingProtocol
+from yosai_intel_dashboard.src.services.analytics.publisher import Publisher
 
 
 class PublishingService(PublishingProtocol):

--- a/yosai_intel_dashboard/src/services/report_generation_service.py
+++ b/yosai_intel_dashboard/src/services/report_generation_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from services.analytics.protocols import ReportGeneratorProtocol
+from yosai_intel_dashboard.src.services.analytics.protocols import ReportGeneratorProtocol
 from services.summary_report_generator import SummaryReportGenerator
 
 

--- a/yosai_intel_dashboard/src/services/stream_processor.py
+++ b/yosai_intel_dashboard/src/services/stream_processor.py
@@ -2,7 +2,7 @@ import logging
 from typing import IO, Any, List, Tuple, Union
 
 import pandas as pd
-from config.constants import DataProcessingLimits
+from yosai_intel_dashboard.src.infrastructure.config.constants import DataProcessingLimits
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/summary_reporter.py
+++ b/yosai_intel_dashboard/src/services/summary_reporter.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
-from services.interfaces import (
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     UploadDataServiceProtocol,
     get_upload_data_service,
 )

--- a/yosai_intel_dashboard/src/services/summary_reporting.py
+++ b/yosai_intel_dashboard/src/services/summary_reporting.py
@@ -33,7 +33,7 @@ class SummaryReporter:
             health["database"] = "not_configured"
 
         try:
-            from services.interfaces import get_upload_data_service
+            from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
             from services.upload_data_service import get_uploaded_filenames
 
             health["uploaded_files"] = len(
@@ -47,7 +47,7 @@ class SummaryReporter:
         """Return available data source options."""
         options = [{"label": "Sample Data", "value": "sample"}]
         try:
-            from services.interfaces import get_upload_data_service
+            from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
             from services.upload_data_service import get_uploaded_filenames
 
             uploaded_files = get_uploaded_filenames(get_upload_data_service())
@@ -83,7 +83,7 @@ class SummaryReporter:
             "service_health": self.health_check(),
         }
         try:
-            from services.interfaces import get_upload_data_service
+            from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
             from services.upload_data_service import get_uploaded_filenames
 
             status["uploaded_files"] = len(

--- a/yosai_intel_dashboard/src/services/unified_file_controller.py
+++ b/yosai_intel_dashboard/src/services/unified_file_controller.py
@@ -5,10 +5,10 @@ import time
 from pathlib import Path
 from typing import Callable, Optional, Sequence
 
-from core.callback_events import CallbackEvent
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from core.unicode import UnicodeProcessor
-from services.data_processing.file_handler import FileHandler
+from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
 _logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/upload/__init__.py
+++ b/yosai_intel_dashboard/src/services/upload/__init__.py
@@ -4,7 +4,7 @@ This module exposes the main interfaces for the upload domain.
 Other packages should import from here rather than submodules.
 """
 
-from core.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 from core.unicode import safe_encode_text
 from unicode_toolkit import decode_upload_content
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore as UploadStorage

--- a/yosai_intel_dashboard/src/services/upload/async_processor.py
+++ b/yosai_intel_dashboard/src/services/upload/async_processor.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 
 from core.config import get_max_display_rows
-from services.upload.utils.file_parser import UnicodeFileProcessor
+from yosai_intel_dashboard.src.services.upload.utils.file_parser import UnicodeFileProcessor
 from yosai_intel_dashboard.src.utils.async_pandas_readers import (
     async_read_csv,
     async_read_excel,

--- a/yosai_intel_dashboard/src/services/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/services/upload/callbacks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Callback manager for the upload domain."""
 
 from core.callback_registry import CallbackRegistry, ComponentCallbackManager
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 
 class UploadCallbacks(ComponentCallbackManager):

--- a/yosai_intel_dashboard/src/services/upload/chunked_upload_manager.py
+++ b/yosai_intel_dashboard/src/services/upload/chunked_upload_manager.py
@@ -7,9 +7,9 @@ from typing import Optional
 
 import pandas as pd
 
-from config.connection_retry import ConnectionRetryManager, RetryConfig
-from config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
-from config.protocols import ConnectionRetryManagerProtocol, RetryConfigProtocol
+from yosai_intel_dashboard.src.infrastructure.config.connection_retry import ConnectionRetryManager, RetryConfig
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
+from yosai_intel_dashboard.src.infrastructure.config.protocols import ConnectionRetryManagerProtocol, RetryConfigProtocol
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/upload/chunked_upload_manager_async.py
+++ b/yosai_intel_dashboard/src/services/upload/chunked_upload_manager_async.py
@@ -9,9 +9,9 @@ from typing import Awaitable, Callable, Optional, TypeVar
 
 import pandas as pd
 
-from config.connection_retry import RetryConfig
-from config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
-from config.database_exceptions import ConnectionRetryExhausted
+from yosai_intel_dashboard.src.infrastructure.config.connection_retry import RetryConfig
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE, DataProcessingLimits
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionRetryExhausted
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/upload/file_processor_service.py
+++ b/yosai_intel_dashboard/src/services/upload/file_processor_service.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, Dict, List
 
 import pandas as pd
 
-from core.protocols import FileProcessorProtocol
-from services.upload.protocols import UploadDataServiceProtocol, UploadStorageProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadDataServiceProtocol, UploadStorageProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/upload/learning_coordinator.py
+++ b/yosai_intel_dashboard/src/services/upload/learning_coordinator.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pandas as pd
 
-from services.upload.protocols import DeviceLearningServiceProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import DeviceLearningServiceProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/upload/orchestrator.py
+++ b/yosai_intel_dashboard/src/services/upload/orchestrator.py
@@ -6,12 +6,12 @@ from typing import Any, Callable, Dict, List, Tuple
 import pandas as pd
 
 from yosai_intel_dashboard.src.components.ui_builder import UploadUIBuilder
-from core.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 from services.async_file_processor import AsyncFileProcessor
 from services.data_enhancer.mapping_utils import get_ai_column_suggestions
-from services.upload.file_processor_service import FileProcessor
-from services.upload.learning_coordinator import LearningCoordinator
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.services.upload.file_processor_service import FileProcessor
+from yosai_intel_dashboard.src.services.upload.learning_coordinator import LearningCoordinator
+from yosai_intel_dashboard.src.services.upload.protocols import (
     DeviceLearningServiceProtocol,
     UploadProcessingServiceProtocol,
     UploadStorageProtocol,

--- a/yosai_intel_dashboard/src/services/upload/protocols.py
+++ b/yosai_intel_dashboard/src/services/upload/protocols.py
@@ -17,8 +17,8 @@ from typing import (
 
 import pandas as pd
 
-from core.protocols import FileProcessorProtocol
-from core.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.protocols.device_learning import DeviceLearningServiceProtocol
 
 
@@ -222,7 +222,7 @@ def get_device_learning_service(
     c = _get_container(container)
     if c and c.has("device_learning_service"):
         return c.get("device_learning_service")
-    from services.interfaces import get_device_learning_service as _get
+    from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_device_learning_service as _get
 
     return _get()
 

--- a/yosai_intel_dashboard/src/services/upload/service_registration.py
+++ b/yosai_intel_dashboard/src/services/upload/service_registration.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from yosai_intel_dashboard.src.components.ui_builder import UploadUIBuilder
 from core.interfaces import ConfigProviderProtocol
-from core.protocols import FileProcessorProtocol
-from core.service_container import (
+from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
     CircularDependencyError,
     DependencyInjectionError,
     ServiceContainer,
@@ -13,21 +13,21 @@ from core.service_container import (
 )
 from services.async_file_processor import AsyncFileProcessor
 from services.device_learning_service import DeviceLearningService
-from services.interfaces import (
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     DeviceLearningServiceProtocol,
     UploadDataServiceProtocol,
 )
-from services.upload.controllers.upload_controller import UnifiedUploadController
-from services.upload.file_processor_service import FileProcessor
-from services.upload.learning_coordinator import LearningCoordinator
-from services.upload.processor import UploadProcessingService
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.services.upload.controllers.upload_controller import UnifiedUploadController
+from yosai_intel_dashboard.src.services.upload.file_processor_service import FileProcessor
+from yosai_intel_dashboard.src.services.upload.learning_coordinator import LearningCoordinator
+from yosai_intel_dashboard.src.services.upload.processor import UploadProcessingService
+from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadControllerProtocol,
     UploadProcessingServiceProtocol,
     UploadStorageProtocol,
     UploadValidatorProtocol,
 )
-from services.upload.validator import ClientSideValidator
+from yosai_intel_dashboard.src.services.upload.validator import ClientSideValidator
 from services.upload_data_service import UploadDataService
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 from validation.file_validator import FileValidator

--- a/yosai_intel_dashboard/src/services/upload/upload_core.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_core.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Tuple
 import dash_bootstrap_components as dbc
 from dash import html, no_update
 
-from services.interfaces import get_device_learning_service
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_device_learning_service
 from services.rabbitmq_client import RabbitMQClient
 from services.task_queue import (
     TaskQueue,
@@ -23,12 +23,12 @@ from services.upload import (
     ModalService,
     get_trigger_id,
 )
-from services.upload.protocols import (
+from yosai_intel_dashboard.src.services.upload.protocols import (
     DeviceLearningServiceProtocol,
     UploadProcessingServiceProtocol,
     UploadStorageProtocol,
 )
-from services.upload.upload_queue_manager import UploadQueueManager
+from yosai_intel_dashboard.src.services.upload.upload_queue_manager import UploadQueueManager
 from validation.security_validator import SecurityValidator
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/upload/upload_data_service.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_data_service.py
@@ -11,8 +11,8 @@ except ImportError:  # pragma: no cover - for Python <3.12
 
 import pandas as pd
 
-from core.service_container import ServiceContainer
-from services.interfaces import (
+from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     get_upload_data_service,
     UploadDataServiceProtocol,
 )

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from error_handling import ErrorCategory, ErrorHandler, api_error_response
 
-from services.data_processing.file_handler import FileHandler
+from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.utils.pydantic_decorators import validate_input, validate_output
 
 

--- a/yosai_intel_dashboard/src/services/upload/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_processing.py
@@ -1,4 +1,4 @@
-from services.upload.protocols import UploadAnalyticsProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadAnalyticsProtocol
 
 
 class UploadAnalyticsProcessor(UploadAnalyticsProtocol):

--- a/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
+++ b/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
@@ -11,14 +11,14 @@ from typing import Any, Dict, Tuple
 
 import pandas as pd
 
-from config.constants import DEFAULT_CHUNK_SIZE
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.performance import get_performance_monitor
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 # Core processing imports only - NO UI COMPONENTS
 from core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
-from services.data_processing.file_processor import (
+from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     decode_contents,
     validate_metadata,
     dataframe_from_bytes,

--- a/yosai_intel_dashboard/src/services/upload/validator.py
+++ b/yosai_intel_dashboard/src/services/upload/validator.py
@@ -2,7 +2,7 @@ import base64
 import json
 from typing import Any, Callable, Iterable, List, Mapping
 
-from services.upload.protocols import UploadValidatorProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadValidatorProtocol
 
 
 class ClientSideValidator(UploadValidatorProtocol):

--- a/yosai_intel_dashboard/src/services/utils/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/utils/event_publisher.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -6,7 +6,7 @@ import threading
 import time
 from typing import Any, Dict
 
-from core.protocols import EventBusProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from services.analytics_summary import generate_sample_analytics
 
 

--- a/yosai_intel_dashboard/src/utils/debug_tools.py
+++ b/yosai_intel_dashboard/src/utils/debug_tools.py
@@ -25,7 +25,7 @@ def debug_callback_registration_flow(target_class: Any | None = None) -> None:
 
     if target_class is None:
         try:
-            from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+            from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
             target_class = TrulyUnifiedCallbacks
         except Exception:  # pragma: no cover - best effort

--- a/yosai_intel_dashboard/src/utils/preview_utils.py
+++ b/yosai_intel_dashboard/src/utils/preview_utils.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from config.dynamic_config import dynamic_config
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from core.config import get_max_display_rows
-from core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from core.unicode import sanitize_for_utf8
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/utils/upload_store.py
+++ b/yosai_intel_dashboard/src/utils/upload_store.py
@@ -11,10 +11,10 @@ from typing import Any, Dict, List, Optional, Protocol
 
 import pandas as pd
 
-from config.app_config import UploadConfig
+from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadConfig
 from core.cache_manager import CacheConfig, InMemoryCacheManager
 from core.unicode import sanitize_dataframe
-from services.upload.protocols import UploadStorageProtocol
+from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 from unicode_toolkit import safe_encode_text
 
 _cache_manager = InMemoryCacheManager(CacheConfig())

--- a/yosai_intel_dashboard/tests/encoding/test_unicode_handler.py
+++ b/yosai_intel_dashboard/tests/encoding/test_unicode_handler.py
@@ -68,7 +68,7 @@ class UnicodeSecurityValidator:
 security_validator.UnicodeSecurityValidator = UnicodeSecurityValidator
 sys.modules["security.unicode_security_validator"] = security_validator
 
-from config.unicode_handler import UnicodeHandler  # noqa: E402
+from yosai_intel_dashboard.src.infrastructure.config.unicode_handler import UnicodeHandler  # noqa: E402
 
 
 def test_sanitize_removes_surrogates_and_normalizes():


### PR DESCRIPTION
## Summary
- rewrite legacy import paths to new architecture packages
- update import rewrite script

## Testing
- `PYTHONPATH=. python3 scripts/verify_imports.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688ba9cba7b48320848cb7dc601cb729