### PR TITLE
Use lazy module wrappers

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,3 +1,37 @@
-from importlib import import_module as _im
-import sys as _sys
-_sys.modules[__name__] = _im('yosai_intel_dashboard.src.adapters.api')
+"""Lazy loader for :mod:`yosai_intel_dashboard.src.adapters.api`."""
+
+from __future__ import annotations
+
+import importlib
+from importlib import machinery, util
+from types import ModuleType
+
+_TARGET = "yosai_intel_dashboard.src.adapters.api"
+
+_spec = util.find_spec(_TARGET)
+if _spec is None:  # pragma: no cover - underlying package missing
+    raise ImportError(f"Cannot find {_TARGET}")
+
+__path__ = list(_spec.submodule_search_locations or [])
+__spec__ = machinery.ModuleSpec(
+    __name__, loader=None, origin=_spec.origin, is_package=True
+)
+__spec__.submodule_search_locations = __path__
+
+_module: ModuleType | None = None
+
+
+def _load() -> ModuleType:
+    global _module
+    if _module is None:
+        _module = importlib.import_module(_TARGET)
+        globals().update(_module.__dict__)
+    return _module
+
+
+def __getattr__(name: str):
+    return getattr(_load(), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(dir(_load())))

--- a/config.py
+++ b/config.py
@@ -1,3 +1,37 @@
-from importlib import import_module as _im
-import sys as _sys
-_sys.modules[__name__] = _im('yosai_intel_dashboard.src.infrastructure.config')
+"""Lazy loader for :mod:`yosai_intel_dashboard.src.infrastructure.config`."""
+
+from __future__ import annotations
+
+import importlib
+from importlib import machinery, util
+from types import ModuleType
+
+_TARGET = "yosai_intel_dashboard.src.infrastructure.config"
+
+_spec = util.find_spec(_TARGET)
+if _spec is None:  # pragma: no cover - underlying package missing
+    raise ImportError(f"Cannot find {_TARGET}")
+
+__path__ = list(_spec.submodule_search_locations or [])
+__spec__ = machinery.ModuleSpec(
+    __name__, loader=None, origin=_spec.origin, is_package=True
+)
+__spec__.submodule_search_locations = __path__
+
+_module: ModuleType | None = None
+
+
+def _load() -> ModuleType:
+    global _module
+    if _module is None:
+        _module = importlib.import_module(_TARGET)
+        globals().update(_module.__dict__)
+    return _module
+
+
+def __getattr__(name: str):
+    return getattr(_load(), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(dir(_load())))

--- a/core.py
+++ b/core.py
@@ -1,3 +1,37 @@
-from importlib import import_module as _im
-import sys as _sys
-_sys.modules[__name__] = _im('yosai_intel_dashboard.src.core')
+"""Lazy loader for :mod:`yosai_intel_dashboard.src.core`."""
+
+from __future__ import annotations
+
+import importlib
+from importlib import machinery, util
+from types import ModuleType
+
+_TARGET = "yosai_intel_dashboard.src.core"
+
+_spec = util.find_spec(_TARGET)
+if _spec is None:  # pragma: no cover - underlying package missing
+    raise ImportError(f"Cannot find {_TARGET}")
+
+__path__ = list(_spec.submodule_search_locations or [])
+__spec__ = machinery.ModuleSpec(
+    __name__, loader=None, origin=_spec.origin, is_package=True
+)
+__spec__.submodule_search_locations = __path__
+
+_module: ModuleType | None = None
+
+
+def _load() -> ModuleType:
+    global _module
+    if _module is None:
+        _module = importlib.import_module(_TARGET)
+        globals().update(_module.__dict__)
+    return _module
+
+
+def __getattr__(name: str):
+    return getattr(_load(), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(dir(_load())))

--- a/services.py
+++ b/services.py
@@ -1,3 +1,37 @@
-from importlib import import_module as _im
-import sys as _sys
-_sys.modules[__name__] = _im('yosai_intel_dashboard.src.services')
+"""Lazy loader for :mod:`yosai_intel_dashboard.src.services`."""
+
+from __future__ import annotations
+
+import importlib
+from importlib import machinery, util
+from types import ModuleType
+
+_TARGET = "yosai_intel_dashboard.src.services"
+
+_spec = util.find_spec(_TARGET)
+if _spec is None:  # pragma: no cover - underlying package missing
+    raise ImportError(f"Cannot find {_TARGET}")
+
+__path__ = list(_spec.submodule_search_locations or [])
+__spec__ = machinery.ModuleSpec(
+    __name__, loader=None, origin=_spec.origin, is_package=True
+)
+__spec__.submodule_search_locations = __path__
+
+_module: ModuleType | None = None
+
+
+def _load() -> ModuleType:
+    global _module
+    if _module is None:
+        _module = importlib.import_module(_TARGET)
+        globals().update(_module.__dict__)
+    return _module
+
+
+def __getattr__(name: str):
+    return getattr(_load(), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(dir(_load())))


### PR DESCRIPTION
## Summary
- implement lazy import wrappers for config, services, core and api
- make wrappers expose `__getattr__` and `__dir__`

## Testing
- `pre-commit run --files config.py services.py core.py api.py`
- `pytest tests/test_lazystring_fix.py -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688cd7454bfc8320bef7cca4da8f7b29