### PR TITLE
Fix circular imports for models

### DIFF
--- a/yosai_intel_dashboard/__init__.py
+++ b/yosai_intel_dashboard/__init__.py
@@ -1,8 +1,43 @@
+"""Backward compatibility shims for the :mod:`yosai_intel_dashboard` package."""
+
+from __future__ import annotations
+
+import importlib
 import sys
+import types
+from pathlib import Path
 
-# Provide backward compatibility for old import paths
-from . import models as _models
-from . import src as _src
-
-sys.modules.setdefault(__name__ + ".models", _models)
+# Import ``src`` eagerly using :func:`importlib.import_module` to avoid circular
+# dependencies while keeping compatibility with old import paths.
+_src = importlib.import_module(".src", __name__)
 sys.modules.setdefault(__name__ + ".src", _src)
+
+# Insert a lightweight proxy for ``yosai_intel_dashboard.models`` so that
+# submodules can be imported without pulling in heavy dependencies up front.
+_models_proxy = types.ModuleType(__name__ + ".models")
+_models_proxy.__file__ = str(Path(__file__).resolve().parent / "src" / "models" / "__init__.py")
+_models_proxy.__path__ = [str(Path(__file__).resolve().parent / "src" / "models")]
+
+
+def _load_models():
+    module = importlib.import_module(".models", __name__)
+    sys.modules[__name__ + ".models"] = module
+    globals()["models"] = module
+    return module
+
+
+def _models_getattr(attr: str):
+    module = _load_models()
+    return getattr(module, attr)
+
+
+_models_proxy.__getattr__ = _models_getattr  # type: ignore[attr-defined]
+sys.modules.setdefault(__name__ + ".models", _models_proxy)
+
+
+def __getattr__(name: str):
+    """Lazily import :mod:`models` on first access."""
+
+    if name == "models":
+        return _load_models()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- lazily import `models` so wrappers no longer eagerly pull it in
- keep `src` import for backward compatibility

## Testing
- `pytest -q yosai_intel_dashboard/tests/encoding/test_unicode_handler.py` *(fails: cannot import name 'UnicodeSecurityConfig')*

------
https://chatgpt.com/codex/tasks/task_e_688cd743bbc48320b4a31a812f43be8e