### PR TITLE
docs: document local act commands

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,23 @@
+# Local CI/CD with `act`
+
+This repository uses [act](https://github.com/nektos/act) to run GitHub Actions workflows locally.
+
+## Installation
+
+Install `act` by following the [official instructions](https://github.com/nektos/act#installation). On macOS with Apple Silicon, specify the container architecture when running:
+
+```bash
+act --container-architecture linux/amd64
+```
+
+Store GitHub secrets in a `.secrets` file in the repository root so `act` can load them during execution.
+
+## Sample Commands
+
+```bash
+act pull_request -j validate-structure
+act pull_request -j build
+act pull_request -W .github/workflows/ci-cd.yml -j tests
+act pull_request -W .github/workflows/microservices-ci-cd.yml -j deploy
+act push -W .github/workflows/docker-release.yml -j build-and-push
+```


### PR DESCRIPTION
## Summary
- document how to install and run `act` locally
- include sample commands for common CI/CD jobs

## Testing
- `pre-commit run --files docs/ci-cd.md`


------
https://chatgpt.com/codex/tasks/task_e_688e0a7fc498832080e7590432a4d7ac