### PR TITLE
refactor test setup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import config  # noqa: F401 - ensure test configuration executes
+
 pytest_plugins = ["tests.performance_plugin"]

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,6 @@
+"""Entry point for test environment configuration."""
+from __future__ import annotations
+
+# Import optional dependency stubs and other test configuration modules.
+# Importing this module has the side effect of registering all required stubs.
+from . import optional_dependency_config  # noqa: F401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import importlib.util
 import warnings
 
-from . import optional_dependency_config  # registers stubs
+import pytest
+
+from . import config  # load test configuration
 
 _missing_packages = [
     pkg for pkg in ("yaml", "psutil") if importlib.util.find_spec(pkg) is None
@@ -14,3 +16,25 @@ if _missing_packages:
         "Missing required test dependencies: " + ", ".join(_missing_packages),
         RuntimeWarning,
     )
+
+
+@pytest.fixture
+def temp_dir(tmp_path_factory):
+    """Provide a temporary directory unique to each test."""
+    return tmp_path_factory.mktemp("tmp")
+
+
+@pytest.fixture
+def di_container():
+    """Simple dependency injection container instance."""
+    from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
+
+    return ServiceContainer()
+
+
+@pytest.fixture
+def fake_unicode_processor():
+    """Fixture returning a ``FakeUnicodeProcessor`` instance."""
+    from .fake_unicode_processor import FakeUnicodeProcessor
+
+    return FakeUnicodeProcessor()

--- a/tests/import_helpers.py
+++ b/tests/import_helpers.py
@@ -1,0 +1,58 @@
+"""Utilities for test-time module import handling.
+
+These helpers provide a central place for creating and registering lightweight
+stub modules used across the test-suite.  They avoid repetitive manual
+`sys.modules` manipulation in individual tests.
+"""
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any
+
+from optional_dependencies import register_stub
+
+
+def simple_module(name: str, **attrs: Any) -> ModuleType:
+    """Return a new :class:`ModuleType` with *attrs* set."""
+    mod = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def install_stub(name: str, module: ModuleType) -> ModuleType:
+    """Register *module* as a stub and expose it via :data:`sys.modules`."""
+    sys.modules.setdefault(name, module)
+    register_stub(name, module)
+    return module
+
+
+def simple_stub(name: str, **attrs: Any) -> ModuleType:
+    """Convenience wrapper combining :func:`simple_module` and :func:`install_stub`."""
+    mod = simple_module(name, **attrs)
+    return install_stub(name, mod)
+
+
+@contextmanager
+def temp_module(name: str, **attrs: Any) -> ModuleType:
+    """Temporarily register a stub module.
+
+    The module is registered and added to :data:`sys.modules` for the duration of
+    the context, then removed afterwards.
+    """
+    mod = simple_stub(name, **attrs)
+    try:
+        yield mod
+    finally:  # pragma: no cover - cleanup
+        sys.modules.pop(name, None)
+
+
+__all__ = [
+    "install_stub",
+    "simple_module",
+    "simple_stub",
+    "temp_module",
+    "register_stub",
+]

--- a/tests/optional_dependency_config.py
+++ b/tests/optional_dependency_config.py
@@ -10,34 +10,26 @@ from __future__ import annotations
 import types
 from pathlib import Path
 
-from optional_dependencies import register_stub
-
-
-def _simple_module(name: str, **attrs: object) -> types.ModuleType:
-    mod = types.ModuleType(name)
-    for key, value in attrs.items():
-        setattr(mod, key, value)
-    return mod
+from .import_helpers import install_stub, simple_module, simple_stub
 
 
 # ---------------------------------------------------------------------------
 # Lightweight services package used by tests
-services_stub = _simple_module("services")
+services_stub = simple_module("services")
 services_path = Path(__file__).resolve().parents[1] / "services"
 services_stub.__path__ = [str(services_path)]
