### PR TITLE
feat: add test import migration script

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,22 @@ pip install -r tests/requirements-extra.txt
 
 When the optional packages are missing, tests depending on them are automatically skipped.
 
+## Migrating Test Imports
+
+The helper script `tools/migrate_tests.py` updates test files to use the
+current import layout and adds `pytest.importorskip()` checks for optional
+dependencies. Run it in dry‑run mode to preview edits:
+
+```bash
+python tools/migrate_tests.py --dry-run
+```
+
+Remove the flag to apply changes to the repository:
+
+```bash
+python tools/migrate_tests.py
+```
+
 Before running the suite locally, enable the lightweight service mode so heavy
 dependencies are stubbed out:
 


### PR DESCRIPTION
## Summary
- add script to rewrite test imports, stub removed modules, and guard optional dependencies
- document migrate_tests helper in tests README

## Testing
- `python tools/migrate_tests.py --dry-run`
- `pytest tests/test_aggregator.py -q` *(fails: ModuleNotFoundError: No module named 'requests.exceptions'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688e3ed6a35c8320a5e6cdeba31428cf