### PR TITLE
Add monitoring chart with Grafana dashboards and Loki logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ data/learned_mappings.json
 !yosai_intel_dashboard/src/adapters/ui/tsconfig.json
 !dashboards/grafana/*.json
 !dashboards/performance/*.json
+!monitoring/grafana/*.json
+!yosai_intel_dashboard/src/infrastructure/monitoring/grafana/*.json
+!k8s/monitoring/dashboards/*.json
 !config/schema.json
 !gateway/internal/config/circuitbreakers_schema.json
 logs/

--- a/k8s/monitoring/Chart.yaml
+++ b/k8s/monitoring/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: monitoring
+version: 0.1.0
+description: Helm chart for application monitoring components

--- a/k8s/monitoring/alerts/critical-rules.yaml
+++ b/k8s/monitoring/alerts/critical-rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: service-critical-rules
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: service.rules
+      rules:
+        - alert: HighCPUUsage
+          expr: sum(rate(container_cpu_usage_seconds_total[5m])) > 0.9
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: CPU usage above 90%
+            description: High CPU usage detected
+        - alert: HighMemoryUsage
+          expr: sum(container_memory_usage_bytes) / sum(container_spec_memory_limit_bytes) > 0.9
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Memory usage above 90%
+            description: High memory usage detected
+        - alert: HighErrorRate
+          expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Error rate above 5%
+            description: High error rate detected

--- a/k8s/monitoring/application.yaml
+++ b/k8s/monitoring/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/yosai_intel_dashboard_fresh
+    path: k8s/monitoring
+    targetRevision: HEAD
+    helm:
+      releaseName: monitoring
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/monitoring/dashboards/service-dashboard.json
+++ b/k8s/monitoring/dashboards/service-dashboard.json
@@ -1,0 +1,29 @@
+{
+  "title": "Service Metrics",
+  "schemaVersion": 16,
+  "timezone": "browser",
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[5m]))"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        {"expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\"})"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))"}
+      ]
+    }
+  ]
+}

--- a/k8s/monitoring/logging/loki-configmap.yaml
+++ b/k8s/monitoring/logging/loki-configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  labels:
+    app: loki
+data:
+  config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    ingester:
+      lifecycler:
+        address: 127.0.0.1
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+        final_sleep: 0s
+      chunk_idle_period: 5m
+      chunk_retain_period: 30s
+    schema_config:
+      configs:
+        - from: 2020-10-15
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /tmp/loki/index
+        shared_store: filesystem
+      filesystem:
+        directory: /tmp/loki/chunks
+    limits_config:
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+    chunk_store_config:
+      max_look_back_period: 0s
+    table_manager:
+      retention_deletes_enabled: false
+      retention_period: 0s

--- a/k8s/monitoring/logging/loki-service.yaml
+++ b/k8s/monitoring/logging/loki-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  labels:
+    app: loki
+spec:
+  ports:
+    - port: 3100
+      targetPort: 3100
+  selector:
+    app: loki

--- a/k8s/monitoring/logging/loki-statefulset.yaml
+++ b/k8s/monitoring/logging/loki-statefulset.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  labels:
+    app: loki
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.1
+          args:
+            - -config.file=/etc/loki/config.yaml
+          ports:
+            - containerPort: 3100
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config

--- a/k8s/monitoring/logging/promtail-configmap.yaml
+++ b/k8s/monitoring/logging/promtail-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  labels:
+    app: promtail
+data:
+  config.yaml: |
+    server:
+      http_listen_port: 3101
+      grpc_listen_port: 0
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+    scrape_configs:
+      - job_name: system
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: varlogs
+              __path__: /var/log/*log

--- a/k8s/monitoring/logging/promtail-daemonset.yaml
+++ b/k8s/monitoring/logging/promtail-daemonset.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  labels:
+    app: promtail
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      containers:
+        - name: promtail
+          image: grafana/promtail:2.9.1
+          args:
+            - -config.file=/etc/promtail/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log

--- a/k8s/monitoring/servicemonitors/analytics-service.yaml
+++ b/k8s/monitoring/servicemonitors/analytics-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: analytics-service-monitor
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: analytics-service
+  endpoints:
+    - path: /metrics
+      targetPort: 8001

--- a/k8s/monitoring/servicemonitors/api-gateway.yaml
+++ b/k8s/monitoring/servicemonitors/api-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: api-gateway-monitor
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  endpoints:
+    - path: /metrics
+      targetPort: 8080

--- a/k8s/monitoring/servicemonitors/event-ingestion.yaml
+++ b/k8s/monitoring/servicemonitors/event-ingestion.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: event-ingestion-monitor
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: event-ingestion
+  endpoints:
+    - path: /metrics
+      targetPort: 8000

--- a/k8s/monitoring/templates/grafana-dashboards.yaml
+++ b/k8s/monitoring/templates/grafana-dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  labels:
+    grafana_dashboard: "1"
+data:
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{ base $path }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}

--- a/k8s/monitoring/templates/logging.yaml
+++ b/k8s/monitoring/templates/logging.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $_ := .Files.Glob "logging/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}

--- a/k8s/monitoring/templates/prometheus-rules.yaml
+++ b/k8s/monitoring/templates/prometheus-rules.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $_ := .Files.Glob "alerts/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}

--- a/k8s/monitoring/templates/servicemonitors.yaml
+++ b/k8s/monitoring/templates/servicemonitors.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $_ := .Files.Glob "servicemonitors/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}

--- a/k8s/monitoring/values.yaml
+++ b/k8s/monitoring/values.yaml
@@ -1,0 +1,2 @@
+# Default values for monitoring chart
+namespace: default

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/grafana/service-dashboard.json
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/grafana/service-dashboard.json
@@ -1,0 +1,29 @@
+{
+  "title": "Service Metrics",
+  "schemaVersion": 16,
+  "timezone": "browser",
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[5m]))"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        {"expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\"})"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create Helm-based monitoring stack with ServiceMonitors for core services
- add Grafana dashboard JSON with ConfigMap for auto-import
- define Prometheus alert rules and Loki/Promtail logging
- expose monitoring stack via ArgoCD Application

## Testing
- `helm lint k8s/monitoring`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688e24cf6a1c83209a01e150b2f38383