### PR TITLE
feat: monitor deprecation usage

### DIFF
--- a/dashboards/grafana/deprecation-usage.json
+++ b/dashboards/grafana/deprecation-usage.json
@@ -1,15 +1,15 @@
 {
   "uid": "deprecation-usage",
-  "title": "Deprecated Usage",
+  "title": "Deprecation Usage",
   "panels": [
     {
       "type": "graph",
-      "title": "Deprecated Function Calls",
+      "title": "deprecation.usage",
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "sum(rate(deprecated_function_calls_total[1m])) by (function)",
-          "legendFormat": "{{function}}"
+          "expr": "sum(rate(deprecation_usage_total[1m])) by (component)",
+          "legendFormat": "{{component}}"
         }
       ]
     }

--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -14,3 +14,9 @@ Migration instructions for deprecated components will appear here.
 ## Impact Analysis
 
 This section will detail user impact and remediation steps.
+
+## Monitoring
+
+Deprecated component usage is tracked via the `deprecation_usage_total` Prometheus metric.
+The Grafana dashboard lives in `dashboards/grafana/deprecation-usage.json` and alert rules
+are defined in `monitoring/prometheus/rules/deprecation_alerts.yml`.

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -160,7 +160,7 @@ Aggregated counts are returned via `get_performance_monitor().get_deprecation_co
 Prioritise migrations by addressing functions with the highest counts first.
 Example alerting rules live in `monitoring/prometheus/rules/deprecation_alerts.yml`
 and a companion Grafana dashboard in
-`monitoring/grafana/dashboards/deprecation-usage.json`.
+`dashboards/grafana/deprecation-usage.json`.
 
 ### Logstash
 

--- a/scripts/generate_deprecation_docs.py
+++ b/scripts/generate_deprecation_docs.py
@@ -43,6 +43,12 @@ def generate_docs(yaml_path: Path = YAML_FILE, output_path: Path = OUTPUT_FILE) 
             "",
             "This section will detail user impact and remediation steps.",
             "",
+            "## Monitoring",
+            "",
+            "Deprecated component usage is tracked via the `deprecation_usage_total` Prometheus metric.",
+            "The Grafana dashboard lives in `dashboards/grafana/deprecation-usage.json` and alert rules",
+            "are defined in `monitoring/prometheus/rules/deprecation_alerts.yml`.",
+            "",
         ]
     )
 

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/deprecation.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/deprecation.py
@@ -1,19 +1,19 @@
-"""Prometheus metrics for deprecated function usage."""
+"""Prometheus metrics for deprecated component usage."""
 
 from prometheus_client import REGISTRY, Counter, start_http_server
 from prometheus_client.core import CollectorRegistry
 
-if "deprecated_function_calls_total" not in REGISTRY._names_to_collectors:
-    deprecated_calls = Counter(
-        "deprecated_function_calls_total",
-        "Count of deprecated function calls",
-        ["function"],
+if "deprecation_usage_total" not in REGISTRY._names_to_collectors:
+    deprecation_usage = Counter(
+        "deprecation_usage_total",
+        "Count of deprecated component usage",
+        ["component"],
     )
 else:  # pragma: no cover - defensive
-    deprecated_calls = Counter(
-        "deprecated_function_calls_total",
-        "Count of deprecated function calls",
-        ["function"],
+    deprecation_usage = Counter(
+        "deprecation_usage_total",
+        "Count of deprecated component usage",
+        ["component"],
         registry=CollectorRegistry(),
     )
 
@@ -28,13 +28,13 @@ def start_deprecation_metrics_server(port: int = 8006) -> None:
         _metrics_started = True
 
 
-def record_deprecated_call(function: str) -> None:
-    """Increment Prometheus counter for ``function``."""
-    deprecated_calls.labels(function=function).inc()
+def record_deprecated_call(component: str) -> None:
+    """Increment Prometheus counter for ``component``."""
+    deprecation_usage.labels(component=component).inc()
 
 
 __all__ = [
-    "deprecated_calls",
+    "deprecation_usage",
     "start_deprecation_metrics_server",
     "record_deprecated_call",
 ]

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/deprecation_alerts.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/deprecation_alerts.yml
@@ -2,9 +2,17 @@ groups:
 - name: deprecations
   rules:
   - alert: DeprecatedFunctionCalled
-    expr: rate(deprecated_function_calls_total[5m]) > 0
+    expr: rate(deprecation_usage_total[5m]) > 0
     for: 10m
     labels:
       severity: warning
     annotations:
-      summary: Deprecated function invoked recently
+      summary: Deprecated component invoked recently
+
+  - alert: DeprecatedHighUsage
+    expr: sum(rate(deprecation_usage_total[5m])) by (component) > 100
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: High usage of deprecated component; migration required


### PR DESCRIPTION
## Summary
- track deprecated component usage via `deprecation_usage_total`
- visualize usage in Grafana and alert on high usage
- document deprecation monitoring setup

## Testing
- `pytest tests/test_deprecation.py -q` *(fails: ImportError: cannot import name 'CacheConfig' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f71421c832090f2cdc5386293f6