### PR TITLE
feat: versioned api docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ The running application exposes Swagger-based API docs at `http://<host>:<port>/
 - Ops reference: [docs/operations_guide.md](docs/operations_guide.md)
 - Callback migration: [docs/migration_callback_system.md](docs/migration_callback_system.md)
 
-Update the spec by running `go run ./api/openapi` which writes `docs/openapi.json` for the UI.
+Update the spec by running `go run ./api/openapi` which writes `docs/api/v2/openapi.json` for the UI.
 
 ### API Examples
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ converted to JSON with:
 go run ./api/openapi
 ```
 
-This writes `docs/openapi.json`. Once generated, this file can be served
+This writes `docs/api/v2/openapi.json`. Once generated, this file can be served
 by Swagger UI to display the API reference or used to generate client SDKs.
 
 The CI workflow runs this command and uploads the generated `openapi.json` as an
@@ -19,16 +19,17 @@ artifact so the specification is available from workflow runs.
 ### FastAPI microservices
 
 The analytics and event ingestion services are built with FastAPI. Each
-service dumps its own OpenAPI description at startup under the `docs`
-directory. Regenerate these files along with the main spec by running:
+service dumps its own OpenAPI description at startup under the
+`docs/api/v2` directory. Regenerate these files along with the main spec by
+running:
 
 ```bash
 make docs
 ```
 
 This command runs the Go generator and then imports both FastAPI services to
-write `docs/analytics_microservice_openapi.json` and
-`docs/event_ingestion_openapi.json`.
+write `docs/api/v2/analytics_microservice_openapi.json` and
+`docs/api/v2/event_ingestion_openapi.json`.
 
 ## Flask/FastAPI Adapter
 

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Generate API documentation for the project.
+
+This script collects OpenAPI specifications from the various services and
+writes them to a versioned directory under ``docs/api/<version>``.
+The version is detected from ``pyproject.toml`` or the Go ``versioning``
+module as a fallback.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore
+except Exception:  # pragma: no cover
+    tomllib = None  # type: ignore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def get_project_version() -> str:
+    """Return project version from ``pyproject.toml`` or ``versioning`` module."""
+    pyproject = ROOT / "pyproject.toml"
+    if tomllib and pyproject.exists():
+        data = tomllib.loads(pyproject.read_text())
+        version = (
+            data.get("project", {}).get("version")
+            or data.get("tool", {}).get("poetry", {}).get("version")
+        )
+        if version:
+            return str(version)
+
+    version_file = ROOT / "versioning" / "versioning.go"
+    if version_file.exists():
+        match = re.search(r"currentVersion:\s*\"([^\"]+)\"", version_file.read_text())
+        if match:
+            return match.group(1)
+
+    raise RuntimeError("Unable to determine project version")
+
+
+def main() -> None:
+    version = get_project_version()
+    out_dir = ROOT / "docs" / "api" / version
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate specs using existing scripts
+    subprocess.run(["go", "run", "./api/openapi"], cwd=ROOT, check=True)
+    subprocess.run([sys.executable, "scripts/generate_fastapi_openapi.py"], cwd=ROOT, check=True)
+    subprocess.run([sys.executable, "scripts/generate_flask_openapi.py"], cwd=ROOT, check=True)
+
+    # Move generated files into the versioned directory
+    for name in [
+        "openapi.json",
+        "analytics_microservice_openapi.json",
+        "event_ingestion_openapi.json",
+        "flask_openapi.json",
+    ]:
+        src = ROOT / "docs" / name
+        if src.exists():
+            shutil.move(str(src), out_dir / name)
+
+    print(f"API docs written to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- detect project version and generate OpenAPI docs in `docs/api/<version>`
- document new versioned API paths

## Testing
- `python scripts/generate_api_docs.py` *(fails: cannot find main module)*
- `pytest tests/test_upload_csrf.py::test_upload_requires_csrf -q` *(fails: NameError: dataclass)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d230b088320a7c225df9f1521d8