### PR TITLE
Rename circuit breaker metrics accessor

### DIFF
--- a/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
@@ -5,8 +5,8 @@ import time
 from typing import Any, Awaitable, Callable, Optional
 
 
-def _metrics():
-    """Return Prometheus metrics lazily to avoid import costs."""
+def _get_circuit_breaker_state():
+    """Return Prometheus metric for circuit breaker state lazily."""
     from yosai_intel_dashboard.src.services.resilience.metrics import (
         circuit_breaker_state,
     )
@@ -47,7 +47,7 @@ class CircuitBreaker:
         async with self._lock:
             self._failures = 0
             if self._state != "closed":
-                _metrics().labels(self._name, "closed").inc()
+                _get_circuit_breaker_state().labels(self._name, "closed").inc()
             self._state = "closed"
             self._opened_at = None
 
@@ -56,7 +56,7 @@ class CircuitBreaker:
         async with self._lock:
             self._failures += 1
             if self._failures >= self.failure_threshold and self._state != "open":
-                _metrics().labels(self._name, "open").inc()
+                _get_circuit_breaker_state().labels(self._name, "open").inc()
                 self._state = "open"
                 self._opened_at = time.time()
 
@@ -68,7 +68,7 @@ class CircuitBreaker:
                     self._opened_at
                     and time.time() - self._opened_at >= self.recovery_timeout
                 ):
-                    _metrics().labels(self._name, "half_open").inc()
+                    _get_circuit_breaker_state().labels(self._name, "half_open").inc()
                     self._state = "half_open"
                     return True
                 return False

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -24,7 +24,7 @@ from typing import (
 from dash import Dash
 from dash.dependencies import Input, Output, State
 
-from .callback_events import CallbackEvent
+from .events import CallbackEvent
 from .callback_registry import CallbackRegistry, ComponentCallbackManager
 from ...core.dash_callback_middleware import wrap_callback
 from ...core.error_handling import ErrorSeverity, error_handler, with_retry

--- a/yosai_intel_dashboard/src/services/resilience/__init__.py
+++ b/yosai_intel_dashboard/src/services/resilience/__init__.py
@@ -1,8 +1,7 @@
 from .circuit_breaker import CircuitBreaker, CircuitBreakerOpen
-from .metrics import circuit_breaker_state, start_metrics_server
+from .metrics import start_metrics_server
 
 __all__ = [
-    "circuit_breaker_state",
     "start_metrics_server",
     "CircuitBreaker",
     "CircuitBreakerOpen",


### PR DESCRIPTION
## Summary
- rename `_metrics` helper to `_get_circuit_breaker_state`
- replace calls with new helper
- drop `circuit_breaker_state` from service exports
- fix callback event import path

## Testing
- `PYTHONPATH=$(pwd) python -c "from yosai_intel_dashboard.src.core.async_utils import async_circuit_breaker"` *(fails: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_688ceef8742c83209287809387df2aa0