### PR TITLE
docs: add ErrorBoundary and Select docs and stories

### DIFF
--- a/docs/ErrorBoundary.md
+++ b/docs/ErrorBoundary.md
@@ -1,0 +1,46 @@
+# ErrorBoundary
+
+The `ErrorBoundary` component wraps part of the React tree and renders a fallback UI when a child throws an error. It prevents entire pages from crashing and logs diagnostic information.
+
+## Props
+
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `children` | `ReactNode` | Content to be protected by the boundary. |
+
+## Basic Usage
+
+```tsx
+<ErrorBoundary>
+  <DangerousWidget />
+</ErrorBoundary>
+```
+
+## Retry Example
+
+Use a changing `key` to reset the boundary after an error.
+
+```tsx
+function ExplodingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Kaboom');
+  }
+  return <div>All good</div>;
+}
+
+export function RetryExample() {
+  const [key, setKey] = React.useState(0);
+  const [throwErr, setThrowErr] = React.useState(false);
+  return (
+    <ErrorBoundary key={key}>
+      <ExplodingComponent shouldThrow={throwErr} />
+      <button onClick={() => setThrowErr(true)}>Trigger Error</button>
+      <button onClick={() => setKey(k => k + 1)}>Retry</button>
+    </ErrorBoundary>
+  );
+}
+```
+
+## Design System
+
+Follow the guidance in [UI Accessibility](ui_accessibility.md) and [UI Design](ui_design/README.md) for consistent error messaging and focus handling.

--- a/docs/Select.md
+++ b/docs/Select.md
@@ -1,0 +1,80 @@
+# Select
+
+The `Select` component is a styled wrapper around the native `<select>` element. It supports single and multiple selection while remaining accessible and keyboard friendly.
+
+## Props
+
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `value` | `string | string[]` | The current selection. |
+| `onChange` | `(value: any) => void` | Callback fired when the selection changes. |
+| `options` | `{ value: string; label: string }[]` | Available choices. |
+| `multiple` | `boolean` | Enables multi-select mode. |
+| `placeholder` | `string` | Placeholder text for single select. |
+| `className` | `string` | Additional CSS classes. |
+| `...rest` | `SelectHTMLAttributes` | Any other native `<select>` props (e.g. `aria-label`). |
+
+## Searchable Example
+
+```tsx
+const fruits = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+];
+
+function SearchableSelect() {
+  const [query, setQuery] = React.useState('');
+  const [value, setValue] = React.useState('');
+  const filtered = fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase()));
+  return (
+    <div>
+      <input
+        aria-label="Search options"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="Search..."
+        className="mb-2 border px-2 py-1"
+      />
+      <Select
+        aria-label="Fruit"
+        options={filtered}
+        value={value}
+        onChange={setValue}
+        placeholder="Pick a fruit"
+      />
+    </div>
+  );
+}
+```
+
+## Multi-select Example
+
+```tsx
+const languages = [
+  { value: 'html', label: 'HTML' },
+  { value: 'css', label: 'CSS' },
+  { value: 'js', label: 'JavaScript' },
+];
+
+function LanguagePicker() {
+  const [value, setValue] = React.useState<string[]>([]);
+  return (
+    <Select
+      multiple
+      aria-label="Languages"
+      options={languages}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
+```
+
+## Keyboard Interaction
+
+The component relies on the native `<select>` element, enabling users to navigate with arrow keys, typeahead search, and `Space` or `Enter` to confirm selection. Custom key handling can be added via the `onKeyDown` prop.
+
+## Design System
+
+Refer to [UI Accessibility](ui_accessibility.md) and [Component Styling](ui_design/component_styling.md) to align with design tokens and interaction patterns.

--- a/stories/ErrorBoundary.stories.tsx
+++ b/stories/ErrorBoundary.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import ErrorBoundary from '../yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary';
+
+interface PlaygroundArgs {
+  shouldThrow: boolean;
+}
+
+const meta: Meta<PlaygroundArgs> = {
+  title: 'Components/ErrorBoundary',
+  component: ErrorBoundary,
+  argTypes: {
+    shouldThrow: {
+      control: 'boolean',
+      description: 'Trigger the child component to throw an error.'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'Catches runtime errors and displays a fallback message. Ensure the fallback content is descriptive for screen readers.'
+      }
+    },
+    controls: { expanded: true }
+  }
+};
+
+export default meta;
+type Story = StoryObj<PlaygroundArgs>;
+
+const Buggy: React.FC<PlaygroundArgs> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error('Boom');
+  }
+  return <div>No error</div>;
+};
+
+export const Playground: Story = {
+  args: { shouldThrow: false },
+  render: ({ shouldThrow }) => {
+    const [key, setKey] = React.useState(0);
+    return (
+      <ErrorBoundary key={key}>
+        <Buggy shouldThrow={shouldThrow} />
+        <button onClick={() => setKey(k => k + 1)}>Retry</button>
+      </ErrorBoundary>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Use the **shouldThrow** control to trigger an error. The **Retry** button remounts the boundary and is keyboard focusable.'
+      }
+    }
+  }
+};

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from '../yosai_intel_dashboard/src/adapters/ui/components/shared/Select';
+
+const fruitOptions = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' }
+];
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/Select',
+  component: Select,
+  args: {
+    options: fruitOptions,
+    value: '',
+    'aria-label': 'Fruit picker'
+  },
+  argTypes: {
+    multiple: { control: 'boolean' }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'Accessible select component supporting single and multiple selection. Provide an `aria-label` or associated `<label>`.'
+      }
+    },
+    controls: { expanded: true }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Playground: Story = {
+  args: {
+    placeholder: 'Choose fruit'
+  },
+  render: (args) => {
+    const [value, setValue] = React.useState(args.value as string);
+    const [query, setQuery] = React.useState('');
+    const filtered = (args.options || []).filter(o =>
+      o.label.toLowerCase().includes(query.toLowerCase())
+    );
+    return (
+      <div>
+        <input
+          aria-label="Search options"
+          placeholder="Search..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          className="mb-2 border px-2 py-1"
+        />
+        <Select
+          {...args}
+          options={filtered}
+          value={value}
+          onChange={setValue}
+          onKeyDown={e => console.log('Key pressed', e.key)}
+        />
+        <div className="mt-2">Selected: {JSON.stringify(value)}</div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Includes a search field and logs key presses to demonstrate keyboard interaction.'
+      }
+    }
+  }
+};
+
+export const MultiSelect: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState<string[]>([]);
+    return (
+      <Select {...args} multiple value={value} onChange={setValue} />
+    );
+  },
+  args: {
+    options: [
+      { value: 'html', label: 'HTML' },
+      { value: 'css', label: 'CSS' },
+      { value: 'js', label: 'JavaScript' }
+    ],
+    'aria-label': 'Languages'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Use standard keyboard modifiers (Shift, Ctrl/Command) for multi-selection.'
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- document ErrorBoundary with retry guidance and design references
- add Select documentation showing search, multi-select, and keyboard info
- provide Storybook stories for ErrorBoundary and Select with interactive controls and accessibility notes

## Testing
- `npm install --no-audit --no-fund --legacy-peer-deps`
- `npm test` *(fails: Cannot find module '.../ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688e51abbb7c8320a595e65a3ecb36bc