### PR TITLE
docs: expand dashboard integration

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -419,16 +419,60 @@ def update_compliance_metrics(n):
         consents = data.get('metrics_by_category', {}).get('consent_management', {}).get('active_consents', {}).get('value', 0)
         dsars = data.get('metrics_by_category', {}).get('data_subject_rights', {}).get('pending_dsars_due_soon', {}).get('value', 0)
         alerts = data.get('alerts_summary', {}).get('total_alerts', 0)
-        
+
         return f"{score}%", str(consents), str(dsars), str(alerts)
-        
+
     except Exception as e:
         return "Error", "Error", "Error", "Error"
+
+
+# -----------------------------------------------------------------------------
+# Wire the dashboard into the main application
+# -----------------------------------------------------------------------------
+
+from flask_login import login_required, current_user
+
+def register_compliance_dashboard(app, container):
+    """Attach the compliance dashboard to the Flask app"""
+    dashboard_app = dash.Dash(
+        __name__,
+        server=app,
+        url_base_pathname="/compliance/",
+    )
+    dashboard_app.layout = create_compliance_dashboard_layout()
+
+    @app.route("/compliance/")
+    @login_required
+    def compliance_dashboard_view():
+        if "compliance_admin" not in getattr(current_user, "roles", []):
+            return "Forbidden", 403
+        return dashboard_app.index()
+
+    app.config["compliance_dashboard"] = dashboard_app
+
+register_compliance_dashboard(app, container)
+
+# Sample environment variables:
+#   YOSAI_ENV=production
+#   YOSAI_PORT=8050
+#   COMPLIANCE_DASHBOARD_ROUTE=/compliance/
+#   DASHBOARD_ALLOWED_ROLES=compliance_admin,security_team
+
+# Example NGINX routing:
+#   location /compliance/ {
+#       proxy_pass http://dashboard:8050/compliance/;
+#       proxy_set_header Host $host;
+#       proxy_set_header X-Forwarded-Proto $scheme;
+#   }
 
 
 # =============================================================================
 # STEP 6: Deployment configuration
 # =============================================================================
+
+# WSGI/Gunicorn deployment:
+#   gunicorn wsgi:server --config gunicorn.conf.py
+# The default gunicorn.conf.py binds to port 8050 and uses gevent workers.
 
 # Update your production configuration:
 


### PR DESCRIPTION
## Summary
- add example for registering and securing the compliance dashboard
- document sample env vars and nginx routing for the dashboard
- describe WSGI/Gunicorn deployment using existing configuration

## Testing
- `pytest` *(fails: Environment variable SECRET_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_688e4472d45083209c3bff7ee6aca7e3