### PR TITLE
add test setup instructions

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,14 @@
+# Testing Setup
+
+To run the test suite you must install both the core and testing dependencies:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-test.txt
+```
+
+After installing the packages you can verify that `pytest` discovers the tests without executing them:
+
+```bash
+pytest --collect-only -q
+```


### PR DESCRIPTION
## Summary
- add docs/testing.md with instructions for installing test dependencies
- show how to verify test discovery with pytest

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest --collect-only -q` *(fails: 281 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688c011c75dc83209eec21f655ede4a9