### PR TITLE
chore: update ArgoCD repo URL

### DIFF
--- a/argocd/applications/dev.yaml
+++ b/argocd/applications/dev.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-dashboard-dev
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/WSG23/yosai_intel_dashboard_fresh.git
+    path: k8s/dev
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/applications/prod.yaml
+++ b/argocd/applications/prod.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-dashboard-prod
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/WSG23/yosai_intel_dashboard_fresh.git
+    path: k8s/production
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: production
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/applications/staging.yaml
+++ b/argocd/applications/staging.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: yosai-intel-dashboard-staging
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/WSG23/yosai_intel_dashboard_fresh.git
+    path: k8s/staging
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- add ArgoCD applications for dev, staging, and prod environments pointing to the correct repository

## Testing
- `pre-commit run --files argocd/applications/dev.yaml argocd/applications/staging.yaml argocd/applications/prod.yaml`


------
https://chatgpt.com/codex/tasks/task_e_688e2d6aa0c0832085a061626e8e6f13