### PR TITLE
feat: add configurable model monitoring thresholds

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/config/base.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base.py
@@ -14,8 +14,6 @@ from .cache_config import CacheConfig
 from .constants import (
     DEFAULT_APP_HOST,
     DEFAULT_APP_PORT,
-    DEFAULT_CACHE_HOST,
-    DEFAULT_CACHE_PORT,
     DEFAULT_DB_HOST,
     DEFAULT_DB_PORT,
 )
@@ -170,6 +168,10 @@ class MonitoringConfig:
     sentry_dsn: Optional[str] = None
     log_retention_days: int = 30
     model_evaluation_interval: int = 60
+    model_check_interval_minutes: int = 60
+    drift_threshold_ks: float = 0.1
+    drift_threshold_psi: float = 0.1
+    drift_threshold_wasserstein: float = 0.1
 
 
 @dataclass

--- a/yosai_intel_dashboard/src/infrastructure/config/pydantic_models.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/pydantic_models.py
@@ -92,6 +92,22 @@ class MonitoringModel(BaseModel):
     error_reporting_enabled: bool = True
     sentry_dsn: Optional[str] = None
     log_retention_days: int = 30
+    model_check_interval_minutes: int = Field(
+        default=60,
+        json_schema_extra={"env": "MODEL_CHECK_INTERVAL_MINUTES"},
+    )
+    drift_threshold_ks: float = Field(
+        default=0.1,
+        json_schema_extra={"env": "DRIFT_THRESHOLD_KS"},
+    )
+    drift_threshold_psi: float = Field(
+        default=0.1,
+        json_schema_extra={"env": "DRIFT_THRESHOLD_PSI"},
+    )
+    drift_threshold_wasserstein: float = Field(
+        default=0.1,
+        json_schema_extra={"env": "DRIFT_THRESHOLD_WASSERSTEIN"},
+    )
 
 
 class CacheModel(BaseModel):

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import warnings
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
@@ -14,8 +13,6 @@ from .cache_config import CacheConfig
 from .constants import (
     DEFAULT_APP_HOST,
     DEFAULT_APP_PORT,
-    DEFAULT_CACHE_HOST,
-    DEFAULT_CACHE_PORT,
     DEFAULT_DB_HOST,
     DEFAULT_DB_PORT,
 )
@@ -151,6 +148,10 @@ class MonitoringSettings(BaseModel):
     sentry_dsn: Optional[str] = None
     log_retention_days: int = 30
     model_evaluation_interval: int = 60
+    model_check_interval_minutes: int = 60
+    drift_threshold_ks: float = 0.1
+    drift_threshold_psi: float = 0.1
+    drift_threshold_wasserstein: float = 0.1
 
 
 class DataQualityThresholds(BaseModel):

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 """Scheduled monitoring of active ML models."""
 
 import threading
-import time
 import warnings
 from typing import Optional
 
+from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
 from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
-from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (
+from yosai_intel_dashboard.src.utils.scipy_compat import stats
+
+from .model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,
 )
-from yosai_intel_dashboard.src.infrastructure.monitoring.prometheus.model_metrics import update_model_metrics
-from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
+from .prometheus.model_metrics import update_model_metrics
 
 
 class ModelMonitor:
@@ -26,11 +27,12 @@ class ModelMonitor:
         interval_minutes: Optional[int] = None,
     ) -> None:
         cfg = get_monitoring_config()
-        mm_cfg = getattr(cfg, "model_monitor", {})
-        if isinstance(mm_cfg, dict):
-            default_interval = mm_cfg.get("evaluation_interval_minutes", 60)
-        else:
-            default_interval = getattr(mm_cfg, "evaluation_interval_minutes", 60)
+        default_interval = getattr(cfg, "model_check_interval_minutes", 60)
+        self.drift_threshold_ks = getattr(cfg, "drift_threshold_ks", 0.1)
+        self.drift_threshold_psi = getattr(cfg, "drift_threshold_psi", 0.1)
+        self.drift_threshold_wasserstein = getattr(
+            cfg, "drift_threshold_wasserstein", 0.1
+        )
         self.interval_minutes = interval_minutes or default_interval
         self.registry = registry
         self.monitor = get_model_performance_monitor()
@@ -80,6 +82,46 @@ class ModelMonitor:
                     RuntimeWarning,
                 )
                 self.monitor.baseline = metrics
+
+            # Feature drift checks using registry metrics
+            psi_metrics = self.registry.get_drift_metrics(rec.name)
+            for feature, psi in psi_metrics.items():
+                if psi > self.drift_threshold_psi:
+                    warnings.warn(
+                        f"PSI drift detected for {rec.name} {feature}: {psi:.4f}",
+                        RuntimeWarning,
+                    )
+
+            base_features = getattr(self.registry, "_baseline_features", {}).get(
+                rec.name
+            )
+            curr_features = getattr(self.registry, "_latest_features", {}).get(rec.name)
+            if base_features is None or curr_features is None:
+                continue
+            common = base_features.columns.intersection(curr_features.columns)
+            for col in common:
+                base_col = base_features[col].dropna()
+                curr_col = curr_features[col].dropna()
+                if base_col.empty or curr_col.empty:
+                    continue
+                if hasattr(stats, "ks_2samp"):
+                    result = stats.ks_2samp(base_col, curr_col)
+                    ks_stat = getattr(result, "statistic", result[0])
+                    if ks_stat > self.drift_threshold_ks:
+                        warnings.warn(
+                            f"KS drift detected for {rec.name} {col}: {ks_stat:.4f}",
+                            RuntimeWarning,
+                        )
+                if hasattr(stats, "wasserstein_distance"):
+                    w_dist = stats.wasserstein_distance(base_col, curr_col)
+                    if w_dist > self.drift_threshold_wasserstein:
+                        warnings.warn(
+                            (
+                                f"Wasserstein drift detected for {rec.name} {col}: "
+                                f"{w_dist:.4f}"
+                            ),
+                            RuntimeWarning,
+                        )
 
 
 __all__ = ["ModelMonitor"]


### PR DESCRIPTION
## Summary
- allow monitoring config to read drift thresholds and check interval from env vars
- wire ModelMonitor to use monitoring config for PSI/KS/Wasserstein drift checks

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/pydantic_models.py yosai_intel_dashboard/src/infrastructure/config/schema.py yosai_intel_dashboard/src/infrastructure/config/base.py yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py` *(with `SKIP=mypy,bandit`)*
- `pytest tests/test_model_performance_monitor.py tests/test_inference_drift_job.py tests/monitoring/test_model_performance_monitor_drift.py` *(fails: ModuleNotFoundError: No module named 'requests.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_688e1332065c83208ceddd27054e2158