### PR TITLE
Add minimal navbar stub

### DIFF
--- a/tests/stubs/components/ui/navbar.py
+++ b/tests/stubs/components/ui/navbar.py
@@ -1,11 +1,33 @@
+"""Test stub for navbar component.
+
+This module provides minimal stand-ins for the real navbar implementation so
+tests can import and use basic functionality without pulling in the full UI
+stack.
+"""
+
 from __future__ import annotations
 
 
-def create_navbar_layout(*_args, **_kwargs):
+class Navbar:
+    """Minimal placeholder navbar used in tests."""
+
+    def render(self) -> str:
+        """Return mock HTML for the navbar."""
+
+        return "<nav>navbar</nav>"
+
+
+def create_navbar_layout(*_args, **_kwargs) -> str:
     """Return a dummy navbar layout, ignoring any parameters."""
 
-    return "navbar"
+    return Navbar().render()
 
 
-def register_navbar_callbacks(manager, service=None):
+def register_navbar_callbacks(manager, service=None) -> None:
+    """Record that navbar callbacks were registered."""
+
     manager.navbar_registered = True
+
+
+__all__ = ["Navbar", "create_navbar_layout", "register_navbar_callbacks"]
+


### PR DESCRIPTION
## Summary
- replace JSON placeholder with minimal Navbar stub
- add create_navbar_layout and register_navbar_callbacks helpers

## Testing
- `pytest tests/utils/test_assets_debug.py tests/utils/test_icon_cache_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5053718883208e7dfe8acb4ccbd2