### PR TITLE
Fix entrypoint imports to use clean architecture

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 
 from api.adapter import create_api_app
-
-from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 from core.di.bootstrap import bootstrap_container
 from core.env_validation import validate_required_env
+from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)

--- a/start_api.py
+++ b/start_api.py
@@ -14,12 +14,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Import Flask app directly from adapter
 from api.adapter import create_api_app
+from core.di.bootstrap import bootstrap_container
 
 # Import Dash app factory from the package
 from yosai_intel_dashboard.src.core.app_factory import create_app
-
 from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
-from core.di.bootstrap import bootstrap_container
 
 
 def main() -> None:

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from core.app_factory import create_app
 from core.env_validation import validate_required_env
+from yosai_intel_dashboard.src.core.app_factory import create_app
 
 validate_required_env()
 


### PR DESCRIPTION
## Summary
- update `wsgi.py` to import from `yosai_intel_dashboard.src.core.app_factory`
- reorder imports in entrypoint scripts via pre-commit

## Testing
- `pre-commit run --files wsgi.py start_api.py run_api.py` *(fails: flake8 and mypy errors)*
- `LIGHTWEIGHT_SERVICES=1 PYTHONPATH=./yosai_intel_dashboard python -m yosai_intel_dashboard.src.core.app_factory` *(fails: ModuleNotFoundError: yosai_intel_dashboard.src.core.interfaces.protocols)*

------
https://chatgpt.com/codex/tasks/task_e_688c011af6e08320847434fbda9d5754