### PR TITLE
Fix missing HeuristicMappingModel

### DIFF
--- a/yosai_intel_dashboard/src/mapping/models/__init__.py
+++ b/yosai_intel_dashboard/src/mapping/models/__init__.py
@@ -1,3 +1,51 @@
-from .rule_based import ColumnRules, load_rules
+"""Mapping model implementations and helpers."""
 
-__all__ = ["ColumnRules", "load_rules"]
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import MappingModel
+from .heuristic import HeuristicMappingModel
+from .rule_based import ColumnRules, RuleBasedModel, load_rules
+
+
+class MLMappingModel(HeuristicMappingModel):
+    """Placeholder ML-based model using heuristics."""
+
+
+_MODEL_REGISTRY: Dict[str, Type[MappingModel]] = {
+    "heuristic": HeuristicMappingModel,
+    "rule_based": RuleBasedModel,
+    "ml": MLMappingModel,
+}
+
+
+def register_model(name: str, cls: Type[MappingModel]) -> None:
+    _MODEL_REGISTRY[name] = cls
+
+
+def get_registered_model(name: str) -> Type[MappingModel]:
+    if name not in _MODEL_REGISTRY:
+        raise KeyError(f"Unknown model type: {name}")
+    return _MODEL_REGISTRY[name]
+
+
+def load_model_from_config(path: str) -> MappingModel:
+    return MappingModel.load_from_config(path)
+
+
+# Backwards compatibility
+load_model = load_model_from_config
+
+__all__ = [
+    "ColumnRules",
+    "load_rules",
+    "MappingModel",
+    "HeuristicMappingModel",
+    "RuleBasedModel",
+    "MLMappingModel",
+    "register_model",
+    "get_registered_model",
+    "load_model_from_config",
+    "load_model",
+]

--- a/yosai_intel_dashboard/src/mapping/models/heuristic.py
+++ b/yosai_intel_dashboard/src/mapping/models/heuristic.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from .base import MappingModel
+
+
+class HeuristicMappingModel(MappingModel):
+    """Simple heuristic-based mapping model."""
+
+    def suggest(self, df: pd.DataFrame, filename: str) -> Dict[str, Dict[str, Any]]:
+        suggestions: Dict[str, Dict[str, Any]] = {}
+        for column in df.columns:
+            column_lower = str(column).lower()
+            field = ""
+            confidence = 0.0
+            if any(k in column_lower for k in ["person", "user", "employee", "name"]):
+                field, confidence = "person_id", 0.7
+            elif any(k in column_lower for k in ["door", "location", "device", "room"]):
+                field, confidence = "door_id", 0.7
+            elif any(k in column_lower for k in ["time", "date", "stamp"]):
+                field, confidence = "timestamp", 0.8
+            elif any(k in column_lower for k in ["result", "status", "access"]):
+                field, confidence = "access_result", 0.7
+            elif any(k in column_lower for k in ["token", "badge", "card"]):
+                field, confidence = "token_id", 0.6
+            suggestions[column] = {"field": field, "confidence": confidence}
+        return suggestions

--- a/yosai_intel_dashboard/src/mapping/models/rule_based.py
+++ b/yosai_intel_dashboard/src/mapping/models/rule_based.py
@@ -22,3 +22,24 @@ def load_rules(data_dir: Path = DATA_DIR) -> ColumnRules:
     with open(data_dir / "japanese_columns.yaml", "r", encoding="utf-8") as f:
         japanese = yaml.safe_load(f) or {}
     return ColumnRules(english=english, japanese=japanese)
+
+from typing import Any
+import pandas as pd
+
+from .base import MappingModel
+
+
+class RuleBasedModel(MappingModel):
+    """Simple mapping model using explicit column mappings."""
+
+    def __init__(self, mappings: Dict[str, str]) -> None:
+        super().__init__()
+        self.mappings = mappings
+
+    def suggest(self, df: pd.DataFrame, filename: str) -> Dict[str, Dict[str, Any]]:
+        suggestions: Dict[str, Dict[str, Any]] = {}
+        for column in df.columns:
+            field = self.mappings.get(column, "")
+            confidence = 1.0 if field else 0.0
+            suggestions[column] = {"field": field, "confidence": confidence}
+        return suggestions


### PR DESCRIPTION
## Summary
- implement heuristic and rule-based mapping models
- expose model loading helpers

## Testing
- `python - <<'EOF'
from yosai_intel_dashboard.src.core.interfaces import UnicodeProcessorProtocol
print('UnicodeProcessorProtocol loaded:', UnicodeProcessorProtocol.__name__)
EOF`
- `python - <<'EOF'
import os
os.environ.setdefault('SECRET_KEY','foo')
modules = {
    'config': 'import config',
    'services': 'import services', 
    'core': 'import core',
    'validation': 'import validation',
    'api': 'import api',
    'models': 'import models',
    'Config class': 'from config import Config',
    'Callbacks': 'from core.callbacks import TrulyUnifiedCallbacks',
    'SecurityValidator': 'from validation import SecurityValidator'
}
for name, stmt in modules.items():
    try:
        exec(stmt, {})
        print(f"{name}: OK")
    except Exception as e:
        print(f"{name}: FAIL - {e}")
EOF`
- `pytest tests/test_mapping_models.py tests/test_mapping_modular.py tests/test_ai_processor_model_integration.py -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688cf932dfcc832085c995240798e657