### PR TITLE
Add model monitoring events to Timescale

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
@@ -2,18 +2,24 @@ from __future__ import annotations
 
 """Scheduled monitoring of active ML models."""
 
+import asyncio
 import threading
 import time
 import warnings
 from typing import Optional
 
+from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
 from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
 from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,
 )
-from yosai_intel_dashboard.src.infrastructure.monitoring.prometheus.model_metrics import update_model_metrics
-from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
+from yosai_intel_dashboard.src.infrastructure.monitoring.prometheus.model_metrics import (
+    update_model_metrics,
+)
+from yosai_intel_dashboard.src.services.model_monitoring_service import (
+    ModelMonitoringService,
+)
 
 
 class ModelMonitor:
@@ -34,6 +40,7 @@ class ModelMonitor:
         self.interval_minutes = interval_minutes or default_interval
         self.registry = registry
         self.monitor = get_model_performance_monitor()
+        self._monitoring_service = ModelMonitoringService()
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
 
@@ -74,7 +81,20 @@ class ModelMonitor:
                 recall=metrics_dict.get("recall", 0.0),
             )
             update_model_metrics(metrics)
-            if self.monitor.detect_drift(metrics):
+            drift = self.monitor.detect_drift(metrics)
+            status = "drift" if drift else "ok"
+            for name, value in metrics.__dict__.items():
+                asyncio.run(
+                    self._monitoring_service.log_evaluation(
+                        rec.name,
+                        str(getattr(rec, "version", "")),
+                        name,
+                        float(value),
+                        "performance",
+                        status,
+                    )
+                )
+            if drift:
                 warnings.warn(
                     f"Model drift detected for {rec.name} {rec.version}",
                     RuntimeWarning,

--- a/yosai_intel_dashboard/src/services/model_monitoring_service.py
+++ b/yosai_intel_dashboard/src/services/model_monitoring_service.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from .timescale.manager import TimescaleDBManager
+
+
+class ModelMonitoringService:
+    """Service for logging model evaluation metrics to TimescaleDB."""
+
+    def __init__(self, manager: TimescaleDBManager | None = None) -> None:
+        self.manager = manager or TimescaleDBManager()
+
+    async def log_evaluation(
+        self,
+        model_name: str,
+        version: str,
+        metric: str,
+        value: float,
+        drift_type: str,
+        status: str,
+        *,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
+        """Record an evaluation result in TimescaleDB."""
+        ts = timestamp or datetime.utcnow()
+        await self.manager.fetch(
+            """
+            INSERT INTO model_monitoring_events (
+                time, model_name, version, metric, value, drift_type, status
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            """,
+            ts,
+            model_name,
+            version,
+            metric,
+            value,
+            drift_type,
+            status,
+        )

--- a/yosai_intel_dashboard/src/services/timescale/models.py
+++ b/yosai_intel_dashboard/src/services/timescale/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Integer, MetaData, String, text
+from sqlalchemy import Column, DateTime, Float, Integer, MetaData, String, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import declarative_base
@@ -57,6 +57,20 @@ class AccessEventHourly(Base):
     event_count = Column(Integer)
 
 
+class ModelMonitoringEvent(Base):
+    """Recorded model evaluation metrics."""
+
+    __tablename__ = "model_monitoring_events"
+
+    time = Column(DateTime(timezone=True), primary_key=True)
+    model_name = Column(String(100), index=True)
+    version = Column(String(50))
+    metric = Column(String(50))
+    value = Column(Float)
+    drift_type = Column(String(50))
+    status = Column(String(20))
+
+
 # ---------------------------------------------------------------------------
 # Helper functions
 # ---------------------------------------------------------------------------
@@ -103,4 +117,5 @@ __all__ = [
     "AccessEvent",
     "AccessEvent5Min",
     "AccessEventHourly",
+    "ModelMonitoringEvent",
 ]


### PR DESCRIPTION
## Summary
- track model evaluations in TimescaleDB via new ModelMonitoringEvent table
- create hypertable/policies for model monitoring events
- log model evaluation metrics to Timescale

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/timescale/models.py yosai_intel_dashboard/src/services/timescale/manager.py yosai_intel_dashboard/src/services/model_monitoring_service.py yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_688e132eeb248320938eedeec3b00905