### PR TITLE
feat: improve error boundary reporting

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx
@@ -1,5 +1,16 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ErrorBoundary from './ErrorBoundary';
+
+// Silence expected console errors in tests
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+  (global.fetch as jest.Mock).mockClear();
+});
 
 test('renders children when no error', () => {
   render(
@@ -8,4 +19,57 @@ test('renders children when no error', () => {
     </ErrorBoundary>
   );
   expect(screen.getByText('content')).toBeInTheDocument();
+});
+
+test('shows fallback UI and posts error report', () => {
+  const ThrowError = () => {
+    throw new Error('boom');
+  };
+
+  render(
+    <ErrorBoundary>
+      <ThrowError />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+  expect(screen.getByText('Retry')).toBeInTheDocument();
+  expect(screen.getByText('Report Issue')).toBeInTheDocument();
+  expect(global.fetch).toHaveBeenCalledWith('/api/error-report', expect.any(Object));
+});
+
+test('retry resets error boundary', () => {
+  let shouldThrow = true;
+  const ProblemChild = () => {
+    if (shouldThrow) throw new Error('fail');
+    return <div>safe</div>;
+  };
+
+  render(
+    <ErrorBoundary>
+      <ProblemChild />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+  shouldThrow = false;
+  fireEvent.click(screen.getByText('Retry'));
+  expect(screen.getByText('safe')).toBeInTheDocument();
+});
+
+test('displays error details in development mode', () => {
+  const prevEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  const ThrowError = () => {
+    throw new Error('dev boom');
+  };
+
+  render(
+    <ErrorBoundary>
+      <ThrowError />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText(/dev boom/)).toBeInTheDocument();
+  process.env.NODE_ENV = prevEnv;
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.tsx
@@ -1,26 +1,81 @@
 import React from 'react';
+import { Alert, AlertDescription } from './ui/alert';
+import { Button } from './ui/button';
 
 interface ErrorBoundaryState {
   hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
 }
 
 class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, ErrorBoundaryState> {
   constructor(props: React.PropsWithChildren<{}>) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: null, errorInfo: null };
+    this.handleRetry = this.handleRetry.bind(this);
+    this.handleReport = this.handleReport.bind(this);
   }
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error, errorInfo: null };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // Store component stack for potential display and reporting
+    this.setState({ errorInfo: info });
+
+    // Report error to backend
+    fetch('/api/error-report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        componentStack: info.componentStack
+      })
+    }).catch((err) => console.error('Failed to report error', err));
+
     console.error('ErrorBoundary caught an error', error, info);
   }
 
+  handleRetry() {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  }
+
+  handleReport() {
+    const { error, errorInfo } = this.state;
+    if (!error) return;
+    fetch('/api/error-report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        componentStack: errorInfo?.componentStack
+      })
+    }).catch((err) => console.error('Failed to report error', err));
+  }
+
   render() {
-    if (this.state.hasError) {
-      return <div>Something went wrong.</div>;
+    const { hasError, error, errorInfo } = this.state;
+    if (hasError) {
+      return (
+        <Alert className="bg-red-50 border-red-200 text-red-800">
+          <AlertDescription>
+            <p className="font-medium">Something went wrong.</p>
+            {process.env.NODE_ENV === 'development' && error && (
+              <pre className="mt-2 whitespace-pre-wrap text-sm">{error.stack}</pre>
+            )}
+            {process.env.NODE_ENV === 'development' && errorInfo && (
+              <pre className="mt-2 whitespace-pre-wrap text-xs">{errorInfo.componentStack}</pre>
+            )}
+            <div className="mt-4 flex gap-2">
+              <Button onClick={this.handleRetry}>Retry</Button>
+              <Button variant="outline" onClick={this.handleReport}>Report Issue</Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      );
     }
 
     return this.props.children;


### PR DESCRIPTION
## Summary
- enhance ErrorBoundary with error state, retry, and issue report actions
- send component stack and error details to `/api/error-report`
- expand unit tests for fallback UI and retry behavior

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.tsx yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx`
- `npm test -- ErrorBoundary.test.tsx` *(fails: Cannot find module '.../ui/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688e51a00498832093f9d2a834aa965a