### PR TITLE
Refactor unicode processor imports

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import logging
 import unicodedata
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable
 
+from security.events import SecurityEvent, emit_security_event
 from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.interfaces.protocols import UnicodeProcessorProtocol
-from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor as UnicodeHelper
-from yosai_intel_dashboard.src.core.unicode import contains_surrogates
-from security.events import SecurityEvent, emit_security_event
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from yosai_intel_dashboard.src.core.unicode import (  # noqa: F401
+        UnicodeProcessor as _UnicodeProcessor,
+    )
+    from yosai_intel_dashboard.src.core.unicode import (  # noqa: F401
+        contains_surrogates as _contains_surrogates,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +28,8 @@ class QueryUnicodeHandler:
     @staticmethod
     def _encode(value: Any, processor: UnicodeProcessorProtocol) -> Any:
         if isinstance(value, str):
+            from yosai_intel_dashboard.src.core.unicode import contains_surrogates
+
             clean = processor.safe_encode_text(value)
             if contains_surrogates(value):
                 emit_security_event(
@@ -46,6 +54,8 @@ class QueryUnicodeHandler:
         on_surrogate: Callable[[str], None] | None = None,
     ) -> str:
         processor = processor or get_unicode_processor()
+        from yosai_intel_dashboard.src.core.unicode import contains_surrogates
+
         if contains_surrogates(query):
             (on_surrogate or logger.info)("Surrogates detected in query")
         return cls._encode(query, processor)
@@ -62,6 +72,8 @@ class QueryUnicodeHandler:
 
         def _cb(text: str) -> None:
             (on_surrogate or logger.info)("Surrogates detected in query parameters")
+
+        from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 
         if isinstance(params, str) and contains_surrogates(params):
             _cb(params)
@@ -84,6 +96,8 @@ class FileUnicodeHandler:
             if isinstance(content, bytes)
             else processor.safe_encode_text(content)
         )
+        from yosai_intel_dashboard.src.core.unicode import contains_surrogates
+
         if contains_surrogates(text):
             (on_surrogate or logger.info)("Surrogates detected in file content")
             emit_security_event(
@@ -100,6 +114,8 @@ class FileUnicodeHandler:
     ) -> str:
         processor = processor or get_unicode_processor()
         text = str(name)
+        from yosai_intel_dashboard.src.core.unicode import contains_surrogates
+
         if contains_surrogates(text):
             (on_surrogate or logger.info)("Surrogates detected in filename")
             emit_security_event(
@@ -116,6 +132,8 @@ class UnicodeSecurityValidator:
     def validate_input(text: Any) -> str:
         processor = get_unicode_processor()
         cleaned = processor.safe_encode_text(text)
+        from yosai_intel_dashboard.src.core.unicode import contains_surrogates
+
         if contains_surrogates(text):
             emit_security_event(
                 SecurityEvent.VALIDATION_FAILED, {"issue": "surrogate_input"}


### PR DESCRIPTION
## Summary
- lazily import unicode helpers to avoid circular imports
- move contains_surrogates import inside methods

## Testing
- `isort config/unicode_processor.py yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py`
- `black config/unicode_processor.py yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py`
- `flake8 config/unicode_processor.py yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py`
- `mypy config/unicode_processor.py` *(fails: Cannot find implementations)*
- `pytest -k unicode_processor -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ce542206883208d03b65ad9b84542