### PR TITLE
Add rollback plan and monitoring for clean architecture migration

### DIFF
--- a/dashboards/grafana/clean_architecture.json
+++ b/dashboards/grafana/clean_architecture.json
@@ -1,0 +1,48 @@
+{
+  "uid": "clean-arch",
+  "title": "Clean Architecture Migration",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Import Resolution Time (p95)",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "import_resolution_seconds:p95", "legendFormat": "p95"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Module Loading Errors",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "module_loading_error_rate:5m", "legendFormat": "errors/s"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Legacy vs New Import Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "rate(legacy_import_usage_total[5m])", "legendFormat": "legacy"},
+        {"expr": "rate(clean_import_usage_total[5m])", "legendFormat": "new"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "System Resource Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"yosai-dashboard.*\"}[5m]))", "legendFormat": "cpu"},
+        {"expr": "sum(container_memory_usage_bytes{pod=~\"yosai-dashboard.*\"})", "legendFormat": "memory"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "API Response Time P95",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "api_response_time_p95:5m", "legendFormat": "p95"}
+      ]
+    }
+  ]
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  echo "[DRY RUN] Would deploy image tag $(git rev-parse --short HEAD)"
+  exit 0
+fi
+
+echo "Deploying image tag $(git rev-parse --short HEAD)"
+# Placeholder for real deployment commands

--- a/docs/rollback_plan.md
+++ b/docs/rollback_plan.md
@@ -1,0 +1,49 @@
+# Rollback Plan
+
+## Pre-deployment Checklist
+
+- [ ] Backup current deployment state
+- [ ] Document current version/image tag
+- [ ] Test rollback procedure in staging
+- [ ] Ensure team knows rollback process
+
+## Rollback Triggers
+
+Define when to rollback:
+
+- Import errors > X%
+- Health check failures
+- Performance degradation > Y%
+- Critical functionality broken
+
+## Rollback Procedures
+
+**Level 1: Quick Rollback (< 5 minutes)**
+
+```bash
+# Kubernetes deployment rollback
+kubectl rollout undo deployment/yosai-dashboard
+
+# Verify
+kubectl rollout status deployment/yosai-dashboard
+```
+
+**Level 2: Image Rollback (< 15 minutes)**
+
+```bash
+# Revert to specific image
+kubectl set image deployment/yosai-dashboard \
+  yosai-dashboard=ghcr.io/wsg23/yosai-dashboard:<previous-tag>
+```
+
+**Level 3: Full Rollback (< 30 minutes)**
+
+- Database migration rollback
+- Configuration rollback
+- Code revert
+
+## Post-Rollback Actions
+
+- Incident report template
+- Communication plan
+- Root cause analysis

--- a/docs/runbooks/clean_architecture_runbook.md
+++ b/docs/runbooks/clean_architecture_runbook.md
@@ -1,0 +1,21 @@
+# Clean Architecture Migration Runbook
+
+## Diagnosing Import Issues
+- Check `structure_validation_status` gauge in Prometheus.
+- Inspect application logs for `ImportError` or `ModuleNotFoundError`.
+- Verify symlinks for legacy imports remain intact.
+
+## Common Problems and Solutions
+- **Missing module**: run `scripts/update_imports.py` and redeploy.
+- **Legacy import used**: identify caller from `legacy_import_usage_total` metric and refactor to new module.
+- **Validation failures**: execute `scripts/validate_structure.py` to locate violations.
+
+## Performance Troubleshooting
+- Examine `import_resolution_seconds:p95` for spikes.
+- Compare `api_response_time_p95:5m` between previous and current versions.
+- Review system CPU and memory panels in Grafana.
+
+## Contact Information
+- DevOps On-Call: devops@example.com
+- Architecture Team: architecture@example.com
+- Slack: #yosai-ops

