### PR TITLE
Add OpenAPI examples to request/response schemas

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
 from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager
@@ -25,6 +25,14 @@ async def init_cache_manager() -> None:
 class AnalyticsQuery(BaseModel):
     facility_id: Optional[str] = Query(default="default")
     range: Optional[str] = Query(default="30d")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"facility_id": "fac-123", "range": "7d"}
+            ]
+        }
+    )
 
 
 @router.get("/patterns")

--- a/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
+++ b/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from .base_model import BaseModel

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -23,7 +23,7 @@ from fastapi import (
 )
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
 from yosai_intel_dashboard.src.infrastructure.config import get_database_config
@@ -165,6 +165,14 @@ class PatternsRequest(BaseModel):
 
 class PredictRequest(BaseModel):
     data: Any
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"data": {"features": [0.1, 0.2, 0.3]}}
+            ]
+        }
+    )
 
 
 @app.on_event("startup")

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -4,7 +4,7 @@ import base64
 from flask import Blueprint, jsonify, request
 from flask_apispec import doc
 from flask_wtf.csrf import validate_csrf
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from error_handling import ErrorCategory, ErrorHandler, api_error_response
 
@@ -16,9 +16,30 @@ class UploadRequestSchema(BaseModel):
     contents: list[str] | None = None
     filenames: list[str] | None = None
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "contents": [
+                        "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="
+                    ],
+                    "filenames": ["hello.txt"],
+                }
+            ]
+        }
+    )
+
 
 class UploadResponseSchema(BaseModel):
     job_id: str
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {"job_id": "123e4567-e89b-12d3-a456-426614174000"}
+            ]
+        }
+    )
 
 
 class StatusSchema(BaseModel):


### PR DESCRIPTION
## Summary
- add `json_schema_extra` examples to AnalyticsQuery and PredictRequest models
- document example payloads for upload request/response schemas
- fix missing imports in hierarchical cache manager to enable schema generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions')*
- `JWT_SECRET=secret make docs`
- `python scripts/generate_flask_openapi.py` *(fails: ImportError: cannot import name 'CacheConfig' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d1e0acc832088b1d2b24e4fcde2