### PR TITLE
Add detailed migration guides for deprecated components

### DIFF
--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -9,7 +9,8 @@ This file is auto-generated from `deprecation.yml`.
 
 ## Migration Guides
 
-Migration instructions for deprecated components will appear here.
+- [Legacy Auth Migration](migration/legacy-auth.md)
+- [New Dashboard Migration](migration/new-dashboard.md)
 
 ## Impact Analysis
 

--- a/docs/migration/legacy-auth.md
+++ b/docs/migration/legacy-auth.md
@@ -2,8 +2,33 @@
 
 The legacy authentication system relied on a collection of Flask blueprints and custom session handlers. This implementation has been superseded by the unified authentication service located in `services/auth_service.py`.
 
+## Legacy Usage
+
+```python
+from legacy_auth import login_user
+
+token = login_user("alice", "p@ssw0rd")
+```
+
+## New Usage
+
+```python
+from services.auth_service import AuthService
+
+auth = AuthService()
+token = auth.login("alice", "p@ssw0rd")
+```
+
+## Caveats
+
+- Tokens issued by `AuthService` are JWTs and require synchronized clocks.
+- Set the `AUTH_SERVICE_URL` environment variable before calling the service.
+- Session cookies used by the legacy system are no longer supported.
+
 ## Migration Steps
 
 1. Remove any imports of `legacy_auth` modules.
 2. Update your login flows to call methods on `AuthService`.
 3. Ensure tokens are issued via the new service and update configuration files accordingly.
+
+See the [Deprecation Timeline](../deprecation_timeline.md) for important dates.

--- a/docs/migration/new-dashboard.md
+++ b/docs/migration/new-dashboard.md
@@ -2,8 +2,36 @@
 
 The original dashboard interface served from `yosai_intel_dashboard` has been replaced with the redesigned React frontend in `ui/`.
 
+## Legacy Usage
+
+```html
+<!-- templates/dashboard.html -->
+{% extends "base.html" %}
+{% block content %}
+  <h1>Legacy Dashboard</h1>
+{% endblock %}
+```
+
+## New Usage
+
+```javascript
+import { createRoot } from 'react-dom/client';
+import Dashboard from './Dashboard';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<Dashboard />);
+```
+
+## Caveats
+
+- Requires Node.js 18+ and npm 9+ for building assets.
+- Custom Jinja plugins must be reimplemented as React components.
+- Server-side rendering from the legacy system is no longer available.
+
 ## Migration Steps
 
 1. Update deployment pipelines to build the React assets using `npm run build`.
 2. Serve the compiled files from the `ui/dist` directory.
 3. Remove references to the legacy Jinja templates and associated routes.
+
+Refer to the [Deprecation Timeline](../deprecation_timeline.md) for key dates.


### PR DESCRIPTION
## Summary
- expand legacy auth migration guide with usage examples and caveats
- document new dashboard migration with legacy vs. React usage
- cross-link migration guides with deprecation timeline

## Testing
- `pre-commit run --files docs/deprecation_timeline.md docs/migration/legacy-auth.md docs/migration/new-dashboard.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests.exceptions'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f7005088320a824d5432a3e4370