### PR TITLE
feat: add argocd applications and gitops workflow

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -211,28 +211,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - run: pip install -r requirements.lock
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
-      - name: Configure kubeconfig
-        run: |
-          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
-      - name: Deploy canary
-        run: |
-          kubectl apply -f k8s/canary
-      - name: Wait for canary rollout
-        run: |
-          kubectl rollout status deployment/yosai-dashboard-canary --timeout=120s
-      - name: Health check canary
-        run: |
-          kubectl wait --for=condition=ready pod -l app=yosai-dashboard,track=canary --timeout=60s
-      - name: Promote canary to production
-        run: |
-          kubectl apply -f k8s/base
-          kubectl apply -f k8s/production
-          kubectl delete -f k8s/canary
+        - uses: actions/checkout@v3
+        - name: Push manifests to GitOps
+          env:
+            GITOPS_USER: github-actions
+            GITOPS_EMAIL: github-actions@github.com
+          run: |
+            git config user.name "$GITOPS_USER"
+            git config user.email "$GITOPS_EMAIL"
+            git add argocd/applications environments
+            git commit -m "Sync manifests to GitOps" || echo "No changes to commit"
+            git push
 

--- a/argocd/applications/dev.yaml
+++ b/argocd/applications/dev.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-dev
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/yosai_intel_dashboard_fresh.git
+    targetRevision: HEAD
+    path: helm/yosai-intel
+    helm:
+      valueFiles:
+        - ../../environments/dev/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: yosai-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/applications/prod.yaml
+++ b/argocd/applications/prod.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/yosai_intel_dashboard_fresh.git
+    targetRevision: HEAD
+    path: helm/yosai-intel
+    helm:
+      valueFiles:
+        - ../../environments/prod/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: yosai-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/applications/staging.yaml
+++ b/argocd/applications/staging.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-staging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/yosai_intel_dashboard_fresh.git
+    targetRevision: HEAD
+    path: helm/yosai-intel
+    helm:
+      valueFiles:
+        - ../../environments/staging/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: yosai-staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -1,0 +1,44 @@
+# GitOps with ArgoCD
+
+This repository uses a GitOps workflow powered by [ArgoCD](https://argo-cd.readthedocs.io/).
+Kubernetes manifests and Helm values are stored in the repository and
+synchronized to the cluster by ArgoCD.
+
+## Repository Structure
+
+```
+argocd/
+  applications/   # ArgoCD Application CRDs
+environments/
+  dev/            # Environment specific Helm values
+  staging/
+  prod/
+helm/
+  yosai-intel/    # Helm chart for the dashboard
+```
+
+Each environment has an `Application` definition in `argocd/applications/`
+which references the common Helm chart and the environment specific values
+file under `environments/<env>/values.yaml`.
+
+## RBAC
+
+ArgoCD runs in the `argocd` namespace. Application resources are created in
+namespaces specific to each environment (`yosai-dev`, `yosai-staging`, and
+`yosai-prod`). Access to modify the GitOps directories is restricted to
+operators with write access to the repository.
+
+## Sync Policies
+
+Applications use automated sync with self-healing enabled:
+
+```
+syncPolicy:
+  automated:
+    prune: true
+    selfHeal: true
+```
+
+This ensures ArgoCD continuously reconciles the desired state from Git with
+the cluster. Changes merged into `main` are automatically picked up by the
+running ArgoCD instance and applied to the target namespaces.

--- a/environments/dev/values.yaml
+++ b/environments/dev/values.yaml
@@ -1,0 +1,3 @@
+replicaCount: 1
+image:
+  tag: dev

--- a/environments/prod/values.yaml
+++ b/environments/prod/values.yaml
@@ -1,0 +1,3 @@
+replicaCount: 3
+image:
+  tag: prod

--- a/environments/staging/values.yaml
+++ b/environments/staging/values.yaml
@@ -1,0 +1,3 @@
+replicaCount: 2
+image:
+  tag: staging


### PR DESCRIPTION
## Summary
- add ArgoCD Applications for dev, staging and prod
- add environment-specific Helm values and onboarding doc
- switch deployment job to push manifests to GitOps repo

## Testing
- `pre-commit run --files .github/workflows/unified-ci.yml docs/gitops.md argocd/applications/dev.yaml argocd/applications/staging.yaml argocd/applications/prod.yaml environments/dev/values.yaml environments/staging/values.yaml environments/prod/values.yaml`


------
https://chatgpt.com/codex/tasks/task_e_688e24d254008320bf4e325659894e6d