### PR TITLE
Defer heavy imports in core init

### DIFF
--- a/yosai_intel_dashboard/src/core/__init__.py
+++ b/yosai_intel_dashboard/src/core/__init__.py
@@ -1,5 +1,8 @@
 """Core package exports and typing utilities."""
 
+from __future__ import annotations
+
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from .advanced_query_optimizer import AdvancedQueryOptimizer
@@ -13,20 +16,19 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
         async_retry,
         circuit_breaker,
     )
-
-from ..infrastructure.cache.cache_manager import (
-    CacheConfig,
-    InMemoryCacheManager,
-    RedisCacheManager,
-    cache_with_lock,
-)
-from ..infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from .base_database_service import BaseDatabaseService
+    from ..infrastructure.cache.cache_manager import (
+        CacheConfig,
+        InMemoryCacheManager,
+        RedisCacheManager,
+        cache_with_lock,
+    )
+    from ..infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+    from .base_database_service import BaseDatabaseService
+    from .deprecation import deprecated
 from .base_model import BaseModel
 from .cache_warmer import IntelligentCacheWarmer
 from .callback_modules import CallbackModule, CallbackModuleRegistry
 from .cpu_optimizer import CPUOptimizer
-from .deprecation import deprecated
 from .di_decorators import inject, injectable
 from .env_validation import validate_env
 from .hierarchical_cache_manager import HierarchicalCacheManager
@@ -83,12 +85,37 @@ _ASYNC_EXPORTS = {
     "circuit_breaker",
 }
 
+_LAZY_EXPORTS = {
+    "TrulyUnifiedCallbacks": (
+        "..infrastructure.callbacks.unified_callbacks",
+        "TrulyUnifiedCallbacks",
+    ),
+    "CacheConfig": ("..infrastructure.cache.cache_manager", "CacheConfig"),
+    "InMemoryCacheManager": (
+        "..infrastructure.cache.cache_manager",
+        "InMemoryCacheManager",
+    ),
+    "RedisCacheManager": (
+        "..infrastructure.cache.cache_manager",
+        "RedisCacheManager",
+    ),
+    "cache_with_lock": ("..infrastructure.cache.cache_manager", "cache_with_lock"),
+    "BaseDatabaseService": (".base_database_service", "BaseDatabaseService"),
+    "deprecated": (".deprecation", "deprecated"),
+}
+
 
 def __getattr__(name: str) -> Any:
     if name in _ASYNC_EXPORTS:
         from . import async_utils
 
         value = getattr(async_utils, name)
+        globals()[name] = value
+        return value
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        module = import_module(module_name, __package__)
+        value = getattr(module, attr_name)
         globals()[name] = value
         return value
     raise AttributeError(name)

--- a/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
+++ b/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
@@ -13,7 +13,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import redis.asyncio as redis
 
-from yosai_intel_dashboard.src.infrastructure.config.base import CacheConfig
+from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import CacheConfig
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/__init__.py
+++ b/yosai_intel_dashboard/src/utils/__init__.py
@@ -1,7 +1,12 @@
 """Utility helpers for Yōsai Intel Dashboard."""
 
 import importlib
-from mapping.processors.ai_processor import AIColumnMapperAdapter
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from mapping.processors.ai_processor import AIColumnMapperAdapter
+else:  # pragma: no cover - fallback at runtime
+    AIColumnMapperAdapter = Any  # type: ignore[misc]
 
 from .assets_debug import (
     check_navbar_assets,
@@ -71,9 +76,22 @@ __all__ = [
     "resolve_upload_chunk_size",
 ]
 
+_LAZY_EXPORTS = {
+    "AIColumnMapperAdapter": (
+        "mapping.processors.ai_processor",
+        "AIColumnMapperAdapter",
+    ),
+}
+
 
 def __getattr__(name: str):
-    """Lazily load attributes from ``yosai_intel_dashboard.src.core.unicode``."""
+    """Lazily load selected attributes to avoid heavy imports."""
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        module = importlib.import_module(module_name)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
     module = importlib.import_module("yosai_intel_dashboard.src.core.unicode")
     if hasattr(module, name):
         attr = getattr(module, name)

--- a/yosai_intel_dashboard/src/utils/mapping_helpers.py
+++ b/yosai_intel_dashboard/src/utils/mapping_helpers.py
@@ -1,11 +1,16 @@
 """Utility functions for mapping uploaded data columns."""
 
+from __future__ import annotations
+
 import re
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import pandas as pd
 
-from mapping.models import ColumnRules, load_rules
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from mapping.models import ColumnRules
+else:  # pragma: no cover - fallback at runtime
+    ColumnRules = Any  # type: ignore[misc]
 
 # Standard column mapping used across the project
 STANDARD_COLUMN_MAPPING: Dict[str, str] = {
@@ -52,7 +57,10 @@ def standardize_column_names(
 ) -> pd.DataFrame:
     """Return a new DataFrame with normalized column names."""
 
-    rules = rules or load_rules()
+    if rules is None:
+        from mapping.models import load_rules
+
+        rules = load_rules()
     df_out = df.copy()
 
     mappings: Dict[str, list[str]] = {**rules.english}

--- a/yosai_intel_dashboard/src/utils/preview_utils.py
+++ b/yosai_intel_dashboard/src/utils/preview_utils.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import json
 import logging
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import pandas as pd
 
-from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from yosai_intel_dashboard.src.core.config import get_max_display_rows
 from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationProtocol
 from yosai_intel_dashboard.src.core.unicode import sanitize_for_utf8
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+        dynamic_config,
+    )
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- avoid expensive runtime imports in `core.__init__`
- lazily import AI mapping utils
- delay loading mapping helper rules
- drop eager dynamic config usage in preview utils
- update cache imports for intelligent cache

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/__init__.py yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py yosai_intel_dashboard/src/utils/__init__.py yosai_intel_dashboard/src/utils/mapping_helpers.py yosai_intel_dashboard/src/utils/preview_utils.py`
- `python -c "import yosai_intel_dashboard.src.core; print('imported successfully')"`

------
https://chatgpt.com/codex/tasks/task_e_688ceefaf2bc832082950e7b709d9ed6