### PR TITLE
feat: enhance hierarchical cache

### DIFF
--- a/tests/test_hierarchical_cache_manager.py
+++ b/tests/test_hierarchical_cache_manager.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from core.cache_manager import cache_with_lock
+from core.hierarchical_cache_manager import HierarchicalCacheManager
+from yosai_intel_dashboard.src.core.performance import cache_monitor
+
+
+@pytest.mark.asyncio
+async def test_cache_with_lock_hierarchical_async():
+    manager = HierarchicalCacheManager()
+    cache_monitor.cache_stats.clear()
+    calls = {"n": 0}
+
+    @cache_with_lock(manager, ttl=1, name="asyncfunc")
+    async def compute(x):
+        calls["n"] += 1
+        return x * 2
+
+    assert await compute(3) == 6
+    assert await compute(3) == 6
+    assert calls["n"] == 1
+
+    stats = cache_monitor.cache_stats["asyncfunc"]
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+
+
+def test_cache_with_lock_hierarchical_sync():
+    manager = HierarchicalCacheManager()
+    cache_monitor.cache_stats.clear()
+    calls = {"n": 0}
+
+    @cache_with_lock(manager, ttl=1, name="syncfunc")
+    def compute(x):
+        calls["n"] += 1
+        return x + 5
+
+    assert compute(1) == 6
+    assert compute(1) == 6
+    assert calls["n"] == 1
+
+    stats = cache_monitor.cache_stats["syncfunc"]
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+
+
+def test_sync_helpers():
+    manager = HierarchicalCacheManager()
+    manager.set_sync("key", "value")
+    assert manager.get_sync("key") == "value"
+    assert manager.delete_sync("key") is True
+    assert manager.get_sync("key") is None

--- a/yosai_intel_dashboard/src/core/cache_manager.py
+++ b/yosai_intel_dashboard/src/core/cache_manager.py
@@ -1,1 +1,3 @@
-from ..infrastructure.cache.cache_manager import *
+from __future__ import annotations
+
+from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import *  # noqa: F401,F403

--- a/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
+++ b/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 """Simple hierarchical cache with two levels."""
 
+import asyncio
 import logging
+import time
 from typing import Any, Dict, Optional
 
 from .base_model import BaseModel
@@ -19,23 +21,83 @@ class HierarchicalCacheManager(BaseModel):
     ) -> None:
         """Create the cache manager with optional config, DB and logger."""
         super().__init__(config, db, logger)
-        self._level1: Dict[str, Any] = {}
-        self._level2: Dict[str, Any] = {}
+        self._level1: Dict[str, tuple[Any, Optional[float]]] = {}
+        self._level2: Dict[str, tuple[Any, Optional[float]]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
 
-    def get(self, key: str) -> Optional[Any]:
-        if key in self._level1:
-            return self._level1[key]
-        return self._level2.get(key)
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve value from cache, checking level1 then level2."""
+        item = self._level1.get(key)
+        if item is not None:
+            value, expiry = item
+            if expiry is None or time.time() <= expiry:
+                return value
+            del self._level1[key]
+        item = self._level2.get(key)
+        if item is not None:
+            value, expiry = item
+            if expiry is None or time.time() <= expiry:
+                return value
+            del self._level2[key]
+        return None
 
-    def set(self, key: str, value: Any, *, level: int = 1) -> None:
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        ttl: Optional[int] = None,
+        *,
+        level: int = 1,
+    ) -> None:
+        """Store ``value`` at the specified cache ``level``."""
+        expiry = time.time() + ttl if ttl else None
         if level == 1:
-            self._level1[key] = value
+            self._level1[key] = (value, expiry)
         else:
-            self._level2[key] = value
+            self._level2[key] = (value, expiry)
 
-    def clear(self) -> None:
+    async def delete(self, key: str) -> bool:
+        """Delete ``key`` from any level and return if removed."""
+        removed = False
+        if self._level1.pop(key, None) is not None:
+            removed = True
+        if self._level2.pop(key, None) is not None:
+            removed = True
+        return removed
+
+    async def clear(self) -> None:
+        """Clear all cache levels."""
         self._level1.clear()
         self._level2.clear()
+
+    def get_lock(self, key: str, timeout: int = 10) -> asyncio.Lock:
+        """Return an asyncio lock for ``key``."""
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+    # ------------------------------------------------------------------
+    # Synchronous helpers
+    def get_sync(self, key: str) -> Optional[Any]:
+        """Synchronous wrapper around :meth:`get`."""
+        return asyncio.run(self.get(key))
+
+    def set_sync(
+        self,
+        key: str,
+        value: Any,
+        ttl: Optional[int] = None,
+        *,
+        level: int = 1,
+    ) -> None:
+        """Synchronous wrapper around :meth:`set`."""
+        asyncio.run(self.set(key, value, ttl, level=level))
+
+    def delete_sync(self, key: str) -> bool:
+        """Synchronous wrapper around :meth:`delete`."""
+        return asyncio.run(self.delete(key))
 
 
 __all__ = ["HierarchicalCacheManager"]


### PR DESCRIPTION
## Summary
- refactor HierarchicalCacheManager to async interface with sync helpers
- extend cache_with_lock to record hit/miss metrics and handle sync backends
- add tests for hierarchical cache usage in sync and async contexts

## Testing
- `pre-commit run --files core/cache_manager.py yosai_intel_dashboard/src/core/hierarchical_cache_manager.py yosai_intel_dashboard/src/infrastructure/cache/cache_manager.py tests/test_hierarchical_cache_manager.py`
- `pytest tests/test_advanced_cache.py tests/test_cache_env_ttl.py tests/test_hierarchical_cache_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688e1750656c8320b16cf7a4ea8b97ca