### PR TITLE
feat(ui): add multi-select support

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
@@ -1,15 +1,36 @@
-import { render } from '@testing-library/react';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './select';
 
-test('renders select components', () => {
-  render(
-    <Select value="" onValueChange={() => {}}>
-      <SelectTrigger>
-        <SelectValue placeholder="choose" />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="1">One</SelectItem>
-      </SelectContent>
-    </Select>
-  );
+test('supports multi-selection with keyboard', () => {
+  const onValueChange = jest.fn();
+  const Wrapper = () => {
+    const [values, setValues] = React.useState<string[]>([]);
+    const handleChange = (vals: string[]) => {
+      onValueChange(vals);
+      setValues(vals);
+    };
+    return (
+      <Select value={values} onValueChange={handleChange} multiple>
+        <SelectTrigger>
+          <SelectValue placeholder="choose" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="1">One</SelectItem>
+          <SelectItem value="2">Two</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  };
+  render(<Wrapper />);
+
+  const item1 = screen.getByText('One');
+  fireEvent.click(item1);
+  expect(onValueChange).toHaveBeenLastCalledWith(['1']);
+  expect((item1.querySelector('input') as HTMLInputElement).checked).toBe(true);
+
+  const item2 = screen.getByText('Two');
+  fireEvent.keyDown(item2, { key: ' ', code: 'Space' });
+  expect(onValueChange).toHaveBeenLastCalledWith(['1', '2']);
+  expect((item2.querySelector('input') as HTMLInputElement).checked).toBe(true);
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/select.tsx
@@ -1,6 +1,73 @@
-import React from 'react';
-export const Select: React.FC<{ value: string; onValueChange: (value: string) => void; children: React.ReactNode }> = ({ children }) => <div className="relative">{children}</div>;
-export const SelectTrigger: React.FC<{ className?: string; children: React.ReactNode }> = ({ className = '', children }) => <div className={`border rounded px-3 py-2 ${className}`}>{children}</div>;
-export const SelectValue: React.FC<{ placeholder?: string }> = ({ placeholder }) => <span className="text-gray-500">{placeholder}</span>;
-export const SelectContent: React.FC<{ children: React.ReactNode }> = ({ children }) => <div className="absolute z-10 bg-white border rounded shadow-lg">{children}</div>;
-export const SelectItem: React.FC<{ value: string; children: React.ReactNode }> = ({ children }) => <div className="px-3 py-2 hover:bg-gray-100 cursor-pointer">{children}</div>;
+import React, { createContext, useContext } from 'react';
+
+interface SelectContextProps {
+  value: string[];
+  multiple: boolean;
+  onValueChange: (values: string[]) => void;
+}
+
+const SelectContext = createContext<SelectContextProps | null>(null);
+
+interface SelectProps {
+  value: string[];
+  onValueChange: (values: string[]) => void;
+  multiple?: boolean;
+  children: React.ReactNode;
+}
+
+export const Select: React.FC<SelectProps> = ({ value, onValueChange, multiple = false, children }) => (
+  <SelectContext.Provider value={{ value, onValueChange, multiple }}>
+    <div className="relative">{children}</div>
+  </SelectContext.Provider>
+);
+
+export const SelectTrigger: React.FC<{ className?: string; children: React.ReactNode }> = ({ className = '', children }) => (
+  <div className={`border rounded px-3 py-2 ${className}`}>{children}</div>
+);
+
+export const SelectValue: React.FC<{ placeholder?: string }> = ({ placeholder }) => (
+  <span className="text-gray-500">{placeholder}</span>
+);
+
+export const SelectContent: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="absolute z-10 bg-white border rounded shadow-lg">{children}</div>
+);
+
+interface SelectItemProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+export const SelectItem: React.FC<SelectItemProps> = ({ value, children }) => {
+  const ctx = useContext(SelectContext);
+  if (!ctx) return null;
+  const { value: selected, onValueChange, multiple } = ctx;
+  const checked = selected.includes(value);
+  const toggle = () => {
+    if (checked) {
+      onValueChange(selected.filter((v) => v !== value));
+    } else {
+      onValueChange(multiple ? [...selected, value] : [value]);
+    }
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      toggle();
+    }
+  };
+  return (
+    <div
+      tabIndex={0}
+      role={multiple ? 'checkbox' : 'option'}
+      aria-checked={multiple ? checked : undefined}
+      aria-selected={!multiple ? checked : undefined}
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      className="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center"
+    >
+      {multiple && <input type="checkbox" checked={checked} readOnly className="mr-2" />}
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add `multiple` prop to Select with context-based state management
- allow SelectItem to toggle via checkbox or Space key
- test multi-selection behavior

## Testing
- `npm test -- select` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688e51a4cdd48320a6561a508ba34ee2