### PR TITLE
Add Kolmogorov-Smirnov and Wasserstein drift metrics

### DIFF
--- a/yosai_intel_dashboard/src/services/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/services/monitoring/__init__.py
@@ -1,5 +1,17 @@
 """Monitoring utilities."""
 
-from .drift import compute_psi, population_stability_index
+from .drift import (
+    compute_psi,
+    detect_drift,
+    kolmogorov_smirnov,
+    population_stability_index,
+    wasserstein_distance,
+)
 
-__all__ = ["compute_psi", "population_stability_index"]
+__all__ = [
+    "compute_psi",
+    "detect_drift",
+    "kolmogorov_smirnov",
+    "population_stability_index",
+    "wasserstein_distance",
+]


### PR DESCRIPTION
## Summary
- add KS statistic and Wasserstein distance functions for drift monitoring
- provide detect_drift helper returning PSI, KS, Wasserstein metrics
- expose new drift utilities via module and package `__all__`

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/monitoring/drift.py yosai_intel_dashboard/src/services/monitoring/__init__.py`
- `pytest tests/test_performance_monitor_drift.py tests/monitoring/test_model_performance_monitor_drift.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e132a416883208c828f49f9b61acf