### PR TITLE
feat: add keyboard navigation to Select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/node": "^24.0.15",
         "@types/papaparse": "^5.3.16",
         "@types/uuid": "^10.0.0",
@@ -5079,6 +5080,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^24.0.15",
     "@types/papaparse": "^5.3.16",
     "@types/uuid": "^10.0.0",

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
@@ -1,14 +1,42 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Select } from './Select';
 
 const options = [
   { value: 'a', label: 'A' },
-  { value: 'b', label: 'B' }
+  { value: 'b', label: 'B' },
+  { value: 'c', label: 'C' }
 ];
 
-test('calls onChange with selected value', () => {
+test('calls onChange when option clicked', async () => {
+  const user = userEvent.setup();
   const onChange = jest.fn();
   render(<Select value="" onChange={onChange} options={options} />);
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'a' } });
+  await user.click(screen.getByText('A'));
   expect(onChange).toHaveBeenCalledWith('a');
 });
+
+test('supports keyboard navigation and selection', async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<Select value="" onChange={onChange} options={options} />);
+
+  const listbox = screen.getByRole('listbox');
+  listbox.focus();
+
+  await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+  expect(onChange).toHaveBeenCalledWith('c');
+
+  onChange.mockClear();
+  await user.keyboard('{Home}{Enter}');
+  expect(onChange).toHaveBeenCalledWith('a');
+
+  onChange.mockClear();
+  await user.keyboard('{End}{Enter}');
+  expect(onChange).toHaveBeenCalledWith('c');
+
+  onChange.mockClear();
+  await user.keyboard('{ArrowUp}{Escape}{Enter}');
+  expect(onChange).not.toHaveBeenCalled();
+});
+

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
-interface Option { value: string; label: string; }
-interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   value: string | string[];
   onChange: (value: any) => void;
   options: Option[];
@@ -10,26 +14,97 @@ interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
   className?: string;
 }
 
-export const Select: React.FC<Props> = ({ value, onChange, options, multiple = false, placeholder, className='', ...rest }) => {
+export const Select: React.FC<Props> = ({
+  value,
+  onChange,
+  options,
+  multiple = false,
+  placeholder,
+  className = '',
+  ...rest
+}) => {
+  const displayOptions = React.useMemo(() => {
+    return !multiple && placeholder
+      ? [{ value: '', label: placeholder }, ...options]
+      : options;
+  }, [options, placeholder, multiple]);
+
+  const [focusIndex, setFocusIndex] = React.useState(0);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const selectOption = (index: number) => {
+    const opt = displayOptions[index];
+    if (!opt) return;
+    if (multiple) {
+      const current = Array.isArray(value) ? value : [];
+      if (current.includes(opt.value)) {
+        onChange(current.filter(v => v !== opt.value));
+      } else {
+        onChange([...current, opt.value]);
+      }
+    } else {
+      onChange(opt.value);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setFocusIndex(i => Math.min(i + 1, displayOptions.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setFocusIndex(i => Math.max(i - 1, 0));
+        break;
+      case 'Home':
+        e.preventDefault();
+        setFocusIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setFocusIndex(displayOptions.length - 1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        selectOption(focusIndex);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setFocusIndex(-1);
+        containerRef.current?.blur();
+        break;
+    }
+  };
+
   return (
-    <select
-      multiple={multiple}
-      value={value}
+    <div
       {...rest}
-      onChange={(e) => {
-        if (multiple) {
-          const selected = Array.from(e.target.selectedOptions).map(o => o.value);
-          onChange(selected);
-        } else {
-          onChange(e.target.value);
-        }
-      }}
+      ref={containerRef}
+      tabIndex={0}
+      role="listbox"
+      onKeyDown={handleKeyDown}
       className={`border rounded-md px-2 py-1 ${className}`}
     >
-      {!multiple && placeholder && <option value="">{placeholder}</option>}
-      {options.map(opt => (
-        <option key={opt.value} value={opt.value}>{opt.label}</option>
-      ))}
-    </select>
+      {displayOptions.map((opt, index) => {
+        const selected = multiple
+          ? Array.isArray(value) && value.includes(opt.value)
+          : value === opt.value;
+        const focused = index === focusIndex;
+        return (
+          <div
+            key={opt.value}
+            role="option"
+            aria-selected={selected}
+            data-focused={focused}
+            className={focused ? 'bg-blue-500 text-white' : ''}
+            onMouseEnter={() => setFocusIndex(index)}
+            onClick={() => selectOption(index)}
+          >
+            {opt.label}
+          </div>
+        );
+      })}
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- add internal focus management to Select component
- support arrow keys, Home/End, Enter, and Escape for navigation and selection
- test keyboard navigation with `@testing-library/user-event`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npx jest yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688e51a47a6883209b5a45d83ede4f18