### PR TITLE
fix: restore performance budget alert

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml
@@ -2,15 +2,25 @@
 # Trigger when replication lag exceeds 60 seconds
 ---
 groups:
-- name: timescale
-  rules:
-  - alert: TimescaleReplicationLag
-    expr: replication_lag_seconds > 60
-    for: 5m
-    labels:
-      severity: warning
-    annotations:
-      summary: Replication lag to TimescaleDB exceeds 60 seconds
-      channels:
-        - performance-alerts
+  - name: timescale
+    rules:
+      - alert: TimescaleReplicationLag
+        expr: replication_lag_seconds > 60
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Replication lag to TimescaleDB exceeds 60 seconds
+          channels: performance-alerts
+
+  - name: performance-budgets
+    rules:
+      - alert: PerformanceBudgetExceeded
+        expr: performance_budget_exceeded_total > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: A performance budget was exceeded
+          channels: performance-alerts
 


### PR DESCRIPTION
## Summary
- fix Prometheus alert YAML and add `PerformanceBudgetExceeded` rule

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml`
- `promtool check rules yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml`
- `curl -X POST http://localhost:9090/-/reload` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_688e302a32d48320b3eef37572840ca5