### PR TITLE
Fix HeuristicMappingModel imports

### DIFF
--- a/mapping.py
+++ b/mapping.py
@@ -1,3 +1,9 @@
 from importlib import import_module as _im
 import sys as _sys
-_sys.modules[__name__] = _im('yosai_intel_dashboard.src.mapping')
+
+_pkg = _im('yosai_intel_dashboard.src.mapping')
+
+__spec__ = _pkg.__spec__
+__path__ = _pkg.__path__
+__package__ = _pkg.__package__
+_sys.modules[__name__] = _pkg

--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -119,7 +119,9 @@ def register_analytics_services(container: ServiceContainer) -> None:
         EventBusProtocol,
         StorageProtocol,
     )
-    from mapping.factories.service_factory import create_mapping_service
+    from yosai_intel_dashboard.src.mapping.factories.service_factory import (
+        create_mapping_service,
+    )
     from yosai_intel_dashboard.src.services.analytics.calculator import create_calculator
     from yosai_intel_dashboard.src.services.analytics.protocols import (
         CalculatorProtocol,

--- a/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Protocol, runtime_checkable
 
-from mapping.core.interfaces import ProcessorInterface, StorageInterface
-from mapping.core.models import MappingData
+from yosai_intel_dashboard.src.mapping.core.interfaces import (
+    ProcessorInterface,
+    StorageInterface,
+)
+from yosai_intel_dashboard.src.mapping.core.models import MappingData
 
 import pandas as pd
 
@@ -151,7 +154,9 @@ def get_mapping_service(
     c = _get_container(container)
     if c and c.has("mapping_service"):
         return c.get("mapping_service")
-    from mapping.factories.service_factory import create_mapping_service
+    from yosai_intel_dashboard.src.mapping.factories.service_factory import (
+        create_mapping_service,
+    )
 
     return create_mapping_service(container=c)
 

--- a/yosai_intel_dashboard/src/infrastructure/di/service_container.py
+++ b/yosai_intel_dashboard/src/infrastructure/di/service_container.py
@@ -18,7 +18,7 @@ from typing import (
     get_type_hints,
 )
 
-from .base_model import BaseModel
+from yosai_intel_dashboard.src.core.base_model import BaseModel
 
 T = TypeVar("T")
 

--- a/yosai_intel_dashboard/src/mapping/factories/service_factory.py
+++ b/yosai_intel_dashboard/src/mapping/factories/service_factory.py
@@ -3,16 +3,22 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from yosai_intel_dashboard.src.core.container import container as default_container
-from mapping.models import (
+from yosai_intel_dashboard.src.mapping.models import (
     HeuristicMappingModel,
     MappingModel,
     load_model_from_config,
 )
-from mapping.processors.ai_processor import AIColumnMapperAdapter
-from mapping.processors.column_processor import ColumnProcessor
-from mapping.processors.device_processor import DeviceProcessor
-from mapping.service import MappingService
-from mapping.storage.base import JsonStorage, MemoryStorage
+from yosai_intel_dashboard.src.mapping.processors.ai_processor import (
+    AIColumnMapperAdapter,
+)
+from yosai_intel_dashboard.src.mapping.processors.column_processor import (
+    ColumnProcessor,
+)
+from yosai_intel_dashboard.src.mapping.processors.device_processor import (
+    DeviceProcessor,
+)
+from yosai_intel_dashboard.src.mapping.service import MappingService
+from yosai_intel_dashboard.src.mapping.storage.base import JsonStorage, MemoryStorage
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from yosai_intel_dashboard.src.services.learning.src.api.coordinator import LearningCoordinator

--- a/yosai_intel_dashboard/src/mapping/models/base.py
+++ b/yosai_intel_dashboard/src/mapping/models/base.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Tuple
 import pandas as pd
 import yaml
 
-from yosai_intel_dashboard.src.core.performance import MetricType, get_performance_monitor
 
 
 class MappingModel(ABC):
@@ -19,6 +18,10 @@ class MappingModel(ABC):
     CACHE_SIZE = 128
 
     def __init__(self) -> None:
+        from yosai_intel_dashboard.src.core.performance import (
+            get_performance_monitor,
+        )
+
         self._cache: "OrderedDict[Tuple[str, str], Dict[str, Dict[str, Any]]]" = (
             OrderedDict()
         )
@@ -43,6 +46,8 @@ class MappingModel(ABC):
         start = time.time()
         result = self.suggest(df, filename)
         duration = time.time() - start
+        from yosai_intel_dashboard.src.core.performance import MetricType
+
         self.monitor.record_metric(
             "mapping.suggest.latency", duration, MetricType.FILE_PROCESSING
         )

--- a/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/ai_processor.py
@@ -6,7 +6,10 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.core.container import container as default_container
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from mapping.models import HeuristicMappingModel, MappingModel
+from yosai_intel_dashboard.src.mapping.models import (
+    HeuristicMappingModel,
+    MappingModel,
+)
 
 
 class AIColumnMapperAdapter:

--- a/yosai_intel_dashboard/src/mapping/processors/column_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/column_processor.py
@@ -5,10 +5,12 @@ from typing import Any
 import pandas as pd
 
 from yosai_intel_dashboard.src.core.container import container as default_container
-from mapping.core.interfaces import ProcessorInterface
-from mapping.core.models import ProcessingResult
-from mapping.helpers import map_and_clean
-from mapping.processors.ai_processor import AIColumnMapperAdapter
+from yosai_intel_dashboard.src.mapping.core.interfaces import ProcessorInterface
+from yosai_intel_dashboard.src.mapping.core.models import ProcessingResult
+from yosai_intel_dashboard.src.mapping.helpers import map_and_clean
+from yosai_intel_dashboard.src.mapping.processors.ai_processor import (
+    AIColumnMapperAdapter,
+)
 
 
 class ColumnProcessor(ProcessorInterface):

--- a/yosai_intel_dashboard/src/mapping/processors/device_processor.py
+++ b/yosai_intel_dashboard/src/mapping/processors/device_processor.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import pandas as pd
 
-from mapping.core.interfaces import ProcessorInterface
-from mapping.core.models import ProcessingResult
+from yosai_intel_dashboard.src.mapping.core.interfaces import ProcessorInterface
+from yosai_intel_dashboard.src.mapping.core.models import ProcessingResult
 
 
 class DeviceProcessor(ProcessorInterface):

--- a/yosai_intel_dashboard/src/mapping/service.py
+++ b/yosai_intel_dashboard/src/mapping/service.py
@@ -4,8 +4,11 @@ import logging
 
 import pandas as pd
 
-from mapping.core.interfaces import ProcessorInterface, StorageInterface
-from mapping.core.models import MappingData
+from yosai_intel_dashboard.src.mapping.core.interfaces import (
+    ProcessorInterface,
+    StorageInterface,
+)
+from yosai_intel_dashboard.src.mapping.core.models import MappingData
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/mapping/storage/base.py
+++ b/yosai_intel_dashboard/src/mapping/storage/base.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-from mapping.core.interfaces import StorageInterface
+from yosai_intel_dashboard.src.mapping.core.interfaces import StorageInterface
 
 
 class JsonStorage(StorageInterface):

--- a/yosai_intel_dashboard/src/services/learning/src/api/coordinator.py
+++ b/yosai_intel_dashboard/src/services/learning/src/api/coordinator.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
-from mapping.core.interfaces import LearningInterface, StorageInterface
+from yosai_intel_dashboard.src.mapping.core.interfaces import (
+    LearningInterface,
+    StorageInterface,
+)
 from yosai_intel_dashboard.src.services.learning.src.ml.fingerprint_service import FingerprintService
 
 logger = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/utils/__init__.py
+++ b/yosai_intel_dashboard/src/utils/__init__.py
@@ -4,7 +4,9 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from mapping.processors.ai_processor import AIColumnMapperAdapter
+    from yosai_intel_dashboard.src.mapping.processors.ai_processor import (
+        AIColumnMapperAdapter,
+    )
 else:  # pragma: no cover - fallback at runtime
     AIColumnMapperAdapter = Any  # type: ignore[misc]
 
@@ -78,7 +80,7 @@ __all__ = [
 
 _LAZY_EXPORTS = {
     "AIColumnMapperAdapter": (
-        "mapping.processors.ai_processor",
+        "yosai_intel_dashboard.src.mapping.processors.ai_processor",
         "AIColumnMapperAdapter",
     ),
 }

--- a/yosai_intel_dashboard/src/utils/ai_column_mapper.py
+++ b/yosai_intel_dashboard/src/utils/ai_column_mapper.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 import pandas as pd
 
 from yosai_intel_dashboard.src.components.plugin_adapter import ComponentPluginAdapter
-from mapping.models import ColumnRules, load_rules
+from yosai_intel_dashboard.src.mapping.models import ColumnRules, load_rules
 
 # ---------------------------------------------------------------------------
 # Header variant dictionaries

--- a/yosai_intel_dashboard/src/utils/mapping_helpers.py
+++ b/yosai_intel_dashboard/src/utils/mapping_helpers.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import pandas as pd
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from mapping.models import ColumnRules
+    from yosai_intel_dashboard.src.mapping.models import ColumnRules
 else:  # pragma: no cover - fallback at runtime
     ColumnRules = Any  # type: ignore[misc]
 
@@ -58,7 +58,7 @@ def standardize_column_names(
     """Return a new DataFrame with normalized column names."""
 
     if rules is None:
-        from mapping.models import load_rules
+        from yosai_intel_dashboard.src.mapping.models import load_rules
 
         rules = load_rules()
     df_out = df.copy()


### PR DESCRIPTION
## Summary
- fix HeuristicMappingModel imports
- update mapping alias wrapper
- adjust service factory and processors
- use BaseModel from core in DI container
- adjust mapping helpers

## Testing
- `pytest tests/test_mapping_models.py::test_mapping_model_import -q` *(fails: ImportError: cannot import name 'Config' from partially initialized module)*
- `pytest -k nonexistent -q` *(fails: ImportError: cannot import name 'safe_encode_text')*

------
https://chatgpt.com/codex/tasks/task_e_688cfdb929a083209dea09052ec9c856