### PR TITLE
feat: generate API docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,16 @@ jobs:
           path: coverage/lcov.info
       - name: Cypress Tests
         run: npx cypress run
+      - name: Generate API documentation
+        run: |
+          set -xe
+          pip install fpdf
+          python scripts/generate_api_docs.py
+      - name: Upload API documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-docs
+          path: docs/api_docs.*
       - name: Upload audit report
         uses: actions/upload-artifact@v4
         with:

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1,0 +1,6 @@
+# API Documentation
+
+Generated from OpenAPI specification.
+
+## GET /events
+List access events

--- a/docs/api_docs.pdf
+++ b/docs/api_docs.pdf
@@ -1,0 +1,70 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 156>>
+stream
+xe0O1	ԖF$=HYPs"\7lD9k"fCx*KRN.4Blv%3/Q_PmgGnlUpLc&y/Bwk|XPCc=0
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20250802141933)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000313 00000 n 
+0000000496 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000400 00000 n 
+0000000600 00000 n 
+0000000709 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+812
+%%EOF

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate basic API documentation from OpenAPI spec."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+OPENAPI_PATH = Path("docs/openapi.json")
+OUTPUT_MD = Path("docs/api_docs.md")
+OUTPUT_PDF = Path("docs/api_docs.pdf")
+
+
+def build_markdown(spec: dict) -> str:
+    lines: list[str] = [
+        "# API Documentation",
+        "",
+        "Generated from OpenAPI specification.",
+        "",
+    ]
+    for path, methods in sorted(spec.get("paths", {}).items()):
+        for method, info in methods.items():
+            summary = info.get("summary", "")
+            lines.append(f"## {method.upper()} {path}")
+            if summary:
+                lines.append(summary)
+            lines.append("")
+    return "\n".join(lines)
+
+
+def write_pdf(text: str) -> None:
+    try:
+        from fpdf import FPDF  # type: ignore
+    except Exception as exc:
+        print(f"PDF generation skipped (missing fpdf): {exc}")
+        return
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    for line in text.splitlines():
+        pdf.multi_cell(0, 10, line)
+    pdf.output(str(OUTPUT_PDF))
+
+
+def main() -> None:
+    if not OPENAPI_PATH.exists():
+        raise FileNotFoundError(f"OpenAPI spec not found at {OPENAPI_PATH}")
+    spec = json.loads(OPENAPI_PATH.read_text())
+    markdown = build_markdown(spec)
+    OUTPUT_MD.write_text(markdown)
+    write_pdf(markdown)
+    print(f"Generated {OUTPUT_MD} and {OUTPUT_PDF}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run API doc generator and upload as CI artifacts
- add script to build basic markdown/PDF from OpenAPI spec
- commit initial generated API docs

## Testing
- `python scripts/generate_api_docs.py`
- `pre-commit run --files .github/workflows/ci.yml scripts/generate_api_docs.py docs/api_docs.md`


------
https://chatgpt.com/codex/tasks/task_e_688e1d23ecd88320ada56c286e92766c