### PR TITLE
Lazy load core async utils

### DIFF
--- a/yosai_intel_dashboard/src/core/__init__.py
+++ b/yosai_intel_dashboard/src/core/__init__.py
@@ -3,22 +3,26 @@
 from typing import TYPE_CHECKING, Any
 
 from .advanced_query_optimizer import AdvancedQueryOptimizer
-from .async_utils import (
-    AsyncContextManager,
-    CircuitBreaker,
-    CircuitBreakerOpen,
-    async_batch,
-    async_retry,
-    circuit_breaker,
-)
-from .base_database_service import BaseDatabaseService
-from .base_model import BaseModel
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .async_utils import (
+        AsyncContextManager,
+        CircuitBreaker,
+        CircuitBreakerOpen,
+        async_batch,
+        async_retry,
+        circuit_breaker,
+    )
+
 from ..infrastructure.cache.cache_manager import (
     CacheConfig,
     InMemoryCacheManager,
     RedisCacheManager,
     cache_with_lock,
 )
+from ..infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from .base_database_service import BaseDatabaseService
+from .base_model import BaseModel
 from .cache_warmer import IntelligentCacheWarmer
 from .callback_modules import CallbackModule, CallbackModuleRegistry
 from .cpu_optimizer import CPUOptimizer
@@ -31,7 +35,6 @@ from .intelligent_multilevel_cache import (
     create_intelligent_cache_manager,
 )
 from .memory_manager import MemoryManager
-from ..infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from ..infrastructure.callbacks.unified_callbacks import (
@@ -62,4 +65,30 @@ __all__ = [
     "injectable",
     "inject",
     "validate_env",
+    "AsyncContextManager",
+    "async_retry",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "circuit_breaker",
+    "async_batch",
 ]
+
+
+_ASYNC_EXPORTS = {
+    "AsyncContextManager",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "async_batch",
+    "async_retry",
+    "circuit_breaker",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _ASYNC_EXPORTS:
+        from . import async_utils
+
+        value = getattr(async_utils, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- lazily import async utilities in `core`

## Testing
- `black yosai_intel_dashboard/src/core/__init__.py`
- `isort yosai_intel_dashboard/src/core/__init__.py --check`
- `flake8 yosai_intel_dashboard/src/core/__init__.py`
- `pre-commit run --files yosai_intel_dashboard/src/core/__init__.py` *(fails: mypy reports repo-wide issues)*

------
https://chatgpt.com/codex/tasks/task_e_688ce540c5ac8320bc5afde678936920