### PR TITLE
Add deployment and disaster recovery docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ This project follows a fully modular design built around a dependency injection 
 - [API Adapter](docs/api.md)
 - [Clean Architecture Guide](docs/developer_guide_clean_arch.md)
 - [Migration Guide](docs/migration_guide.md)
+- [Deployment Guide](docs/deployment_guide.md)
+- [Troubleshooting Runbook](docs/troubleshooting_runbook.md)
+- [Disaster Recovery](docs/disaster_recovery.md)
 
 <p align="center">
   <img src="docs/architecture.svg" alt="High-level architecture diagram" width="600" />

--- a/docs/architecture/automation.svg
+++ b/docs/architecture/automation.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="120">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0,10 3.5,0 7" />
+    </marker>
+  </defs>
+  <rect x="20" y="40" width="80" height="40" fill="#e2f0d9" stroke="#333" />
+  <text x="60" y="65" font-size="12" text-anchor="middle">Git Repo</text>
+  <rect x="160" y="40" width="80" height="40" fill="#e2f0d9" stroke="#333" />
+  <text x="200" y="65" font-size="12" text-anchor="middle">ArgoCD</text>
+  <rect x="300" y="40" width="80" height="40" fill="#e2f0d9" stroke="#333" />
+  <text x="340" y="65" font-size="12" text-anchor="middle">Cluster</text>
+  <line x1="100" y1="60" x2="160" y2="60" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="240" y1="60" x2="300" y2="60" stroke="#333" marker-end="url(#arrow)" />
+</svg>

--- a/docs/architecture/observability_stack.svg
+++ b/docs/architecture/observability_stack.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="180">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0,10 3.5,0 7" />
+    </marker>
+  </defs>
+  <rect x="170" y="20" width="80" height="40" fill="#fde9d9" stroke="#333" />
+  <text x="210" y="45" font-size="12" text-anchor="middle">Cluster</text>
+  <rect x="20" y="100" width="80" height="40" fill="#fde9d9" stroke="#333" />
+  <text x="60" y="125" font-size="12" text-anchor="middle">Prometheus</text>
+  <rect x="170" y="100" width="80" height="40" fill="#fde9d9" stroke="#333" />
+  <text x="210" y="125" font-size="12" text-anchor="middle">Loki</text>
+  <rect x="320" y="100" width="80" height="40" fill="#fde9d9" stroke="#333" />
+  <text x="360" y="125" font-size="12" text-anchor="middle">Grafana</text>
+  <line x1="210" y1="60" x2="60" y2="100" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="210" y1="60" x2="210" y2="100" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="210" y1="60" x2="360" y2="100" stroke="#333" marker-end="url(#arrow)" />
+</svg>

