### PR TITLE
feat: add searchable select content

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './select';
 
 test('renders select components', () => {
@@ -12,4 +12,43 @@ test('renders select components', () => {
       </SelectContent>
     </Select>
   );
+});
+
+test('filters options when searchable is enabled', () => {
+  render(
+    <Select value="" onValueChange={() => {}}>
+      <SelectTrigger>
+        <SelectValue placeholder="choose" />
+      </SelectTrigger>
+      <SelectContent searchable>
+        <SelectItem value="1">Apple</SelectItem>
+        <SelectItem value="2">Banana</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+
+  const input = screen.getByPlaceholderText('Search...');
+  fireEvent.change(input, { target: { value: 'ban' } });
+
+  expect(screen.queryByText('Apple')).toBeNull();
+  expect(screen.getByText('Banana')).toBeInTheDocument();
+});
+
+test('calls onSearch when provided', () => {
+  const onSearch = jest.fn();
+  render(
+    <Select value="" onValueChange={() => {}}>
+      <SelectTrigger>
+        <SelectValue placeholder="choose" />
+      </SelectTrigger>
+      <SelectContent searchable onSearch={onSearch}>
+        <SelectItem value="1">Apple</SelectItem>
+        <SelectItem value="2">Banana</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+
+  const input = screen.getByPlaceholderText('Search...');
+  fireEvent.change(input, { target: { value: 'app' } });
+  expect(onSearch).toHaveBeenCalledWith('app');
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/select.tsx
@@ -1,6 +1,50 @@
 import React from 'react';
+
 export const Select: React.FC<{ value: string; onValueChange: (value: string) => void; children: React.ReactNode }> = ({ children }) => <div className="relative">{children}</div>;
+
 export const SelectTrigger: React.FC<{ className?: string; children: React.ReactNode }> = ({ className = '', children }) => <div className={`border rounded px-3 py-2 ${className}`}>{children}</div>;
+
 export const SelectValue: React.FC<{ placeholder?: string }> = ({ placeholder }) => <span className="text-gray-500">{placeholder}</span>;
-export const SelectContent: React.FC<{ children: React.ReactNode }> = ({ children }) => <div className="absolute z-10 bg-white border rounded shadow-lg">{children}</div>;
+
+export const SelectContent: React.FC<{
+  children: React.ReactNode;
+  searchable?: boolean;
+  onSearch?: (query: string) => void;
+}> = ({ children, searchable = false, onSearch }) => {
+  const [query, setQuery] = React.useState('');
+  const items = React.Children.toArray(children);
+  const filteredItems = !onSearch && searchable && query
+    ? items.filter((child) => {
+        if (React.isValidElement(child)) {
+          const text = String(child.props.children).toLowerCase();
+          return text.includes(query.toLowerCase());
+        }
+        return true;
+      })
+    : items;
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setQuery(value);
+    if (onSearch) {
+      onSearch(value);
+    }
+  };
+
+  return (
+    <div className="absolute z-10 bg-white border rounded shadow-lg">
+      {searchable && (
+        <input
+          type="text"
+          value={query}
+          onChange={handleSearch}
+          placeholder="Search..."
+          className="w-full p-2 border-b outline-none"
+        />
+      )}
+      {filteredItems}
+    </div>
+  );
+};
+
 export const SelectItem: React.FC<{ value: string; children: React.ReactNode }> = ({ children }) => <div className="px-3 py-2 hover:bg-gray-100 cursor-pointer">{children}</div>;


### PR DESCRIPTION
## Summary
- add optional text input to SelectContent for filtering
- support `searchable` prop and `onSearch` callback
- test filtering and custom search behavior

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npx jest yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688e51a4200c8320b76993dc2b21c8b6