### PR TITLE
Fix imports for new package layout

### DIFF
--- a/start_api.py
+++ b/start_api.py
@@ -15,6 +15,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Import Flask app directly from adapter
 from api.adapter import create_api_app
 
+# Import Dash app factory from the package
+from yosai_intel_dashboard.src.core.app_factory import create_app
+
 from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from core.di.bootstrap import bootstrap_container
 

--- a/yosai_intel_dashboard/src/core/app_factory/__init__.py
+++ b/yosai_intel_dashboard/src/core/app_factory/__init__.py
@@ -6,8 +6,12 @@ import dash_bootstrap_components as dbc
 from dash import dcc, html
 
 # Import Path for building robust file paths
-from yosai_intel_dashboard.src.components.ui.navbar import create_navbar_layout
-from core.error_handlers import register_error_handlers
+from yosai_intel_dashboard.src.adapters.ui.components.ui.navbar import (
+    create_navbar_layout,
+)
+from yosai_intel_dashboard.src.infrastructure.error_handling.handlers import (
+    register_error_handlers,
+)
 
 
 def create_app(mode=None, **kwargs):


### PR DESCRIPTION
## Summary
- align navbar and error handler imports with new adapters package
- import Dash app factory using updated package path in `start_api.py`

## Testing
- `python -m py_compile core/app_factory/__init__.py start_api.py yosai_intel_dashboard/src/core/app_factory/__init__.py`
- `pytest tests/utils/test_asset_serving.py::test_debug_dash_asset_serving -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_688bcac1d3708320a9b801d0a405b2fa