### PR TITLE
feat: migrate test stubs

### DIFF
--- a/scripts/migrate_tests.py
+++ b/scripts/migrate_tests.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Automate migration of test modules.
+
+This script rewrites ``sys.modules`` stubbing patterns in ``tests/`` to use the
+helpers provided in ``tests.import_helpers``.  It also updates imports to pull
+fixtures from ``tests.config``.
+
+Any unhandled ``sys.modules`` manipulations are reported as TODO items for
+manual follow-up.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import List, Tuple
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parents[1] / "tests"
+
+# Regex patterns for sys.modules manipulations
+SETDEFAULT_RE = re.compile(
+    r"^(\s*)sys\.modules\.setdefault\((['\"])([^'\"]+)\2,\s*(.*)\)\s*(#.*)?$"
+)
+ASSIGN_RE = re.compile(
+    r"^(\s*)sys\.modules\[(['\"])([^'\"]+)\2\]\s*=\s*(.+)"
+)
+MONKEYPATCH_RE = re.compile(
+    r"^(\s*)monkeypatch\.setitem\(sys\.modules,\s*(['\"])([^'\"]+)\2,\s*(.*)\)\s*(#.*)?$"
+)
+
+# Regex for fixture import replacements
+FAKE_CONFIG_RE = re.compile(r"^(\s*)from\s+tests\.fake_configuration\s+import\s+(.*)")
+FAKE_CONFIG_IMPORT_AS_RE = re.compile(r"^(\s*)import\s+tests\.fake_configuration\s+as\s+(\w+)")
+
+IMPORT_HELPERS_LINE = "from tests.import_helpers import safe_import, import_optional"
+
+
+def ensure_import_helpers(lines: List[str]) -> None:
+    """Insert import for helper functions if not already present."""
+    if any("tests.import_helpers" in line for line in lines):
+        return
+    insert_pos = 0
+    for idx, line in enumerate(lines):
+        if line.startswith("from") or line.startswith("import"):
+            insert_pos = idx + 1
+        elif line.strip():
+            break
+    lines.insert(insert_pos, IMPORT_HELPERS_LINE)
+
+
+def replace_sys_modules(lines: List[str]) -> Tuple[List[str], List[Tuple[int, str]]]:
+    """Replace sys.modules patterns returning modified lines and TODO items."""
+    todos: List[Tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        m = SETDEFAULT_RE.match(line)
+        if m:
+            indent, name, stub, comment = m.group(1), m.group(3), m.group(4), m.group(5) or ""
+            call = f"safe_import('{name}', {stub})"
+            lines[i] = f"{indent}{call}{comment}"
+            continue
+        m = ASSIGN_RE.match(line)
+        if m:
+            indent, name, stub = m.group(1), m.group(3), m.group(4)
+            call = f"safe_import('{name}', {stub})"
+            lines[i] = f"{indent}{call}"
+            continue
+        m = MONKEYPATCH_RE.match(line)
+        if m:
+            indent, name, stub, comment = m.group(1), m.group(3), m.group(4), m.group(5) or ""
+            call = f"safe_import('{name}', {stub})"
+            lines[i] = f"{indent}{call}{comment}"
+            continue
+        if "sys.modules" in line and "safe_import" not in line and "import_optional" not in line:
+            todos.append((i + 1, line.rstrip()))
+    return lines, todos
+
+
+def replace_fixture_imports(lines: List[str]) -> List[str]:
+    """Update fixture imports to use ``tests.config``."""
+    for i, line in enumerate(lines):
+        m = FAKE_CONFIG_RE.match(line)
+        if m:
+            indent, rest = m.groups()
+            lines[i] = f"{indent}from tests.config import {rest}"
+            continue
+        m = FAKE_CONFIG_IMPORT_AS_RE.match(line)
+        if m:
+            indent, alias = m.groups()
+            lines[i] = f"{indent}import tests.config as {alias}"
+    return lines
+
+
+def process_file(path: pathlib.Path) -> List[Tuple[int, str]]:
+    text = path.read_text().splitlines()
+    original_lines = list(text)
+    text = replace_fixture_imports(text)
+    text, todos = replace_sys_modules(text)
+    if text != original_lines:
+        ensure_import_helpers(text)
+        path.write_text("\n".join(text) + "\n")
+    return [(path, ln, content) for ln, content in todos]
+
+
+def main() -> None:
+    todos: List[Tuple[pathlib.Path, int, str]] = []
+    for py_file in TESTS_DIR.rglob("*.py"):
+        if py_file == TESTS_DIR / "config.py":
+            continue
+        todos.extend(process_file(py_file))
+    if todos:
+        print("\nTODO: manual review required for the following sys.modules usages:")
+        for path, line_no, content in todos:
+            print(f"- {path}:{line_no}: {content}")
+    else:
+        print("All sys.modules manipulations migrated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/adapters/api/test_cors.py
+++ b/tests/adapters/api/test_cors.py
@@ -4,16 +4,17 @@ import types
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.import_helpers import safe_import, import_optional
 
 # Provide stubs when optional dependencies are missing
 if "flask_wtf" not in sys.modules:
     fw = importlib.import_module("tests.stubs.flask_wtf")
-    sys.modules["flask_wtf"] = fw
-    sys.modules["flask_wtf.csrf"] = fw
+    safe_import('flask_wtf', fw)
+    safe_import('flask_wtf.csrf', fw)
 if "flask_cors" not in sys.modules:
-    sys.modules["flask_cors"] = importlib.import_module("flask_cors")
+    safe_import('flask_cors', importlib.import_module("flask_cors"))
 if "services" not in sys.modules:
-    sys.modules["services"] = importlib.import_module("tests.stubs.services")
+    safe_import('services', importlib.import_module("tests.stubs.services"))
 
 
 def _create_app(monkeypatch, origins):

--- a/tests/analytics/test_processor_io.py
+++ b/tests/analytics/test_processor_io.py
@@ -8,25 +8,26 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 # Dynamically import AsyncFileProcessor to avoid heavy service deps
 services_root = Path(__file__).resolve().parents[2] / "services"
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(services_root)]
-sys.modules.setdefault("services", services_pkg)
+safe_import('services', services_pkg)
 
 data_processing_pkg = types.ModuleType("services.data_processing")
 data_processing_pkg.__path__ = [str(services_root / "data_processing")]
-sys.modules.setdefault("services.data_processing", data_processing_pkg)
+safe_import('services.data_processing', data_processing_pkg)
 
 analytics_pkg = types.ModuleType("services.analytics")
 analytics_pkg.__path__ = [str(services_root / "analytics")]
-sys.modules.setdefault("services.analytics", analytics_pkg)
+safe_import('services.analytics', analytics_pkg)
 
 mapping_root = Path(__file__).resolve().parents[2] / "mapping"
 mapping_pkg = types.ModuleType("mapping")
 mapping_pkg.__path__ = [str(mapping_root)]
-sys.modules.setdefault("mapping", mapping_pkg)
+safe_import('mapping', mapping_pkg)
 
 # Provide minimal config.dynamic_config for AsyncFileProcessor
 config_pkg = types.ModuleType("config")
@@ -50,8 +51,8 @@ config_pkg.DatabaseSettings = DatabaseSettings
 
 config_dynamic_pkg = types.ModuleType("config.dynamic_config")
 config_dynamic_pkg.dynamic_config = dynamic
-sys.modules.setdefault("config", config_pkg)
-sys.modules.setdefault("config.dynamic_config", config_dynamic_pkg)
+safe_import('config', config_pkg)
+safe_import('config.dynamic_config', config_dynamic_pkg)
 
 protocols_pkg = types.ModuleType("core.protocols")
 
@@ -64,42 +65,42 @@ class ConfigurationProtocol: ...
 
 protocols_pkg.FileProcessorProtocol = FileProcessorProtocol
 protocols_pkg.ConfigurationProtocol = ConfigurationProtocol
-sys.modules.setdefault("core.protocols", protocols_pkg)
+safe_import('core.protocols', protocols_pkg)
 
 core_pkg = types.ModuleType("core")
 config_mod = types.ModuleType("core.config")
 config_mod.get_max_display_rows = lambda config=None: 5
 core_pkg.config = config_mod
-sys.modules.setdefault("core", core_pkg)
-sys.modules.setdefault("core.config", config_mod)
+safe_import('core', core_pkg)
+safe_import('core.config', config_mod)
 
 perf_mod = types.ModuleType("core.performance")
 perf_mod.get_performance_monitor = lambda: types.SimpleNamespace(
     throttle_if_needed=lambda: None
 )
-sys.modules.setdefault("core.performance", perf_mod)
+safe_import('core.performance', perf_mod)
 
 perf_fp_mod = types.ModuleType("core.performance_file_processor")
 perf_fp_mod.PerformanceFileProcessor = object
-sys.modules.setdefault("core.performance_file_processor", perf_fp_mod)
+safe_import('core.performance_file_processor', perf_fp_mod)
 
 rabbit_pkg = types.ModuleType("services.rabbitmq_client")
 rabbit_pkg.RabbitMQClient = object
-sys.modules.setdefault("services.rabbitmq_client", rabbit_pkg)
+safe_import('services.rabbitmq_client', rabbit_pkg)
 
 memory_pkg = types.ModuleType("utils.memory_utils")
 memory_pkg.check_memory_limit = lambda *a, **k: None
-sys.modules.setdefault("utils.memory_utils", memory_pkg)
+safe_import('utils.memory_utils', memory_pkg)
 
 task_queue_pkg = types.ModuleType("services.task_queue")
 task_queue_pkg.create_task = lambda func: "tid"
 task_queue_pkg.get_status = lambda tid: {"progress": 100, "result": None, "done": True}
 task_queue_pkg.clear_task = lambda tid: None
-sys.modules.setdefault("services.task_queue", task_queue_pkg)
+safe_import('services.task_queue', task_queue_pkg)
 
 chardet_pkg = types.ModuleType("chardet")
 chardet_pkg.detect = lambda b: {"encoding": "utf-8"}
-sys.modules.setdefault("chardet", chardet_pkg)
+safe_import('chardet', chardet_pkg)
 
 spec = importlib.util.spec_from_file_location(
     "services.data_processing.async_file_processor",

--- a/tests/api/test_settings_endpoint.py
+++ b/tests/api/test_settings_endpoint.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 from flask import Flask
+from tests.import_helpers import safe_import, import_optional
 
 
 class DummyLock:
@@ -38,8 +39,8 @@ def test_get_and_update_settings(monkeypatch):
     }
     fake_pkg = ModuleType("yosai_framework")
     fake_pkg.errors = fake_errors
-    monkeypatch.setitem(sys.modules, "yosai_framework", fake_pkg)
-    monkeypatch.setitem(sys.modules, "yosai_framework.errors", fake_errors)
+    safe_import('yosai_framework', fake_pkg)
+    safe_import('yosai_framework.errors', fake_errors)
 
     # Load utils.pydantic_decorators without importing utils package
     spec = importlib.util.spec_from_file_location(
@@ -51,8 +52,8 @@ def test_get_and_update_settings(monkeypatch):
     spec.loader.exec_module(pyd_module)
     utils_pkg = ModuleType("utils")
     utils_pkg.pydantic_decorators = pyd_module
-    monkeypatch.setitem(sys.modules, "utils", utils_pkg)
-    monkeypatch.setitem(sys.modules, "utils.pydantic_decorators", pyd_module)
+    safe_import('utils', utils_pkg)
+    safe_import('utils.pydantic_decorators', pyd_module)
 
     settings_endpoint = importlib.import_module("api.settings_endpoint")
 

--- a/tests/callbacks/conftest.py
+++ b/tests/callbacks/conftest.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -12,11 +13,11 @@ try:
     import dash
 except ModuleNotFoundError:
     dash = types.SimpleNamespace(no_update=None)
-    sys.modules["dash"] = dash
+    safe_import('dash', dash)
 
 # Provide dash.exceptions.PreventUpdate when dash isn't installed
 if "dash.exceptions" not in sys.modules:
-    sys.modules["dash.exceptions"] = types.SimpleNamespace(PreventUpdate=Exception)
+    safe_import('dash.exceptions', types.SimpleNamespace(PreventUpdate=Exception))
 
 # Ensure dash.no_update is defined for tests
 if not hasattr(dash, "no_update"):

--- a/tests/cli/test_model_registry_cli.py
+++ b/tests/cli/test_model_registry_cli.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 # Dynamically load the ModelRegistry implementation while providing lightweight
 # stubs for heavy optional dependencies. ``tests.conftest`` already injects
@@ -27,9 +28,9 @@ class DummyS3:
 @pytest.fixture
 def cli_module(monkeypatch: pytest.MonkeyPatch):
     path = Path(__file__).resolve().parents[2] / "scripts" / "model_registry_cli.py"
-    monkeypatch.setitem(sys.modules, "models", types.ModuleType("models"))
-    monkeypatch.setitem(sys.modules, "models.ml", types.ModuleType("models.ml"))
-    monkeypatch.setitem(sys.modules, "models.ml.model_registry", mr)
+    safe_import('models', types.ModuleType("models"))
+    safe_import('models.ml', types.ModuleType("models.ml"))
+    safe_import('models.ml.model_registry', mr)
     spec = importlib.util.spec_from_file_location("model_registry_cli", path)
     mod = importlib.util.module_from_spec(spec)
     assert spec.loader

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,10 @@
+"""Centralised test configuration helpers.
+
+This module aggregates commonly used test configuration objects so that tests
+can import from ``tests.config`` instead of scattered modules.
+"""
+from tests.fake_configuration import FakeConfiguration
+from tests.stubs.config.config import Dummy, get_config, get_analytics_config
+
+__all__ = ["FakeConfiguration", "Dummy", "get_config", "get_analytics_config"]
+

--- a/tests/database/test_database_manager_retry.py
+++ b/tests/database/test_database_manager_retry.py
@@ -5,6 +5,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 
 def load_database_manager():
@@ -18,13 +19,13 @@ def load_database_manager():
                 return str(query)
 
         unicode_mod.UnicodeSQLProcessor = UnicodeSQLProcessor
-        sys.modules["core.unicode"] = unicode_mod
+        safe_import('core.unicode', unicode_mod)
 
     pkg = types.ModuleType("config")
     pkg.__path__ = []
-    sys.modules["config"] = pkg
+    safe_import('config', pkg)
 
-    sys.modules["config.dynamic_config"] = types.ModuleType("config.dynamic_config")
+    safe_import('config.dynamic_config', types.ModuleType("config.dynamic_config"))
     sys.modules["config.dynamic_config"].dynamic_config = types.SimpleNamespace(
         get_db_connection_timeout=lambda: 1,
         get_db_pool_size=lambda: 1,
@@ -45,7 +46,7 @@ def load_database_manager():
 
     schema_mod = types.ModuleType("config.schema")
     schema_mod.DatabaseSettings = DatabaseSettings
-    sys.modules["config.schema"] = schema_mod
+    safe_import('config.schema', schema_mod)
 
     ex_mod = types.ModuleType("config.database_exceptions")
 
@@ -61,7 +62,7 @@ def load_database_manager():
     ex_mod.ConnectionRetryExhausted = ConnectionRetryExhausted
     ex_mod.ConnectionValidationFailed = ConnectionValidationFailed
     ex_mod.DatabaseError = DatabaseError
-    sys.modules["config.database_exceptions"] = ex_mod
+    safe_import('config.database_exceptions', ex_mod)
 
     prot_mod = types.ModuleType("config.protocols")
 
@@ -71,18 +72,18 @@ def load_database_manager():
 
     prot_mod.RetryConfigProtocol = RetryConfigProtocol
     prot_mod.ConnectionRetryManagerProtocol = ConnectionRetryManagerProtocol
-    sys.modules["config.protocols"] = prot_mod
+    safe_import('config.protocols', prot_mod)
 
     retry_path = Path(__file__).resolve().parents[2] / "config" / "connection_retry.py"
     spec = importlib.util.spec_from_file_location("config.connection_retry", retry_path)
     conn_retry_mod = importlib.util.module_from_spec(spec)
-    sys.modules["config.connection_retry"] = conn_retry_mod
+    safe_import('config.connection_retry', conn_retry_mod)
     spec.loader.exec_module(conn_retry_mod)
 
     dm_path = Path(__file__).resolve().parents[2] / "config" / "database_manager.py"
     spec = importlib.util.spec_from_file_location("config.database_manager", dm_path)
     dbm = importlib.util.module_from_spec(spec)
-    sys.modules["config.database_manager"] = dbm
+    safe_import('config.database_manager', dbm)
     spec.loader.exec_module(dbm)
     return dbm
 

--- a/tests/database/test_query_limits.py
+++ b/tests/database/test_query_limits.py
@@ -1,23 +1,24 @@
 import sys
 import types
+from tests.import_helpers import safe_import, import_optional
 
 flask_stub = types.SimpleNamespace(
     request=types.SimpleNamespace(path=""), url_for=lambda *a, **k: ""
 )
-sys.modules.setdefault("scipy", types.ModuleType("scipy"))
+safe_import('scipy', types.ModuleType("scipy"))
 sys.modules["scipy"].stats = types.SimpleNamespace()
-sys.modules.setdefault("flask", flask_stub)
+safe_import('flask', flask_stub)
 import tests.stubs.flask_caching as flask_caching_stub
 
-sys.modules.setdefault("flask_caching", flask_caching_stub)
+safe_import('flask_caching', flask_caching_stub)
 if "dask" not in sys.modules:
     dask_stub = types.ModuleType("dask")
     dask_stub.__path__ = []
     dist_stub = types.ModuleType("dask.distributed")
     dist_stub.Client = object
     dist_stub.LocalCluster = object
-    sys.modules["dask"] = dask_stub
-    sys.modules["dask.distributed"] = dist_stub
+    safe_import('dask', dask_stub)
+    safe_import('dask.distributed', dist_stub)
 
 import importlib.util
 from pathlib import Path

--- a/tests/examples/test_debug_deep_analytics.py
+++ b/tests/examples/test_debug_deep_analytics.py
@@ -1,4 +1,5 @@
 from examples.debug_deep_analytics import (
+from tests.import_helpers import safe_import, import_optional
     check_upload_store,
     create_test_dataset,
     find_hardcoded_values,
@@ -32,7 +33,7 @@ def test_check_upload_store(tmp_path, monkeypatch):
     dummy_store = DummyStore()
     dummy_module.UploadedDataStore = DummyStore
     dummy_module.uploaded_data_store = dummy_store
-    monkeypatch.setitem(sys.modules, "utils.upload_store", dummy_module)
+    safe_import('utils.upload_store', dummy_module)
 
     df = create_test_dataset(5)
     stored = check_upload_store(df)

--- a/tests/file_processing/test_chunk_cache.py
+++ b/tests/file_processing/test_chunk_cache.py
@@ -7,9 +7,10 @@ import types
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 # Stub heavy optional dependencies before importing the services package
-sys.modules.setdefault("scipy", types.ModuleType("scipy"))
+safe_import('scipy', types.ModuleType("scipy"))
 sys.modules["scipy"].stats = types.SimpleNamespace()
 
 import importlib.util
@@ -20,7 +21,7 @@ module_path = Path(__file__).resolve().parents[2] / "services" / "chunked_analys
 spec = importlib.util.spec_from_file_location("services.chunked_analysis", module_path)
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(module_path.parent)]
-sys.modules.setdefault("services", services_pkg)
+safe_import('services', services_pkg)
 chunk_mod = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = chunk_mod
 spec.loader.exec_module(chunk_mod)

--- a/tests/file_processing/test_data_processor_pipeline.py
+++ b/tests/file_processing/test_data_processor_pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -43,22 +44,22 @@ class UnsupportedFormatError(Exception):
 
 format_stub.FormatDetector = FormatDetector
 format_stub.UnsupportedFormatError = UnsupportedFormatError
-sys.modules.setdefault("file_processing.format_detector", format_stub)
+safe_import('file_processing.format_detector', format_stub)
 
 readers_stub = types.ModuleType("file_processing.readers")
 for name in ["CSVReader", "ExcelReader", "JSONReader", "FWFReader", "ArchiveReader"]:
     setattr(readers_stub, name, type(name, (), {}))
-sys.modules.setdefault("file_processing.readers", readers_stub)
-sys.modules.setdefault("core.callback_events", cb_events_stub)
-sys.modules.setdefault("core.container", container_stub)
+safe_import('file_processing.readers', readers_stub)
+safe_import('core.callback_events', cb_events_stub)
+safe_import('core.container', container_stub)
 pkg = types.ModuleType("file_processing")
 pkg.__path__ = [str(MODULE_PATH.parent)]
-sys.modules.setdefault("file_processing", pkg)
+safe_import('file_processing', pkg)
 spec = importlib.util.spec_from_file_location(
     "file_processing.data_processor", MODULE_PATH
 )
 dp_mod = importlib.util.module_from_spec(spec)
-sys.modules["file_processing.data_processor"] = dp_mod
+safe_import('file_processing.data_processor', dp_mod)
 assert spec.loader is not None
 spec.loader.exec_module(dp_mod)
 DataProcessor = dp_mod.DataProcessor

--- a/tests/import_helpers.py
+++ b/tests/import_helpers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+from optional_dependencies import import_optional as _import_optional
+
+
+def safe_import(name: str, stub: ModuleType | Any) -> ModuleType | Any:
+    """Import ``name`` or register ``stub`` in ``sys.modules``.
+
+    Parameters
+    ----------
+    name:
+        Dotted module path.
+    stub:
+        Module or object to return/register when the import fails.
+    """
+    module = _import_optional(name, fallback=stub)
+    if module is not None:
+        sys.modules.setdefault(name, module)
+    return module
+
+
+# Re-export for convenience
+import_optional = _import_optional
+
+__all__ = ["safe_import", "import_optional"]

--- a/tests/integration/test_api_csrf.py
+++ b/tests/integration/test_api_csrf.py
@@ -3,8 +3,9 @@ import os
 import sys
 import types
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("yosai_intel_dashboard", types.ModuleType("yosai_intel_dashboard"))
+safe_import('yosai_intel_dashboard', types.ModuleType("yosai_intel_dashboard"))
 sys.modules["yosai_intel_dashboard"].__path__ = [str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard")]
 
 import pytest

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.import_helpers import safe_import, import_optional
 
 # Use lightweight imports
 os.environ["LIGHTWEIGHT_SERVICES"] = "1"
@@ -36,7 +37,7 @@ analytics_stub = types.ModuleType("services.analytics_service")
 analytics_stub.create_analytics_service = lambda: DummyAnalytics()
 import sys
 
-sys.modules["services.analytics_service"] = analytics_stub
+safe_import('services.analytics_service', analytics_stub)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_plugin_health_endpoint.py
+++ b/tests/integration/test_plugin_health_endpoint.py
@@ -6,6 +6,7 @@ import sys
 import types
 
 from flask.json.provider import DefaultJSONProvider
+from tests.import_helpers import safe_import, import_optional
 
 # Minimal services stubs
 spec = importlib.util.spec_from_file_location(
@@ -26,11 +27,11 @@ data_proc_mod = types.ModuleType("services.data_processing")
 data_proc_mod.core = core_mod
 services_mod.data_processing = data_proc_mod
 
-sys.modules["services"] = services_mod
-sys.modules["services.registry"] = registry_mod
-sys.modules["services.data_processing"] = data_proc_mod
-sys.modules["services.data_processing.core"] = core_mod
-sys.modules["core.protocols.plugin"] = protocols_mod
+safe_import('services', services_mod)
+safe_import('services.registry', registry_mod)
+safe_import('services.data_processing', data_proc_mod)
+safe_import('services.data_processing.core', core_mod)
+safe_import('core.protocols.plugin', protocols_mod)
 
 import pytest
 from flask import Flask

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -1,3 +1,4 @@
+from tests.import_helpers import safe_import, import_optional
 # flake8: noqa: E402
 from __future__ import annotations
 
@@ -25,8 +26,8 @@ for _mod in (
 ):
     sys.modules.setdefault(_mod, types.ModuleType(_mod))
 if "scipy" not in sys.modules:
-    sys.modules["scipy"] = types.ModuleType("scipy")
-sys.modules.setdefault("scipy.stats", types.ModuleType("scipy.stats"))
+    safe_import('scipy', types.ModuleType("scipy"))
+safe_import('scipy.stats', types.ModuleType("scipy.stats"))
 sys.modules["scipy"].stats = sys.modules["scipy.stats"]
 
 from config import create_config_manager

--- a/tests/metadata/test_metadata_engine.py
+++ b/tests/metadata/test_metadata_engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Protocol, Tuple, runtime_checkable
 
 import pandas as pd
+from tests.import_helpers import safe_import, import_optional
 
 
 @runtime_checkable
@@ -108,18 +109,18 @@ def _create_engine() -> Tuple[Any, _Store]:
     analytics_proto_mod.AnalyticsServiceProtocol = AnalyticsServiceProtocol
     services_stub.upload = upload_mod
     services_stub.analytics = analytics_mod
-    sys.modules.setdefault("services", services_stub)
-    sys.modules.setdefault("services.upload", upload_mod)
-    sys.modules.setdefault("services.upload.protocols", upload_proto_mod)
-    sys.modules.setdefault("services.analytics", analytics_mod)
-    sys.modules.setdefault("services.analytics.protocols", analytics_proto_mod)
+    safe_import('services', services_stub)
+    safe_import('services.upload', upload_mod)
+    safe_import('services.upload.protocols', upload_proto_mod)
+    safe_import('services.analytics', analytics_mod)
+    safe_import('services.analytics.protocols', analytics_proto_mod)
     import tests.stubs.dash as dash_stub
 
-    sys.modules.setdefault("dash", dash_stub)
-    sys.modules.setdefault("dash.html", dash_stub.html)
-    sys.modules.setdefault("dash.dcc", dash_stub.dcc)
-    sys.modules.setdefault("dash.dependencies", dash_stub.dependencies)
-    sys.modules.setdefault("dash._callback", dash_stub._callback)
+    safe_import('dash', dash_stub)
+    safe_import('dash.html', dash_stub.html)
+    safe_import('dash.dcc', dash_stub.dcc)
+    safe_import('dash.dependencies', dash_stub.dependencies)
+    safe_import('dash._callback', dash_stub._callback)
     dash_stub.no_update = dash_stub._callback.NoUpdate()
     sys.modules.setdefault(
         "dash.exceptions", types.SimpleNamespace(PreventUpdate=Exception)

--- a/tests/models/test_data_processor.py
+++ b/tests/models/test_data_processor.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import pandas as pd
+from tests.import_helpers import safe_import, import_optional
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2] / "models" / "ml" / "data_processor.py"
@@ -12,14 +13,14 @@ MODULE_PATH = (
 # Provide lightweight stubs to avoid heavy imports during module loading
 constants_mod = types.ModuleType("config.constants")
 constants_mod.DEFAULT_CHUNK_SIZE = 50_000
-sys.modules.setdefault("config.constants", constants_mod)
+safe_import('config.constants', constants_mod)
 
 memory_utils_mod = types.ModuleType("utils.memory_utils")
 memory_utils_mod.check_memory_limit = lambda *a, **k: None
 utils_pkg = types.ModuleType("utils")
 utils_pkg.memory_utils = memory_utils_mod
-sys.modules.setdefault("utils.memory_utils", memory_utils_mod)
-sys.modules.setdefault("utils", utils_pkg)
+safe_import('utils.memory_utils', memory_utils_mod)
+safe_import('utils', utils_pkg)
 
 spec = importlib.util.spec_from_file_location("data_processor", MODULE_PATH)
 dp_mod = importlib.util.module_from_spec(spec)

--- a/tests/monitoring/test_model_monitoring_service.py
+++ b/tests/monitoring/test_model_monitoring_service.py
@@ -1,10 +1,11 @@
+from tests.import_helpers import safe_import, import_optional
 # tests need minimal stubs for heavy dependencies
 import sys
 import types
 from dataclasses import dataclass
 
 # Stub out heavy dependencies before importing the service
-sys.modules["yosai_intel_dashboard.src.infrastructure.config"] = types.SimpleNamespace(
+safe_import('yosai_intel_dashboard.src.infrastructure.config', types.SimpleNamespace()
     get_monitoring_config=lambda: {}
 )
 

--- a/tests/monitoring/test_model_performance_monitor_drift.py
+++ b/tests/monitoring/test_model_performance_monitor_drift.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from types import SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 # minimal config stub to avoid heavy imports
 cfg_mod = types.ModuleType("config")
@@ -15,8 +16,8 @@ cfg_mod.DatabaseSettings = DatabaseSettings
 cfg_mod.dynamic_config = SimpleNamespace(
     performance=SimpleNamespace(memory_usage_threshold_mb=1024)
 )
-sys.modules["config"] = cfg_mod
-sys.modules["config.dynamic_config"] = cfg_mod
+safe_import('config', cfg_mod)
+safe_import('config.dynamic_config', cfg_mod)
 
 # minimal performance monitor stub
 perf_mod = types.ModuleType("core.performance")
@@ -30,13 +31,13 @@ perf_mod.MetricType = MetricType
 perf_mod.get_performance_monitor = lambda: SimpleNamespace(
     record_metric=lambda *a, **k: None, aggregated_metrics={}
 )
-sys.modules["core.performance"] = perf_mod
+safe_import('core.performance', perf_mod)
 
 # extend prometheus metrics stub
 prom_mod = types.ModuleType("monitoring.prometheus.model_metrics")
 prom_mod.update_model_metrics = lambda *a, **k: None
 prom_mod.start_model_metrics_server = lambda *a, **k: None
-sys.modules["monitoring.prometheus.model_metrics"] = prom_mod
+safe_import('monitoring.prometheus.model_metrics', prom_mod)
 
 # Stub services.resilience.metrics to avoid heavy deps
 metrics_mod = types.ModuleType("services.resilience.metrics")
@@ -45,9 +46,9 @@ metrics_mod.circuit_breaker_state = SimpleNamespace(
 )
 resilience_pkg = types.ModuleType("services.resilience")
 resilience_pkg.metrics = metrics_mod
-sys.modules.setdefault("services", types.ModuleType("services"))
-sys.modules.setdefault("services.resilience", resilience_pkg)
-sys.modules.setdefault("services.resilience.metrics", metrics_mod)
+safe_import('services', types.ModuleType("services"))
+safe_import('services.resilience', resilience_pkg)
+safe_import('services.resilience.metrics', metrics_mod)
 
 import monitoring.model_performance_monitor as mpm
 

--- a/tests/plugins/test_compliance_plugin.py
+++ b/tests/plugins/test_compliance_plugin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 
 def _load_compliance_plugin(monkeypatch, db_success=True, services_success=True):
@@ -24,7 +25,7 @@ def _load_compliance_plugin(monkeypatch, db_success=True, services_success=True)
             pass
 
     base_mod.BasePlugin = BasePlugin
-    monkeypatch.setitem(sys.modules, "core.plugins.base", base_mod)
+    safe_import('core.plugins.base', base_mod)
 
     db = MagicMock()
     db.ensure_schema.return_value = db_success

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -11,6 +11,7 @@ import pytest
 
 from config import create_config_manager
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+from tests.import_helpers import safe_import, import_optional
 
 
 def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:
@@ -60,9 +61,9 @@ def _install_protocol_stubs(monkeypatch: "pytest.MonkeyPatch") -> None:
     core_pkg = types.ModuleType("services.data_processing.core")
     core_pkg.__path__ = []
 
-    monkeypatch.setitem(sys.modules, "services", services_pkg)
-    monkeypatch.setitem(sys.modules, "services.data_processing", data_processing_pkg)
-    monkeypatch.setitem(sys.modules, "services.data_processing.core", core_pkg)
+    safe_import('services', services_pkg)
+    safe_import('services.data_processing', data_processing_pkg)
+    safe_import('services.data_processing.core', core_pkg)
     monkeypatch.setitem(
         sys.modules,
         "core.protocols.plugin",

--- a/tests/repositories/test_sql_injection_repo.py
+++ b/tests/repositories/test_sql_injection_repo.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 # Provide minimal Flask stub required by utility modules
 if "flask" not in sys.modules:
@@ -13,7 +14,7 @@ if "flask" not in sys.modules:
     flask_stub = types.ModuleType("flask")
     flask_stub.request = None
     flask_stub.url_for = lambda *a, **k: ""
-    sys.modules["flask"] = flask_stub
+    safe_import('flask', flask_stub)
 
 # Provide minimal ``utils.unicode_handler`` without importing heavy utils package
 if "utils.unicode_handler" not in sys.modules:
@@ -27,8 +28,8 @@ if "utils.unicode_handler" not in sys.modules:
     spec.loader.exec_module(unicode_mod)
     utils_pkg = util.module_from_spec(machinery.ModuleSpec("utils", None))
     utils_pkg.unicode_handler = unicode_mod
-    sys.modules["utils"] = utils_pkg
-    sys.modules["utils.unicode_handler"] = unicode_mod
+    safe_import('utils', utils_pkg)
+    safe_import('utils.unicode_handler', unicode_mod)
 
 # Map project modules into the expected namespace if they aren't installed
 if "yosai_intel_dashboard.src.core.domain.entities" not in sys.modules:
@@ -44,11 +45,11 @@ if "yosai_intel_dashboard.src.core.domain.entities" not in sys.modules:
     enums_stub = importlib.util.module_from_spec(
         importlib.machinery.ModuleSpec("yosai_intel_dashboard.src.core.domain.value_objects", None)
     )
-    sys.modules["yosai_intel_dashboard.models"] = importlib.util.module_from_spec(
+    safe_import('yosai_intel_dashboard.models', importlib.util.module_from_spec()
         importlib.machinery.ModuleSpec("yosai_intel_dashboard.models", None)
     )
-    sys.modules["yosai_intel_dashboard.src.core.domain.entities"] = entities_stub
-    sys.modules["yosai_intel_dashboard.src.core.domain.value_objects"] = enums_stub
+    safe_import('yosai_intel_dashboard.src.core.domain.entities', entities_stub)
+    safe_import('yosai_intel_dashboard.src.core.domain.value_objects', enums_stub)
 
     class AccessResult(enum.Enum):
         GRANTED = "granted"

--- a/tests/resilience/test_circuit_breaker.py
+++ b/tests/resilience/test_circuit_breaker.py
@@ -4,11 +4,12 @@ import sys
 import types
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 services_path = pathlib.Path(__file__).resolve().parents[2] / "services"
 stub_pkg = types.ModuleType("services")
 stub_pkg.__path__ = [str(services_path)]
-sys.modules.setdefault("services", stub_pkg)
+safe_import('services', stub_pkg)
 stub_interfaces = types.ModuleType("services.interfaces")
 
 
@@ -17,8 +18,8 @@ class AnalyticsServiceProtocol:
 
 
 stub_interfaces.AnalyticsServiceProtocol = AnalyticsServiceProtocol
-sys.modules["services.interfaces"] = stub_interfaces
-sys.modules.setdefault("kafka", types.ModuleType("kafka"))
+safe_import('services.interfaces', stub_interfaces)
+safe_import('kafka', types.ModuleType("kafka"))
 setattr(sys.modules["kafka"], "KafkaProducer", object)
 
 circuit_path = services_path / "resilience" / "circuit_breaker.py"

--- a/tests/resilience/test_service_client.py
+++ b/tests/resilience/test_service_client.py
@@ -6,17 +6,18 @@ import types
 
 import aiohttp
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 services_path = pathlib.Path(__file__).resolve().parents[2] / "services"
 stub_pkg = types.ModuleType("services")
 stub_pkg.__path__ = [str(services_path)]
-sys.modules.setdefault("services", stub_pkg)
+safe_import('services', stub_pkg)
 stub_resilience = types.ModuleType("services.resilience")
 stub_resilience.__path__ = [str(services_path / "resilience")]
-sys.modules.setdefault("services.resilience", stub_resilience)
+safe_import('services.resilience', stub_resilience)
 stub_tracing = types.ModuleType("tracing")
 stub_tracing.propagate_context = lambda headers: None
-sys.modules.setdefault("tracing", stub_tracing)
+safe_import('tracing', stub_tracing)
 
 metrics_path = services_path / "resilience" / "metrics.py"
 metrics_spec = importlib.util.spec_from_file_location(
@@ -24,7 +25,7 @@ metrics_spec = importlib.util.spec_from_file_location(
 )
 metrics_module = importlib.util.module_from_spec(metrics_spec)
 metrics_spec.loader.exec_module(metrics_module)  # type: ignore
-sys.modules["services.resilience.metrics"] = metrics_module
+safe_import('services.resilience.metrics', metrics_module)
 
 cb_path = services_path / "resilience" / "circuit_breaker.py"
 cb_spec = importlib.util.spec_from_file_location(
@@ -32,7 +33,7 @@ cb_spec = importlib.util.spec_from_file_location(
 )
 cb_module = importlib.util.module_from_spec(cb_spec)
 cb_spec.loader.exec_module(cb_module)  # type: ignore
-sys.modules["services.resilience.circuit_breaker"] = cb_module
+safe_import('services.resilience.circuit_breaker', cb_module)
 
 module_path = (
     pathlib.Path(__file__).resolve().parents[2] / "adapters" / "service_client.py"

--- a/tests/services/test_async_file_processor_nodisk.py
+++ b/tests/services/test_async_file_processor_nodisk.py
@@ -8,13 +8,14 @@ import pandas as pd
 import asyncio
 import tempfile
 import os
+from tests.import_helpers import safe_import, import_optional
 
 # Set up minimal stub modules for dependencies
 config_mod = types.SimpleNamespace()
 config_mod.dynamic_config = types.SimpleNamespace(
     analytics=types.SimpleNamespace(chunk_size=2, max_memory_mb=1024)
 )
-sys.modules.setdefault("config.dynamic_config", config_mod)
+safe_import('config.dynamic_config', config_mod)
 sys.modules.setdefault(
     "core.protocols",
     types.SimpleNamespace(FileProcessorProtocol=object),

--- a/tests/services/test_jwt_service.py
+++ b/tests/services/test_jwt_service.py
@@ -6,6 +6,7 @@ import time
 import types
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
 
@@ -19,19 +20,19 @@ def load_jwt_service(monkeypatch, secret: str | None = None):
     services_mod = sys.modules.get("services")
     if services_mod is None:
         services_mod = types.ModuleType("services")
-        sys.modules["services"] = services_mod
+        safe_import('services', services_mod)
     services_mod.__path__ = [str(SERVICES_PATH)]
 
     security_mod = sys.modules.get("services.security")
     if security_mod is None:
         security_mod = types.ModuleType("services.security")
-        sys.modules["services.security"] = security_mod
+        safe_import('services.security', security_mod)
     security_mod.__path__ = [str(SERVICES_PATH / "security")]
 
     secrets_mod = types.ModuleType("services.common.secrets")
     secrets_mod.get_secret = lambda key: secret
     secrets_mod.invalidate_secret = lambda key=None: None
-    monkeypatch.setitem(sys.modules, "services.common.secrets", secrets_mod)
+    safe_import('services.common.secrets', secrets_mod)
 
     module_name = "services.security.jwt_service"
     if module_name in sys.modules:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -12,7 +13,7 @@ except Exception:
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
+safe_import('services', services_stub)
 
 from yosai_intel_dashboard.src.services.analytics.processing.aggregator import Aggregator  # noqa: E402
 

--- a/tests/test_ai_processor_model_integration.py
+++ b/tests/test_ai_processor_model_integration.py
@@ -6,13 +6,14 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from services.mapping.models import RuleBasedModel
+from tests.import_helpers import safe_import, import_optional
 
 # Insert stub before importing the adapter
 stub = importlib.util.module_from_spec(
     importlib.machinery.ModuleSpec("components.plugin_adapter", None)
 )
 stub.ComponentPluginAdapter = object
-sys.modules.setdefault("components.plugin_adapter", stub)
+safe_import('components.plugin_adapter', stub)
 
 from services.mapping.processors.ai_processor import AIColumnMapperAdapter
 

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,29 +1,30 @@
 import sys
 import types
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("flask_caching", types.SimpleNamespace(Cache=object))
+safe_import('flask_caching', types.SimpleNamespace(Cache=object))
 if "dask" not in sys.modules:
     dask_stub = types.ModuleType("dask")
     dask_stub.__path__ = []
     dist_stub = types.ModuleType("dask.distributed")
     dist_stub.Client = object
     dist_stub.LocalCluster = object
-    sys.modules["dask"] = dask_stub
-    sys.modules["dask.distributed"] = dist_stub
+    safe_import('dask', dask_stub)
+    safe_import('dask.distributed', dist_stub)
 if "dash" not in sys.modules:
     dash_stub = types.ModuleType("dash")
-    sys.modules.setdefault("dash", dash_stub)
-    sys.modules.setdefault("dash.dash", dash_stub)
-    sys.modules.setdefault("dash.html", types.ModuleType("dash.html"))
-    sys.modules.setdefault("dash.dcc", types.ModuleType("dash.dcc"))
-    sys.modules.setdefault("dash.dependencies", types.ModuleType("dash.dependencies"))
-    sys.modules.setdefault("dash._callback", types.ModuleType("dash._callback"))
+    safe_import('dash', dash_stub)
+    safe_import('dash.dash', dash_stub)
+    safe_import('dash.html', types.ModuleType("dash.html"))
+    safe_import('dash.dcc', types.ModuleType("dash.dcc"))
+    safe_import('dash.dependencies', types.ModuleType("dash.dependencies"))
+    safe_import('dash._callback', types.ModuleType("dash._callback"))
 if "chardet" not in sys.modules:
-    sys.modules["chardet"] = types.ModuleType("chardet")
+    safe_import('chardet', types.ModuleType("chardet"))
 import pandas as pd
 
 from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
 
 
 def _make_df():

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -12,7 +13,7 @@ except Exception:
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
+safe_import('services', services_stub)
 
 from yosai_intel_dashboard.src.services.analytics.processing.analyzer import Analyzer  # noqa: E402
 

--- a/tests/test_async_file_processor.py
+++ b/tests/test_async_file_processor.py
@@ -10,15 +10,16 @@ import pandas as pd
 import pytest
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
+from tests.import_helpers import safe_import, import_optional
 
 services_root = Path(__file__).resolve().parents[1] / "services"
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(services_root)]
-sys.modules.setdefault("services", services_pkg)
+safe_import('services', services_pkg)
 
 upload_pkg = types.ModuleType("services.upload")
 upload_pkg.__path__ = [str(services_root / "upload")]
-sys.modules.setdefault("services.upload", upload_pkg)
+safe_import('services.upload', upload_pkg)
 
 spec = importlib.util.spec_from_file_location(
     "services.upload.protocols", services_root / "upload" / "protocols.py"
@@ -26,11 +27,11 @@ spec = importlib.util.spec_from_file_location(
 protocols_mod = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(protocols_mod)
-sys.modules.setdefault("services.upload.protocols", protocols_mod)
+safe_import('services.upload.protocols', protocols_mod)
 
 data_processing_pkg = types.ModuleType("services.data_processing")
 data_processing_pkg.__path__ = [str(services_root / "data_processing")]
-sys.modules.setdefault("services.data_processing", data_processing_pkg)
+safe_import('services.data_processing', data_processing_pkg)
 
 spec = importlib.util.spec_from_file_location(
     "services.task_queue", services_root / "task_queue.py"
@@ -38,7 +39,7 @@ spec = importlib.util.spec_from_file_location(
 task_queue_module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(task_queue_module)
-sys.modules.setdefault("services.task_queue", task_queue_module)
+safe_import('services.task_queue', task_queue_module)
 clear_task = task_queue_module.clear_task
 create_task = task_queue_module.create_task
 get_status = task_queue_module.get_status

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -2,12 +2,13 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 stub_dynamic_config = SimpleNamespace(
     security=SimpleNamespace(max_upload_mb=10),
     upload=SimpleNamespace(allowed_file_types=[".csv", ".json", ".xlsx", ".xls"]),
 )
-sys.modules["config.dynamic_config"] = SimpleNamespace(
+safe_import('config.dynamic_config', SimpleNamespace()
     dynamic_config=stub_dynamic_config
 )
 

--- a/tests/test_base_database_service.py
+++ b/tests/test_base_database_service.py
@@ -5,6 +5,7 @@ import pytest
 
 from config import DatabaseSettings
 from core.base_database_service import BaseDatabaseService
+from tests.import_helpers import safe_import, import_optional
 
 
 def _install_fake_module(monkeypatch, name, factory_attr):
@@ -31,7 +32,7 @@ def test_mongodb_connection(monkeypatch):
     module = types.ModuleType("pymongo")
     conn = object()
     module.MongoClient = lambda *a, **k: conn
-    monkeypatch.setitem(sys.modules, "pymongo", module)
+    safe_import('pymongo', module)
     service = BaseDatabaseService(DatabaseSettings(type="mongodb"))
     assert service.connection is conn
 
@@ -40,7 +41,7 @@ def test_redis_connection(monkeypatch):
     module = types.ModuleType("redis")
     conn = object()
     module.Redis = lambda *a, **k: conn
-    monkeypatch.setitem(sys.modules, "redis", module)
+    safe_import('redis', module)
     service = BaseDatabaseService(DatabaseSettings(type="redis"))
     assert service.connection is conn
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -13,11 +14,11 @@ import pandas as pd
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
-sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
-sys.modules.setdefault("opentelemetry.context", types.ModuleType("otel_ctx"))
-sys.modules.setdefault("opentelemetry.propagate", types.ModuleType("otel_prop"))
-sys.modules.setdefault("opentelemetry.trace", types.ModuleType("otel_trace"))
+safe_import('services', services_stub)
+safe_import('opentelemetry', types.ModuleType("opentelemetry"))
+safe_import('opentelemetry.context', types.ModuleType("otel_ctx"))
+safe_import('opentelemetry.propagate', types.ModuleType("otel_prop"))
+safe_import('opentelemetry.trace', types.ModuleType("otel_trace"))
 sys.modules["opentelemetry.trace"].get_current_span = lambda: types.SimpleNamespace(
     get_span_context=lambda: None
 )
@@ -25,15 +26,15 @@ sys.modules.setdefault(
     "opentelemetry.exporter.jaeger.thrift", types.ModuleType("otel_jaeger")
 )
 sys.modules["opentelemetry.exporter.jaeger.thrift"].JaegerExporter = object
-sys.modules.setdefault("opentelemetry.sdk.resources", types.ModuleType("otel_res"))
+safe_import('opentelemetry.sdk.resources', types.ModuleType("otel_res"))
 sys.modules["opentelemetry.sdk.resources"].Resource = object
-sys.modules.setdefault("opentelemetry.sdk.trace", types.ModuleType("otel_tr_sdk"))
+safe_import('opentelemetry.sdk.trace', types.ModuleType("otel_tr_sdk"))
 sys.modules["opentelemetry.sdk.trace"].TracerProvider = object
 sys.modules.setdefault(
     "opentelemetry.sdk.trace.export", types.ModuleType("otel_tr_exp")
 )
 sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+safe_import('structlog', types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
 from yosai_intel_dashboard.src.services.analytics.calculator import Calculator  # noqa: E402

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 stub_utils = ModuleType("utils")
 stub_utils.__path__ = []
@@ -15,12 +16,12 @@ stub_core.get_upload_chunk_size = lambda: 128
 stub_core_pkg = ModuleType("core")
 stub_core_pkg.__path__ = []
 stub_core_pkg.config = stub_core
-sys.modules["core"] = stub_core_pkg
-sys.modules["core.config"] = stub_core
+safe_import('core', stub_core_pkg)
+safe_import('core.config', stub_core)
 
 stub_config_pkg = ModuleType("config")
 stub_config_pkg.__path__ = []
-sys.modules["config"] = stub_config_pkg
+safe_import('config', stub_config_pkg)
 
 spec_resolvers = importlib.util.spec_from_file_location(
     "utils.config_resolvers",
@@ -29,8 +30,8 @@ spec_resolvers = importlib.util.spec_from_file_location(
 config_resolvers = importlib.util.module_from_spec(spec_resolvers)
 spec_resolvers.loader.exec_module(config_resolvers)
 stub_utils.config_resolvers = config_resolvers
-sys.modules["utils"] = stub_utils
-sys.modules["utils.config_resolvers"] = config_resolvers
+safe_import('utils', stub_utils)
+safe_import('utils.config_resolvers', config_resolvers)
 
 spec_utils = importlib.util.spec_from_file_location(
     "config.utils", Path(__file__).resolve().parents[1] / "config" / "utils.py"

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -6,15 +6,16 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 pkg = types.ModuleType("config")
 pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "config")]
-sys.modules.setdefault("config", pkg)
+safe_import('config', pkg)
 
 _cfg_path = Path(__file__).resolve().parents[1] / "config" / "config_manager.py"
 spec = importlib.util.spec_from_file_location("config.config_manager", _cfg_path)
 _cfg_module = importlib.util.module_from_spec(spec)
-sys.modules["config.config_manager"] = _cfg_module
+safe_import('config.config_manager', _cfg_module)
 spec.loader.exec_module(_cfg_module)  # type: ignore
 create_config_manager = _cfg_module.create_config_manager
 

--- a/tests/test_csv_parsing.py
+++ b/tests/test_csv_parsing.py
@@ -5,12 +5,13 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 stub_dynamic_config = SimpleNamespace(
     security=SimpleNamespace(max_upload_mb=10),
     upload=SimpleNamespace(allowed_file_types=[".csv", ".json", ".xlsx", ".xls"]),
 )
-sys.modules["config.dynamic_config"] = SimpleNamespace(
+safe_import('config.dynamic_config', SimpleNamespace()
     dynamic_config=stub_dynamic_config
 )
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -13,11 +14,11 @@ import pandas as pd
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
-sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
-sys.modules.setdefault("opentelemetry.context", types.ModuleType("otel_ctx"))
-sys.modules.setdefault("opentelemetry.propagate", types.ModuleType("otel_prop"))
-sys.modules.setdefault("opentelemetry.trace", types.ModuleType("otel_trace"))
+safe_import('services', services_stub)
+safe_import('opentelemetry', types.ModuleType("opentelemetry"))
+safe_import('opentelemetry.context', types.ModuleType("otel_ctx"))
+safe_import('opentelemetry.propagate', types.ModuleType("otel_prop"))
+safe_import('opentelemetry.trace', types.ModuleType("otel_trace"))
 sys.modules["opentelemetry.trace"].get_current_span = lambda: types.SimpleNamespace(
     get_span_context=lambda: None
 )
@@ -25,15 +26,15 @@ sys.modules.setdefault(
     "opentelemetry.exporter.jaeger.thrift", types.ModuleType("otel_jaeger")
 )
 sys.modules["opentelemetry.exporter.jaeger.thrift"].JaegerExporter = object
-sys.modules.setdefault("opentelemetry.sdk.resources", types.ModuleType("otel_res"))
+safe_import('opentelemetry.sdk.resources', types.ModuleType("otel_res"))
 sys.modules["opentelemetry.sdk.resources"].Resource = object
-sys.modules.setdefault("opentelemetry.sdk.trace", types.ModuleType("otel_tr_sdk"))
+safe_import('opentelemetry.sdk.trace', types.ModuleType("otel_tr_sdk"))
 sys.modules["opentelemetry.sdk.trace"].TracerProvider = object
 sys.modules.setdefault(
     "opentelemetry.sdk.trace.export", types.ModuleType("otel_tr_exp")
 )
 sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+safe_import('structlog', types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
 from yosai_intel_dashboard.src.services.analytics.data.loader import DataLoader  # noqa: E402

--- a/tests/test_data_quality_monitor.py
+++ b/tests/test_data_quality_monitor.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from monitoring.data_quality_monitor import (
+from tests.import_helpers import safe_import, import_optional
     DataQualityMetrics,
     DataQualityMonitor,
     DataQualityThresholds,
@@ -53,7 +54,7 @@ def test_processor_evaluates_quality(monkeypatch):
                 return {}
 
         module.Processor = Processor
-        sys.modules["services.data_processing.processor"] = module
+        safe_import('services.data_processing.processor', module)
 
     from yosai_intel_dashboard.src.services.data_processing.processor import Processor
 

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -3,7 +3,8 @@ import pytest
 from config import DatabaseSettings
 from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 
 def factory():

--- a/tests/test_device_endpoint_utils.py
+++ b/tests/test_device_endpoint_utils.py
@@ -1,8 +1,9 @@
 import sys
 import types
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("yosai_intel_dashboard", types.ModuleType("yosai_intel_dashboard"))
+safe_import('yosai_intel_dashboard', types.ModuleType("yosai_intel_dashboard"))
 sys.modules["yosai_intel_dashboard"].__path__ = [str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard")]
 
 import pandas as pd
@@ -18,8 +19,8 @@ service_reg_stub = types.ModuleType("services.upload.service_registration")
 service_reg_stub.register_upload_services = lambda c: c.register_singleton(
     "uploader", object()
 )
-sys.modules.setdefault("core.container", core_container_stub)
-sys.modules.setdefault("services.upload.service_registration", service_reg_stub)
+safe_import('core.container', core_container_stub)
+safe_import('services.upload.service_registration', service_reg_stub)
 
 # Allow importing submodules from the real "services" package
 services_mod = sys.modules.setdefault("services", types.ModuleType("services"))
@@ -100,7 +101,7 @@ def test_build_device_mappings_ai(monkeypatch):
     sdm_stub.generate_ai_device_defaults = lambda df, profile="auto": None
     components_pkg = types.ModuleType("yosai_intel_dashboard.src.components")
     components_pkg.simple_device_mapping = sdm_stub
-    sys.modules["yosai_intel_dashboard.src.components"] = components_pkg
+    safe_import('yosai_intel_dashboard.src.components', components_pkg)
     sys.modules[
         "yosai_intel_dashboard.src.components.simple_device_mapping"
     ] = sdm_stub
@@ -131,7 +132,7 @@ def test_build_ai_device_mappings_helper(monkeypatch):
     sdm_stub.generate_ai_device_defaults = lambda df, profile="auto": None
     components_pkg = types.ModuleType("yosai_intel_dashboard.src.components")
     components_pkg.simple_device_mapping = sdm_stub
-    sys.modules["yosai_intel_dashboard.src.components"] = components_pkg
+    safe_import('yosai_intel_dashboard.src.components', components_pkg)
     sys.modules[
         "yosai_intel_dashboard.src.components.simple_device_mapping"
     ] = sdm_stub

--- a/tests/test_event_publisher.py
+++ b/tests/test_event_publisher.py
@@ -2,27 +2,28 @@ import importlib
 import sys
 import types
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("flask_caching", types.SimpleNamespace(Cache=object))
+safe_import('flask_caching', types.SimpleNamespace(Cache=object))
 flask_stub = types.ModuleType("flask")
 flask_stub.request = types.SimpleNamespace()
 flask_stub.url_for = lambda *a, **k: ""
-sys.modules.setdefault("flask", flask_stub)
+safe_import('flask', flask_stub)
 dash_stub = sys.modules.get("dash", types.ModuleType("dash"))
 dash_stub.no_update = getattr(dash_stub, "no_update", object())
 dash_stub.dash_table = getattr(dash_stub, "dash_table", types.ModuleType("dash_table"))
-sys.modules.setdefault("dash", dash_stub)
-sys.modules.setdefault("dash.dash", dash_stub)
-sys.modules.setdefault("dash.html", types.ModuleType("dash.html"))
-sys.modules.setdefault("dash.dcc", types.ModuleType("dash.dcc"))
-sys.modules.setdefault("dash.dependencies", types.ModuleType("dash.dependencies"))
-sys.modules.setdefault("dash._callback", types.ModuleType("dash._callback"))
-sys.modules.setdefault("dash.dash_table", types.ModuleType("dash_table"))
-sys.modules.setdefault("chardet", types.ModuleType("chardet"))
+safe_import('dash', dash_stub)
+safe_import('dash.dash', dash_stub)
+safe_import('dash.html', types.ModuleType("dash.html"))
+safe_import('dash.dcc', types.ModuleType("dash.dcc"))
+safe_import('dash.dependencies', types.ModuleType("dash.dependencies"))
+safe_import('dash._callback', types.ModuleType("dash._callback"))
+safe_import('dash.dash_table', types.ModuleType("dash_table"))
+safe_import('chardet', types.ModuleType("chardet"))
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules.setdefault("services", services_stub)
+safe_import('services', services_stub)
 publish_event = importlib.import_module("services.event_publisher").publish_event
 
 from services.event_publisher import publish_event

--- a/tests/test_feature_pipeline.py
+++ b/tests/test_feature_pipeline.py
@@ -4,15 +4,16 @@ import json
 import sys
 import types
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
 if "services.resilience" not in sys.modules:
-    sys.modules["services.resilience"] = types.ModuleType("services.resilience")
+    safe_import('services.resilience', types.ModuleType("services.resilience"))
 if "services.resilience.metrics" not in sys.modules:
     metrics_stub = types.ModuleType("services.resilience.metrics")
     metrics_stub.circuit_breaker_state = types.SimpleNamespace(
         labels=lambda *a, **k: types.SimpleNamespace(inc=lambda *a, **k: None)
     )
-    sys.modules["services.resilience.metrics"] = metrics_stub
+    safe_import('services.resilience.metrics', metrics_stub)
 
 import pandas as pd
 from sklearn.linear_model import LogisticRegression

--- a/tests/test_feature_store.py
+++ b/tests/test_feature_store.py
@@ -5,15 +5,16 @@ import os
 import sys
 import types
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
 if "services.resilience" not in sys.modules:
-    sys.modules["services.resilience"] = types.ModuleType("services.resilience")
+    safe_import('services.resilience', types.ModuleType("services.resilience"))
 if "services.resilience.metrics" not in sys.modules:
     metrics_stub = types.ModuleType("services.resilience.metrics")
     metrics_stub.circuit_breaker_state = types.SimpleNamespace(
         labels=lambda *a, **k: types.SimpleNamespace(inc=lambda *a, **k: None)
     )
-    sys.modules["services.resilience.metrics"] = metrics_stub
+    safe_import('services.resilience.metrics', metrics_stub)
 
 import pandas as pd
 

--- a/tests/test_file_processor_enhanced.py
+++ b/tests/test_file_processor_enhanced.py
@@ -2,8 +2,9 @@ import base64
 
 import pandas as pd
 
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
+from tests.import_helpers import safe_import, import_optional
 
 fake_cfg = FakeConfiguration()
 from services.data_enhancer.mapping_utils import (

--- a/tests/test_file_processor_service_surrogates.py
+++ b/tests/test_file_processor_service_surrogates.py
@@ -1,7 +1,8 @@
 import importlib.util
 import sys
 
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 spec = importlib.util.spec_from_file_location(
     "services.file_processor_service", "services/file_processor_service.py"

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -3,12 +3,13 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 stub_dynamic_config = SimpleNamespace(
     security=SimpleNamespace(max_upload_mb=10),
     upload=SimpleNamespace(allowed_file_types=[".csv", ".json", ".xlsx", ".xls"]),
 )
-sys.modules["config.dynamic_config"] = SimpleNamespace(
+safe_import('config.dynamic_config', SimpleNamespace()
     dynamic_config=stub_dynamic_config
 )
 

--- a/tests/test_max_display_rows.py
+++ b/tests/test_max_display_rows.py
@@ -5,7 +5,8 @@ import os
 import pandas as pd
 
 from config import create_config_manager
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 fake_cfg = FakeConfiguration()
 from yosai_intel_dashboard.src.infrastructure.config.constants import MAX_DISPLAY_ROWS

--- a/tests/test_memory_limit.py
+++ b/tests/test_memory_limit.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import pytest
 
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 fake_cfg = FakeConfiguration()
 from core.performance import get_performance_monitor

--- a/tests/test_migration_adapter.py
+++ b/tests/test_migration_adapter.py
@@ -6,6 +6,7 @@ import types
 from typing import Any
 
 import pandas as pd
+from tests.import_helpers import safe_import, import_optional
 
 # Provide a lightweight stub for services.interfaces to avoid heavy imports
 stub_pkg = types.ModuleType("services")
@@ -19,7 +20,7 @@ flags_spec = importlib.util.spec_from_file_location(
 flags_module = importlib.util.module_from_spec(flags_spec)
 flags_spec.loader.exec_module(flags_module)
 stub_pkg.feature_flags = flags_module
-sys.modules["services.feature_flags"] = flags_module
+safe_import('services.feature_flags', flags_module)
 
 # Minimal registry stub
 registry_stub = types.ModuleType("services.registry")
@@ -32,7 +33,7 @@ class ServiceDiscovery:
 
 registry_stub.ServiceDiscovery = ServiceDiscovery
 stub_pkg.registry = registry_stub
-sys.modules["services.registry"] = registry_stub
+safe_import('services.registry', registry_stub)
 
 # Minimal resilience.circuit_breaker stub
 resilience_pkg = types.ModuleType("services.resilience")
@@ -52,8 +53,8 @@ cb_module.CircuitBreaker = CircuitBreaker
 cb_module.CircuitBreakerOpen = CircuitBreakerOpen
 resilience_pkg.circuit_breaker = cb_module
 stub_pkg.resilience = resilience_pkg
-sys.modules["services.resilience"] = resilience_pkg
-sys.modules["services.resilience.circuit_breaker"] = cb_module
+safe_import('services.resilience', resilience_pkg)
+safe_import('services.resilience.circuit_breaker', cb_module)
 
 
 class AnalyticsServiceProtocol:
@@ -61,8 +62,8 @@ class AnalyticsServiceProtocol:
 
 
 stub_interfaces.AnalyticsServiceProtocol = AnalyticsServiceProtocol
-sys.modules.setdefault("services", stub_pkg)
-sys.modules["services.interfaces"] = stub_interfaces
+safe_import('services', stub_pkg)
+safe_import('services.interfaces', stub_interfaces)
 
 spec = importlib.util.spec_from_file_location(
     "migration_adapter",

--- a/tests/test_model_ab_tester.py
+++ b/tests/test_model_ab_tester.py
@@ -7,12 +7,13 @@ from pathlib import Path
 
 import joblib
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 # Load ModelABTester directly to avoid heavy service imports
 services_path = pathlib.Path(__file__).resolve().parents[1] / "services"
 stub_pkg = types.ModuleType("services")
 stub_pkg.__path__ = [str(services_path)]
-sys.modules.setdefault("services", stub_pkg)
+safe_import('services', stub_pkg)
 
 ab_path = services_path / "ab_testing.py"
 spec = importlib.util.spec_from_file_location("services.ab_testing", ab_path)

--- a/tests/test_model_performance_monitor.py
+++ b/tests/test_model_performance_monitor.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime
 from types import ModuleType, SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 # minimal config stub to avoid heavy imports
 cfg_mod = ModuleType("config")
@@ -15,8 +16,8 @@ cfg_mod.DatabaseSettings = DatabaseSettings
 cfg_mod.dynamic_config = SimpleNamespace(
     performance=SimpleNamespace(memory_usage_threshold_mb=1024)
 )
-sys.modules["config"] = cfg_mod
-sys.modules["config.dynamic_config"] = cfg_mod
+safe_import('config', cfg_mod)
+safe_import('config.dynamic_config', cfg_mod)
 
 # minimal performance monitor stub
 perf_mod = ModuleType("core.performance")
@@ -30,13 +31,13 @@ perf_mod.MetricType = MetricType
 perf_mod.get_performance_monitor = lambda: SimpleNamespace(
     record_metric=lambda *a, **k: None, aggregated_metrics={}
 )
-sys.modules["core.performance"] = perf_mod
+safe_import('core.performance', perf_mod)
 
 # extend prometheus metrics stub
 prom_mod = ModuleType("monitoring.prometheus.model_metrics")
 prom_mod.update_model_metrics = lambda *a, **k: None
 prom_mod.start_model_metrics_server = lambda *a, **k: None
-sys.modules["monitoring.prometheus.model_metrics"] = prom_mod
+safe_import('monitoring.prometheus.model_metrics', prom_mod)
 
 # stub services.resilience.metrics to avoid heavy deps
 metrics_mod = ModuleType("services.resilience.metrics")
@@ -45,9 +46,9 @@ metrics_mod.circuit_breaker_state = SimpleNamespace(
 )
 resilience_pkg = ModuleType("services.resilience")
 resilience_pkg.metrics = metrics_mod
-sys.modules.setdefault("services", ModuleType("services"))
-sys.modules.setdefault("services.resilience", resilience_pkg)
-sys.modules.setdefault("services.resilience.metrics", metrics_mod)
+safe_import('services', ModuleType("services"))
+safe_import('services.resilience', resilience_pkg)
+safe_import('services.resilience.metrics', metrics_mod)
 
 import monitoring.model_performance_monitor as mpm
 

--- a/tests/test_model_registry_async.py
+++ b/tests/test_model_registry_async.py
@@ -4,11 +4,12 @@ import sys
 import types
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 services_path = pathlib.Path(__file__).resolve().parents[1] / "services"
 stub_pkg = types.ModuleType("services")
 stub_pkg.__path__ = [str(services_path)]
-sys.modules["services"] = stub_pkg
+safe_import('services', stub_pkg)
 
 from services.common.model_registry import ModelRegistry
 

--- a/tests/test_performance_monitor_drift.py
+++ b/tests/test_performance_monitor_drift.py
@@ -1,5 +1,6 @@
 import sys
 from types import ModuleType, SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 # minimal config stub
 cfg_mod = ModuleType("config")
@@ -14,15 +15,15 @@ cfg_mod.DatabaseSettings = DatabaseSettings
 cfg_mod.dynamic_config = SimpleNamespace(
     performance=SimpleNamespace(memory_usage_threshold_mb=1024)
 )
-sys.modules["config"] = cfg_mod
-sys.modules["config.dynamic_config"] = cfg_mod
+safe_import('config', cfg_mod)
+safe_import('config.dynamic_config', cfg_mod)
 
 import importlib.util
 from pathlib import Path
 
 core_pkg = ModuleType("core")
 core_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "core")]
-sys.modules.setdefault("core", core_pkg)
+safe_import('core', core_pkg)
 
 spec = importlib.util.spec_from_file_location(
     "core.performance", Path(__file__).resolve().parents[1] / "core" / "performance.py"

--- a/tests/test_performance_monitor_model_drift.py
+++ b/tests/test_performance_monitor_model_drift.py
@@ -3,14 +3,15 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 # stub config.dynamic_config for PerformanceMonitor
 cfg = ModuleType("config")
 cfg.dynamic_config = SimpleNamespace(
     performance=SimpleNamespace(memory_usage_threshold_mb=1024)
 )
-sys.modules["config"] = cfg
-sys.modules["config.dynamic_config"] = cfg
+safe_import('config', cfg)
+safe_import('config.dynamic_config', cfg)
 
 # minimal ModelMetrics stub used by detect_model_drift
 mpm_stub = ModuleType("monitoring.model_performance_monitor")
@@ -24,12 +25,12 @@ class ModelMetrics:
 
 
 mpm_stub.ModelMetrics = ModelMetrics
-sys.modules["monitoring.model_performance_monitor"] = mpm_stub
+safe_import('monitoring.model_performance_monitor', mpm_stub)
 
 # create minimal package structure for core
 core_pkg = ModuleType("core")
 core_pkg.__path__ = []  # mark as package
-sys.modules["core"] = core_pkg
+safe_import('core', core_pkg)
 
 # load dependencies used by performance.py
 for name in ["base_model", "cpu_optimizer", "memory_manager"]:
@@ -46,7 +47,7 @@ spec = importlib.util.spec_from_file_location(
 )
 perf = importlib.util.module_from_spec(spec)
 perf.__package__ = "core"
-sys.modules["core.performance"] = perf
+safe_import('core.performance', perf)
 spec.loader.exec_module(perf)
 
 PerformanceMonitor = perf.PerformanceMonitor

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -11,11 +12,11 @@ except Exception:  # pragma: no cover - skip if missing
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
-sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
-sys.modules.setdefault("opentelemetry.context", types.ModuleType("otel_ctx"))
-sys.modules.setdefault("opentelemetry.propagate", types.ModuleType("otel_prop"))
-sys.modules.setdefault("opentelemetry.trace", types.ModuleType("otel_trace"))
+safe_import('services', services_stub)
+safe_import('opentelemetry', types.ModuleType("opentelemetry"))
+safe_import('opentelemetry.context', types.ModuleType("otel_ctx"))
+safe_import('opentelemetry.propagate', types.ModuleType("otel_prop"))
+safe_import('opentelemetry.trace', types.ModuleType("otel_trace"))
 sys.modules["opentelemetry.trace"].get_current_span = lambda: types.SimpleNamespace(
     get_span_context=lambda: None
 )
@@ -23,15 +24,15 @@ sys.modules.setdefault(
     "opentelemetry.exporter.jaeger.thrift", types.ModuleType("otel_jaeger")
 )
 sys.modules["opentelemetry.exporter.jaeger.thrift"].JaegerExporter = object
-sys.modules.setdefault("opentelemetry.sdk.resources", types.ModuleType("otel_res"))
+safe_import('opentelemetry.sdk.resources', types.ModuleType("otel_res"))
 sys.modules["opentelemetry.sdk.resources"].Resource = object
-sys.modules.setdefault("opentelemetry.sdk.trace", types.ModuleType("otel_tr_sdk"))
+safe_import('opentelemetry.sdk.trace', types.ModuleType("otel_tr_sdk"))
 sys.modules["opentelemetry.sdk.trace"].TracerProvider = object
 sys.modules.setdefault(
     "opentelemetry.sdk.trace.export", types.ModuleType("otel_tr_exp")
 )
 sys.modules["opentelemetry.sdk.trace.export"].BatchSpanProcessor = object
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+safe_import('structlog', types.ModuleType("structlog"))
 sys.modules["structlog"].BoundLogger = object
 
 from yosai_intel_dashboard.src.services.analytics.publisher import Publisher  # noqa: E402

--- a/tests/test_redis_cache_fallback.py
+++ b/tests/test_redis_cache_fallback.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+from tests.import_helpers import safe_import, import_optional
 
 
 def test_redis_cache_manager_fallback(monkeypatch, fake_dash):
@@ -19,7 +20,7 @@ def test_redis_cache_manager_fallback(monkeypatch, fake_dash):
     redis_mod = sys.modules.get("redis")
     if redis_mod is None:
         redis_mod = types.SimpleNamespace()
-        sys.modules["redis"] = redis_mod
+        safe_import('redis', redis_mod)
     redis_mod.Redis = FakeRedis
     cm = importlib.import_module("core.plugins.config.cache_manager")
     monkeypatch.setattr(cm, "redis", types.SimpleNamespace(Redis=FakeRedis))

--- a/tests/test_redis_cache_json.py
+++ b/tests/test_redis_cache_json.py
@@ -3,6 +3,7 @@ import json
 import pickle
 import sys
 import types
+from tests.import_helpers import safe_import, import_optional
 
 
 def _setup_manager(monkeypatch, fake_redis):
@@ -13,7 +14,7 @@ def _setup_manager(monkeypatch, fake_redis):
     redis_mod = sys.modules.get("redis")
     if redis_mod is None:
         redis_mod = types.SimpleNamespace()
-        sys.modules["redis"] = redis_mod
+        safe_import('redis', redis_mod)
     redis_mod.Redis = lambda *a, **k: fake_redis
     cm = importlib.import_module("core.plugins.config.cache_manager")
     monkeypatch.setattr(

--- a/tests/test_risk_scoring.py
+++ b/tests/test_risk_scoring.py
@@ -1,14 +1,15 @@
+from tests.import_helpers import safe_import, import_optional
 # Provide minimal dash stub if dash is unavailable
 import sys
 
 if "dash" not in sys.modules:
     from tests.stubs import dash as dash_stub
 
-    sys.modules["dash"] = dash_stub  # type: ignore
-    sys.modules["dash.html"] = dash_stub.html  # type: ignore
-    sys.modules["dash.dcc"] = dash_stub.dcc  # type: ignore
-    sys.modules["dash.dependencies"] = dash_stub.dependencies  # type: ignore
-    sys.modules["dash._callback"] = dash_stub._callback  # type: ignore
+    safe_import('dash', dash_stub  # type: ignore)
+    safe_import('dash.html', dash_stub.html  # type: ignore)
+    safe_import('dash.dcc', dash_stub.dcc  # type: ignore)
+    safe_import('dash.dependencies', dash_stub.dependencies  # type: ignore)
+    safe_import('dash._callback', dash_stub._callback  # type: ignore)
 
 import importlib.util
 import types
@@ -28,8 +29,8 @@ spec_feat.loader.exec_module(feature_mod)
 analytics_stub = types.ModuleType("analytics")
 analytics_stub.feature_extraction = feature_mod
 analytics_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "analytics")]
-sys.modules.setdefault("analytics", analytics_stub)
-sys.modules.setdefault("services.analytics.feature_extraction", feature_mod)
+safe_import('analytics', analytics_stub)
+safe_import('services.analytics.feature_extraction', feature_mod)
 
 # Stub dependent modules to avoid heavy imports
 anom_types = types.ModuleType("services.analytics.anomaly_detection.types")
@@ -45,7 +46,7 @@ class AnomalyAnalysis:
 
 
 anom_types.AnomalyAnalysis = AnomalyAnalysis
-sys.modules["services.analytics.anomaly_detection.types"] = anom_types
+safe_import('services.analytics.anomaly_detection.types', anom_types)
 
 sec_analyzer = types.ModuleType("services.analytics.security_patterns.analyzer")
 
@@ -61,7 +62,7 @@ class SecurityAssessment:
 
 
 sec_analyzer.SecurityAssessment = SecurityAssessment
-sys.modules["services.analytics.security_patterns.analyzer"] = sec_analyzer
+safe_import('services.analytics.security_patterns.analyzer', sec_analyzer)
 
 behav_mod = types.ModuleType("services.analytics.user_behavior")
 
@@ -76,12 +77,12 @@ class BehaviorAnalysis:
 
 
 behav_mod.BehaviorAnalysis = BehaviorAnalysis
-sys.modules["services.analytics.user_behavior"] = behav_mod
+safe_import('services.analytics.user_behavior', behav_mod)
 
 RISK_PATH = Path(__file__).resolve().parents[1] / "analytics" / "risk_scoring.py"
 spec_risk = importlib.util.spec_from_file_location("services.analytics.risk_scoring", RISK_PATH)
 risk_mod = importlib.util.module_from_spec(spec_risk)
-sys.modules["services.analytics.risk_scoring"] = risk_mod
+safe_import('services.analytics.risk_scoring', risk_mod)
 spec_risk.loader.exec_module(risk_mod)
 
 AnomalyAnalysis = (
@@ -98,11 +99,11 @@ BehaviorAnalysis = risk_mod.BehaviorAnalysis
 if "dash" not in sys.modules:
     from tests.stubs import dash as dash_stub
 
-    sys.modules["dash"] = dash_stub  # type: ignore
-    sys.modules["dash.html"] = dash_stub.html  # type: ignore
-    sys.modules["dash.dcc"] = dash_stub.dcc  # type: ignore
-    sys.modules["dash.dependencies"] = dash_stub.dependencies  # type: ignore
-    sys.modules["dash._callback"] = dash_stub._callback  # type: ignore
+    safe_import('dash', dash_stub  # type: ignore)
+    safe_import('dash.html', dash_stub.html  # type: ignore)
+    safe_import('dash.dcc', dash_stub.dcc  # type: ignore)
+    safe_import('dash.dependencies', dash_stub.dependencies  # type: ignore)
+    safe_import('dash._callback', dash_stub._callback  # type: ignore)
 
 
 def test_calculate_risk_score_numeric():

--- a/tests/test_security_service.py
+++ b/tests/test_security_service.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 fake_cfg = FakeConfiguration()
 from validation.security_validator import SecurityValidator

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -12,7 +13,7 @@ except Exception:
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
+safe_import('services', services_stub)
 
 from yosai_intel_dashboard.src.services.analytics.data.transformer import DataTransformer  # noqa: E402
 

--- a/tests/test_unified_file_controller.py
+++ b/tests/test_unified_file_controller.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from tests.import_helpers import safe_import, import_optional
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -18,7 +19,7 @@ class CallbackEvent(Enum):
     DATA_PROCESSED = auto()
 
 callback_events_stub.CallbackEvent = CallbackEvent
-sys.modules.setdefault("core.callback_events", callback_events_stub)
+safe_import('core.callback_events', callback_events_stub)
 
 
 class DummyManager:

--- a/tests/test_upload_csrf.py
+++ b/tests/test_upload_csrf.py
@@ -3,20 +3,21 @@ import os
 import sys
 from pathlib import Path
 import types
+from tests.import_helpers import safe_import, import_optional
 
 # Provide stubs when optional dependencies are missing
 if "flask_wtf" not in sys.modules:
     fw = importlib.import_module("tests.stubs.flask_wtf")
-    sys.modules["flask_wtf"] = fw
-    sys.modules["flask_wtf.csrf"] = fw
+    safe_import('flask_wtf', fw)
+    safe_import('flask_wtf.csrf', fw)
 if "flask_caching" not in sys.modules:
-    sys.modules["flask_caching"] = importlib.import_module("tests.stubs.flask_caching")
+    safe_import('flask_caching', importlib.import_module("tests.stubs.flask_caching"))
 if "flask_cors" not in sys.modules:
-    sys.modules["flask_cors"] = importlib.import_module("tests.stubs.flask_cors")
+    safe_import('flask_cors', importlib.import_module("tests.stubs.flask_cors"))
 if "services" not in sys.modules:
-    sys.modules["services"] = importlib.import_module("tests.stubs.services")
+    safe_import('services', importlib.import_module("tests.stubs.services"))
 
-sys.modules.setdefault("yosai_intel_dashboard", types.ModuleType("yosai_intel_dashboard"))
+safe_import('yosai_intel_dashboard', types.ModuleType("yosai_intel_dashboard"))
 sys.modules["yosai_intel_dashboard"].__path__ = [str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard")]
 
 import werkzeug

--- a/tests/test_upload_data_service.py
+++ b/tests/test_upload_data_service.py
@@ -1,25 +1,26 @@
 import sys
 import types
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("flask_caching", types.SimpleNamespace(Cache=object))
+safe_import('flask_caching', types.SimpleNamespace(Cache=object))
 if "dask" not in sys.modules:
     dask_stub = types.ModuleType("dask")
     dask_stub.__path__ = []
     dist_stub = types.ModuleType("dask.distributed")
     dist_stub.Client = object
     dist_stub.LocalCluster = object
-    sys.modules["dask"] = dask_stub
-    sys.modules["dask.distributed"] = dist_stub
+    safe_import('dask', dask_stub)
+    safe_import('dask.distributed', dist_stub)
 if "dash" not in sys.modules:
     dash_stub = types.ModuleType("dash")
-    sys.modules.setdefault("dash", dash_stub)
-    sys.modules.setdefault("dash.dash", dash_stub)
-    sys.modules.setdefault("dash.html", types.ModuleType("dash.html"))
-    sys.modules.setdefault("dash.dcc", types.ModuleType("dash.dcc"))
-    sys.modules.setdefault("dash.dependencies", types.ModuleType("dash.dependencies"))
-    sys.modules.setdefault("dash._callback", types.ModuleType("dash._callback"))
+    safe_import('dash', dash_stub)
+    safe_import('dash.dash', dash_stub)
+    safe_import('dash.html', types.ModuleType("dash.html"))
+    safe_import('dash.dcc', types.ModuleType("dash.dcc"))
+    safe_import('dash.dependencies', types.ModuleType("dash.dependencies"))
+    safe_import('dash._callback', types.ModuleType("dash._callback"))
 if "chardet" not in sys.modules:
-    sys.modules["chardet"] = types.ModuleType("chardet")
+    safe_import('chardet', types.ModuleType("chardet"))
 from unittest.mock import MagicMock
 
 import pandas as pd

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -8,8 +8,9 @@ import pandas as pd
 from flask import Flask
 from pathlib import Path
 import types
+from tests.import_helpers import safe_import, import_optional
 
-sys.modules.setdefault("yosai_intel_dashboard", types.ModuleType("yosai_intel_dashboard"))
+safe_import('yosai_intel_dashboard', types.ModuleType("yosai_intel_dashboard"))
 sys.modules["yosai_intel_dashboard"].__path__ = [str(Path(__file__).resolve().parents[1] / "yosai_intel_dashboard")]
 
 from error_handling import ErrorHandler
@@ -42,7 +43,7 @@ def _create_app(monkeypatch):
     fake_reg.register_upload_services = lambda c: c.register_singleton(
         "uploader", object()
     )
-    monkeypatch.setitem(sys.modules, "services.upload.service_registration", fake_reg)
+    safe_import('services.upload.service_registration', fake_reg)
 
     service = DummyUploadService()
     upload_ep = importlib.import_module("yosai_intel_dashboard.src.services.upload_endpoint")
@@ -87,7 +88,7 @@ class FailingUploadService:
 def test_upload_returns_error_on_exception(monkeypatch):
     fake_reg = types.ModuleType("services.upload.service_registration")
     fake_reg.register_upload_services = lambda c: None
-    monkeypatch.setitem(sys.modules, "services.upload.service_registration", fake_reg)
+    safe_import('services.upload.service_registration', fake_reg)
 
     service = FailingUploadService()
     upload_ep = importlib.import_module("yosai_intel_dashboard.src.services.upload_endpoint")
@@ -128,7 +129,7 @@ class DummyFileProcessor:
 def _create_validator_app(monkeypatch):
     fake_reg = types.ModuleType("services.upload.service_registration")
     fake_reg.register_upload_services = lambda c: None
-    monkeypatch.setitem(sys.modules, "services.upload.service_registration", fake_reg)
+    safe_import('services.upload.service_registration', fake_reg)
 
     upload_ep = importlib.import_module("yosai_intel_dashboard.src.services.upload_endpoint")
 

--- a/tests/test_upload_service_env.py
+++ b/tests/test_upload_service_env.py
@@ -2,7 +2,8 @@ import base64
 import importlib
 
 from services.data_processing import file_processor as upload_module
-from tests.fake_configuration import FakeConfiguration
+from tests.config import FakeConfiguration
+from tests.import_helpers import safe_import, import_optional
 
 
 def test_env_max_upload_limit(monkeypatch):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+from tests.import_helpers import safe_import, import_optional
 
 try:
     import flask  # noqa: F401
@@ -11,7 +12,7 @@ except Exception:
 
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "services")]
-sys.modules["services"] = services_stub
+safe_import('services', services_stub)
 
 import pandas as pd
 

--- a/tests/unit/test_prediction_logging.py
+++ b/tests/unit/test_prediction_logging.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from types import ModuleType, SimpleNamespace
+from tests.import_helpers import safe_import, import_optional
 
 # Stub resilience metrics to avoid optional dependency errors
 metrics_mod = ModuleType("services.resilience.metrics")
@@ -10,9 +11,9 @@ metrics_mod.circuit_breaker_state = SimpleNamespace(
 resilience_pkg = ModuleType("services.resilience")
 resilience_pkg.metrics = metrics_mod
 services_pkg = ModuleType("services")
-sys.modules.setdefault("services", services_pkg)
-sys.modules.setdefault("services.resilience", resilience_pkg)
-sys.modules.setdefault("services.resilience.metrics", metrics_mod)
+safe_import('services', services_pkg)
+safe_import('services.resilience', resilience_pkg)
+safe_import('services.resilience.metrics', metrics_mod)
 
 from monitoring import model_performance_monitor as mpm
 from yosai_intel_dashboard.models.ml.base_model import BaseModel, ModelMetadata


### PR DESCRIPTION
## Summary
- add migration script to convert sys.modules stubs to `tests.import_helpers.safe_import`
- centralize test configuration imports in `tests.config`
- update tests to use new helpers

## Testing
- `pytest tests/test_utils_unicode.py -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_688e51dc2c0883209fb662fbfc3f19a3