--- a/docs/architecture/service_topology.svg
+++ b/docs/architecture/service_topology.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="160">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0,10 3.5,0 7" />
+    </marker>
+  </defs>
+  <rect x="10" y="60" width="80" height="40" fill="#cfe2f3" stroke="#333" />
+  <text x="50" y="85" font-size="12" text-anchor="middle">Client</text>
+  <rect x="150" y="60" width="80" height="40" fill="#cfe2f3" stroke="#333" />
+  <text x="190" y="85" font-size="12" text-anchor="middle">Gateway</text>
+  <rect x="290" y="20" width="80" height="40" fill="#cfe2f3" stroke="#333" />
+  <text x="330" y="45" font-size="12" text-anchor="middle">Analytics</text>
+  <rect x="290" y="100" width="80" height="40" fill="#cfe2f3" stroke="#333" />
+  <text x="330" y="125" font-size="12" text-anchor="middle">Database</text>
+  <line x1="90" y1="80" x2="150" y2="80" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="230" y1="80" x2="290" y2="40" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="230" y1="80" x2="290" y2="120" stroke="#333" marker-end="url(#arrow)" />
+</svg>

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -1,0 +1,61 @@
+# Deployment Guide
+
+This guide describes how to install ArgoCD, apply Helm charts, and verify deployments for the dashboard.
+
+![ArgoCD automation flow](architecture/automation.svg)
+
+## Prerequisites
+
+- A Kubernetes cluster with `kubectl` configured
+- [Helm](https://helm.sh/) installed locally
+- Access to the Git repository containing the Helm charts
+
+## Install ArgoCD
+
+1. Create the ArgoCD namespace:
+   ```bash
+   kubectl create namespace argocd
+   ```
+2. Install ArgoCD using the official manifests:
+   ```bash
+   kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+   ```
+3. Expose the ArgoCD API server (optionally via a LoadBalancer or port-forward) and log in:
+   ```bash
+   kubectl port-forward svc/argocd-server -n argocd 8080:443
+   argocd login localhost:8080 --username admin --password <initial-password>
+   ```
+
+## Apply Helm Charts
+
+1. Add the chart repository and update:
+   ```bash
+   helm repo add yosai https://example.com/charts
+   helm repo update
+   ```
+2. Create an ArgoCD application pointing at the chart and Git repository:
+   ```bash
+   argocd app create yosai-dashboard \
+     --repo https://github.com/WSG23/yosai_intel_dashboard_fresh.git \
+     --path helm/chart \
+     --dest-server https://kubernetes.default.svc \
+     --dest-namespace default
+   ```
+3. Sync the application to install the release:
+   ```bash
+   argocd app sync yosai-dashboard
+   ```
+
+## Verify Deployments
+
+1. Check that all pods are running:
+   ```bash
+   kubectl get pods -n default
+   ```
+2. Confirm the ArgoCD application is healthy:
+   ```bash
+   argocd app list
+   argocd app get yosai-dashboard
+   ```
+3. Verify services respond as expected by inspecting logs or accessing exposed endpoints.
+

--- a/docs/disaster_recovery.md
+++ b/docs/disaster_recovery.md
@@ -1,0 +1,52 @@
+# Disaster Recovery
+
+This document outlines backup and restore procedures for critical components of the dashboard deployment.
+
+## Database Backup
+
+Regularly back up all databases:
+```bash
+kubectl exec -it postgres-0 -- pg_dumpall -U postgres > backup/all.sql
+```
+Store the dump in a secure, off-cluster location.
+
+## Database Restore
+
+To restore from a backup:
+```bash
+kubectl cp backup/all.sql postgres-0:/tmp/all.sql
+kubectl exec -it postgres-0 -- psql -U postgres -f /tmp/all.sql
+```
+Verify application connectivity after the restore.
+
+## Configuration Backup
+
+Export Kubernetes manifests and ArgoCD configuration:
+```bash
+kubectl get apps,cm,secret,deploy,svc -A -o yaml > backup/cluster-config.yaml
+argocd app export yosai-dashboard > backup/argocd-app.yaml
+```
+Keep encrypted copies of these files in version control or secure storage.
+
+## Helm Release Backup
+
+Capture the installed Helm chart values:
+```bash
+helm get values yosai-dashboard -n default > backup/yosai-values.yaml
+```
+Retain the chart version information with:
+```bash
+helm list -n default > backup/helm-releases.txt
+```
+
+## Restore Helm Release
+
+Reinstall the chart using the saved values:
+```bash
+helm upgrade --install yosai-dashboard helm/chart -n default -f backup/yosai-values.yaml
+```
+Synchronize ArgoCD after restoration:
+```bash
+argocd app sync yosai-dashboard
+```
+

--- a/docs/troubleshooting_runbook.md
+++ b/docs/troubleshooting_runbook.md
@@ -1,0 +1,48 @@
+# Troubleshooting Runbook
+
+This runbook documents common operational failures and the steps to mitigate them.
+
+## Pod Crash Loops
+
+**Symptoms**: Pods repeatedly restart and `kubectl get pods` shows a `CrashLoopBackOff` status.
+
+**Mitigation Steps**:
+1. Inspect events and logs:
+   ```bash
+   kubectl describe pod <pod-name>
+   kubectl logs <pod-name> --previous
+   ```
+2. Identify configuration or image errors and update values in the Helm chart or container image.
+3. Redeploy the affected component:
+   ```bash
+   kubectl delete pod <pod-name>
+   argocd app sync yosai-dashboard
+   ```
+
+## Failed Migrations
+
+**Symptoms**: Deployments fail during startup because database migrations did not complete.
+
+**Mitigation Steps**:
+1. Review the migration job logs:
+   ```bash
+   kubectl logs job/<migration-job>
+   ```
+2. Run the migration manually if necessary:
+   ```bash
+   kubectl exec -it <migration-pod> -- alembic upgrade head
+   ```
+3. If migrations continue to fail, roll back to the previous release and investigate the schema state.
+
+## Secret Sync Issues
+
+**Symptoms**: Applications cannot access required secrets or ArgoCD reports `OutOfSync` on secret resources.
+
+**Mitigation Steps**:
+1. Check that the secret management sidecar or controller is running.
+2. Re-run secret synchronization:
+   ```bash
+   argocd app sync yosai-dashboard --resource secrets
+   ```
+3. Validate access to the secret backend (e.g., Vault) and ensure the Kubernetes service account has correct permissions.
+


### PR DESCRIPTION
## Summary
- add ArgoCD deployment guide with helm instructions and verification
- provide troubleshooting runbook for crash loops, migrations, and secret sync
- document disaster recovery with backup and restore steps and include architecture diagrams

## Testing
- `pytest tests/test_fastapi_error_handler.py::test_fastapi_error_format -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions')*


------
https://chatgpt.com/codex/tasks/task_e_688e24d09d388320a40eb68498e0caf7