### PR TITLE
Update callbacks docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,8 +1184,8 @@ safe_query = SQLProcessor.encode_query(query)
 
 ### Firing events
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 
 callbacks = TrulyUnifiedCallbacks()
 callbacks.trigger_event(

--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -9,8 +9,8 @@ namespace.
 ## Registering Callbacks
 
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 
 callbacks = TrulyUnifiedCallbacks(app)
 
@@ -48,8 +48,8 @@ def submit_query(n):
 `TrulyUnifiedCallbacks` delivers application events outside of Dash callbacks.
 
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 
 events = TrulyUnifiedCallbacks()
 
@@ -67,7 +67,7 @@ manually chaining functions.
 
 
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
 
 ops = TrulyUnifiedCallbacks()
 ops.register_operation("refresh", load_data)
@@ -93,7 +93,7 @@ A single startup task should orchestrate all callback registration steps to prev
 2. Register Dash and event callbacks through one `TrulyUnifiedCallbacks` instance.
 3. Deduplicate IDs using `GlobalCallbackRegistry` and expose conflict details.
 4. Provide a unified decorator so modules never call `app.callback` directly.
-5. Import `TrulyUnifiedCallbacks` from `core.truly_unified_callbacks` in new
+5. Import `TrulyUnifiedCallbacks` from `yosai_intel_dashboard.src.infrastructure.callbacks` in new
    code. Avoid deprecated aliases like `MasterCallbackSystem`.
 
 Running this task at initialization ensures consistent behavior and avoids code conflicts across the application.

--- a/docs/column_verification.md
+++ b/docs/column_verification.md
@@ -12,7 +12,7 @@ features. The function expects a `TrulyUnifiedCallbacks` instance:
 
 ```python
 from yosai_intel_dashboard.src.components.column_verification import register_callbacks
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
 
 callbacks = TrulyUnifiedCallbacks(app)
 register_callbacks(callbacks)

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -19,7 +19,7 @@ services/
 - **`DataEnhancer`** – Applies normalisation and adds computed columns.
 - **`Processor`** – High level wrapper that uses `FileValidator` and `DataEnhancer` to produce a clean dataframe.
 - **`AnalyticsEngine`** – Generates statistics from the processed dataframe.
-- **``core.truly_unified_callbacks.TrulyUnifiedCallbacks``** – Emits events throughout the pipeline so plugins can react.
+- **``yosai_intel_dashboard.src.infrastructure.callbacks.TrulyUnifiedCallbacks``** – Emits events throughout the pipeline so plugins can react.
 
 ## Relationships
 
@@ -35,8 +35,8 @@ This separation makes the pipeline extensible and easier to test as new data sou
 
 Example event:
 ```python
-from core.truly_unified_callbacks import TrulyUnifiedCallbacks
-from core.callback_events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 
 manager = TrulyUnifiedCallbacks()
 manager.trigger_event(

--- a/docs/type_import_pattern.md
+++ b/docs/type_import_pattern.md
@@ -6,7 +6,7 @@ Use this template when you need the `TrulyUnifiedCallbacksType` for type hints w
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from core.truly_unified_callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
+    from yosai_intel_dashboard.src.infrastructure.callbacks import TrulyUnifiedCallbacks as TrulyUnifiedCallbacksType
 else:  # pragma: no cover - fallback runtime alias
     TrulyUnifiedCallbacksType = Any
 ```


### PR DESCRIPTION
## Summary
- update docs to use `yosai_intel_dashboard.src.infrastructure.callbacks`
- update CallbackEvent imports

## Testing
- `pip install -q -r requirements.txt -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests.adapters'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688bf5aab280832098410d1a9ad8f4f1