### PR TITLE
Add Locust load testing and regression reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ config.zip
 app.log
 
 !load-tests/thresholds.json
+!load-tests/baseline.json
 archive/
 !yosai_intel_dashboard/src/infrastructure/cache/
 yosai_intel_dashboard/src/**/__pycache__/

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -335,3 +335,30 @@ Two helper scripts under `monitoring/` capture runtime resource usage.
   ```bash
   python -m monitoring.tracemalloc_profile scripts/my_job.py --snapshot allocs.snap
   ```
+
+## Load Testing with Locust
+
+The `load-tests` folder provides utilities for exercising key API endpoints under load.
+
+### Local execution
+
+Install the development requirements and run:
+
+```bash
+./load-tests/run_locust.sh
+```
+
+This script runs Locust in headless mode against `http://localhost:8000` by default and
+writes results to `load-tests/results/`.
+
+### Continuous integration
+
+CI environments should invoke:
+
+```bash
+./load-tests/run_locust_ci.sh
+```
+
+It generates JSON and HTML regression reports comparing the current metrics with the
+baseline (`load-tests/baseline.json`) and validates p50/p95/p99 latency targets defined in
+`load-tests/thresholds.json`.

--- a/load-tests/baseline.json
+++ b/load-tests/baseline.json
@@ -1,0 +1,20 @@
+{
+  "/api/v1/analytics/dashboard-summary": {
+    "throughput": 100,
+    "p50": 200,
+    "p95": 500,
+    "p99": 800
+  },
+  "/api/v1/analytics/access-patterns": {
+    "throughput": 80,
+    "p50": 200,
+    "p95": 500,
+    "p99": 800
+  },
+  "/health": {
+    "throughput": 50,
+    "p50": 50,
+    "p95": 100,
+    "p99": 200
+  }
+}

