### PR TITLE
test: rename unified callback tests

### DIFF
--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -157,7 +157,7 @@ class TestChunkedUnicodeProcessor:
         assert result == "Test\U0001f600Content" * 500
 
 
-class TestUnifiedCallbackController:
+class TestTrulyUnifiedCallbacks:
     def test_callback_registration_and_firing(self):
         controller = TrulyUnifiedCallbacks()
         controller._callbacks.clear()


### PR DESCRIPTION
## Summary
- rename TestUnifiedCallbackController to TestTrulyUnifiedCallbacks

## Testing
- `pytest tests/test_unicode_handler_full.py::TestTrulyUnifiedCallbacks -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688d8cf703988320938b7e983d304883