### PR TITLE
feat(cache): add invalidation and demotion

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -248,6 +248,11 @@ The `IntelligentMultiLevelCache` combines memory, Redis and disk. Enable it with
 layer. The manager promotes entries between levels automatically and exposes a
 `report()` method for basic statistics.
 
+Upstream services can invalidate stale data by calling `invalidate(key)` to purge
+an individual entry from all tiers or `clear(level)` to wipe a specific tier or
+the entire cache. These hooks allow microservices to trigger cache purges when
+underlying datasets change.
+
 ```python
 from yosai_intel_dashboard.src.infrastructure.config.cache_manager import get_cache_manager
 

--- a/tests/test_intelligent_multilevel_cache.py
+++ b/tests/test_intelligent_multilevel_cache.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 
 import pytest
 
-from yosai_intel_dashboard.src.infrastructure.config.base import CacheConfig
 from core.intelligent_multilevel_cache import IntelligentMultiLevelCache
+from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import CacheConfig
 
 
 @pytest.mark.asyncio
 async def test_disk_promotion(tmp_path: Path):
-    cfg = CacheConfig(timeout_seconds=10, disk_path=str(tmp_path))
+    cfg = CacheConfig(timeout_seconds=10)
+    cfg.disk_path = str(tmp_path)
     cache = IntelligentMultiLevelCache(cfg)
     await cache.start()
     await cache.set("a", "b")
@@ -21,7 +24,8 @@ async def test_disk_promotion(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_expiration(tmp_path: Path):
-    cfg = CacheConfig(timeout_seconds=1, disk_path=str(tmp_path))
+    cfg = CacheConfig(timeout_seconds=1)
+    cfg.disk_path = str(tmp_path)
     cache = IntelligentMultiLevelCache(cfg)
     await cache.start()
     await cache.set("k", "v", ttl=1)
@@ -32,11 +36,44 @@ async def test_expiration(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_cache_report(tmp_path: Path):
-    cfg = CacheConfig(timeout_seconds=10, disk_path=str(tmp_path))
+    cfg = CacheConfig(timeout_seconds=10)
+    cfg.disk_path = str(tmp_path)
     cache = IntelligentMultiLevelCache(cfg)
     await cache.start()
     await cache.set("r", 1)
     report = cache.report()
     assert report["memory_entries"] == 1
     assert report["disk_entries"] == 1
+    await cache.stop()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_and_clear(tmp_path: Path):
+    cfg = CacheConfig(timeout_seconds=10)
+    cfg.disk_path = str(tmp_path)
+    cache = IntelligentMultiLevelCache(cfg)
+    await cache.start()
+    await cache.set("x", "y")
+    await cache.invalidate("x")
+    assert await cache.get("x") is None
+    await cache.set("x", "y")
+    await cache.clear(level=1)
+    assert "x" not in cache._memory
+    await cache.clear()
+    assert await cache.get("x") is None
+    await cache.stop()
+
+
+@pytest.mark.asyncio
+async def test_demotion_moves_cold_entries(tmp_path: Path):
+    cfg = CacheConfig(timeout_seconds=10)
+    cfg.disk_path = str(tmp_path)
+    cache = IntelligentMultiLevelCache(cfg)
+    await cache.start()
+    await cache.set("cold", "data", ttl=10)
+    await asyncio.sleep(6)
+    await cache.demote()
+    assert "cold" not in cache._memory
+    assert await cache.get("cold") == "data"
+    assert "cold" not in cache._memory
     await cache.stop()


### PR DESCRIPTION
## Summary
- add `invalidate` and tier-aware `clear` to `IntelligentMultiLevelCache`
- demote cold entries on access and purge expired Redis data
- document cache invalidation hooks for upstream services

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py docs/performance_monitoring.md tests/test_intelligent_multilevel_cache.py`
- `pytest tests/test_intelligent_multilevel_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_688e1751b76c83208ccaaa4340c5b239