### PR TITLE
ci: run symlink script before Docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,6 +13,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python scripts/create_symlinks.py
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- setup Python 3.11 in docker release workflow
- run `scripts/create_symlinks.py` before building
- push both `ghcr.io/${{ github.repository }}:${{ github.ref_name }}` and `ghcr.io/${{ github.repository }}:latest`

## Testing
- `pre-commit run --files .github/workflows/docker-release.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e0a7cd0dc8320b454aeee2e3861c7