--- a/load-tests/generate_report.py
+++ b/load-tests/generate_report.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Generate JSON and HTML regression reports from Locust stats."""
+
+import csv
+import json
+import pathlib
+import sys
+from typing import Dict
+
+
+def load_current(csv_path: str) -> Dict[str, Dict[str, float]]:
+    stats = {}
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row["Name"]
+            if name == "Aggregated":
+                continue
+            stats[name] = {
+                "throughput": float(row["Requests/s"]),
+                "p50": float(row["50%"]),
+                "p95": float(row["95%"]),
+                "p99": float(row["99%"]),
+            }
+    return stats
+
+
+def compare(
+    current: Dict[str, Dict[str, float]], baseline: Dict[str, Dict[str, float]]
+):
+    report = {}
+    for ep, cur in current.items():
+        base = baseline.get(ep, {})
+        report[ep] = {}
+        for metric in ["throughput", "p50", "p95", "p99"]:
+            report[ep][metric] = {
+                "current": cur.get(metric),
+                "baseline": base.get(metric),
+                "delta": cur.get(metric) - base.get(metric, 0),
+            }
+    return report
+
+
+def write_html(
+    report: Dict[str, Dict[str, Dict[str, float]]], out_file: pathlib.Path
+) -> None:
+    with out_file.open("w") as f:
+        f.write("<html><body><table border='1'>")
+        f.write(
+            "<tr><th>Endpoint</th><th>Metric</th><th>Current</th><th>Baseline</th><th>Delta</th></tr>"
+        )
+        for ep, metrics in report.items():
+            for metric, values in metrics.items():
+                f.write(
+                    f"<tr><td>{ep}</td><td>{metric}</td><td>{values['current']}</td><td>{values['baseline']}</td><td>{values['delta']}</td></tr>"
+                )
+        f.write("</table></body></html>")
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print("Usage: generate_report.py <current_csv> <baseline_json> <output_dir>")
+        return 1
+
+    csv_path, baseline_path, out_dir = sys.argv[1:]
+    out_dir = pathlib.Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    current = load_current(csv_path)
+    baseline = {}
+    if pathlib.Path(baseline_path).exists():
+        with open(baseline_path) as f:
+            baseline = json.load(f)
+
+    report = compare(current, baseline)
+
+    with open(out_dir / "regression_report.json", "w") as f:
+        json.dump(report, f, indent=2)
+
+    write_html(report, out_dir / "regression_report.html")
+    print(f"Regression report written to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/load-tests/locustfile.py
+++ b/load-tests/locustfile.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from locust import HttpUser, SequentialTaskSet, between, task
+
+
+class AnalyticsJourney(SequentialTaskSet):
+    """User journey hitting common analytics endpoints sequentially."""
+
+    @task
+    def dashboard_summary(self):
+        self.client.get("/api/v1/analytics/dashboard-summary")
+
+    @task
+    def access_patterns(self):
+        self.client.get("/api/v1/analytics/access-patterns")
+
+    @task
+    def stop(self):
+        # Finish the journey
+        self.interrupt()
+
+
+class WebsiteUser(HttpUser):
+    wait_time = between(1, 5)
+    tasks = {AnalyticsJourney: 5}
+
+    @task(1)
+    def health(self):
+        self.client.get("/health")

--- a/load-tests/run_locust.sh
+++ b/load-tests/run_locust.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST=${HOST:-http://localhost:8000}
+USERS=${USERS:-10}
+SPAWN_RATE=${SPAWN_RATE:-2}
+RUN_TIME=${RUN_TIME:-1m}
+OUTPUT_DIR=${OUTPUT_DIR:-load-tests/results}
+
+mkdir -p "$OUTPUT_DIR"
+
+locust -f "$(dirname "$0")/locustfile.py" \
+  --headless \
+  --host "$HOST" \
+  -u "$USERS" \
+  -r "$SPAWN_RATE" \
+  -t "$RUN_TIME" \
+  --csv="$OUTPUT_DIR/locust" \
+  --html="$OUTPUT_DIR/locust.html"

--- a/load-tests/run_locust_ci.sh
+++ b/load-tests/run_locust_ci.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(dirname "$0")"
+OUTPUT_DIR=${OUTPUT_DIR:-$DIR/results}
+BASELINE=${BASELINE:-$DIR/baseline.json}
+
+export OUTPUT_DIR
+"$DIR/run_locust.sh"
+
+python "$DIR/generate_report.py" "$OUTPUT_DIR/locust_stats.csv" "$BASELINE" "$OUTPUT_DIR"
+python "$DIR/validate_thresholds.py" "$OUTPUT_DIR/locust_stats.csv" "$DIR/thresholds.json"

--- a/load-tests/thresholds.json
+++ b/load-tests/thresholds.json
@@ -1,4 +1,21 @@
 {
   "http_req_failed_rate": 0.01,
-  "http_req_duration_p95": 500
+  "http_req_duration_p95": 500,
+  "endpoints": {
+    "/api/v1/analytics/dashboard-summary": {
+      "p50": 200,
+      "p95": 500,
+      "p99": 800
+    },
+    "/api/v1/analytics/access-patterns": {
+      "p50": 200,
+      "p95": 500,
+      "p99": 800
+    },
+    "/health": {
+      "p50": 50,
+      "p95": 100,
+      "p99": 200
+    }
+  }
 }

--- a/load-tests/validate_thresholds.py
+++ b/load-tests/validate_thresholds.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Validate Locust metrics against threshold targets."""
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+def load_metrics(csv_path: str):
+    metrics = {}
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row["Name"]
+            if name == "Aggregated":
+                continue
+            metrics[name] = {
+                "p50": float(row["50%"]),
+                "p95": float(row["95%"]),
+                "p99": float(row["99%"]),
+            }
+    return metrics
+
+
+def main(csv_path: str, thresholds_path: str) -> int:
+    metrics = load_metrics(csv_path)
+    thresholds = json.load(open(thresholds_path)).get("endpoints", {})
+
+    for ep, limits in thresholds.items():
+        if ep not in metrics:
+            print(f"warning: no data for endpoint {ep}", file=sys.stderr)
+            continue
+        for key in ["p50", "p95", "p99"]:
+            value = metrics[ep][key]
+            target = limits[key]
+            if value > target:
+                raise SystemExit(f"{ep} {key} {value} exceeds threshold {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: validate_thresholds.py <csv_metrics> <thresholds.json>")
+        raise SystemExit(1)
+    raise SystemExit(main(sys.argv[1], sys.argv[2]))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,5 @@ pip-audit
 mlflow
 boto3
 flask-apispec<0.12
+locust
 -r requirements-test.txt


### PR DESCRIPTION
## Summary
- add Locust user journey covering analytics endpoints
- provide scripts to run Locust locally and in CI with regression reporting
- record latency targets per endpoint and document load test execution

## Testing
- `pre-commit run --files .gitignore docs/performance_monitoring.md load-tests/thresholds.json requirements-dev.txt load-tests/baseline.json load-tests/generate_report.py load-tests/locustfile.py load-tests/run_locust.sh load-tests/run_locust_ci.sh load-tests/validate_thresholds.py`
- `pytest tests/test_async_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688e24b70bac832092738e3eb2fc0c53