### PR TITLE
Add Kubernetes microservice manifests

### DIFF
--- a/k8s/microservices/analytics-service-config.yaml
+++ b/k8s/microservices/analytics-service-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-service-config
+  labels:
+    app.kubernetes.io/name: analytics-service
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: analytics
+data:
+  LOG_LEVEL: "INFO"
+  ANALYTICS_BATCH_SIZE: "100"

--- a/k8s/microservices/analytics-service-networkpolicy.yaml
+++ b/k8s/microservices/analytics-service-networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: analytics-service-networkpolicy
+  labels:
+    app.kubernetes.io/name: analytics-service
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: analytics
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: analytics-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api-gateway
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: event-ingestion

--- a/k8s/microservices/analytics-service.yaml
+++ b/k8s/microservices/analytics-service.yaml
@@ -3,16 +3,20 @@ kind: Deployment
 metadata:
   name: analytics-service
   labels:
-    app: analytics-service
+    app.kubernetes.io/name: analytics-service
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: analytics
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: analytics-service
+      app.kubernetes.io/name: analytics-service
   template:
     metadata:
       labels:
-        app: analytics-service
+        app.kubernetes.io/name: analytics-service
+        app.kubernetes.io/part-of: yosai-microservices
+        app.kubernetes.io/component: analytics
     spec:
       containers:
         - name: analytics-service
@@ -26,11 +30,9 @@ spec:
             - containerPort: 8001
           envFrom:
             - configMapRef:
-                name: yosai-config
-            - configMapRef:
-                name: vault-config
+                name: analytics-service-config
             - secretRef:
-                name: vault-secret
+                name: analytics-service-secret
           readinessProbe:
             httpGet:
               path: /health

--- a/k8s/microservices/api-gateway-config.yaml
+++ b/k8s/microservices/api-gateway-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-gateway-config
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: gateway
+data:
+  LOG_LEVEL: "INFO"

--- a/k8s/microservices/api-gateway-hpa.yaml
+++ b/k8s/microservices/api-gateway-hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api-gateway-hpa
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: gateway
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/k8s/microservices/api-gateway-networkpolicy.yaml
+++ b/k8s/microservices/api-gateway-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-gateway-networkpolicy
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: gateway
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: analytics-service
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: event-ingestion

--- a/k8s/microservices/api-gateway.yaml
+++ b/k8s/microservices/api-gateway.yaml
@@ -3,16 +3,20 @@ kind: Deployment
 metadata:
   name: api-gateway
   labels:
-    app: api-gateway
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: gateway
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: api-gateway
+      app.kubernetes.io/name: api-gateway
   template:
     metadata:
       labels:
-        app: api-gateway
+        app.kubernetes.io/name: api-gateway
+        app.kubernetes.io/part-of: yosai-microservices
+        app.kubernetes.io/component: gateway
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
@@ -39,6 +43,11 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: api-gateway-config
+            - secretRef:
+                name: api-gateway-secret
           resources:
             requests:
               cpu: "100m"

--- a/k8s/microservices/event-ingestion-config.yaml
+++ b/k8s/microservices/event-ingestion-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: event-ingestion-config
+  labels:
+    app.kubernetes.io/name: event-ingestion
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: ingestion
+data:
+  LOG_LEVEL: "INFO"
+  INGESTION_WORKERS: "2"

--- a/k8s/microservices/event-ingestion-hpa.yaml
+++ b/k8s/microservices/event-ingestion-hpa.yaml
@@ -1,16 +1,16 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: analytics-service-hpa
+  name: event-ingestion-hpa
   labels:
-    app.kubernetes.io/name: analytics-service
+    app.kubernetes.io/name: event-ingestion
     app.kubernetes.io/part-of: yosai-microservices
-    app.kubernetes.io/component: analytics
+    app.kubernetes.io/component: ingestion
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: analytics-service
+    name: event-ingestion
   minReplicas: 1
   maxReplicas: 5
   metrics:

--- a/k8s/microservices/event-ingestion-networkpolicy.yaml
+++ b/k8s/microservices/event-ingestion-networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: event-ingestion-networkpolicy
+  labels:
+    app.kubernetes.io/name: event-ingestion
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: ingestion
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: event-ingestion
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api-gateway
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: analytics-service

--- a/k8s/microservices/event-ingestion.yaml
+++ b/k8s/microservices/event-ingestion.yaml
@@ -3,16 +3,20 @@ kind: Deployment
 metadata:
   name: event-ingestion
   labels:
-    app: event-ingestion
+    app.kubernetes.io/name: event-ingestion
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: ingestion
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: event-ingestion
+      app.kubernetes.io/name: event-ingestion
   template:
     metadata:
       labels:
-        app: event-ingestion
+        app.kubernetes.io/name: event-ingestion
+        app.kubernetes.io/part-of: yosai-microservices
+        app.kubernetes.io/component: ingestion
     spec:
       containers:
         - name: event-ingestion
@@ -38,11 +42,9 @@ spec:
             periodSeconds: 10
           envFrom:
             - configMapRef:
-                name: yosai-config
-            - configMapRef:
-                name: vault-config
+                name: event-ingestion-config
             - secretRef:
-                name: vault-secret
+                name: event-ingestion-secret
           resources:
             requests:
               cpu: "100m"

--- a/k8s/microservices/secrets/analytics-service-secret.yaml
+++ b/k8s/microservices/secrets/analytics-service-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: analytics-service-secret
+  labels:
+    app.kubernetes.io/name: analytics-service
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: analytics
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: analytics-service-secret
+  data:
+    - secretKey: ANALYTICS_DB_PASSWORD
+      remoteRef:
+        key: secret/data/analytics-service
+        property: ANALYTICS_DB_PASSWORD

--- a/k8s/microservices/secrets/api-gateway-secret.yaml
+++ b/k8s/microservices/secrets/api-gateway-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: api-gateway-secret
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: gateway
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: api-gateway-secret
+  data:
+    - secretKey: API_GATEWAY_TOKEN
+      remoteRef:
+        key: secret/data/api-gateway
+        property: API_GATEWAY_TOKEN

--- a/k8s/microservices/secrets/event-ingestion-secret.yaml
+++ b/k8s/microservices/secrets/event-ingestion-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: event-ingestion-secret
+  labels:
+    app.kubernetes.io/name: event-ingestion
+    app.kubernetes.io/part-of: yosai-microservices
+    app.kubernetes.io/component: ingestion
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: event-ingestion-secret
+  data:
+    - secretKey: INGESTION_API_KEY
+      remoteRef:
+        key: secret/data/event-ingestion
+        property: INGESTION_API_KEY


### PR DESCRIPTION
## Summary
- add ArgoCD-friendly Deployments for api-gateway, analytics-service, and event-ingestion
- configure ConfigMaps, ExternalSecrets, HPAs, and NetworkPolicies for each microservice

## Testing
- `kubectl apply --dry-run=client -f k8s/microservices` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e24cb3168832081dd64d36a3aaccd