### PR TITLE
ci: guard push on commit success

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -1,0 +1,21 @@
+name: Unified CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Commit build artifacts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git commit -m "chore: update build artifacts"; then
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## Summary
- add unified-ci workflow with deploy job
- only push changes when git commit succeeds

## Testing
- `pre-commit run --files .github/workflows/unified-ci.yml`
- `pytest` *(fails: IndentationError in yosai_intel_dashboard/src/core/performance.py)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e2d6bf2ac8320b0d00753e444998c