--- a/rollback.sh
+++ b/rollback.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--test" ]]; then
+  echo "[TEST MODE] Simulating rollback for deployment/yosai-dashboard"
+  echo "kubectl rollout undo deployment/yosai-dashboard"
+  echo "kubectl rollout status deployment/yosai-dashboard"
+  exit 0
+fi
+
+scripts/rollback.sh "$@"

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/clean_architecture.rules.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/clean_architecture.rules.yml
@@ -1,0 +1,13 @@
+groups:
+- name: clean_architecture_metrics
+  rules:
+  - record: import_resolution_seconds:p95
+    expr: histogram_quantile(0.95, rate(import_resolution_seconds_bucket[5m]))
+  - record: module_loading_error_rate:5m
+    expr: rate(module_loading_errors_total[5m])
+  - record: clean_architecture_validation_status
+    expr: structure_validation_status
+  - record: legacy_import_usage_rate:5m
+    expr: rate(legacy_import_usage_total[5m])
+  - record: api_response_time_p95:5m
+    expr: histogram_quantile(0.95, rate(api_response_seconds_bucket[5m]))

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/clean_architecture_metrics.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/clean_architecture_metrics.py
@@ -1,0 +1,78 @@
+"""Prometheus metrics for clean architecture migration."""
+
+from prometheus_client import (
+    REGISTRY,
+    Counter,
+    Gauge,
+    Histogram,
+    start_http_server,
+)
+from prometheus_client.core import CollectorRegistry
+
+if "import_resolution_seconds" not in REGISTRY._names_to_collectors:
+    import_resolution_histogram = Histogram(
+        "import_resolution_seconds",
+        "Time spent resolving imports",
+        buckets=[0.01, 0.1, 0.5, 1, 2, 5],
+    )
+    legacy_import_counter = Counter(
+        "legacy_import_usage_total",
+        "Count of legacy import usages",
+    )
+    structure_validation_gauge = Gauge(
+        "structure_validation_status",
+        "Status of clean architecture validation",
+    )
+else:  # pragma: no cover - defensive
+    import_resolution_histogram = Histogram(
+        "import_resolution_seconds",
+        "Time spent resolving imports",
+        buckets=[0.01, 0.1, 0.5, 1, 2, 5],
+        registry=CollectorRegistry(),
+    )
+    legacy_import_counter = Counter(
+        "legacy_import_usage_total",
+        "Count of legacy import usages",
+        registry=CollectorRegistry(),
+    )
+    structure_validation_gauge = Gauge(
+        "structure_validation_status",
+        "Status of clean architecture validation",
+        registry=CollectorRegistry(),
+    )
+
+_metrics_started = False
+
+
+def start_clean_architecture_metrics_server(port: int = 8007) -> None:
+    """Expose clean architecture metrics on ``port`` if not already started."""
+    global _metrics_started
+    if not _metrics_started:
+        start_http_server(port)
+        _metrics_started = True
+
+
+def record_import_resolution(duration: float) -> None:
+    """Observe import resolution ``duration`` in seconds."""
+    import_resolution_histogram.observe(duration)
+
+
+def increment_legacy_import() -> None:
+    """Increment legacy import counter."""
+    legacy_import_counter.inc()
+
+
+def set_structure_validation(status: int) -> None:
+    """Set structure validation gauge to ``status``."""
+    structure_validation_gauge.set(status)
+
+
+__all__ = [
+    "import_resolution_histogram",
+    "legacy_import_counter",
+    "structure_validation_gauge",
+    "start_clean_architecture_metrics_server",
+    "record_import_resolution",
+    "increment_legacy_import",
+    "set_structure_validation",
+]

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/clean_architecture_alerts.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/clean_architecture_alerts.yml
@@ -1,0 +1,24 @@
+groups:
+- name: clean_architecture
+  rules:
+  - alert: HighImportErrorRate
+    expr: rate(import_errors_total[5m]) > 0.1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: High import error rate detected
+  - alert: CleanArchitectureValidationFailing
+    expr: structure_validation_status == 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Clean architecture validation failing
+  - alert: LegacyImportUsageIncreasing
+    expr: rate(legacy_import_usage_total[5m]) > 0
+    for: 10m
+    labels:
+      severity: info
+    annotations:
+      summary: Legacy import usage detected


### PR DESCRIPTION
## Summary
- Document rollback plan with triggers, procedures, and post-rollback actions
- Add Prometheus metrics, recording rules, alerts, and Grafana dashboard for clean architecture migration
- Provide operational runbook and scripts to dry-run deployments and rollbacks

## Testing
- `pytest tests/monitoring -q`


------
https://chatgpt.com/codex/tasks/task_e_688dedb1e1708320aa44f757e04c19ae