### PR TITLE
Add isolated security testing utilities

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import (
+    CallbackEvent as SecurityEvent,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
+
+from .pattern_detection import Threat, detect_critical_door_risks
+from .odd_time_detection import detect_odd_time
+
+
+# Fallback callback manager used if ``security.events`` cannot be imported.
+fallback_callbacks: TrulyUnifiedCallbacks | None = None
+
+
+class _SimpleCallbacks:
+    """Lightweight callback manager used when dependencies are missing."""
+
+    def __init__(self) -> None:
+        self._event_callbacks: Dict[SecurityEvent, List[Any]] = {e: [] for e in SecurityEvent}
+        self.history: List[tuple[SecurityEvent, Any]] = []
+
+    def register_event(self, event: SecurityEvent, func: Any) -> None:
+        self._event_callbacks.setdefault(event, []).append(func)
+
+    def trigger_event(self, event: SecurityEvent, data: Any | None = None) -> None:
+        for cb in self._event_callbacks.get(event, []):
+            cb(data)
+        self.history.append((event, data))
+
+    def clear_all_callbacks(self) -> None:
+        for lst in self._event_callbacks.values():
+            lst.clear()
+        self.history.clear()
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+
+def prepare_security_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Prepare raw access log dataframe for pattern analysis."""
+    df = df.copy()
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df["hour"] = df["timestamp"].dt.hour
+    return df
+
+
+class SecurityPatternsAnalyzer:
+    """Very small analyzer used in tests."""
+
+    def _prepare_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        return prepare_security_data(df)
+
+    def _analyze_failed_access(self, df: pd.DataFrame) -> Dict[str, Any]:
+        failures = df[df.get("access_result") == "Denied"]
+        total = len(failures)
+        total_events = len(df) or 1
+        failure_rate = total / total_events
+        high_risk_users = failures["person_id"].value_counts().head(3).to_dict()
+        peak_failure_times = failures["hour"].value_counts().head(3).to_dict()
+        top_failure_doors = failures["door_id"].value_counts().head(3).to_dict()
+        patterns: List[Any] = []
+        risk_level = "low"
+        if failure_rate > 0.5:
+            risk_level = "high"
+        elif failure_rate > 0.2:
+            risk_level = "medium"
+        return {
+            "total": total,
+            "failure_rate": failure_rate,
+            "high_risk_users": high_risk_users,
+            "peak_failure_times": peak_failure_times,
+            "top_failure_doors": top_failure_doors,
+            "patterns": patterns,
+            "risk_level": risk_level,
+        }
+
+    def analyze_security_patterns(self, df: pd.DataFrame) -> List[Threat]:
+        prepared = self._prepare_data(df)
+        threats = detect_critical_door_risks(prepared)
+        threats.extend(_detect_rapid_failures(prepared))
+        try:  # pragma: no cover - import may fail in test environment
+            import security.events as se  # type: ignore
+            manager = se.security_unified_callbacks
+        except Exception:  # pragma: no cover
+            manager = fallback_callbacks
+        if manager is None:
+            manager = _SimpleCallbacks()
+        if threats:
+            manager.trigger_event(
+                SecurityEvent.THREAT_DETECTED, {"threats": threats}
+            )
+        manager.trigger_event(
+            SecurityEvent.ANALYSIS_COMPLETE, {"records": len(prepared)}
+        )
+        return threats
+
+
+# ---------------------------------------------------------------------------
+# Test data generators
+
+def generate_failed_access(count: int = 3) -> pd.DataFrame:
+    """Generate a dataframe representing failed access attempts."""
+    ts = pd.Timestamp("2024-01-01 00:00:00")
+    data = [
+        {
+            "event_id": i,
+            "timestamp": ts + pd.Timedelta(minutes=i),
+            "person_id": f"u{i%2}",
+            "door_id": "d1",
+            "access_result": "Denied",
+        }
+        for i in range(count)
+    ]
+    return pd.DataFrame(data)
+
+
+def generate_threat_attempt() -> pd.DataFrame:
+    """Generate data that should trigger a critical threat."""
+    ts = pd.Timestamp("2024-01-01 00:00:00")
+    data = []
+    for i in range(4):
+        data.append(
+            {
+                "event_id": i,
+                "timestamp": ts + pd.Timedelta(seconds=i * 5),
+                "person_id": "baduser",
+                "door_id": "d1",
+                "access_result": "Denied",
+                "door_type": "critical",
+                "required_clearance": 4,
+                "clearance_level": 1,
+            }
+        )
+    return pd.DataFrame(data)
+
+
+def _detect_rapid_failures(df: pd.DataFrame) -> List[Threat]:
+    failures = df[df.get("access_result") == "Denied"].sort_values("timestamp")
+    threats: List[Threat] = []
+    for person, group in failures.groupby("person_id"):
+        times = group["timestamp"].sort_values()
+        if len(times) >= 3 and (times.iloc[-1] - times.iloc[0]).total_seconds() <= 60:
+            threats.append(Threat("rapid_denied_access", {"person_id": person}))
+    return threats
+
+
+# ---------------------------------------------------------------------------
+# Isolated testing context
+
+@dataclass
+class SecurityTestEnv:
+    callback_manager: TrulyUnifiedCallbacks
+    events: Dict[SecurityEvent, List[Any]]
+    logger: logging.Logger
+    log_stream: io.StringIO
+
+
+@contextlib.contextmanager
+def setup_isolated_security_testing() -> Any:
+    """Provide an isolated security testing environment."""
+    global fallback_callbacks
+    try:  # pragma: no cover - may fail if heavy deps missing
+        new_manager = TrulyUnifiedCallbacks()
+    except Exception:  # pragma: no cover
+        new_manager = _SimpleCallbacks()
+    fallback_callbacks = new_manager
+    try:  # pragma: no cover - import may fail if optional deps missing
+        import security.events as se  # type: ignore
+        original_manager = se.security_unified_callbacks
+        se.security_unified_callbacks = new_manager
+    except Exception:  # pragma: no cover
+        se = None
+        original_manager = None
+
+    captured: Dict[SecurityEvent, List[Any]] = {e: [] for e in SecurityEvent}
+    for event in SecurityEvent:
+        new_manager.register_event(event, lambda d, ev=event: captured[ev].append(d))
+
+    logger = logging.getLogger("analytics.security_patterns.tests")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    orig_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+
+    env = SecurityTestEnv(
+        callback_manager=new_manager, events=captured, logger=logger, log_stream=stream
+    )
+
+    try:
+        yield env
+    finally:
+        new_manager.clear_all_callbacks()
+        for lst in captured.values():
+            lst.clear()
+        logger.removeHandler(handler)
+        logger.setLevel(orig_level)
+        handler.close()
+        stream.close()
+        fallback_callbacks = None
+        if original_manager is not None and se is not None:
+            se.security_unified_callbacks = original_manager
+
+
+__all__ = [
+    "SecurityEvent",
+    "SecurityPatternsAnalyzer",
+    "setup_isolated_security_testing",
+    "prepare_security_data",
+    "generate_failed_access",
+    "generate_threat_attempt",
+    "SecurityTestEnv",
+    "detect_critical_door_risks",
+    "detect_odd_time",
+]
+

--- a/analytics/security_patterns/odd_time_detection.py
+++ b/analytics/security_patterns/odd_time_detection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+from .pattern_detection import Threat
+
+
+class BaselineMetricsDB:
+    """Placeholder baseline storage used for testing."""
+
+    def get_baseline(self, person_id: str) -> Dict[str, float]:
+        return {}
+
+    def update_baseline(self, person_id: str, stats: Dict[str, float]) -> None:  # pragma: no cover
+        pass
+
+
+def detect_odd_time(df: pd.DataFrame) -> List[Threat]:
+    """Detect access events occurring at unusual hours."""
+    if df.empty:
+        return []
+
+    threats: List[Threat] = []
+    db = BaselineMetricsDB()
+    for person, group in df.groupby("person_id"):
+        baseline = db.get_baseline(person) or {}
+        mean_hour = baseline.get("mean_hour")
+        std_hour = baseline.get("std_hour", 0)
+        if mean_hour is None:
+            continue
+        hours = group["hour"].tolist()
+        if std_hour == 0:
+            if any(h != mean_hour for h in hours):
+                threats.append(Threat("odd_time_access", {"person_id": person}))
+            continue
+        for h in hours:
+            if abs(h - mean_hour) > 2 * std_hour:
+                threats.append(Threat("odd_time_access", {"person_id": person, "hour": int(h)}))
+                break
+    return threats
+
+
+__all__ = ["BaselineMetricsDB", "detect_odd_time"]

--- a/analytics/security_patterns/pattern_detection.py
+++ b/analytics/security_patterns/pattern_detection.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+
+@dataclass
+class Threat:
+    """Simple representation of a detected threat."""
+
+    threat_type: str
+    details: Dict[str, object]
+
+
+def detect_critical_door_risks(df: pd.DataFrame) -> List[Threat]:
+    """Detect repeated denied attempts on critical doors."""
+    if df.empty:
+        return []
+    crit = df[
+        (df.get("door_type") == "critical")
+        & (df.get("access_result") == "Denied")
+        & (df.get("clearance_level", 0) < df.get("required_clearance", 0))
+    ]
+    if crit.empty:
+        return []
+    return [Threat("critical_door_anomaly", {"events": crit.to_dict("records")})]
+
+
+__all__ = ["Threat", "detect_critical_door_risks"]

--- a/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secure_config_manager.py
@@ -8,7 +8,10 @@ from dataclasses import is_dataclass
 from typing import Any, Dict, Optional
 
 import boto3
-import hvac
+try:  # pragma: no cover - optional dependency for tests
+    import hvac  # type: ignore
+except Exception:  # pragma: no cover
+    hvac = None
 from botocore.exceptions import ClientError
 from cryptography.fernet import Fernet
 from pydantic import BaseModel
@@ -38,7 +41,7 @@ class SecureConfigManager(ConfigManager):
         self.aws_region = aws_region or os.getenv("AWS_REGION")
 
         self.client = None
-        if self.vault_addr and self.vault_token:
+        if hvac and self.vault_addr and self.vault_token:
             try:
                 self.client = hvac.Client(url=self.vault_addr, token=self.vault_token)
             except Exception as exc:  # pragma: no cover - defensive

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -7,7 +7,16 @@ import unicodedata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from security.events import SecurityEvent, emit_security_event
+try:  # pragma: no cover - optional security events
+    from security.events import SecurityEvent, emit_security_event
+except Exception:  # pragma: no cover
+    from enum import Enum
+
+    class SecurityEvent(Enum):  # type: ignore[override]
+        VALIDATION_FAILED = 0
+
+    def emit_security_event(event: SecurityEvent, data: dict | None = None) -> None:
+        pass
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol


### PR DESCRIPTION
## Summary
- add `analytics.security_patterns` package with context manager and threat detection helpers
- capture security event callbacks and logs in isolated test environments
- handle missing optional dependencies for secure config and unicode processing

## Testing
- `pytest tests/test_security_patterns.py tests/callbacks/test_security_callback_controller.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3ede28148320aa4c4343118496e2