### PR TITLE
Update circuit breaker imports

### DIFF
--- a/adapters/service_client.py
+++ b/adapters/service_client.py
@@ -13,7 +13,10 @@ from tenacity import (
     wait_exponential,
 )
 
-from services.resilience.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
 from tracing import propagate_context
 
 

--- a/yosai_intel_dashboard/src/infrastructure/communication/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/communication/__init__.py
@@ -1,4 +1,6 @@
-from yosai_intel_dashboard.src.services.resilience.circuit_breaker import CircuitBreaker
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+)
 
 from .message_queue import AsyncQueueClient
 from .protocols import MessageBus, ServiceClient

--- a/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
+++ b/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
@@ -12,7 +12,10 @@ from tenacity import (
     wait_exponential,
 )
 
-from yosai_intel_dashboard.src.services.resilience.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
 
 from .protocols import ServiceClient
 

--- a/yosai_intel_dashboard/src/services/migration/adapter.py
+++ b/yosai_intel_dashboard/src/services/migration/adapter.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from yosai_intel_dashboard.src.services.feature_flags import feature_flags
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import AnalyticsServiceProtocol
-from yosai_intel_dashboard.src.services.resilience.circuit_breaker import (
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
 )


### PR DESCRIPTION
## Summary
- update references to the circuit breaker utility to use the new async module

## Testing
- `pytest -q tests/resilience/test_service_client.py tests/resilience/test_circuit_breaker.py tests/test_migration_adapter.py` *(fails: ImportError: cannot import name 'ChunkedUnicodeProcessor')*


------
https://chatgpt.com/codex/tasks/task_e_688ce53fc4688320b617cff4a44c4dc8