### PR TITLE
Fix tests for updated unified callbacks path

### DIFF
--- a/tests/file_processing/test_data_processor_pipeline.py
+++ b/tests/file_processing/test_data_processor_pipeline.py
@@ -24,7 +24,10 @@ container_stub.get_unicode_processor = lambda: types.SimpleNamespace(
     sanitize_dataframe=lambda df: df
 )
 
-sys.modules.setdefault("core.truly_unified_callbacks", truly_stub)
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks",
+    truly_stub,
+)
 format_stub = types.ModuleType("file_processing.format_detector")
 
 

--- a/tests/integration/test_upload_integration.py
+++ b/tests/integration/test_upload_integration.py
@@ -26,7 +26,10 @@ cb_events_stub = _types.SimpleNamespace(CallbackEvent=_types.SimpleNamespace(SYS
 container_stub = _types.ModuleType("core.container")
 container_stub.get_unicode_processor = lambda: _types.SimpleNamespace(sanitize_dataframe=lambda df: df)
 
-_sys.modules.setdefault("core.truly_unified_callbacks", truly_stub)
+_sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks",
+    truly_stub,
+)
 format_stub = _types.ModuleType("file_processing.format_detector")
 class FormatDetector:
     def __init__(self, *a, **k): ...

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -96,7 +96,10 @@ def test_create_app(monkeypatch):
         def __init__(self, app):
             captured["manager"] = app
 
-    monkeypatch.setattr("core.truly_unified_callbacks.TrulyUnifiedCallbacks", DummyMCS)
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks.TrulyUnifiedCallbacks",
+        DummyMCS,
+    )
     monkeypatch.setattr(app, "debug_dash_asset_serving", lambda a: True)
 
     app_obj = app._create_app()

--- a/tests/test_unified_file_controller.py
+++ b/tests/test_unified_file_controller.py
@@ -20,12 +20,6 @@ class CallbackEvent(Enum):
 callback_events_stub.CallbackEvent = CallbackEvent
 sys.modules.setdefault("core.callback_events", callback_events_stub)
 
-tuc_stub = types.ModuleType("core.truly_unified_callbacks")
-tuc_stub.TrulyUnifiedCallbacks = DummyManager
-sys.modules.setdefault("core.truly_unified_callbacks", tuc_stub)
-
-from yosai_intel_dashboard.src.services.unified_file_controller import register_callbacks
-
 
 class DummyManager:
     def __init__(self) -> None:
@@ -38,6 +32,16 @@ class DummyManager:
         return [cb(*args, **kwargs) for cb in self.events.get(event, [])]
 
 
+tuc_stub = types.ModuleType(
+    "yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks"
+)
+tuc_stub.TrulyUnifiedCallbacks = DummyManager
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks",
+    tuc_stub,
+)
+
+from yosai_intel_dashboard.src.services.unified_file_controller import register_callbacks
 def test_register_callbacks_processes_upload(tmp_path):
     manager = DummyManager()
     store = UploadedDataStore(storage_dir=tmp_path)


### PR DESCRIPTION
## Summary
- update references to `core.truly_unified_callbacks` in tests
- patch tests to use `yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks.TrulyUnifiedCallbacks`

## Testing
- `pytest tests/test_unified_file_controller.py tests/file_processing/test_data_processor_pipeline.py tests/test_app_helpers.py tests/integration/test_upload_integration.py -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688bf5acd3dc8320944172ae45809e46