### PR TITLE
Add standard error responses to critical endpoints

### DIFF
--- a/shared/errors/types.py
+++ b/shared/errors/types.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from pydantic import BaseModel
+
 
 class ErrorCode(str, Enum):
     """Common error codes returned by services."""
@@ -9,3 +11,10 @@ class ErrorCode(str, Enum):
     NOT_FOUND = "not_found"
     INTERNAL = "internal"
     UNAVAILABLE = "unavailable"
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response model."""
+
+    code: ErrorCode | None = None
+    detail: str

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -43,7 +43,7 @@ from yosai_intel_dashboard.src.services.auth import verify_jwt_token
 from yosai_intel_dashboard.src.services.common import async_db
 from yosai_intel_dashboard.src.services.common.async_db import close_pool, create_pool
 from yosai_intel_dashboard.src.services.common.secrets import get_secret
-from shared.errors.types import ErrorCode
+from shared.errors.types import ErrorCode, ErrorResponse
 from yosai_framework import ServiceBuilder
 from yosai_framework.errors import ServiceError
 from yosai_framework.service import BaseService
@@ -62,6 +62,13 @@ app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(UnicodeSanitizationMiddleware)
 
 rate_limiter = RateLimiter()
+
+ERROR_RESPONSES = {
+    400: {"model": ErrorResponse, "description": "Bad Request"},
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    404: {"model": ErrorResponse, "description": "Not Found"},
+    500: {"model": ErrorResponse, "description": "Internal Server Error"},
+}
 
 
 @app.middleware("http")
@@ -255,7 +262,7 @@ async def _shutdown() -> None:
     service.stop()
 
 
-@app.get("/api/v1/analytics/dashboard-summary")
+@app.get("/api/v1/analytics/dashboard-summary", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def dashboard_summary(
     _: None = Depends(verify_token),
@@ -270,7 +277,7 @@ async def dashboard_summary(
     return result
 
 
-@app.get("/api/v1/analytics/access-patterns")
+@app.get("/api/v1/analytics/access-patterns", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def access_patterns(
     days: int = Query(7),
@@ -288,7 +295,7 @@ async def access_patterns(
     return result
 
 
-@app.post("/api/v1/analytics/threat_assessment")
+@app.post("/api/v1/analytics/threat_assessment", responses=ERROR_RESPONSES)
 async def threat_assessment(
     request: Request,
     file: UploadFile | None = File(None),
@@ -335,7 +342,7 @@ async def threat_assessment(
 models_router = APIRouter(prefix="/api/v1/models", tags=["models"])
 
 
-@models_router.post("/register")
+@models_router.post("/register", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def register_model(
     name: str = Form(...),
@@ -368,7 +375,7 @@ async def register_model(
     return {"name": name, "version": record.version}
 
 
-@models_router.get("/{name}")
+@models_router.get("/{name}", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def list_versions(
     name: str,
@@ -385,7 +392,7 @@ async def list_versions(
     }
 
 
-@models_router.post("/{name}/rollback")
+@models_router.post("/{name}/rollback", responses=ERROR_RESPONSES)
 async def rollback(
     name: str,
     version: str = Form(...),
@@ -404,7 +411,7 @@ async def rollback(
     return {"name": name, "active_version": version}
 
 
-@models_router.post("/{name}/predict")
+@models_router.post("/{name}/predict", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def predict(
     name: str,
@@ -444,7 +451,7 @@ async def predict(
     return {"predictions": result}
 
 
-@models_router.get("/{name}/drift")
+@models_router.get("/{name}/drift", responses=ERROR_RESPONSES)
 @rate_limit_decorator()
 async def get_drift(
     name: str,

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -40,7 +40,13 @@ def create_upload_blueprint(
     @doc(
         description="Upload a file",
         tags=["upload"],
-        responses={202: "Accepted", 400: "Invalid CSRF token", 500: "Server Error"},
+        responses={
+            202: "Accepted",
+            400: "Bad Request",
+            401: "Unauthorized",
+            404: "Not Found",
+            500: "Internal Server Error",
+        },
     )
     @validate_input(UploadRequestSchema)
     @validate_output(UploadResponseSchema)
@@ -115,7 +121,13 @@ def create_upload_blueprint(
             }
         },
         tags=["upload"],
-        responses={200: "Success"},
+        responses={
+            200: "Success",
+            400: "Bad Request",
+            401: "Unauthorized",
+            404: "Not Found",
+            500: "Internal Server Error",
+        },
     )
     @validate_output(StatusSchema)
     def upload_status(job_id: str):


### PR DESCRIPTION
## Summary
- add reusable `ErrorResponse` model
- document common error responses on analytics and model APIs
- document error responses for upload endpoints

## Testing
- `pytest` *(fails: NameError: name 'dataclass' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d200eb48320991256cfca975500