-register_stub("services", services_stub)
-register_stub("services.resilience", _simple_module("services.resilience"))
-metrics_mod = _simple_module(
+install_stub("services", services_stub)
+simple_stub("services.resilience")
+metrics_mod = simple_stub(
     "services.resilience.metrics",
     circuit_breaker_state=types.SimpleNamespace(
         labels=lambda *a, **k: types.SimpleNamespace(inc=lambda *a, **k: None)
     ),
 )
-register_stub("services.resilience.metrics", metrics_mod)
 
 
 # Core optional third-party libraries ---------------------------------------
-register_stub("hvac", _simple_module("hvac", Client=object))
+simple_stub("hvac", Client=object)
 
 class _DummyFernet:
     def __init__(self, *a, **k): ...
@@ -52,11 +44,9 @@ class _DummyFernet:
     def decrypt(self, data: bytes) -> bytes:
         return data
 
-register_stub(
-    "cryptography.fernet", _simple_module("cryptography.fernet", Fernet=_DummyFernet)
-)
+simple_stub("cryptography.fernet", Fernet=_DummyFernet)
 
-register_stub("boto3", _simple_module("boto3", client=lambda *a, **k: object()))
+simple_stub("boto3", client=lambda *a, **k: object())
 
 class _DummyRun:
     def __init__(self) -> None:
@@ -68,43 +58,40 @@ class _DummyRun:
     def __exit__(self, exc_type, exc, tb):
         pass
 
-register_stub(
+simple_stub(
     "mlflow",
-    _simple_module(
-        "mlflow",
-        start_run=lambda *a, **k: _DummyRun(),
-        log_metric=lambda *a, **k: None,
-        log_artifact=lambda *a, **k: None,
-        log_text=lambda *a, **k: None,
-        set_tracking_uri=lambda *a, **k: None,
-    ),
+    start_run=lambda *a, **k: _DummyRun(),
+    log_metric=lambda *a, **k: None,
+    log_artifact=lambda *a, **k: None,
+    log_text=lambda *a, **k: None,
+    set_tracking_uri=lambda *a, **k: None,
 )
 
-register_stub("asyncpg", _simple_module("asyncpg", create_pool=lambda *a, **k: None))
-register_stub(
-    "httpx", _simple_module("httpx", ASGITransport=object, AsyncClient=object)
-)
-register_stub("structlog", _simple_module("structlog", BoundLogger=object))
-register_stub("confluent_kafka", _simple_module("confluent_kafka"))
+simple_stub("asyncpg", create_pool=lambda *a, **k: None)
+simple_stub("httpx", ASGITransport=object, AsyncClient=object)
+simple_stub("structlog", BoundLogger=object)
+simple_stub("confluent_kafka")
 
 # Dash and related packages used by UI tests
-_dash = _simple_module("dash")
-_dash.html = _simple_module("dash.html")
-_dash.dcc = _simple_module("dash.dcc")
-_dash.dependencies = _simple_module("dash.dependencies")
-_dash._callback = _simple_module("dash._callback")
-register_stub("dash", _dash)
-register_stub("dash.html", _dash.html)
-register_stub("dash.dcc", _dash.dcc)
-register_stub("dash.dependencies", _dash.dependencies)
-register_stub("dash._callback", _dash._callback)
-register_stub("dash_bootstrap_components", _simple_module("dash_bootstrap_components"))
+_dash = simple_stub("dash", Dash=object)
+_dash.html = simple_stub("dash.html")
+_dash.dcc = simple_stub("dash.dcc")
+_dash.dependencies = simple_stub(
+    "dash.dependencies", Input=object, Output=object, State=object
+)
+_dash._callback = simple_stub("dash._callback")
+install_stub("dash", _dash)
+install_stub("dash.html", _dash.html)
+install_stub("dash.dcc", _dash.dcc)
+install_stub("dash.dependencies", _dash.dependencies)
+install_stub("dash._callback", _dash._callback)
+simple_stub("dash_bootstrap_components")
 
 # Redis and requests
-_redis = _simple_module("redis")
-_redis.asyncio = _simple_module("redis.asyncio")
-register_stub("redis", _redis)
-register_stub("redis.asyncio", _redis.asyncio)
-register_stub("requests", _simple_module("requests"))
+_redis = simple_stub("redis")
+_redis.asyncio = simple_stub("redis.asyncio")
+install_stub("redis", _redis)
+install_stub("redis.asyncio", _redis.asyncio)
+simple_stub("requests")
 
 # No shap/lime stubs; tests will skip explainability features if missing


### PR DESCRIPTION
## Summary
- centralize stub logic with new import helpers and configuration module
- expose thread-safe fixtures for DI, temp directories, and unicode processing

## Testing
- `pytest -n auto tests/test_fake_unicode_processor.py::test_fake_processor_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_688e51dae09083208d500dd65f220770