### PR TITLE
feat: add performance profiling

### DIFF
--- a/middleware/performance.py
+++ b/middleware/performance.py
@@ -4,19 +4,26 @@ from typing import Awaitable, Callable
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from monitoring.performance_profiler import PerformanceProfiler
 from monitoring.request_metrics import request_duration
 
 
 class TimingMiddleware(BaseHTTPMiddleware):
-    """Measure request processing time and update Prometheus metrics."""
+    """Measure request processing time and update profiling metrics."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.profiler = PerformanceProfiler()
 
     async def dispatch(
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
+        endpoint = request.url.path
         start = time.perf_counter()
         try:
-            response = await call_next(request)
-            return response
+            with self.profiler.profile_endpoint(endpoint):
+                response = await call_next(request)
+                return response
         finally:
             elapsed = time.perf_counter() - start
             request_duration.observe(elapsed)

--- a/yosai_intel_dashboard/src/core/async_utils/async_batch.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_batch.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from collections.abc import AsyncIterable, Iterable
 from typing import AsyncIterator, List, TypeVar
 
+from monitoring.performance_profiler import PerformanceProfiler
+
 T = TypeVar("T")
+
+_profiler = PerformanceProfiler()
 
 
 async def async_batch(
@@ -15,18 +19,19 @@ async def async_batch(
     items smaller than ``size`` are yielded at the end.
     """
 
-    batch: List[T] = []
-    if isinstance(source, AsyncIterable):
-        async for item in source:
-            batch.append(item)
-            if len(batch) >= size:
-                yield batch
-                batch = []
-    else:
-        for item in source:
-            batch.append(item)
-            if len(batch) >= size:
-                yield batch
-                batch = []
-    if batch:
-        yield batch
+    async with _profiler.track_task("async_batch"):
+        batch: List[T] = []
+        if isinstance(source, AsyncIterable):
+            async for item in source:
+                batch.append(item)
+                if len(batch) >= size:
+                    yield batch
+                    batch = []
+        else:
+            for item in source:
+                batch.append(item)
+                if len(batch) >= size:
+                    yield batch
+                    batch = []
+        if batch:
+            yield batch

--- a/yosai_intel_dashboard/src/core/async_utils/async_context_manager.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_context_manager.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Awaitable, Callable, TypeVar
 
+from monitoring.performance_profiler import PerformanceProfiler
+
 T = TypeVar("T")
+
+_profiler = PerformanceProfiler()
 
 
 class AsyncContextManager:
@@ -17,7 +21,9 @@ class AsyncContextManager:
         self._exit = exit
 
     async def __aenter__(self) -> T:
-        return await self._enter()
+        async with _profiler.track_task("async_context_enter"):
+            return await self._enter()
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        await self._exit(exc_type, exc, tb)
+        async with _profiler.track_task("async_context_exit"):
+            await self._exit(exc_type, exc, tb)

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/performance_profiler.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/performance_profiler.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+"""Lightweight performance profiling utilities."""
+
+import time
+from contextlib import asynccontextmanager, contextmanager
+from typing import Optional
+
+import psutil
+
+from yosai_intel_dashboard.src.core.performance import (
+    MetricType,
+    PerformanceThresholds,
+    get_performance_monitor,
+)
+
+
+class PerformanceProfiler:
+    """Record execution metrics and detect bottlenecks."""
+
+    def __init__(self) -> None:
+        self.monitor = get_performance_monitor()
+
+    # ------------------------------------------------------------------
+    @contextmanager
+    def profile_endpoint(self, endpoint: str):
+        """Profile CPU, memory, and time for a web endpoint."""
+        proc = psutil.Process()
+        start_cpu = proc.cpu_percent(interval=None)
+        start_mem = proc.memory_info().rss / (1024 * 1024)
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            end_cpu = proc.cpu_percent(interval=None)
+            end_mem = proc.memory_info().rss / (1024 * 1024)
+            cpu_delta = max(0.0, end_cpu - start_cpu)
+            mem_delta = end_mem - start_mem
+            tags = {"endpoint": endpoint}
+            self.monitor.record_metric(
+                f"endpoint.{endpoint}.time",
+                duration,
+                MetricType.EXECUTION_TIME,
+                duration=duration,
+                tags=tags,
+            )
+            self.monitor.record_metric(
+                f"endpoint.{endpoint}.cpu",
+                cpu_delta,
+                MetricType.CPU_USAGE,
+                tags=tags,
+            )
+            self.monitor.record_metric(
+                f"endpoint.{endpoint}.memory",
+                mem_delta,
+                MetricType.MEMORY_USAGE,
+                tags=tags,
+            )
+            self._detect_bottleneck(
+                f"endpoint.{endpoint}", duration, cpu_delta, mem_delta
+            )
+
+    # ------------------------------------------------------------------
+    @asynccontextmanager
+    async def track_db_query(self, query: str):
+        """Measure execution time for a database query."""
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.monitor.record_metric(
+                "db.query",
+                duration,
+                MetricType.DATABASE_QUERY,
+                duration=duration,
+                tags={"query": query},
+            )
+            if duration > PerformanceThresholds.SLOW_QUERY_SECONDS:
+                self.monitor.logger.warning(
+                    f"Slow DB query: {query} took {duration:.3f}s"
+                )
+
+    # ------------------------------------------------------------------
+    @asynccontextmanager
+    async def track_task(self, name: str):
+        """Measure execution time for an async task."""
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.monitor.record_metric(
+                f"task.{name}",
+                duration,
+                MetricType.EXECUTION_TIME,
+                duration=duration,
+                tags={"task": name},
+            )
+            self._detect_bottleneck(f"task.{name}", duration)
+
+    # ------------------------------------------------------------------
+    def _detect_bottleneck(
+        self,
+        name: str,
+        duration: float,
+        cpu: Optional[float] = None,
+        memory: Optional[float] = None,
+    ) -> None:
+        """Log potential bottlenecks based on thresholds."""
+        if duration > PerformanceThresholds.SLOW_QUERY_SECONDS:
+            self.monitor.logger.warning(
+                f"Bottleneck detected: {name} took {duration:.3f}s"
+            )
+        if cpu is not None and cpu > 80.0:
+            self.monitor.logger.warning(
+                f"High CPU usage detected for {name}: {cpu:.1f}%"
+            )
+        if memory is not None and memory > 100.0:
+            self.monitor.logger.warning(
+                f"High memory usage detected for {name}: {memory:.1f}MB"
+            )
+
+
+__all__ = ["PerformanceProfiler"]


### PR DESCRIPTION
## Summary
- add PerformanceProfiler for endpoint, database, and task metrics
- integrate profiler with request middleware and async utilities
- record database query durations and attach endpoint identifiers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688e24b47e58832096eaa2cb66712a8a