### PR TITLE
feat: track N+1 queries with profiler and CLI

### DIFF
--- a/tests/services/test_query_optimizer.py
+++ b/tests/services/test_query_optimizer.py
@@ -1,0 +1,20 @@
+from services.query_optimizer import (
+    end_request_tracking,
+    start_request_tracking,
+    track_query,
+)
+from yosai_intel_dashboard.src.core.performance import profiler
+
+
+def test_n_plus_one_detection_records_queries():
+    profiler.n_plus_one_queries.clear()
+    start_request_tracking()
+    track_query("SELECT * FROM users WHERE id=1")
+    track_query("SELECT * FROM users WHERE id=2")
+    end_request_tracking("/users")
+
+    data = profiler.get_n_plus_one_queries()
+    assert "/users" in data
+    assert data["/users"][0]["stacks"]
+    assert data["/users"][0]["query"].startswith("SELECT * FROM users")
+

--- a/yosai_intel_dashboard/src/core/performance.py
+++ b/yosai_intel_dashboard/src/core/performance.py
@@ -476,6 +476,8 @@ class PerformanceProfiler(BaseModel):
         super().__init__(config, db, logger)
         self.profile_data: Dict[str, List[Tuple[str, float]]] = defaultdict(list)
         self.active_profiles: Dict[str, float] = {}
+        # Track N+1 query occurrences keyed by endpoint
+        self.n_plus_one_queries: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
 
     def start_profiling(self, session_name: str) -> None:
         """Start a profiling session"""
@@ -528,6 +530,18 @@ class PerformanceProfiler(BaseModel):
             }
 
         return report
+
+    def record_n_plus_one(
+        self, endpoint: str, query: str, stacks: List[str]
+    ) -> None:
+        """Record an N+1 query occurrence for an endpoint."""
+        self.n_plus_one_queries[endpoint].append(
+            {"query": query, "stacks": stacks, "timestamp": datetime.now()}
+        )
+
+    def get_n_plus_one_queries(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Return recorded N+1 query occurrences."""
+        return self.n_plus_one_queries
 
 
 class CacheMonitor(BaseModel):

--- a/yosai_intel_dashboard/src/services/query_optimizer.py
+++ b/yosai_intel_dashboard/src/services/query_optimizer.py
@@ -1,0 +1,75 @@
+"""N+1 query detection utilities."""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from collections import defaultdict
+from contextvars import ContextVar
+from typing import Dict, List
+
+from yosai_intel_dashboard.src.core.performance import profiler
+
+logger = logging.getLogger(__name__)
+
+
+# Context variable to store queries executed during a request
+_request_queries: ContextVar[Dict[str, List[str]]] = ContextVar(
+    "n_plus_one_queries", default=None
+)
+
+
+def _normalize_query(query: str) -> str:
+    """Normalize query string to compare structural similarity."""
+    import re
+
+    normalized = re.sub(r"'[^']*'", "'?'", query)
+    normalized = re.sub(r"\b\d+\b", "?", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def start_request_tracking() -> None:
+    """Begin tracking queries for the current request."""
+    _request_queries.set(defaultdict(list))
+
+
+def track_query(query: str) -> None:
+    """Record a query execution for N+1 detection."""
+    queries = _request_queries.get()
+    if queries is None:
+        return
+
+    pattern = _normalize_query(query)
+    stack = "".join(traceback.format_stack(limit=5))
+    queries[pattern].append(stack)
+
+
+def end_request_tracking(endpoint: str) -> Dict[str, List[str]]:
+    """Stop tracking and report any N+1 query patterns.
+
+    Returns mapping of offending query pattern to stack traces.
+    """
+
+    queries = _request_queries.get()
+    if not queries:
+        return {}
+
+    n_plus_one = {q: stacks for q, stacks in queries.items() if len(stacks) > 1}
+    if n_plus_one:
+        for query, stacks in n_plus_one.items():
+            profiler.record_n_plus_one(endpoint, query, stacks)
+            logger.warning("N+1 query detected on %s: %s", endpoint, query)
+            for stack in stacks:
+                logger.debug("Stack trace:\n%s", stack)
+
+    _request_queries.set(None)
+    return n_plus_one
+
+
+__all__ = [
+    "start_request_tracking",
+    "track_query",
+    "end_request_tracking",
+]
+

--- a/yosai_intel_dashboard/src/services/query_optimizer_cli.py
+++ b/yosai_intel_dashboard/src/services/query_optimizer_cli.py
@@ -1,0 +1,38 @@
+"""CLI to inspect detected N+1 queries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+from yosai_intel_dashboard.src.core.performance import profiler
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Show detected N+1 queries")
+    parser.add_argument("--json", action="store_true", help="Output in JSON format")
+    args = parser.parse_args(argv)
+
+    data = profiler.get_n_plus_one_queries()
+
+    if args.json:
+        print(json.dumps(data, indent=2, default=str))
+        return
+
+    if not data:
+        print("No N+1 queries detected")
+        return
+
+    for endpoint, entries in data.items():
+        print(f"Endpoint: {endpoint}")
+        for entry in entries:
+            print(f"  Query: {entry['query']}")
+            for stack in entry["stacks"]:
+                print("  Stack trace:")
+                print(stack)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()
+


### PR DESCRIPTION
## Summary
- add N+1 query tracker service and CLI to review occurrences
- integrate tracking with PerformanceProfiler to surface offenders
- add tests verifying detection

## Testing
- `pytest tests/services/test_query_optimizer.py tests/database/test_query_optimizer.py`


------
https://chatgpt.com/codex/tasks/task_e_688e24c11df883208f4b7e2185f10a91