### PR TITLE
feat: add cache layer stats

### DIFF
--- a/tests/test_hierarchical_cache_manager.py
+++ b/tests/test_hierarchical_cache_manager.py
@@ -1,0 +1,34 @@
+from core.hierarchical_cache_manager import HierarchicalCacheManager
+from core.performance import cache_monitor
+
+
+def test_stats_and_monitoring():
+    cache = HierarchicalCacheManager()
+    cache_monitor.register_cache("hc", cache)
+
+    cache.get("missing")
+    cache.set("a", 1, level=1)
+    cache.get("a")
+    cache.set("b", 2, level=2)
+    cache.get("b")
+    cache.set("c", 3, level=3)
+    cache.get("c")
+    cache.evict("a", level=1)
+    cache.clear()
+
+    stats = cache.stats()
+    assert stats["l1"]["hits"] == 1
+    assert stats["l1"]["misses"] == 3
+    assert stats["l1"]["evictions"] == 1
+    assert stats["l2"]["hits"] == 1
+    assert stats["l2"]["misses"] == 2
+    assert stats["l2"]["evictions"] == 1
+    assert stats["l3"]["hits"] == 1
+    assert stats["l3"]["misses"] == 1
+    assert stats["l3"]["evictions"] == 1
+
+    all_stats = cache_monitor.get_all_cache_stats()
+    assert "hc" in all_stats
+    assert all_stats["hc"] == stats
+
+    cache_monitor._caches.pop("hc", None)

--- a/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
+++ b/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Simple hierarchical cache with two levels."""
+"""Simple hierarchical cache with three levels and basic metrics."""
 
 import logging
 from typing import Any, Dict, Optional
@@ -9,7 +9,7 @@ from .base_model import BaseModel
 
 
 class HierarchicalCacheManager(BaseModel):
-    """Manage a two-level in-memory cache."""
+    """Manage a three-level in-memory cache and record basic stats."""
 
     def __init__(
         self,
@@ -21,21 +21,72 @@ class HierarchicalCacheManager(BaseModel):
         super().__init__(config, db, logger)
         self._level1: Dict[str, Any] = {}
         self._level2: Dict[str, Any] = {}
+        self._level3: Dict[str, Any] = {}
+        self._hits = {"l1": 0, "l2": 0, "l3": 0}
+        self._misses = {"l1": 0, "l2": 0, "l3": 0}
+        self._evictions = {"l1": 0, "l2": 0, "l3": 0}
 
     def get(self, key: str) -> Optional[Any]:
         if key in self._level1:
+            self._hits["l1"] += 1
             return self._level1[key]
-        return self._level2.get(key)
+        self._misses["l1"] += 1
+
+        if key in self._level2:
+            self._hits["l2"] += 1
+            return self._level2[key]
+        self._misses["l2"] += 1
+
+        if key in self._level3:
+            self._hits["l3"] += 1
+            return self._level3[key]
+        self._misses["l3"] += 1
+        return None
 
     def set(self, key: str, value: Any, *, level: int = 1) -> None:
         if level == 1:
             self._level1[key] = value
-        else:
+        elif level == 2:
             self._level2[key] = value
+        else:
+            self._level3[key] = value
 
     def clear(self) -> None:
+        self._evictions["l1"] += len(self._level1)
+        self._evictions["l2"] += len(self._level2)
+        self._evictions["l3"] += len(self._level3)
         self._level1.clear()
         self._level2.clear()
+        self._level3.clear()
+
+    def evict(self, key: str, *, level: int | None = None) -> None:
+        if level is None:
+            for lvl in (1, 2, 3):
+                self.evict(key, level=lvl)
+            return
+        cache = {1: self._level1, 2: self._level2, 3: self._level3}[level]
+        if key in cache:
+            del cache[key]
+            self._evictions[f"l{level}"] += 1
+
+    def stats(self) -> Dict[str, Dict[str, int]]:
+        return {
+            "l1": {
+                "hits": self._hits["l1"],
+                "misses": self._misses["l1"],
+                "evictions": self._evictions["l1"],
+            },
+            "l2": {
+                "hits": self._hits["l2"],
+                "misses": self._misses["l2"],
+                "evictions": self._evictions["l2"],
+            },
+            "l3": {
+                "hits": self._hits["l3"],
+                "misses": self._misses["l3"],
+                "evictions": self._evictions["l3"],
+            },
+        }
 
 
 __all__ = ["HierarchicalCacheManager"]


### PR DESCRIPTION
## Summary
- track hits, misses, and evictions for three cache layers
- expose cache layer statistics via stats()
- allow CacheMonitor to register caches and surface stats

## Testing
- `pytest tests/test_hierarchical_cache_manager.py tests/test_cache_warmer.py`

------
https://chatgpt.com/codex/tasks/task_e_688e174e06588320a6f0769bdcce5868