### PR TITLE
Align Docker config with clean architecture layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies in a virtual environment
-COPY requirements.txt .
+COPY requirements.txt requirements.lock ./
 RUN python -m venv /opt/venv \
-    && /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
+    && /opt/venv/bin/pip install --no-cache-dir -r requirements.lock
 
 # Copy application source
 COPY . .
+RUN python scripts/create_symlinks.py
+RUN chmod +x start.sh
 
 FROM python:3.11-slim
 WORKDIR /app
+
 ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
 # Copy virtual env and application from builder stage
 COPY --from=builder /opt/venv /opt/venv
@@ -31,8 +35,5 @@ ENV YOSAI_ENV=production
 EXPOSE 8050
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 CMD curl -f http://localhost:8050/ || exit 1
-
-COPY start.sh ./start.sh
-RUN chmod +x start.sh
 
 CMD ["./start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 x-shared-env: &shared-env
   JAEGER_ENDPOINT: http://jaeger:14268/api/traces
   REPLICATION_METRICS_PORT: 8004
+  PYTHONPATH: /app:/app/yosai_intel_dashboard/src
 
 services:
   service-registry:
@@ -88,13 +89,21 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
+    command: ["python", "-m", "uvicorn", "yosai_intel_dashboard.src.services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
+    volumes:
+      - .:/app
     environment:
       <<: *shared-env
       YOSAI_ENV: development
       SERVICE_REGISTRY_URL: http://service-registry:8500
     depends_on:
       - service-registry
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
 
   api-gateway:
@@ -113,12 +122,20 @@ services:
     depends_on:
       - analytics-service
       - service-registry
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
 
   event-ingestion:
     build:
-      context: ./services/event-ingestion/
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/event-ingestion/Dockerfile
+    volumes:
+      - .:/app
     environment:
       <<: *shared-env
       KAFKA_BROKERS: kafka1:9092,kafka2:9093,kafka3:9094

--- a/scripts/create_symlinks.py
+++ b/scripts/create_symlinks.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Create legacy symlinks for backward compatibility."""
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = ROOT / "yosai_intel_dashboard" / "src"
+
+SYMLINKS = {
+    "core": SRC_ROOT / "core",
+    "models": SRC_ROOT / "models",
+    "services": SRC_ROOT / "services",
+    "config": SRC_ROOT / "infrastructure" / "config",
+    "monitoring": SRC_ROOT / "infrastructure" / "monitoring",
+    "security": SRC_ROOT / "infrastructure" / "security",
+    "api": SRC_ROOT / "adapters" / "api",
+    "plugins": SRC_ROOT / "adapters" / "api" / "plugins",
+    "mapping": SRC_ROOT / "mapping",
+    "database": SRC_ROOT / "database",
+}
+
+for name, target in SYMLINKS.items():
+    link = ROOT / name
+    if link.exists():
+        continue
+    if not target.exists():
+        continue
+    link.symlink_to(target)
+    print(f"Created symlink {link} -> {target}")

--- a/yosai_intel_dashboard/src/services/event-ingestion/Dockerfile
+++ b/yosai_intel_dashboard/src/services/event-ingestion/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 RUN pip install --no-cache-dir fastapi uvicorn kafka-python prometheus-fastapi-instrumentator opentelemetry-instrumentation-fastapi
 
 COPY . .
+RUN python scripts/create_symlinks.py
+
+ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- run symlink creation script during image build and expose new src tree via `PYTHONPATH`
- update analytics and ingestion service Docker builds and compose paths to use `yosai_intel_dashboard/src`
- add common `PYTHONPATH`, volumes, and health checks in docker-compose

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml services/event-ingestion/Dockerfile scripts/create_symlinks.py`
- `docker build -t test-image .` *(fails: command not found)*
- `docker run --rm test-image python -c "from yosai_intel_dashboard.src.infrastructure.config import Settings; print('OK')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dee96e65c8320979d876e68c27416