### PR TITLE
update imports to clean architecture paths

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -6,10 +6,10 @@ from flask import Flask, Response, jsonify, request, send_from_directory
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect, generate_csrf
 
-from config import get_security_config
-from core.rbac import RBACService, create_rbac_service
-from core.secrets_validator import validate_all_secrets
-from services.security import require_token
+from yosai_intel_dashboard.src.infrastructure.config import get_security_config
+from yosai_intel_dashboard.src.core.rbac import RBACService, create_rbac_service
+from yosai_intel_dashboard.src.core.secrets_validator import validate_all_secrets
+from yosai_intel_dashboard.src.services.security import require_token
 from yosai_framework.service import BaseService
 
 csrf = CSRFProtect()
@@ -22,11 +22,11 @@ from settings_endpoint import settings_bp
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from middleware.performance import TimingMiddleware
-from core.container import container
-from services.device_endpoint import create_device_blueprint
-from services.mappings_endpoint import create_mappings_blueprint
-from services.token_endpoint import create_token_blueprint
-from services.upload_endpoint import create_upload_blueprint
+from yosai_intel_dashboard.src.core.container import container
+from yosai_intel_dashboard.src.services.device_endpoint import create_device_blueprint
+from yosai_intel_dashboard.src.services.mappings_endpoint import create_mappings_blueprint
+from yosai_intel_dashboard.src.services.token_endpoint import create_token_blueprint
+from yosai_intel_dashboard.src.services.upload_endpoint import create_upload_blueprint
 
 
 def create_api_app() -> "FastAPI":

--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -4,11 +4,11 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from config import get_cache_config
-from core.cache_manager import CacheConfig, InMemoryCacheManager
+from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager
 from yosai_intel_dashboard.src.error_handling import http_error
-from services.cached_analytics import CachedAnalyticsService
-from services.security import require_permission
+from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsService
+from yosai_intel_dashboard.src.services.security import require_permission
 from shared.errors.types import ErrorCode
 
 router = APIRouter(prefix="/api/v1/analytics", tags=["analytics"])

--- a/yosai_intel_dashboard/src/adapters/api/plugin_performance.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugin_performance.py
@@ -8,9 +8,9 @@ from flask_apispec import doc, marshal_with, use_kwargs
 from marshmallow import Schema, fields
 
 from app import app
-from config import get_cache_config
-from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
-from core.plugins.performance_manager import EnhancedThreadSafePluginManager
+from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+from yosai_intel_dashboard.src.core.plugins.performance_manager import EnhancedThreadSafePluginManager
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler
 from shared.errors.types import ErrorCode
 from validation.security_validator import SecurityValidator

--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/plugin.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/plugin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
-from core.protocols.plugin import PluginMetadata
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginMetadata
 
 from .config import AIClassificationConfig, get_ai_config
 from .database.csv_storage import CSVStorageRepository

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_controller.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_controller.py
@@ -9,14 +9,14 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, jsonify, request
 from flask_login import current_user, login_required
 
-from core.audit_logger import ComplianceAuditLogger
-from core.container import Container
-from core.rbac import require_role
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.container import Container
+from yosai_intel_dashboard.src.core.rbac import require_role
 from database.secure_exec import execute_query
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler
-from services.compliance.consent_service import ConsentService
-from services.compliance.dsar_service import DSARService
-from services.security import require_role
+from yosai_intel_dashboard.src.services.compliance.consent_service import ConsentService
+from yosai_intel_dashboard.src.services.compliance.dsar_service import DSARService
+from yosai_intel_dashboard.src.services.security import require_role
 from shared.errors.types import ErrorCode
 from validation.security_validator import SecurityValidator
 from yosai_framework.errors import CODE_TO_STATUS

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_dashboard.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_dashboard.py
@@ -8,13 +8,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Protocol
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_query
-from services.compliance.consent_service import ConsentService
-from services.compliance.data_retention_service import DataRetentionService
-from services.compliance.dpia_service import DPIAService
-from services.compliance.dsar_service import DSARService
+from yosai_intel_dashboard.src.services.compliance.consent_service import ConsentService
+from yosai_intel_dashboard.src.services.compliance.data_retention_service import DataRetentionService
+from yosai_intel_dashboard.src.services.compliance.dpia_service import DPIAService
+from yosai_intel_dashboard.src.services.compliance.dsar_service import DSARService
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
@@ -8,12 +8,12 @@ from typing import Any, Dict
 
 from controllers.compliance_controller import register_compliance_routes
 
-from core.audit_logger import create_audit_logger
-from core.container import Container
+from yosai_intel_dashboard.src.core.audit_logger import create_audit_logger
+from yosai_intel_dashboard.src.core.container import Container
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
-from services.compliance.consent_service import create_consent_service
-from services.compliance.dsar_service import create_dsar_service
+from yosai_intel_dashboard.src.services.compliance.consent_service import create_consent_service
+from yosai_intel_dashboard.src.services.compliance.dsar_service import create_dsar_service
 from yosai_intel_dashboard.models.compliance import CREATE_COMPLIANCE_TABLES_SQL
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ def audit_decorator(action_type: str, resource_type: str):
         def wrapper(*args, **kwargs):
             from flask_login import current_user
 
-            from core.container import Container
+            from yosai_intel_dashboard.src.core.container import Container
 
             try:
                 # Execute the function first
@@ -168,7 +168,7 @@ def consent_required(consent_type: str, jurisdiction: str = "EU"):
             from flask import jsonify
             from flask_login import current_user
 
-            from core.container import Container
+            from yosai_intel_dashboard.src.core.container import Container
             from yosai_intel_dashboard.models.compliance import ConsentType
 
             try:
@@ -226,8 +226,8 @@ def create_compliance_enabled_app(config_name: str = None):
     """
     from flask import Flask
 
-    from config import create_config_manager
-    from core.container import Container
+    from yosai_intel_dashboard.src.infrastructure.config import create_config_manager
+    from yosai_intel_dashboard.src.core.container import Container
     from database.connection import create_database_connection
 
     # Create Flask app
@@ -285,7 +285,7 @@ def setup_data_retention_scheduler():
         try:
             from datetime import datetime, timezone
 
-            from core.container import Container
+            from yosai_intel_dashboard.src.core.container import Container
 
             container = Container()
             db = container.get("database")

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/middleware.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/middleware.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 
 from flask import g, request
 
-from core.error_handling import ErrorSeverity, error_handler, handle_errors
+from yosai_intel_dashboard.src.core.error_handling import ErrorSeverity, error_handler, handle_errors
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/plugin.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/plugin.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from core.plugins.base import BasePlugin
+from yosai_intel_dashboard.src.core.plugins.base import BasePlugin
 from plugins.common_callbacks import csv_pre_process_callback
 
 from .api import ComplianceAPI

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/__init__.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from core.container import Container
+from yosai_intel_dashboard.src.core.container import Container
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/audit_logger.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/audit_logger.py
@@ -12,7 +12,7 @@ from flask import g, request
 from flask_login import current_user
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
-from core.unicode import safe_unicode_encode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/breach_notification_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/breach_notification_service.py
@@ -9,9 +9,9 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
-from core.unicode import safe_unicode_encode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command, execute_query
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
@@ -10,11 +10,11 @@ from uuid import uuid4
 
 import pandas as pd
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_query
-from services.compliance.consent_service import ConsentService
-from services.compliance.data_retention_service import DataRetentionService
+from yosai_intel_dashboard.src.services.compliance.consent_service import ConsentService
+from yosai_intel_dashboard.src.services.compliance.data_retention_service import DataRetentionService
 from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor
 from yosai_intel_dashboard.models.compliance import ConsentType, DataSensitivityLevel
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
@@ -12,7 +12,7 @@ from flask import request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import (

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/cross_border_transfer_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/cross_border_transfer_service.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/data_retention_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/data_retention_service.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import DataSensitivityLevel

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dpia_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dpia_service.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
 from database.secure_exec import execute_command, execute_query
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
@@ -9,9 +9,9 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
 from yosai_intel_dashboard.src.core.interfaces.protocols import DatabaseProtocol
-from core.unicode import safe_unicode_encode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_encode
 from database.secure_exec import execute_command, execute_query
 from yosai_intel_dashboard.models.compliance import (
     DSARRequest,
@@ -201,7 +201,7 @@ class DSARService:
             user_data = {}
 
             # Get user profile data
-            from services.optimized_queries import OptimizedQueryService
+            from yosai_intel_dashboard.src.services.optimized_queries import OptimizedQueryService
 
             query_service = OptimizedQueryService(self.db)
             users = query_service.batch_get_users([user_id])

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/toggle_manager.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/toggle_manager.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
-from core.rbac import require_role
+from yosai_intel_dashboard.src.core.rbac import require_role
 from database.secure_exec import execute_command, execute_query
 from plugins.common_callbacks import csv_pre_process_callback
 from yosai_intel_dashboard.src.services.data_processing.file_processor import FileProcessor

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/tests/test_compliance_framework.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/tests/test_compliance_framework.py
@@ -8,11 +8,11 @@ from uuid import uuid4
 
 import pytest
 
-from core.audit_logger import ComplianceAuditLogger
-from services.compliance.consent_service import ConsentService
-from services.compliance.data_retention_service import DataRetentionService
-from services.compliance.dpia_service import DPIAService, DPIATrigger, RiskLevel
-from services.compliance.dsar_service import DSARRequestType, DSARService, DSARStatus
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.services.compliance.consent_service import ConsentService
+from yosai_intel_dashboard.src.services.compliance.data_retention_service import DataRetentionService
+from yosai_intel_dashboard.src.services.compliance.dpia_service import DPIAService, DPIATrigger, RiskLevel
+from yosai_intel_dashboard.src.services.compliance.dsar_service import DSARRequestType, DSARService, DSARStatus
 from yosai_intel_dashboard.models.compliance import ConsentType, DataSensitivityLevel
 
 
@@ -471,7 +471,7 @@ class ComplianceUsageExamples:
         example_code = """
         from flask import request, jsonify
         from flask_login import current_user
-        from core.container import Container
+        from yosai_intel_dashboard.src.core.container import Container
         from yosai_intel_dashboard.models.compliance import ConsentType
         
         @app.route('/api/users/register', methods=['POST'])
