### PR TITLE
Add API doc generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ coverage/
 # Documentation
 docs/_build/
 docs/portal/
+docs/api/*.pdf
 # Mac
 .DS_Store
 # Windows

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -1,0 +1,76 @@
+# Yōsai Intel Dashboard API
+Physical security intelligence and access control API.
+
+# Authentication
+Use Bearer token (JWT) for inter-service communication and require an
+`X-CSRF-Token` header on state-changing requests.
+
+# Versioning
+API version is included in the URL path (e.g., /v2/events).
+
+
+## Version: 2.0.0
+
+### Terms of service
+https://yosai.com/terms
+
+**Contact information:**  
+api-support@yosai.com  
+
+**License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
+
+### /events
+
+#### GET
+##### Summary:
+
+List access events
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | Successful response |
+| 400 |  |
+| 404 |  |
+
+### Models
+
+
+#### AccessEvent
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| door_id | string |  | Yes |
+| event_id | string |  | No |
+| person_id | string |  | Yes |
+| result | string |  | No |
+| timestamp | dateTime |  | Yes |
+
+#### AnalyticsUpdate
+
+Generic analytics update broadcast over WebSocket.
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| AnalyticsUpdate | object | Generic analytics update broadcast over WebSocket. |  |
+
+#### Error
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| code | string |  | Yes |
+| details | object |  | No |
+| message | string |  | Yes |
+
+#### EventListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| events | [ [AccessEvent](#accessevent) ] |  | No |
+
+#### WebhookAlertPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| message | string |  | Yes |

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate Markdown and PDF API docs from the OpenAPI spec."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Possible converter commands. Each entry should include placeholders for
+# the input and output paths.
+CONVERTER_CMDS = [
+    ["npx", "--yes", "openapi-markdown", "-i", "{input}", "-o", "{output}"],
+    ["npx", "--yes", "openapi2markdown", "{input}", "-o", "{output}"],
+    ["npx", "--yes", "swagger-markdown", "-i", "{input}", "-o", "{output}"],
+]
+
+
+def convert_to_markdown(spec: Path, dest: Path) -> None:
+    """Convert the OpenAPI spec JSON to Markdown.
+
+    Tries a series of known converters until one succeeds.
+    """
+    for template in CONVERTER_CMDS:
+        cmd = [part.format(input=str(spec), output=str(dest)) for part in template]
+        try:
+            subprocess.run(cmd, check=True)
+            return
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue
+    raise RuntimeError(
+        "No OpenAPI to Markdown converter found. "
+        "Install openapi-markdown, openapi2markdown, or swagger-markdown."
+    )
+
+
+def convert_to_pdf(md_file: Path, pdf_file: Path) -> None:
+    """Convert Markdown to PDF using pandoc."""
+    subprocess.run(
+        [
+            "pandoc",
+            str(md_file),
+            "-o",
+            str(pdf_file),
+            "--pdf-engine=wkhtmltopdf",
+        ],
+        check=True,
+    )
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    spec_path = root / "docs" / "openapi.json"
+    out_dir = root / "docs" / "api"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    md_path = out_dir / "openapi.md"
+    pdf_path = out_dir / "openapi.pdf"
+
+    convert_to_markdown(spec_path, md_path)
+    convert_to_pdf(md_path, pdf_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- script to convert docs/openapi.json into Markdown and PDF docs
- store generated files under docs/api/
- ignore generated PDF to avoid merge conflicts

## Testing
- `pre-commit run --files .gitignore`
- `python scripts/generate_api_docs.py` *(fails: FileNotFoundError: 'pandoc')*

------
https://chatgpt.com/codex/tasks/task_e_688e1d211b3c8320abecb3c2b10c8dbe