### PR TITLE
Add init files and update callback references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ app.log
 
 !load-tests/thresholds.json
 archive/
+!yosai_intel_dashboard/src/infrastructure/cache/

--- a/tests/test_callbacks_alias.py
+++ b/tests/test_callbacks_alias.py
@@ -1,10 +1,4 @@
-import dash
-
-# Ensure dash.no_update exists for the import chain
-if not hasattr(dash, "no_update"):
-    dash.no_update = None
-
-import core.callbacks as callbacks
+import yosai_intel_dashboard.src.infrastructure.callbacks as callbacks
 
 
 def test_unified_callback_manager_removed():

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -44,7 +44,7 @@ def callback_handler(event: CallbackEvent):
     return decorator
 
 
-_GLOBAL = CallbackController()
+_GLOBAL = TrulyUnifiedCallbacks()
 fire_event = _GLOBAL.fire_event
 from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor as RobustFileProcessor
 from yosai_intel_dashboard.src.services.data_processing.file_processor import (
@@ -158,7 +158,7 @@ class TestChunkedUnicodeProcessor:
 
 class TestCallbackController:
     def test_callback_registration_and_firing(self):
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         called = {}
 
@@ -172,7 +172,7 @@ class TestCallbackController:
         assert called["s"] == "src"
 
     def test_callback_unregistration(self):
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         hits = []
 
@@ -186,7 +186,7 @@ class TestCallbackController:
         assert len(hits) == 1
 
     def test_multiple_callbacks_same_event(self):
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         results = []
 
@@ -202,7 +202,7 @@ class TestCallbackController:
         assert results == ["cb1", "cb2"]
 
     def test_callback_error_handling(self):
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         seen = []
 
@@ -222,7 +222,7 @@ class TestCallbackController:
         assert "boom" in seen and "ok" in seen
 
     def test_callback_decorator(self):
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         executed = []
 
@@ -306,7 +306,7 @@ class TestRobustFileProcessor:
         def track(ctx):
             events.append(ctx.event_type)
 
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         controller.register_callback(CallbackEvent.FILE_PROCESSING_START, track)
         controller.register_callback(CallbackEvent.FILE_PROCESSING_COMPLETE, track)
@@ -351,7 +351,7 @@ class TestIntegration:
         def tracker(ctx):
             events.append(ctx.event_type)
 
-        controller = CallbackController()
+        controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()
         controller.register_callback(CallbackEvent.FILE_PROCESSING_START, tracker)
         controller.register_callback(CallbackEvent.FILE_PROCESSING_COMPLETE, tracker)

--- a/yosai_intel_dashboard/src/__init__.py
+++ b/yosai_intel_dashboard/src/__init__.py
@@ -1,0 +1,1 @@
+"""Clean architecture implementation of Yosai Intel Dashboard."""

--- a/yosai_intel_dashboard/src/adapters/__init__.py
+++ b/yosai_intel_dashboard/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters layer for external interfaces."""

--- a/yosai_intel_dashboard/src/infrastructure/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure utilities for Yosai Intel Dashboard."""

--- a/yosai_intel_dashboard/src/infrastructure/cache/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/cache/__init__.py
@@ -1,0 +1,14 @@
+"""Caching implementations for Yosai Intel Dashboard."""
+from .cache_manager import (
+    CacheConfig,
+    InMemoryCacheManager,
+    RedisCacheManager,
+    cache_with_lock,
+)
+
+__all__ = [
+    "CacheConfig",
+    "InMemoryCacheManager",
+    "RedisCacheManager",
+    "cache_with_lock",
+]

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
@@ -1,0 +1,11 @@
+"""Unified callback utilities and registry."""
+from .events import CallbackEvent
+from .callback_registry import CallbackRegistry, ComponentCallbackManager
+from .unified_callbacks import TrulyUnifiedCallbacks
+
+__all__ = [
+    "CallbackEvent",
+    "CallbackRegistry",
+    "ComponentCallbackManager",
+    "TrulyUnifiedCallbacks",
+]

--- a/yosai_intel_dashboard/src/infrastructure/di/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/di/__init__.py
@@ -1,0 +1,4 @@
+"""Dependency injection helpers."""
+from .service_container import ServiceContainer
+
+__all__ = ["ServiceContainer"]

--- a/yosai_intel_dashboard/src/infrastructure/error_handling/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/error_handling/__init__.py
@@ -1,0 +1,4 @@
+"""Error handling utilities for infrastructure layer."""
+from .handlers import log_and_raise
+
+__all__ = ["log_and_raise"]

--- a/yosai_intel_dashboard/src/infrastructure/logging/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/logging/__init__.py
@@ -1,0 +1,4 @@
+"""Logging setup for the application."""
+from .setup import configure_logging
+
+__all__ = ["configure_logging"]


### PR DESCRIPTION
## Summary
- create `__init__` modules for new packages
- switch tests from `CallbackController` instantiation to `TrulyUnifiedCallbacks`
- adjust callback alias test import
- permit infrastructure cache package in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', then 302 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bcb3698dc8320bae6824fdb50065f