@@ -515,9 +515,9 @@ class ComplianceUsageExamples:
     def example_biometric_processing_with_consent_check(self):
         """Example: Biometric processing with consent verification"""
         example_code = '''
-        from services.compliance.consent_service import ConsentService
+        from yosai_intel_dashboard.src.services.compliance.consent_service import ConsentService
         from yosai_intel_dashboard.models.compliance import ConsentType
-        from core.audit_logger import ComplianceAuditLogger
+        from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
         
         def process_facial_recognition(user_id: str, image_data: bytes):
             """Process facial recognition with consent verification"""
@@ -566,7 +566,7 @@ class ComplianceUsageExamples:
         import schedule
         import time
         from threading import Thread
-        from core.container import Container
+        from yosai_intel_dashboard.src.core.container import Container
         
         def setup_automated_retention():
             """Setup automated data retention processing"""

--- a/yosai_intel_dashboard/src/adapters/api/plugins/example/plugin.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/example/plugin.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
-from core.protocols.plugin import CallbackPluginProtocol, PluginMetadata
+from yosai_intel_dashboard.src.core.protocols.plugin import CallbackPluginProtocol, PluginMetadata
 
 
 @dataclass

--- a/yosai_intel_dashboard/src/adapters/api/plugins/lazystring_fix_plugin.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/lazystring_fix_plugin.py
@@ -7,9 +7,9 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Any
 
-from core.protocols.plugin import PluginMetadata
-from core.serialization import SafeJSONSerializer
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginMetadata
+from yosai_intel_dashboard.src.core.serialization import SafeJSONSerializer
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 # Optional Babel import
 try:

--- a/yosai_intel_dashboard/src/adapters/api/plugins/service_locator.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/service_locator.py
@@ -1,5 +1,5 @@
 """Compatibility wrapper importing :class:`PluginServiceLocator`."""
 
-from core.plugins.service_locator import PluginServiceLocator
+from yosai_intel_dashboard.src.core.plugins.service_locator import PluginServiceLocator
 
 __all__ = ["PluginServiceLocator"]

--- a/yosai_intel_dashboard/src/adapters/api/spec.py
+++ b/yosai_intel_dashboard/src/adapters/api/spec.py
@@ -111,11 +111,11 @@ def create_flask_app() -> Flask:
     """Create a Flask app with all blueprints registered."""
     from api.settings_endpoint import settings_bp
 
-    from core.container import container
-    from services.device_endpoint import create_device_blueprint
-    from services.mappings_endpoint import create_mappings_blueprint
-    from services.token_endpoint import create_token_blueprint
-    from services.upload_endpoint import create_upload_blueprint
+    from yosai_intel_dashboard.src.core.container import container
+    from yosai_intel_dashboard.src.services.device_endpoint import create_device_blueprint
+    from yosai_intel_dashboard.src.services.mappings_endpoint import create_mappings_blueprint
+    from yosai_intel_dashboard.src.services.token_endpoint import create_token_blueprint
+    from yosai_intel_dashboard.src.services.upload_endpoint import create_upload_blueprint
 
     if not os.environ.get("SPEC_STUBS"):
         import api.plugin_performance as plugin_perf

--- a/yosai_intel_dashboard/src/adapters/ui/pages/data_enhancer/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/data_enhancer/callbacks.py
@@ -8,7 +8,7 @@ from dash import Input, Output, State, dash_table, dcc, html
 from dash.exceptions import PreventUpdate
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from services.data_enhancer.processor import DataEnhancerProcessor
+from yosai_intel_dashboard.src.services.data_enhancer.processor import DataEnhancerProcessor
 
 
 def register_callbacks(app, container) -> None:

--- a/yosai_intel_dashboard/src/core/app_factory/health.py
+++ b/yosai_intel_dashboard/src/core/app_factory/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.secret_manager import validate_secrets
+from yosai_intel_dashboard.src.core.secret_manager import validate_secrets
 
 
 def register_health_endpoints(server: Any, progress_events: Any | None = None) -> None:

--- a/yosai_intel_dashboard/src/core/app_factory/plugins.py
+++ b/yosai_intel_dashboard/src/core/app_factory/plugins.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from dash import Dash
 
-from core.plugins.auto_config import PluginAutoConfiguration
+from yosai_intel_dashboard.src.core.plugins.auto_config import PluginAutoConfiguration
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 

--- a/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
@@ -4,7 +4,7 @@ import asyncio
 import time
 from typing import Any, Awaitable, Callable, Optional
 
-from services.resilience.metrics import circuit_breaker_state
+from yosai_intel_dashboard.src.services.resilience.metrics import circuit_breaker_state
 
 
 class CircuitBreakerOpen(Exception):

--- a/yosai_intel_dashboard/src/core/auth.py
+++ b/yosai_intel_dashboard/src/core/auth.py
@@ -24,7 +24,7 @@ from flask_login import (
 )
 from jose import jwt
 
-from config import get_cache_config, get_security_config
+from yosai_intel_dashboard.src.infrastructure.config import get_cache_config, get_security_config
 
 from .secret_manager import SecretsManager
 

--- a/yosai_intel_dashboard/src/core/base_database_service.py
+++ b/yosai_intel_dashboard/src/core/base_database_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from config import DatabaseSettings
+from yosai_intel_dashboard.src.infrastructure.config import DatabaseSettings
 
 
 class BaseDatabaseService:

--- a/yosai_intel_dashboard/src/core/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/core/callbacks/__init__.py
@@ -1,5 +1,5 @@
 """Unified callback utilities."""
 
-from core.truly_unified_callbacks import Operation, TrulyUnifiedCallbacks
+from yosai_intel_dashboard.src.core.truly_unified_callbacks import Operation, TrulyUnifiedCallbacks
 
 __all__ = ["Operation", "TrulyUnifiedCallbacks"]

--- a/yosai_intel_dashboard/src/core/config.py
+++ b/yosai_intel_dashboard/src/core/config.py
@@ -9,7 +9,7 @@ from yosai_intel_dashboard.src.infrastructure.config.utils import (
     get_ai_confidence_threshold as _get_ai_confidence_threshold,
     get_upload_chunk_size as _get_upload_chunk_size,
 )
-from core.container import container
+from yosai_intel_dashboard.src.core.container import container
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints

--- a/yosai_intel_dashboard/src/core/di/decorators.py
+++ b/yosai_intel_dashboard/src/core/di/decorators.py
@@ -4,7 +4,7 @@ import inspect
 from functools import wraps
 from typing import Any, Callable, Optional, Type
 
-from core.container import container as _global_container
+from yosai_intel_dashboard.src.core.container import container as _global_container
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer, ServiceLifetime
 
 # ---------------------------------------------------------------------------

--- a/yosai_intel_dashboard/src/core/domain/entities/access_events.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/access_events.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DataProcessingLimits
-from core.query_optimizer import monitor_query_performance
+from yosai_intel_dashboard.src.core.query_optimizer import monitor_query_performance
 from database.secure_exec import execute_command, execute_query
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
@@ -103,7 +103,7 @@ def get_export_service(
     c = _get_container(container)
     if c and c.has("export_service"):
         return c.get("export_service")
-    import services.export_service as svc
+    import yosai_intel_dashboard.src.services.export_service as svc
 
     return svc
 
@@ -114,7 +114,7 @@ def get_door_mapping_service(
     c = _get_container(container)
     if c and c.has("door_mapping_service"):
         return c.get("door_mapping_service")
-    from services.door_mapping_service import door_mapping_service
+    from yosai_intel_dashboard.src.services.door_mapping_service import door_mapping_service
 
     return door_mapping_service
 
@@ -126,7 +126,7 @@ def get_device_learning_service(
     c = _get_container(container)
     if c and c.has("device_learning_service"):
         return c.get("device_learning_service")
-    from services.device_learning_service import create_device_learning_service
+    from yosai_intel_dashboard.src.services.device_learning_service import create_device_learning_service
 
     return create_device_learning_service()
 
@@ -138,7 +138,7 @@ def get_upload_data_service(
     c = _get_container(container)
     if c and c.has("upload_data_service"):
         return c.get("upload_data_service")
-    from services.upload_data_service import UploadDataService as UploadDataSvc
+    from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService as UploadDataSvc
     from yosai_intel_dashboard.src.utils.upload_store import uploaded_data_store
 
     return UploadDataSvc(uploaded_data_store)
@@ -278,6 +278,6 @@ def get_database_analytics_retriever(
     c = _get_container(container)
     if c and c.has("database_analytics_retriever"):
         return c.get("database_analytics_retriever")
-    from services.database_retriever import DatabaseAnalyticsRetriever
+    from yosai_intel_dashboard.src.services.database_retriever import DatabaseAnalyticsRetriever
 
     return DatabaseAnalyticsRetriever(helper)

--- a/yosai_intel_dashboard/src/core/json_serialization_plugin.py
+++ b/yosai_intel_dashboard/src/core/json_serialization_plugin.py
@@ -13,8 +13,8 @@ from typing import Any, Dict, Optional, cast
 
 import pandas as pd
 
-from core.protocols.plugin import PluginMetadata
-from core.serialization import SafeJSONSerializer
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginMetadata
+from yosai_intel_dashboard.src.core.serialization import SafeJSONSerializer
 
 from .base_model import BaseModel
 

--- a/yosai_intel_dashboard/src/core/monitoring/performance_analytics.py
+++ b/yosai_intel_dashboard/src/core/monitoring/performance_analytics.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from core.base_model import BaseModel
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 
 
 class PerformanceAnalytics(BaseModel):

--- a/yosai_intel_dashboard/src/core/monitoring/performance_budget_system.py
+++ b/yosai_intel_dashboard/src/core/monitoring/performance_budget_system.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 
 from .user_experience_metrics import AlertDispatcher
 

--- a/yosai_intel_dashboard/src/core/monitoring/real_time_performance_tracker.py
+++ b/yosai_intel_dashboard/src/core/monitoring/real_time_performance_tracker.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, Optional
 
 import psutil
 
-from core.base_model import BaseModel
-from core.performance import MetricType, get_performance_monitor
+from yosai_intel_dashboard.src.core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 
 
 @dataclass

--- a/yosai_intel_dashboard/src/core/plugins/auto_config.py
+++ b/yosai_intel_dashboard/src/core/plugins/auto_config.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 from dash import Dash
 
-from config import ConfigManager, create_config_manager
+from yosai_intel_dashboard.src.infrastructure.config import ConfigManager, create_config_manager
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 from .unified_registry import UnifiedPluginRegistry

--- a/yosai_intel_dashboard/src/core/plugins/base.py
+++ b/yosai_intel_dashboard/src/core/plugins/base.py
@@ -9,7 +9,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
-from core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 from .protocols import PluginMetadata, PluginProtocol, PluginStatus
 

--- a/yosai_intel_dashboard/src/core/plugins/config/__init__.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/__init__.py
@@ -1,7 +1,7 @@
 """Minimal plugin config compatibility"""
 
 # Re-export from unified configuration for compatibility
-from config import ConfigManager, get_config
+from yosai_intel_dashboard.src.infrastructure.config import ConfigManager, get_config
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager
 
 

--- a/yosai_intel_dashboard/src/core/plugins/config/factories.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/factories.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Type
 
-from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
+from yosai_intel_dashboard.src.core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 
 from .interfaces import ICacheManager, IDatabaseManager
 

--- a/yosai_intel_dashboard/src/core/plugins/decorators.py
+++ b/yosai_intel_dashboard/src/core/plugins/decorators.py
@@ -5,7 +5,7 @@ import logging
 from functools import wraps
 from typing import Any, Callable, Optional
 
-from core.unicode import sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import sanitize_for_utf8
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/core/plugins/dependency_resolver.py
+++ b/yosai_intel_dashboard/src/core/plugins/dependency_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import DefaultDict, Dict, List, Set
 
-from core.protocols.plugin import PluginProtocol
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginProtocol
 
 
 class CircularDependencyError(ValueError):

--- a/yosai_intel_dashboard/src/core/plugins/manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/manager.py
@@ -8,9 +8,9 @@ import threading
 import time
 from typing import Any, Dict, List
 
-from config import ConfigManager
+from yosai_intel_dashboard.src.infrastructure.config import ConfigManager
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.protocols.plugin import (
+from yosai_intel_dashboard.src.core.protocols.plugin import (
     CallbackPluginProtocol,
     PluginPriority,
     PluginProtocol,

--- a/yosai_intel_dashboard/src/core/plugins/performance_manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/performance_manager.py
@@ -8,8 +8,8 @@ import time
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
-from core.base_model import BaseModel
-from core.protocols.plugin import PluginProtocol
+from yosai_intel_dashboard.src.core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginProtocol
 
 from .manager import ThreadSafePluginManager
 

--- a/yosai_intel_dashboard/src/core/plugins/service_locator.py
+++ b/yosai_intel_dashboard/src/core/plugins/service_locator.py
@@ -14,7 +14,7 @@ class _LocatorMeta(type):
         if name == "get_unicode_handler":
             warnings.warn(
                 "PluginServiceLocator.get_unicode_handler() is deprecated; "
-                "import from core.unicode instead",
+                "import from yosai_intel_dashboard.src.core.unicode instead",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -61,7 +61,7 @@ class PluginServiceLocator(metaclass=_LocatorMeta):
     @classmethod
     def _load_json_plugin(cls) -> Optional[Any]:
         try:
-            from core.json_serialization_plugin import quick_start
+            from yosai_intel_dashboard.src.core.json_serialization_plugin import quick_start
         except Exception as exc:  # pragma: no cover - optional
             logger.warning(f"JSON serialization plugin unavailable: {exc}")
             return None
@@ -131,7 +131,7 @@ def __getattr__(name: str):
     if name == "get_unicode_handler":
         warnings.warn(
             "plugins.service_locator.get_unicode_handler() is deprecated; "
-            "import from core.unicode instead",
+            "import from yosai_intel_dashboard.src.core.unicode instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/yosai_intel_dashboard/src/core/plugins/unified_registry.py
+++ b/yosai_intel_dashboard/src/core/plugins/unified_registry.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from dash import Dash
 
-from config import ConfigManager
+from yosai_intel_dashboard.src.infrastructure.config import ConfigManager
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.plugins.manager import ThreadSafePluginManager
-from core.protocols.plugin import PluginProtocol
+from yosai_intel_dashboard.src.core.plugins.manager import ThreadSafePluginManager
+from yosai_intel_dashboard.src.core.protocols.plugin import PluginProtocol
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from services.registry import registry as service_registry
+from yosai_intel_dashboard.src.services.registry import registry as service_registry
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks

--- a/yosai_intel_dashboard/src/core/profiling/callback_profiler.py
+++ b/yosai_intel_dashboard/src/core/profiling/callback_profiler.py
@@ -5,7 +5,7 @@ import logging
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-from core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 
 class CallbackProfiler(BaseModel):

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -487,6 +487,6 @@ def get_unicode_processor(
     c = _get_container(container)
     if c and c.has("unicode_processor"):
         return c.get("unicode_processor")
-    from core.unicode import UnicodeProcessor
+    from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor
 
     return UnicodeProcessor()

--- a/yosai_intel_dashboard/src/core/rbac.py
+++ b/yosai_intel_dashboard/src/core/rbac.py
@@ -83,7 +83,7 @@ class RBACService:
 # Helper factory ---------------------------------------------------------------
 async def create_rbac_service() -> RBACService:
     """Create and initialize :class:`RBACService` using app configuration."""
-    from config import get_database_config
+    from yosai_intel_dashboard.src.infrastructure.config import get_database_config
 
     db_cfg = get_database_config()
     pool = await asyncpg.create_pool(dsn=db_cfg.get_connection_string())

--- a/yosai_intel_dashboard/src/core/secret_manager.py
+++ b/yosai_intel_dashboard/src/core/secret_manager.py
@@ -64,7 +64,7 @@ class SecretsManager:
 
 def validate_secrets(manager: Optional[SecretsManager] = None) -> dict[str, Any]:
     """Return summary of required secrets presence using the provided manager."""
-    from config import get_config
+    from yosai_intel_dashboard.src.infrastructure.config import get_config
 
     manager = manager or SecretsManager()
     config = get_config()

--- a/yosai_intel_dashboard/src/core/secrets_validator.py
+++ b/yosai_intel_dashboard/src/core/secrets_validator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, Optional
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .secret_manager import SecretsManager
 

--- a/yosai_intel_dashboard/src/core/security.py
+++ b/yosai_intel_dashboard/src/core/security.py
@@ -13,7 +13,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 # Import the high-level ``SecurityValidator`` used across the application.
 # This module keeps no internal validation logic and instead delegates to

--- a/yosai_intel_dashboard/src/core/serialization/safe_json.py
+++ b/yosai_intel_dashboard/src/core/serialization/safe_json.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 try:  # Optional Flask-Babel
     from flask_babel import LazyString

--- a/yosai_intel_dashboard/src/core/storage/database_storage.py
+++ b/yosai_intel_dashboard/src/core/storage/database_storage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 from .protocols import DatabaseStorageProtocol
 

--- a/yosai_intel_dashboard/src/core/theme_manager.py
+++ b/yosai_intel_dashboard/src/core/theme_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Set
 
-from core.unicode import sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_unicode_input
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/database/connection.py
+++ b/yosai_intel_dashboard/src/database/connection.py
@@ -28,7 +28,7 @@ class DatabaseConnection(Protocol):
 def create_database_connection() -> DatabaseConnection:
     """Create database connection using existing DatabaseManager"""
     # Use your existing database manager
-    from config import get_config
+    from yosai_intel_dashboard.src.infrastructure.config import get_config
 
     config_manager = get_config()
     db_config = config_manager.get_database_config()

--- a/yosai_intel_dashboard/src/file_processing/data_processor.py
+++ b/yosai_intel_dashboard/src/file_processing/data_processor.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.error_handling import (
+from yosai_intel_dashboard.src.core.error_handling import (
     ErrorCategory,
     ErrorSeverity,
     with_error_handling,
@@ -217,7 +217,7 @@ class DataProcessor:
         Validate DataFrame against a Pandera schema (core/schemas.py),
         log all violations as warnings, then return df unchanged.
         """
-        from core.schemas import AccessLogSchema
+        from yosai_intel_dashboard.src.core.schemas import AccessLogSchema
 
         try:
             AccessLogSchema.validate(df, lazy=True)

--- a/yosai_intel_dashboard/src/file_processing/exporter.py
+++ b/yosai_intel_dashboard/src/file_processing/exporter.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.container import get_unicode_processor
+from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 from .column_mapper import REQUIRED_COLUMNS

--- a/yosai_intel_dashboard/src/file_processing/format_detector.py
+++ b/yosai_intel_dashboard/src/file_processing/format_detector.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.container import get_unicode_processor
+from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 

--- a/yosai_intel_dashboard/src/file_processing/readers/base.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/base.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 import pandas as pd
 
-from core.container import get_unicode_processor
+from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 

--- a/yosai_intel_dashboard/src/file_processing/utils.py
+++ b/yosai_intel_dashboard/src/file_processing/utils.py
@@ -10,9 +10,9 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.config import get_max_display_rows
-from core.performance_file_processor import PerformanceFileProcessor
-from core.unicode import (
+from yosai_intel_dashboard.src.core.config import get_max_display_rows
+from yosai_intel_dashboard.src.core.performance_file_processor import PerformanceFileProcessor
+from yosai_intel_dashboard.src.core.unicode import (
     UnicodeProcessor,
     safe_format_number,
     safe_unicode_decode,

--- a/yosai_intel_dashboard/src/infrastructure/communication/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/communication/__init__.py
@@ -1,4 +1,4 @@
-from services.resilience.circuit_breaker import CircuitBreaker
+from yosai_intel_dashboard.src.services.resilience.circuit_breaker import CircuitBreaker
 
 from .message_queue import AsyncQueueClient
 from .protocols import MessageBus, ServiceClient

--- a/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
+++ b/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
@@ -12,7 +12,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from services.resilience.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+from yosai_intel_dashboard.src.services.resilience.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
 
 from .protocols import ServiceClient
 

--- a/yosai_intel_dashboard/src/infrastructure/config/base.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base.py
@@ -7,7 +7,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .app_config import UploadConfig
 from .cache_config import CacheConfig

--- a/yosai_intel_dashboard/src/infrastructure/config/base_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base_loader.py
@@ -62,7 +62,7 @@ class BaseConfigLoader:
     def _sanitize(self, obj: Any) -> Any:
         if isinstance(obj, str):
             try:
-                from core.unicode import UnicodeSQLProcessor
+                from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
 
                 return UnicodeSQLProcessor.encode_query(obj)
             except Exception:

--- a/yosai_intel_dashboard/src/infrastructure/config/cache_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/cache_config.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 
 @dataclass

--- a/yosai_intel_dashboard/src/infrastructure/config/cache_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/cache_manager.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
+from yosai_intel_dashboard.src.core.intelligent_multilevel_cache import IntelligentMultiLevelCache
 
 from .constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 

--- a/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import ValidationError
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 from .base import CacheConfig, Config

--- a/yosai_intel_dashboard/src/infrastructure/config/config_transformer.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_transformer.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .base import Config
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .env_overrides import apply_env_overrides
 from .protocols import ConfigTransformerProtocol

--- a/yosai_intel_dashboard/src/infrastructure/config/config_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_validator.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List
 
 import jsonschema
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .protocols import ConfigValidatorProtocol
 

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from core.unicode import UnicodeSQLProcessor
+from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
 from database.query_optimizer import DatabaseQueryOptimizer
 from database.secure_exec import execute_command, execute_query
 from database.types import DatabaseConnection

--- a/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError
 from cryptography.fernet import Fernet
 from pydantic import BaseModel
 
-from core.exceptions import ConfigurationError
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .config_manager import ConfigManager
 

--- a/yosai_intel_dashboard/src/infrastructure/config/secure_db.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secure_db.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from core.unicode import UnicodeSQLProcessor
+from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
 from database.secure_exec import execute_secure_query as _exec_secure_query
 
 __all__ = ["execute_secure_query"]

--- a/yosai_intel_dashboard/src/infrastructure/config/service_integration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/service_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.container import container
+from yosai_intel_dashboard.src.core.container import container
 
 # Lazy import to avoid circular dependencies during module import
 def get_service_registry():

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable
 
-from core.container import get_unicode_processor
+from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
 
 from .unicode_processor import (

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -7,10 +7,10 @@ import unicodedata
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from core.container import get_unicode_processor
+from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
-from core.unicode import UnicodeProcessor as UnicodeHelper
-from core.unicode import contains_surrogates
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor as UnicodeHelper
+from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 from security.events import SecurityEvent, emit_security_event
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
+++ b/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from flask import Flask, jsonify
 from werkzeug.exceptions import HTTPException
 
-from core.exceptions import YosaiBaseException
+from yosai_intel_dashboard.src.core.exceptions import YosaiBaseException
 from shared.errors.types import ErrorCode
 
 from ...core.error_handling import ErrorCategory, ErrorSeverity, error_handler

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
 
 def __getattr__(name: str):
     if name == "PerformanceMonitor":
-        from core.performance import PerformanceMonitor
+        from yosai_intel_dashboard.src.core.performance import PerformanceMonitor
 
         return PerformanceMonitor
     if name in {

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/data_quality_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/data_quality_monitor.py
@@ -42,7 +42,7 @@ else:  # pragma: no cover - runtime import for tests
 
 
 try:  # pragma: no cover - optional dependency
-    from config import get_monitoring_config
+    from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
 except Exception:  # pragma: no cover - minimal fallback for tests
 
     def get_monitoring_config() -> dict:
@@ -51,8 +51,8 @@ except Exception:  # pragma: no cover - minimal fallback for tests
 
 # Local imports are deferred to avoid heavy dependencies during module import
 if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from core.monitoring.user_experience_metrics import AlertConfig, AlertDispatcher
-    from core.performance import MetricType
+    from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import AlertConfig, AlertDispatcher
+    from yosai_intel_dashboard.src.core.performance import MetricType
 
 
 @dataclass
@@ -87,7 +87,7 @@ class DataQualityMonitor:
 
         alert_cfg = getattr(cfg, "alerting", {})
         if isinstance(alert_cfg, dict):
-            from core.monitoring.user_experience_metrics import AlertConfig
+            from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import AlertConfig
 
             ac = AlertConfig(
                 slack_webhook=alert_cfg.get("slack_webhook"),
@@ -95,14 +95,14 @@ class DataQualityMonitor:
                 webhook_url=alert_cfg.get("webhook_url"),
             )
         else:
-            from core.monitoring.user_experience_metrics import AlertConfig
+            from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import AlertConfig
 
             ac = AlertConfig(
                 slack_webhook=getattr(alert_cfg, "slack_webhook", None),
                 email=getattr(alert_cfg, "email", None),
                 webhook_url=getattr(alert_cfg, "webhook_url", None),
             )
-        from core.monitoring.user_experience_metrics import AlertDispatcher
+        from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import AlertDispatcher
 
         self.dispatcher = dispatcher or AlertDispatcher(ac)
         self._avro_failures = 0
@@ -111,7 +111,7 @@ class DataQualityMonitor:
     # ------------------------------------------------------------------
     def emit(self, metrics: DataQualityMetrics) -> None:
         """Record metrics and send alerts if thresholds are exceeded."""
-        from core.performance import MetricType, get_performance_monitor
+        from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 
         monitor = get_performance_monitor()
         monitor.record_metric(

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/inference_drift_job.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/inference_drift_job.py
@@ -6,9 +6,9 @@ import threading
 from statistics import mean
 from typing import Optional
 
-from config import get_monitoring_config
-from core.monitoring.user_experience_metrics import AlertConfig, AlertDispatcher
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
+from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import AlertConfig, AlertDispatcher
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from monitoring.model_performance_monitor import ModelMetrics
 from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
 

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from typing import Optional
 
-from config import get_monitoring_config
+from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
 from monitoring.model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_monitor.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
-from core.performance import MetricType, get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 from monitoring.prometheus.model_metrics import (
     start_model_metrics_server,
     update_model_metrics,

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/ui_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/ui_monitor.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from core.performance import MetricType, get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 
 
 @dataclass

--- a/yosai_intel_dashboard/src/infrastructure/security/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/__init__.py
@@ -4,7 +4,7 @@ This package provides unified security validation through SecurityValidator.
 All deprecated individual validators have been removed and consolidated.
 """
 
-from core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
 from .attack_detection import AttackDetection
 from .secrets_validator import SecretsValidator, register_health_endpoint

--- a/yosai_intel_dashboard/src/infrastructure/security/business_logic_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/business_logic_validator.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
 
 class BusinessLogicValidator:

--- a/yosai_intel_dashboard/src/infrastructure/security/ml_threat_detection.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/ml_threat_detection.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, List
 
-from core.security import SecurityLevel, security_auditor
+from yosai_intel_dashboard.src.core.security import SecurityLevel, security_auditor
 from security.events import SecurityEvent, emit_security_event
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/infrastructure/security/secrets_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/secrets_validator.py
@@ -3,12 +3,12 @@ import re
 from collections import Counter
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
-from core.flask_protocol import FlaskProtocol
+from yosai_intel_dashboard.src.core.flask_protocol import FlaskProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - optional Flask dependency
     from flask import Flask
 
-from core.secret_manager import SecretsManager
+from yosai_intel_dashboard.src.core.secret_manager import SecretsManager
 
 
 class SecretsValidator:

--- a/yosai_intel_dashboard/src/infrastructure/security/secure_query_wrapper.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/secure_query_wrapper.py
@@ -16,7 +16,7 @@ def execute_secure_sql(
     """Safely execute a read query using parameterization."""
     if not isinstance(query, str):
         raise TypeError("query must be a string")
-    from core.unicode import UnicodeSQLProcessor, clean_unicode_surrogates
+    from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor, clean_unicode_surrogates
 
     sanitized_query = UnicodeSQLProcessor.encode_query(query)
     sanitized_params = None
@@ -39,7 +39,7 @@ def execute_secure_command(
     """Safely execute an INSERT/UPDATE/DELETE using parameterization."""
     if not isinstance(command, str):
         raise TypeError("command must be a string")
-    from core.unicode import UnicodeSQLProcessor, clean_unicode_surrogates
+    from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor, clean_unicode_surrogates
 
     sanitized_cmd = UnicodeSQLProcessor.encode_query(command)
     sanitized_params = None

--- a/yosai_intel_dashboard/src/infrastructure/security/unicode_security_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/unicode_security_handler.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pandas as pd
 
-from core.unicode import sanitize_dataframe, sanitize_unicode_input
+from yosai_intel_dashboard.src.core.unicode import sanitize_dataframe, sanitize_unicode_input
 
 
 class UnicodeSecurityHandler:

--- a/yosai_intel_dashboard/src/infrastructure/security/unicode_security_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/unicode_security_validator.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from core.exceptions import SecurityError
+from yosai_intel_dashboard.src.core.exceptions import SecurityError
 
 
 class SecurityThreatLevel(Enum):

--- a/yosai_intel_dashboard/src/infrastructure/security/unicode_surrogate_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/unicode_surrogate_validator.py
@@ -6,8 +6,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from core.exceptions import ValidationError
-from core.unicode import contains_surrogates
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 from security.events import SecurityEvent, emit_security_event
 
 

--- a/yosai_intel_dashboard/src/infrastructure/security/validation_exceptions.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/validation_exceptions.py
@@ -1,6 +1,6 @@
 """Custom security-related exceptions and helpers."""
 
-from core.exceptions import ValidationError as CoreValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError as CoreValidationError
 
 
 class SecurityViolation(Exception):

--- a/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
@@ -7,7 +7,7 @@ from flask import Response, request
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
 from validation.security_validator import SecurityValidator
 
 
@@ -73,7 +73,7 @@ class ValidationMiddleware:
             ):
                 return None
             try:
-                from core.unicode import safe_unicode_decode, sanitize_for_utf8
+                from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode, sanitize_for_utf8
 
                 raw_text = safe_unicode_decode(request.data, "utf-8")
                 sanitized = sanitize_for_utf8(raw_text)

--- a/yosai_intel_dashboard/src/infrastructure/security/xss_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/xss_validator.py
@@ -2,7 +2,7 @@
 
 import html
 
-from core.exceptions import ValidationError
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
 
 class XSSPrevention:

--- a/yosai_intel_dashboard/src/mapping/factories/service_factory.py
+++ b/yosai_intel_dashboard/src/mapping/factories/service_factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from core.container import container as default_container
+from yosai_intel_dashboard.src.core.container import container as default_container
 from mapping.models import (
     HeuristicMappingModel,
     MappingModel,
@@ -15,13 +15,13 @@ from mapping.service import MappingService
 from mapping.storage.base import JsonStorage, MemoryStorage
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
-    from services.learning.src.api.coordinator import LearningCoordinator
+    from yosai_intel_dashboard.src.services.learning.src.api.coordinator import LearningCoordinator
 
 
 def create_learning_service(
     path: str | None = None, in_memory: bool = False
 ) -> "LearningCoordinator":
-    from services.learning.src.api.coordinator import LearningCoordinator
+    from yosai_intel_dashboard.src.services.learning.src.api.coordinator import LearningCoordinator
 
     storage = (
         MemoryStorage()

--- a/yosai_intel_dashboard/src/mapping/metrics.py
+++ b/yosai_intel_dashboard/src/mapping/metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 
 
 def get_mapping_accuracy_summary() -> Dict[str, Any]:

--- a/yosai_intel_dashboard/src/mapping/models/base.py
+++ b/yosai_intel_dashboard/src/mapping/models/base.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Tuple
 import pandas as pd
 import yaml
 
-from core.performance import MetricType, get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 
 
 class MappingModel(ABC):

--- a/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from core.container import container as default_container
+from yosai_intel_dashboard.src.core.container import container as default_container
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from mapping.models import HeuristicMappingModel, MappingModel
 

--- a/yosai_intel_dashboard/src/mapping/processors/column_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/column_processor.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pandas as pd
 
-from core.container import container as default_container
+from yosai_intel_dashboard.src.core.container import container as default_container
 from mapping.core.interfaces import ProcessorInterface
 from mapping.core.models import ProcessingResult
 from mapping.helpers import map_and_clean

--- a/yosai_intel_dashboard/src/models/__init__.py
+++ b/yosai_intel_dashboard/src/models/__init__.py
@@ -3,7 +3,7 @@
 Simplified Models Package
 """
 
-from core.container import container
+from yosai_intel_dashboard.src.core.container import container
 
 from .entities import Door, Facility, Person
 

--- a/yosai_intel_dashboard/src/models/ml/base_model.py
+++ b/yosai_intel_dashboard/src/models/ml/base_model.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 import joblib
 from packaging.version import Version
 
-from core.unicode import clean_unicode_text, contains_surrogates
+from yosai_intel_dashboard.src.core.unicode import clean_unicode_text, contains_surrogates
 from monitoring.model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,

--- a/yosai_intel_dashboard/src/models/ml/model_registry.py
+++ b/yosai_intel_dashboard/src/models/ml/model_registry.py
@@ -238,7 +238,7 @@ class ModelRegistry:
         current = self._latest_features.get(name)
         if base is None or current is None:
             return {}
-        from services.monitoring.drift import compute_psi
+        from yosai_intel_dashboard.src.services.monitoring.drift import compute_psi
 
         return compute_psi(base, current, bins=bins)
 

--- a/yosai_intel_dashboard/src/models/performance_settings.py
+++ b/yosai_intel_dashboard/src/models/performance_settings.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List
 from sqlalchemy import Column, DateTime, Integer, String, Text
 from sqlalchemy.orm import declarative_base
 
-from core.plugins.config.cache_manager import MemoryCacheManager
-from core.plugins.config.interfaces import ICacheManager, IDatabaseManager
+from yosai_intel_dashboard.src.core.plugins.config.cache_manager import MemoryCacheManager
+from yosai_intel_dashboard.src.core.plugins.config.interfaces import ICacheManager, IDatabaseManager
 from database.secure_exec import execute_query
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/__init__.py
+++ b/yosai_intel_dashboard/src/services/__init__.py
@@ -32,7 +32,7 @@ else:
     from .helpers.database_initializer import initialize_database
     from .microservices_architect import MicroservicesArchitect, ServiceBoundary
     from .publishing_service import PublishingService
-    from core.container import container
+    from yosai_intel_dashboard.src.core.container import container
     from .report_generation_service import ReportGenerationService
     from .result_formatting import (
         apply_regular_analysis,

--- a/yosai_intel_dashboard/src/services/ai_suggestions.py
+++ b/yosai_intel_dashboard/src/services/ai_suggestions.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Sequence
 
-from services.data_enhancer.mapping_utils import get_ai_column_suggestions
+from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import get_ai_column_suggestions
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/analytics/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_service.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, NamedTuple, Protocol
 
 import requests
 
-from core.error_handling import (
+from yosai_intel_dashboard.src.core.error_handling import (
     ErrorCategory,
     ErrorSeverity,
     with_error_handling,
@@ -31,9 +31,9 @@ except ImportError:  # pragma: no cover - for Python <3.12
 
 import pandas as pd
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
-from core.di_decorators import inject, injectable
-from core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+from yosai_intel_dashboard.src.core.di_decorators import inject, injectable
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
 from yosai_intel_dashboard.src.core.interfaces.protocols import (
     AnalyticsServiceProtocol,
     DatabaseProtocol,
@@ -51,11 +51,11 @@ from yosai_intel_dashboard.src.services.analytics.protocols import (
 )
 from yosai_intel_dashboard.src.services.analytics.publisher import Publisher
 from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.analytics_summary import generate_sample_analytics
-from services.controllers.protocols import UploadProcessingControllerProtocol
-from services.controllers.upload_controller import UploadProcessingController
+from yosai_intel_dashboard.src.services.analytics_summary import generate_sample_analytics
+from yosai_intel_dashboard.src.services.controllers.protocols import UploadProcessingControllerProtocol
+from yosai_intel_dashboard.src.services.controllers.upload_controller import UploadProcessingController
 from yosai_intel_dashboard.src.services.data_processing.processor import Processor
-from services.helpers.database_initializer import initialize_database
+from yosai_intel_dashboard.src.services.helpers.database_initializer import initialize_database
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     AnalyticsDataLoaderProtocol,
     DatabaseAnalyticsRetrieverProtocol,
@@ -63,8 +63,8 @@ from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     get_database_analytics_retriever,
     get_upload_data_service,
 )
-from services.protocols import UploadDataServiceProtocol
-from services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.protocols import UploadDataServiceProtocol
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
 from validation.security_validator import SecurityValidator
 from yosai_intel_dashboard.models.ml import ModelRegistry
 

--- a/yosai_intel_dashboard/src/services/analytics/async_api.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_api.py
@@ -20,15 +20,15 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.types import ASGIApp
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager
-from core.events import EventBus
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager
+from yosai_intel_dashboard.src.core.events import EventBus
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.services.analytics.analytics_service import get_analytics_service
-from services.cached_analytics import CachedAnalyticsService
-from services.common.async_db import get_pool
-from services.security import require_permission
-from services.summary_report_generator import SummaryReportGenerator
-from services.websocket_server import AnalyticsWebSocketServer
+from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsService
+from yosai_intel_dashboard.src.services.common.async_db import get_pool
+from yosai_intel_dashboard.src.services.security import require_permission
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.websocket_server import AnalyticsWebSocketServer
 from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
     register_health_check,
     setup_health_checks,

--- a/yosai_intel_dashboard/src/services/analytics/async_repository.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_repository.py
@@ -12,8 +12,8 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from config import get_database_config
-from services.timescale.models import AccessEvent, Base
+from yosai_intel_dashboard.src.infrastructure.config import get_database_config
+from yosai_intel_dashboard.src.services.timescale.models import AccessEvent, Base
 
 # ---------------------------------------------------------------------------
 # Engine and session factory

--- a/yosai_intel_dashboard/src/services/analytics/async_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_service.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Protocol
 
 import asyncpg
 
-from core.cache_manager import CacheConfig, RedisCacheManager
-from core.error_handling import with_async_error_handling
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, RedisCacheManager
+from yosai_intel_dashboard.src.core.error_handling import with_async_error_handling
 
 from .common_queries import fetch_access_patterns, fetch_dashboard_summary
 

--- a/yosai_intel_dashboard/src/services/analytics/async_workers.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_workers.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from typing import Awaitable, Callable, Optional
 
-from core.advanced_cache import AdvancedCacheManager, create_advanced_cache_manager
+from yosai_intel_dashboard.src.core.advanced_cache import AdvancedCacheManager, create_advanced_cache_manager
 
 # Optional async queue integrations
 try:

--- a/yosai_intel_dashboard/src/services/analytics/cached_analytics.py
+++ b/yosai_intel_dashboard/src/services/analytics/cached_analytics.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict
 
-from core.cache_manager import CacheManager
+from yosai_intel_dashboard.src.core.cache_manager import CacheManager
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
-from services.analytics_summary import generate_sample_analytics
+from yosai_intel_dashboard.src.services.analytics_summary import generate_sample_analytics
 
 
 class CachedAnalyticsService:

--- a/yosai_intel_dashboard/src/services/analytics/calculator.py
+++ b/yosai_intel_dashboard/src/services/analytics/calculator.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
-from services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
 
 
 class Calculator:

--- a/yosai_intel_dashboard/src/services/analytics/core/exceptions.py
+++ b/yosai_intel_dashboard/src/services/analytics/core/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Analytics domain specific exceptions."""
 
-from core.exceptions import YosaiBaseException
+from yosai_intel_dashboard.src.core.exceptions import YosaiBaseException
 
 
 class AnalyticsError(YosaiBaseException):

--- a/yosai_intel_dashboard/src/services/analytics/data/loader.py
+++ b/yosai_intel_dashboard/src/services/analytics/data/loader.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
-from services.controllers.upload_controller import UploadProcessingController
+from yosai_intel_dashboard.src.services.controllers.upload_controller import UploadProcessingController
 from yosai_intel_dashboard.src.services.data_processing.processor import Processor
-from core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/analytics/database_analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/database_analytics_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
 from database.secure_exec import execute_query
 
 _cache_manager = InMemoryCacheManager(CacheConfig())

--- a/yosai_intel_dashboard/src/services/analytics/events/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/events/publisher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
-from services.event_publisher import publish_event
+from yosai_intel_dashboard.src.services.event_publisher import publish_event
 
 
 class Publisher:

--- a/yosai_intel_dashboard/src/services/analytics/generator.py
+++ b/yosai_intel_dashboard/src/services/analytics/generator.py
@@ -7,8 +7,8 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 
-from config import get_cache_config
-from core.cache_manager import (
+from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
+from yosai_intel_dashboard.src.core.cache_manager import (
     CacheConfig,
     InMemoryCacheManager,
     cache_with_lock,

--- a/yosai_intel_dashboard/src/services/analytics/processing/calculator.py
+++ b/yosai_intel_dashboard/src/services/analytics/processing/calculator.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
-from services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
 
 
 class Calculator:

--- a/yosai_intel_dashboard/src/services/analytics/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/publisher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
-from services.event_publisher import publish_event
+from yosai_intel_dashboard.src.services.event_publisher import publish_event
 
 
 class Publisher:

--- a/yosai_intel_dashboard/src/services/analytics/storage/cache.py
+++ b/yosai_intel_dashboard/src/services/analytics/storage/cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Caching helpers for analytics storage."""
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
 
 _cache_manager = InMemoryCacheManager(CacheConfig())
 

--- a/yosai_intel_dashboard/src/services/analytics/storage/persistence.py
+++ b/yosai_intel_dashboard/src/services/analytics/storage/persistence.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Tuple
 
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseSettings
 
-from services.helpers.database_initializer import initialize_database
+from yosai_intel_dashboard.src.services.helpers.database_initializer import initialize_database
 
 
 class PersistenceManager:

--- a/yosai_intel_dashboard/src/services/analytics/storage/repository.py
+++ b/yosai_intel_dashboard/src/services/analytics/storage/repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from services.db_analytics_helper import DatabaseAnalyticsHelper
+from yosai_intel_dashboard.src.services.db_analytics_helper import DatabaseAnalyticsHelper
 
 
 class AnalyticsRepository:

--- a/yosai_intel_dashboard/src/services/analytics/timescale_queries.py
+++ b/yosai_intel_dashboard/src/services/analytics/timescale_queries.py
@@ -10,7 +10,7 @@ from cachetools import LRUCache
 from sqlalchemy import text
 from sqlalchemy.sql import TextClause
 
-from core.query_optimizer import monitor_query_performance
+from yosai_intel_dashboard.src.core.query_optimizer import monitor_query_performance
 
 # Cache for compiled query plans
 _QUERY_PLAN_CACHE: LRUCache[Tuple[Any, ...], TextClause] = LRUCache(maxsize=64)

--- a/yosai_intel_dashboard/src/services/analytics/upload_analytics.py
+++ b/yosai_intel_dashboard/src/services/analytics/upload_analytics.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from services.analytics_summary import summarize_dataframe
-from services.chunked_analysis import analyze_with_chunking
-from services.upload_processing import (
+from yosai_intel_dashboard.src.services.analytics_summary import summarize_dataframe
+from yosai_intel_dashboard.src.services.chunked_analysis import analyze_with_chunking
+from yosai_intel_dashboard.src.services.upload_processing import (
     UploadAnalyticsProcessor as _UploadAnalyticsProcessor,
 )
 from validation.data_validator import DataValidator, DataValidatorProtocol

--- a/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import asyncpg
 import redis.asyncio as aioredis
 
-from services.common.async_db import close_pool
+from yosai_intel_dashboard.src.services.common.async_db import close_pool
 from yosai_intel_dashboard.models.ml import ModelRegistry
 
 

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -26,23 +26,23 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
-from config import get_database_config
+from yosai_intel_dashboard.src.infrastructure.config import get_database_config
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 from yosai_intel_dashboard.src.infrastructure.config.config_loader import load_service_config
-from core.security import RateLimiter
+from yosai_intel_dashboard.src.core.security import RateLimiter
 from yosai_intel_dashboard.src.error_handling import http_error
-from services.analytics_microservice import async_queries
-from services.analytics_microservice.analytics_service import (
+from yosai_intel_dashboard.src.services.analytics_microservice import async_queries
+from yosai_intel_dashboard.src.services.analytics_microservice.analytics_service import (
     AnalyticsService,
     get_analytics_service,
 )
-from services.analytics_microservice.unicode_middleware import (
+from yosai_intel_dashboard.src.services.analytics_microservice.unicode_middleware import (
     UnicodeSanitizationMiddleware,
 )
-from services.auth import verify_jwt_token
-from services.common import async_db
-from services.common.async_db import close_pool, create_pool
-from services.common.secrets import get_secret
+from yosai_intel_dashboard.src.services.auth import verify_jwt_token
+from yosai_intel_dashboard.src.services.common import async_db
+from yosai_intel_dashboard.src.services.common.async_db import close_pool, create_pool
+from yosai_intel_dashboard.src.services.common.secrets import get_secret
 from shared.errors.types import ErrorCode
 from yosai_framework import ServiceBuilder
 from yosai_framework.errors import ServiceError

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
@@ -455,7 +455,7 @@ async def test_unauthorized_request():
 @pytest.mark.asyncio
 async def test_internal_error_response():
     module, queries_stub, _ = load_app()
-    from services.auth import verify_jwt_token
+    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
 
     queries_stub.fetch_dashboard_summary.side_effect = RuntimeError("boom")
     token = jwt.encode(

--- a/yosai_intel_dashboard/src/services/auth.py
+++ b/yosai_intel_dashboard/src/services/auth.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, status
 
-from services.security.jwt_service import verify_service_jwt
+from yosai_intel_dashboard.src.services.security.jwt_service import verify_service_jwt
 
 
 def verify_jwt_token(token: str) -> dict:

--- a/yosai_intel_dashboard/src/services/base_database_service.py
+++ b/yosai_intel_dashboard/src/services/base_database_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-from core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 
 class BaseDatabaseService(BaseModel):

--- a/yosai_intel_dashboard/src/services/controllers/upload_controller.py
+++ b/yosai_intel_dashboard/src/services/controllers/upload_controller.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from core.di_decorators import inject, injectable
+from yosai_intel_dashboard.src.core.di_decorators import inject, injectable
 from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
-from services.protocols.processor import ProcessorProtocol
+from yosai_intel_dashboard.src.services.protocols.processor import ProcessorProtocol
 from yosai_intel_dashboard.src.services.upload.protocols import UploadAnalyticsProtocol
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import UploadDataServiceProtocol
 from validation.security_validator import SecurityValidator

--- a/yosai_intel_dashboard/src/services/data_enhancer/app.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/app.py
@@ -20,7 +20,7 @@ import pandas as pd
 from dash import dcc, html
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
-from core.unicode import clean_unicode_surrogates
+from yosai_intel_dashboard.src.core.unicode import clean_unicode_surrogates
 
 from .config import (
     AI_COLUMN_SERVICE_AVAILABLE,
@@ -170,7 +170,7 @@ class MultiBuildingDataEnhancer:
         # Try existing service first
         if AI_COLUMN_SERVICE_AVAILABLE:
             try:
-                from services.data_enhancer.mapping_utils import (
+                from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import (
                     get_ai_column_suggestions,
                 )
 

--- a/yosai_intel_dashboard/src/services/data_enhancer/config.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/config.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    from services.data_enhancer.mapping_utils import get_ai_column_suggestions
+    from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import get_ai_column_suggestions
 
     AI_COLUMN_SERVICE_AVAILABLE = True
     logger.info("✅ AI Column Service loaded successfully")
@@ -13,7 +13,7 @@ except Exception:  # pragma: no cover - optional dependency
     logger.warning("⚠️ AI Column Service not available - using fallback")
 
 try:
-    from services.door_mapping_service import DoorMappingService
+    from yosai_intel_dashboard.src.services.door_mapping_service import DoorMappingService
     from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_door_mapping_service
 
     AI_DOOR_SERVICE_AVAILABLE = True
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover - optional dependency
     logger.warning("⚠️ Service Container not available")
 
 try:
-    from services.configuration_service import DynamicConfigurationService
+    from yosai_intel_dashboard.src.services.configuration_service import DynamicConfigurationService
 
     CONFIG_SERVICE_AVAILABLE = True
     logger.info("✅ Configuration Service available")

--- a/yosai_intel_dashboard/src/services/data_loading_service.py
+++ b/yosai_intel_dashboard/src/services/data_loading_service.py
@@ -7,7 +7,7 @@ import pandas as pd
 from yosai_intel_dashboard.src.services.analytics.data.loader import DataLoader
 from yosai_intel_dashboard.src.services.analytics.protocols import DataLoadingProtocol
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import AnalyticsDataLoaderProtocol
-from services.controllers.upload_controller import UploadProcessingController
+from yosai_intel_dashboard.src.services.controllers.upload_controller import UploadProcessingController
 from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 
 

--- a/yosai_intel_dashboard/src/services/data_processing/analytics_engine.py
+++ b/yosai_intel_dashboard/src/services/data_processing/analytics_engine.py
@@ -8,7 +8,7 @@ import pandas as pd
 from services import get_analytics_service  # type: ignore
 
 try:
-    from services.ai_suggestions import generate_column_suggestions
+    from yosai_intel_dashboard.src.services.ai_suggestions import generate_column_suggestions
 
     AI_SUGGESTIONS_AVAILABLE = True
 except Exception:  # pragma: no cover - optional AI suggestions
@@ -36,7 +36,7 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
     """Return dropdown options for available data sources."""
     options: List[Dict[str, str]] = []
     try:
-        from services.upload_data_service import get_uploaded_data  # lazy import
+        from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_data  # lazy import
 
         uploaded_files = get_uploaded_data(get_upload_data_service())
         for filename in uploaded_files.keys():
@@ -71,7 +71,7 @@ def get_data_source_options_safe() -> List[Dict[str, str]]:
 def get_latest_uploaded_source_value() -> Optional[str]:
     """Return the dropdown value for the most recently uploaded file."""
     try:
-        from services.upload_data_service import get_uploaded_filenames  # lazy import
+        from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_filenames  # lazy import
 
         filenames = get_uploaded_filenames(get_upload_data_service())
         if filenames:
@@ -154,7 +154,7 @@ def process_suggests_analysis(data_source: str) -> Dict[str, Any]:
             else:
                 filename = None
 
-            from services.upload_data_service import get_uploaded_data  # lazy import
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:
@@ -236,7 +236,7 @@ def process_quality_analysis(data_source: str) -> Dict[str, Any]:
             else:
                 filename = None
 
-            from services.upload_data_service import get_uploaded_data  # lazy import
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:
@@ -285,7 +285,7 @@ def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str,
             return {"error": "Analytics service not available"}
 
         if data_source.startswith("upload:") or data_source == "service:uploaded":
-            from services.upload_data_service import get_uploaded_data  # lazy import
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_data  # lazy import
 
             uploaded_files = get_uploaded_data()
             if not uploaded_files:

--- a/yosai_intel_dashboard/src/services/data_processing/async_file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/async_file_processor.py
@@ -15,9 +15,9 @@ from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
 import pandas as pd
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
-from core.interfaces import ConfigProviderProtocol
-from services.rabbitmq_client import RabbitMQClient
-from services.task_queue import create_task, get_status
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.services.rabbitmq_client import RabbitMQClient
+from yosai_intel_dashboard.src.services.task_queue import create_task, get_status
 from yosai_intel_dashboard.src.utils.memory_utils import check_memory_limit
 
 from .file_processor import UnicodeFileProcessor

--- a/yosai_intel_dashboard/src/services/data_processing/base_file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/base_file_processor.py
@@ -6,7 +6,7 @@ from typing import IO, Callable, Iterable, List, Union
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
-from core.unicode import UnicodeProcessor as UnicodeHelper
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor as UnicodeHelper
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 from yosai_intel_dashboard.src.utils.memory_utils import check_memory_limit
 
@@ -73,7 +73,7 @@ class BaseFileProcessor:
                     return text
             except Exception:
                 continue
-        from core.unicode import safe_unicode_decode
+        from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode
 
         logger.warning("All encodings failed, using replacement characters")
         return safe_unicode_decode(content, "utf-8")

--- a/yosai_intel_dashboard/src/services/data_processing/core/exceptions.py
+++ b/yosai_intel_dashboard/src/services/data_processing/core/exceptions.py
@@ -1,6 +1,6 @@
 """File processing exception hierarchy."""
 
-from core.exceptions import YosaiBaseException
+from yosai_intel_dashboard.src.core.exceptions import YosaiBaseException
 from shared.errors.types import ErrorCode
 
 

--- a/yosai_intel_dashboard/src/services/data_processing/data_enhancer.py
+++ b/yosai_intel_dashboard/src/services/data_processing/data_enhancer.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pandas as pd
 
-from core.unicode import UnicodeProcessor
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor
 
 
 def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:

--- a/yosai_intel_dashboard/src/services/data_processing/dataframe_utils.py
+++ b/yosai_intel_dashboard/src/services/data_processing/dataframe_utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 

--- a/yosai_intel_dashboard/src/services/data_processing/file_handler.py
+++ b/yosai_intel_dashboard/src/services/data_processing/file_handler.py
@@ -10,14 +10,14 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     process_large_csv_content,
     sanitize_dataframe,
     sanitize_for_utf8,
 )
-from services.common.config_utils import common_init, create_config_methods
+from yosai_intel_dashboard.src.services.common.config_utils import common_init, create_config_methods
 from yosai_intel_dashboard.src.services.data_processing.core.exceptions import (
     FileProcessingError,
     FileValidationError,

--- a/yosai_intel_dashboard/src/services/data_processing/file_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/file_processor.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.file_processing import (
     create_file_preview as _create_preview,
     read_large_csv as _read_large_csv,

--- a/yosai_intel_dashboard/src/services/data_processing/no_limit_processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/no_limit_processor.py
@@ -10,7 +10,7 @@ from typing import Iterable, List
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from unicode_toolkit import safe_encode_text
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/data_processing/processor.py
+++ b/yosai_intel_dashboard/src/services/data_processing/processor.py
@@ -9,13 +9,13 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
-from core.interfaces import ConfigProviderProtocol
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from monitoring.data_quality_monitor import (
     DataQualityMetrics,
     get_data_quality_monitor,
 )
-from services.streaming import StreamingService
+from yosai_intel_dashboard.src.services.streaming import StreamingService
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import MappingServiceProtocol, get_mapping_service
 from unicode_toolkit import safe_encode_text
 from validation.security_validator import SecurityValidator
@@ -122,7 +122,7 @@ class Processor:
                 ) as fh:
                     data = json.load(fh)
 
-            from services.upload_data_service import (
+            from yosai_intel_dashboard.src.services.upload_data_service import (
                 get_uploaded_filenames,
                 load_mapping,
             )
@@ -150,7 +150,7 @@ class Processor:
 
     def _get_uploaded_data(self) -> Dict[str, pd.DataFrame]:
         try:
-            from services.upload_data_service import get_uploaded_data
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_data
 
             data = get_uploaded_data()
             if not data:

--- a/yosai_intel_dashboard/src/services/database_retriever.py
+++ b/yosai_intel_dashboard/src/services/database_retriever.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
 
 _cache_manager = InMemoryCacheManager(CacheConfig())
 

--- a/yosai_intel_dashboard/src/services/device_endpoint.py
+++ b/yosai_intel_dashboard/src/services/device_endpoint.py
@@ -54,7 +54,7 @@ def build_user_device_mappings(user_mappings: dict) -> dict:
 def build_ai_device_mappings(df: pd.DataFrame, filename: str, upload_service) -> dict:
     """Generate mappings for AI-suggested devices."""
 
-    from services.ai_mapping_store import ai_mapping_store
+    from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
     ai_mapping_store.clear()
     learned_applied = upload_service.auto_apply_learned_mappings(df, filename)

--- a/yosai_intel_dashboard/src/services/device_learning_service.py
+++ b/yosai_intel_dashboard/src/services/device_learning_service.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, runtime_checkab
 
 import pandas as pd
 
-from services.learning.src.api.consolidated_service import get_learning_service
-from services.protocols.device_learning import DeviceLearningServiceProtocol
+from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import get_learning_service
+from yosai_intel_dashboard.src.services.protocols.device_learning import DeviceLearningServiceProtocol
 from unicode_toolkit import safe_encode_text
 
 
@@ -186,7 +186,7 @@ class DeviceLearningService(DeviceLearningServiceProtocol):
         logger.info("🔍 DEBUG - filename: %s", safe_encode_text(filename))
 
         try:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
             learned_mappings = self.get_learned_mappings(df, filename)
             logger.info(

--- a/yosai_intel_dashboard/src/services/door_mapping_service.py
+++ b/yosai_intel_dashboard/src/services/door_mapping_service.py
@@ -15,11 +15,11 @@ import pandas as pd
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
 
 # ADD after existing imports
-from services.ai_device_generator import AIDeviceGenerator
-from services.common import ModelRegistry
-from services.common.config_utils import common_init, create_config_methods
-from services.configuration_service import DynamicConfigurationService
-from services.learning.src.api.consolidated_service import get_learning_service
+from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator
+from yosai_intel_dashboard.src.services.common import ModelRegistry
+from yosai_intel_dashboard.src.services.common.config_utils import common_init, create_config_methods
+from yosai_intel_dashboard.src.services.configuration_service import DynamicConfigurationService
+from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import get_learning_service
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/event-ingestion/app.py
+++ b/yosai_intel_dashboard/src/services/event-ingestion/app.py
@@ -12,11 +12,11 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from yosai_intel_dashboard.src.infrastructure.config.config_loader import load_service_config
-from core.security import RateLimiter
+from yosai_intel_dashboard.src.core.security import RateLimiter
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.error_handling.middleware import ErrorHandlingMiddleware
-from services.security import verify_service_jwt
-from services.streaming.service import StreamingService
+from yosai_intel_dashboard.src.services.security import verify_service_jwt
+from yosai_intel_dashboard.src.services.streaming.service import StreamingService
 from shared.errors.types import ErrorCode
 from tracing import trace_async_operation
 from yosai_framework.errors import ServiceError

--- a/yosai_intel_dashboard/src/services/file_processor_service.py
+++ b/yosai_intel_dashboard/src/services/file_processor_service.py
@@ -15,8 +15,8 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE, UPLOAD_ALLOWED_EXTENSIONS
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
-from core.unicode import UnicodeProcessor as UnicodeHelper
-from core.unicode import process_large_csv_content
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor as UnicodeHelper
+from yosai_intel_dashboard.src.core.unicode import process_large_csv_content
 from yosai_intel_dashboard.src.services.data_processing.base_file_processor import BaseFileProcessor
 from yosai_intel_dashboard.src.utils.file_utils import safe_decode_with_unicode_handling
 from yosai_intel_dashboard.src.utils.memory_utils import memory_safe

--- a/yosai_intel_dashboard/src/services/helpers/database_initializer.py
+++ b/yosai_intel_dashboard/src/services/helpers/database_initializer.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Tuple
 
 from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import DatabaseError
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, DatabaseSettings
-from services.db_analytics_helper import DatabaseAnalyticsHelper
-from services.summary_reporter import SummaryReporter
+from yosai_intel_dashboard.src.services.db_analytics_helper import DatabaseAnalyticsHelper
+from yosai_intel_dashboard.src.services.summary_reporter import SummaryReporter
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/kafka/avro_consumer.py
+++ b/yosai_intel_dashboard/src/services/kafka/avro_consumer.py
@@ -11,7 +11,7 @@ from fastavro import parse_schema, schemaless_reader
 
 from confluent_kafka import Consumer, Producer
 from monitoring.data_quality_monitor import get_data_quality_monitor
-from services.common.schema_registry import SchemaRegistryClient
+from yosai_intel_dashboard.src.services.common.schema_registry import SchemaRegistryClient
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/kafka/avro_producer.py
+++ b/yosai_intel_dashboard/src/services/kafka/avro_producer.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, Tuple
 from fastavro import parse_schema, schemaless_writer
 
 from confluent_kafka import Producer
-from services.common.schema_registry import SchemaRegistryClient
+from yosai_intel_dashboard.src.services.common.schema_registry import SchemaRegistryClient
 
 from .metrics import serialization_errors_total
 

--- a/yosai_intel_dashboard/src/services/learning/src/api/consolidated_service.py
+++ b/yosai_intel_dashboard/src/services/learning/src/api/consolidated_service.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from core.cache_manager import CacheConfig, InMemoryCacheManager
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager
 from unicode_toolkit import safe_encode_text
 
 _cache_manager = InMemoryCacheManager(CacheConfig())
@@ -108,7 +108,7 @@ class ConsolidatedLearningService:
     def apply_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
         """Apply learned mappings to global device mapping store."""
         try:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
         except ImportError:
             self.logger.warning("Could not import global device mappings store")
             return False

--- a/yosai_intel_dashboard/src/services/learning/src/api/coordinator.py
+++ b/yosai_intel_dashboard/src/services/learning/src/api/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from mapping.core.interfaces import LearningInterface, StorageInterface
-from services.learning.src.ml.fingerprint_service import FingerprintService
+from yosai_intel_dashboard.src.services.learning.src.ml.fingerprint_service import FingerprintService
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class LearningCoordinator(LearningInterface):
     # ------------------------------------------------------------------
     def apply_to_global_store(self, df: pd.DataFrame, filename: str) -> bool:
         try:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
         except Exception:  # pragma: no cover - optional dependency
             return False
         learned = self.get_learned_mappings(df, filename)

--- a/yosai_intel_dashboard/src/services/mappings_endpoint.py
+++ b/yosai_intel_dashboard/src/services/mappings_endpoint.py
@@ -4,7 +4,7 @@ from flask import Blueprint
 from flask_apispec import doc
 from pydantic import BaseModel
 
-from core.unicode import clean_unicode_surrogates
+from yosai_intel_dashboard.src.core.unicode import clean_unicode_surrogates
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler, api_error_response
 from yosai_intel_dashboard.src.utils.pydantic_decorators import validate_input, validate_output
 

--- a/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
+++ b/yosai_intel_dashboard/src/services/metadata_enhancement_engine.py
@@ -38,7 +38,7 @@ except ImportError:  # pragma: no cover - for Python <3.12
 
 import pandas as pd
 
-from core.di_decorators import inject, injectable
+from yosai_intel_dashboard.src.core.di_decorators import inject, injectable
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from yosai_intel_dashboard.src.services.analytics.protocols import AnalyticsServiceProtocol
 from yosai_intel_dashboard.src.services.upload.protocols import UploadDataServiceProtocol

--- a/yosai_intel_dashboard/src/services/migration/adapter.py
+++ b/yosai_intel_dashboard/src/services/migration/adapter.py
@@ -16,9 +16,9 @@ from kafka import KafkaProducer
 logger = logging.getLogger(__name__)
 
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from services.feature_flags import feature_flags
+from yosai_intel_dashboard.src.services.feature_flags import feature_flags
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import AnalyticsServiceProtocol
-from services.resilience.circuit_breaker import (
+from yosai_intel_dashboard.src.services.resilience.circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
 )
@@ -248,8 +248,8 @@ def register_migration_services(container: MigrationContainer) -> None:
 
     if container._migration_flags["use_timescaledb"]:
         try:
-            from services.timescale import models as timescale_models  # noqa:F401
-            from services.timescale.manager import TimescaleDBManager
+            from yosai_intel_dashboard.src.services.timescale import models as timescale_models  # noqa:F401
+            from yosai_intel_dashboard.src.services.timescale.manager import TimescaleDBManager
         except Exception:  # pragma: no cover - optional dependency
             pass
         else:

--- a/yosai_intel_dashboard/src/services/progress_events.py
+++ b/yosai_intel_dashboard/src/services/progress_events.py
@@ -5,7 +5,7 @@ from typing import Iterator
 
 from flask import Response, stream_with_context
 
-from services.task_queue import get_status
+from yosai_intel_dashboard.src.services.task_queue import get_status
 
 
 class ProgressEventManager:

--- a/yosai_intel_dashboard/src/services/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/services/protocols/__init__.py
@@ -1,4 +1,4 @@
-from services.controllers.protocols import UploadProcessingControllerProtocol
+from yosai_intel_dashboard.src.services.controllers.protocols import UploadProcessingControllerProtocol
 
 from .device_learning import DeviceLearningServiceProtocol
 from .processor import ProcessorProtocol

--- a/yosai_intel_dashboard/src/services/report_generation_service.py
+++ b/yosai_intel_dashboard/src/services/report_generation_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import pandas as pd
 
 from yosai_intel_dashboard.src.services.analytics.protocols import ReportGeneratorProtocol
-from services.summary_report_generator import SummaryReportGenerator
+from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
 
 
 class ReportGenerationService(ReportGeneratorProtocol):

--- a/yosai_intel_dashboard/src/services/resilience/circuit_breaker.py
+++ b/yosai_intel_dashboard/src/services/resilience/circuit_breaker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from core.async_utils.async_circuit_breaker import (
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
     circuit_breaker,

--- a/yosai_intel_dashboard/src/services/security/jwt_service.py
+++ b/yosai_intel_dashboard/src/services/security/jwt_service.py
@@ -2,7 +2,7 @@ import time
 
 from jose import jwt
 
-from services.common.secrets import get_secret
+from yosai_intel_dashboard.src.services.common.secrets import get_secret
 
 _SECRET_PATH = "secret/data/jwt#secret"
 

--- a/yosai_intel_dashboard/src/services/streaming/service.py
+++ b/yosai_intel_dashboard/src/services/streaming/service.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Generator, Optional
 
-from core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
 from yosai_framework.service import BaseService
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/summary_reporting.py
+++ b/yosai_intel_dashboard/src/services/summary_reporting.py
@@ -34,7 +34,7 @@ class SummaryReporter:
 
         try:
             from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
-            from services.upload_data_service import get_uploaded_filenames
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_filenames
 
             health["uploaded_files"] = len(
                 get_uploaded_filenames(get_upload_data_service())
@@ -48,7 +48,7 @@ class SummaryReporter:
         options = [{"label": "Sample Data", "value": "sample"}]
         try:
             from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
-            from services.upload_data_service import get_uploaded_filenames
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_filenames
 
             uploaded_files = get_uploaded_filenames(get_upload_data_service())
             if uploaded_files:
@@ -84,7 +84,7 @@ class SummaryReporter:
         }
         try:
             from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_upload_data_service
-            from services.upload_data_service import get_uploaded_filenames
+            from yosai_intel_dashboard.src.services.upload_data_service import get_uploaded_filenames
 
             status["uploaded_files"] = len(
                 get_uploaded_filenames(get_upload_data_service())

--- a/yosai_intel_dashboard/src/services/timescale/adapter.py
+++ b/yosai_intel_dashboard/src/services/timescale/adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from services.analytics_microservice import queries
+from yosai_intel_dashboard.src.services.analytics_microservice import queries
 
 from .manager import TimescaleDBManager
 

--- a/yosai_intel_dashboard/src/services/timescale/manager.py
+++ b/yosai_intel_dashboard/src/services/timescale/manager.py
@@ -7,9 +7,9 @@ import time
 
 import asyncpg
 
-from core.error_handling import ErrorCategory, with_async_error_handling
+from yosai_intel_dashboard.src.core.error_handling import ErrorCategory, with_async_error_handling
 from database.metrics import queries_total, query_errors_total
-from services.common.secrets import get_secret
+from yosai_intel_dashboard.src.services.common.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/services/token_endpoint.py
+++ b/yosai_intel_dashboard/src/services/token_endpoint.py
@@ -5,7 +5,7 @@ from flask_apispec import doc
 from pydantic import BaseModel
 
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler, api_error_response
-from services.security import refresh_access_token
+from yosai_intel_dashboard.src.services.security import refresh_access_token
 from yosai_intel_dashboard.src.utils.pydantic_decorators import validate_input, validate_output
 
 

--- a/yosai_intel_dashboard/src/services/unified_file_controller.py
+++ b/yosai_intel_dashboard/src/services/unified_file_controller.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Sequence
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from core.unicode import UnicodeProcessor
+from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor
 from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 

--- a/yosai_intel_dashboard/src/services/upload/__init__.py
+++ b/yosai_intel_dashboard/src/services/upload/__init__.py
@@ -5,7 +5,7 @@ Other packages should import from here rather than submodules.
 """
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
-from core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.unicode import safe_encode_text
 from unicode_toolkit import decode_upload_content
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore as UploadStorage
 from validation.security_validator import SecurityValidator

--- a/yosai_intel_dashboard/src/services/upload/ai.py
+++ b/yosai_intel_dashboard/src/services/upload/ai.py
@@ -11,7 +11,7 @@ class AISuggestionService:
 
     def analyze_device_name_with_ai(self, device_name: str) -> Dict[str, Any]:
         try:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
             # Check for any cached mapping first
             mapping = ai_mapping_store.get(device_name)
@@ -24,7 +24,7 @@ class AISuggestionService:
                 return mapping
 
             logger.info("🤖 Generating AI analysis for '%s'", device_name)
-            from services.ai_device_generator import AIDeviceGenerator
+            from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator
 
             ai_generator = AIDeviceGenerator()
             result = ai_generator.generate_device_attributes(device_name)

--- a/yosai_intel_dashboard/src/services/upload/async_processor.py
+++ b/yosai_intel_dashboard/src/services/upload/async_processor.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pandas as pd
 
-from core.config import get_max_display_rows
+from yosai_intel_dashboard.src.core.config import get_max_display_rows
 from yosai_intel_dashboard.src.services.upload.utils.file_parser import UnicodeFileProcessor
 from yosai_intel_dashboard.src.utils.async_pandas_readers import (
     async_read_csv,

--- a/yosai_intel_dashboard/src/services/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/services/upload/callbacks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Callback manager for the upload domain."""
 
-from core.callback_registry import CallbackRegistry, ComponentCallbackManager
+from yosai_intel_dashboard.src.core.callback_registry import CallbackRegistry, ComponentCallbackManager
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 

--- a/yosai_intel_dashboard/src/services/upload/orchestrator.py
+++ b/yosai_intel_dashboard/src/services/upload/orchestrator.py
@@ -7,8 +7,8 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.components.ui_builder import UploadUIBuilder
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
-from services.async_file_processor import AsyncFileProcessor
-from services.data_enhancer.mapping_utils import get_ai_column_suggestions
+from yosai_intel_dashboard.src.services.async_file_processor import AsyncFileProcessor
+from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import get_ai_column_suggestions
 from yosai_intel_dashboard.src.services.upload.file_processor_service import FileProcessor
 from yosai_intel_dashboard.src.services.upload.learning_coordinator import LearningCoordinator
 from yosai_intel_dashboard.src.services.upload.protocols import (
@@ -17,7 +17,7 @@ from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadStorageProtocol,
     UploadValidatorProtocol,
 )
-from services.upload_data_service import UploadDataService, UploadDataServiceProtocol
+from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService, UploadDataServiceProtocol
 from validation.file_validator import FileValidator
 
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ class UploadOrchestrator(UploadProcessingServiceProtocol):
     ) -> None:
         user = self.learner.user_mappings(fname)
         if user:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
             ai_mapping_store.clear()
             for dev, mapping in user.items():
@@ -156,7 +156,7 @@ class UploadOrchestrator(UploadProcessingServiceProtocol):
             result["device_mappings"][fname] = user
             logger.info("✅ Loaded %s saved mappings - AI SKIPPED", len(user))
         else:
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
             ai_mapping_store.clear()
             self.learner.auto_apply(df, fname)

--- a/yosai_intel_dashboard/src/services/upload/protocols.py
+++ b/yosai_intel_dashboard/src/services/upload/protocols.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from services.protocols.device_learning import DeviceLearningServiceProtocol
+from yosai_intel_dashboard.src.services.protocols.device_learning import DeviceLearningServiceProtocol
 
 
 @runtime_checkable

--- a/yosai_intel_dashboard/src/services/upload/service_registration.py
+++ b/yosai_intel_dashboard/src/services/upload/service_registration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from yosai_intel_dashboard.src.components.ui_builder import UploadUIBuilder
-from core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
 from yosai_intel_dashboard.src.infrastructure.di.service_container import (
     CircularDependencyError,
@@ -11,8 +11,8 @@ from yosai_intel_dashboard.src.infrastructure.di.service_container import (
     ServiceContainer,
     ServiceLifetime,
 )
-from services.async_file_processor import AsyncFileProcessor
-from services.device_learning_service import DeviceLearningService
+from yosai_intel_dashboard.src.services.async_file_processor import AsyncFileProcessor
+from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
     DeviceLearningServiceProtocol,
     UploadDataServiceProtocol,
@@ -28,7 +28,7 @@ from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadValidatorProtocol,
 )
 from yosai_intel_dashboard.src.services.upload.validator import ClientSideValidator
-from services.upload_data_service import UploadDataService
+from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 from validation.file_validator import FileValidator
 

--- a/yosai_intel_dashboard/src/services/upload/upload_core.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_core.py
@@ -11,12 +11,12 @@ import dash_bootstrap_components as dbc
 from dash import html, no_update
 
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_device_learning_service
-from services.rabbitmq_client import RabbitMQClient
-from services.task_queue import (
+from yosai_intel_dashboard.src.services.rabbitmq_client import RabbitMQClient
+from yosai_intel_dashboard.src.services.task_queue import (
     TaskQueue,
     TaskQueueProtocol,
 )
-from services.upload import (
+from yosai_intel_dashboard.src.services.upload import (
     AISuggestionService,
     ChunkedUploadManager,
     ClientSideValidator,
@@ -256,7 +256,7 @@ class UploadCore:
                 raise ValueError(f"DataFrame for '{filename}' is empty")
 
             learning_service.save_user_device_mappings(df, filename, user_mappings)
-            from services.ai_mapping_store import ai_mapping_store
+            from yosai_intel_dashboard.src.services.ai_mapping_store import ai_mapping_store
 
             ai_mapping_store.update(user_mappings)
 

--- a/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
+++ b/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
@@ -13,11 +13,11 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.performance import get_performance_monitor
+from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 
 # Core processing imports only - NO UI COMPONENTS
-from core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
 from yosai_intel_dashboard.src.services.data_processing.file_processor import (
     decode_contents,
     validate_metadata,

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -7,7 +7,7 @@ import time
 from typing import Any, Dict
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
-from services.analytics_summary import generate_sample_analytics
+from yosai_intel_dashboard.src.services.analytics_summary import generate_sample_analytics
 
 
 class WebSocketDataProvider:

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -6,7 +6,7 @@ from typing import Optional, Set
 
 from websockets import WebSocketServerProtocol, serve
 
-from core.events import EventBus
+from yosai_intel_dashboard.src.core.events import EventBus
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/__init__.py
+++ b/yosai_intel_dashboard/src/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
-from core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import (
     ChunkedUnicodeProcessor,
     EnhancedUnicodeProcessor,
     SurrogateHandlingConfig,

--- a/yosai_intel_dashboard/src/utils/assets_debug.py
+++ b/yosai_intel_dashboard/src/utils/assets_debug.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
-from core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.unicode import safe_encode_text
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/create_navbar_assets.py
+++ b/yosai_intel_dashboard/src/utils/create_navbar_assets.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     PIL_AVAILABLE = False
 
-from core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.unicode import safe_encode_text
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/file_utils.py
+++ b/yosai_intel_dashboard/src/utils/file_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Helper utilities for working with files."""
 
-from core.unicode import safe_unicode_decode
+from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode
 from security.unicode_security_validator import UnicodeSecurityValidator
 
 _validator = UnicodeSecurityValidator()

--- a/yosai_intel_dashboard/src/utils/lazystring_handler.py
+++ b/yosai_intel_dashboard/src/utils/lazystring_handler.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from core.serialization import SafeJSONSerializer
+from yosai_intel_dashboard.src.core.serialization import SafeJSONSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/preview_utils.py
+++ b/yosai_intel_dashboard/src/utils/preview_utils.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from core.config import get_max_display_rows
+from yosai_intel_dashboard.src.core.config import get_max_display_rows
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
-from core.unicode import sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import sanitize_for_utf8
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/text_utils.py
+++ b/yosai_intel_dashboard/src/utils/text_utils.py
@@ -4,7 +4,7 @@ Text utilities for safe text handling
 
 from typing import Any, Union
 
-from core.unicode import clean_surrogate_chars
+from yosai_intel_dashboard.src.core.unicode import clean_surrogate_chars
 
 
 def safe_text(text: Union[str, Any]) -> str:

--- a/yosai_intel_dashboard/src/utils/unicode_handler.py
+++ b/yosai_intel_dashboard/src/utils/unicode_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterable, Mapping
 
-from core.unicode import sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import sanitize_for_utf8
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/upload_store.py
+++ b/yosai_intel_dashboard/src/utils/upload_store.py
@@ -12,8 +12,8 @@ from typing import Any, Dict, List, Optional, Protocol
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadConfig
-from core.cache_manager import CacheConfig, InMemoryCacheManager
-from core.unicode import sanitize_dataframe
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager
+from yosai_intel_dashboard.src.core.unicode import sanitize_dataframe
 from yosai_intel_dashboard.src.services.upload.protocols import UploadStorageProtocol
 from unicode_toolkit import safe_encode_text
 


### PR DESCRIPTION
## Summary
- rewrite imports to use yosai_intel_dashboard src modules
- update service locator to new service paths

## Testing
- `PYTHONPATH=. python scripts/verify_imports.py yosai_intel_dashboard/src`

------
https://chatgpt.com/codex/tasks/task_e_688c011959b08320ab3bc9b509ccec12