### PR TITLE
refactor: centralize unified callbacks

### DIFF
--- a/yosai_intel_dashboard/src/core/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/core/callbacks/__init__.py
@@ -1,6 +1,6 @@
 """Unified callback utilities."""
 
-from yosai_intel_dashboard.src.core.truly_unified_callbacks import Operation, TrulyUnifiedCallbacks
+from core.truly_unified_callbacks import Operation, TrulyUnifiedCallbacks
 
 UnifiedCallbackManager = TrulyUnifiedCallbacks
 

--- a/yosai_intel_dashboard/src/core/truly_unified_callbacks.py
+++ b/yosai_intel_dashboard/src/core/truly_unified_callbacks.py
@@ -1,1 +1,8 @@
-from ..infrastructure.callbacks.unified_callbacks import *
+from __future__ import annotations
+
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    Operation,
+    TrulyUnifiedCallbacks,
+)
+
+__all__ = ["Operation", "TrulyUnifiedCallbacks"]


### PR DESCRIPTION
## Summary
- import unified callback types via `core.truly_unified_callbacks`
- expose `UnifiedCallbackManager` alias for `TrulyUnifiedCallbacks`
- wrap infrastructure implementation in `core.truly_unified_callbacks`

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/callbacks/__init__.py yosai_intel_dashboard/src/core/truly_unified_callbacks.py` *(fails: mypy returns many errors)*
- `pytest tests/callbacks -q` *(fails: ModuleNotFoundError: No module named 'analytics')*
- `python - <<'PY'
import importlib, core.callbacks
importlib.reload(core.callbacks)
from core.callbacks import UnifiedCallbackManager, TrulyUnifiedCallbacks
assert UnifiedCallbackManager is TrulyUnifiedCallbacks
print('Validation succeeded')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688dc9bcf12483208f6c3baee57a6ed2