### PR TITLE
chore: guard explainability tests for optional deps

### DIFF
--- a/tests/test_explainability_service.py
+++ b/tests/test_explainability_service.py
@@ -1,10 +1,15 @@
-import importlib
+from __future__ import annotations
+
 import pathlib
 import sys
 import types
 
 import pandas as pd
+import pytest
 from sklearn.linear_model import LogisticRegression
+
+pytest.importorskip("shap")
+pytest.importorskip("lime")
 
 SERVICES_PATH = pathlib.Path(__file__).resolve().parents[1] / "services"
 services_mod = sys.modules.get("services")
@@ -13,7 +18,7 @@ if services_mod is None:
     sys.modules["services"] = services_mod
 services_mod.__path__ = [str(SERVICES_PATH)]
 
-from services.explainability_service import ExplainabilityService
+from services.explainability_service import ExplainabilityService  # noqa: E402
 
 
 def _make_dataset():


### PR DESCRIPTION
## Summary
- guard explainability service tests with optional SHAP/LIME imports

## Testing
- `pre-commit run black --files tests/test_explainability_service.py`
- `pre-commit run isort --files tests/test_explainability_service.py`
- `pre-commit run flake8 --files tests/test_explainability_service.py`
- `python tools/organize_imports.py --check tests/test_explainability_service.py`
- `bandit -r tests/test_explainability_service.py`
- `pytest tests/test_explainability_service.py`


------
https://chatgpt.com/codex/tasks/task_e_688e3ed1fa048320b458e474d6a3e4d4