### PR TITLE
refactor: generic select options

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Select } from './Select';
+import { Select, Option } from './Select';
 
-const options = [
+const options: Option<string>[] = [
   { value: 'a', label: 'A' },
   { value: 'b', label: 'B' }
 ];
 
 test('calls onChange with selected value', () => {
   const onChange = jest.fn();
-  render(<Select value="" onChange={onChange} options={options} />);
+  render(<Select<string> value="" onChange={onChange} options={options} />);
   fireEvent.change(screen.getByRole('combobox'), { target: { value: 'a' } });
   expect(onChange).toHaveBeenCalledWith('a');
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 
-interface Option { value: string; label: string; }
-interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
-  value: string | string[];
-  onChange: (value: any) => void;
-  options: Option[];
+export interface Option<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface Props<T extends string> extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  value: T | T[];
+  onChange: (value: T | T[]) => void;
+  options: Option<T>[];
   multiple?: boolean;
   placeholder?: string;
   className?: string;
 }
 
-export const Select: React.FC<Props> = ({ value, onChange, options, multiple = false, placeholder, className='', ...rest }) => {
+export const Select = <T extends string>({
+  value,
+  onChange,
+  options,
+  multiple = false,
+  placeholder,
+  className = '',
+  ...rest
+}: Props<T>) => {
   return (
     <select
       multiple={multiple}
@@ -18,10 +30,10 @@ export const Select: React.FC<Props> = ({ value, onChange, options, multiple = f
       {...rest}
       onChange={(e) => {
         if (multiple) {
-          const selected = Array.from(e.target.selectedOptions).map(o => o.value);
+          const selected = Array.from(e.target.selectedOptions).map(o => o.value as T);
           onChange(selected);
         } else {
-          onChange(e.target.value);
+          onChange(e.target.value as T);
         }
       }}
       className={`border rounded-md px-2 py-1 ${className}`}
@@ -33,3 +45,4 @@ export const Select: React.FC<Props> = ({ value, onChange, options, multiple = f
     </select>
   );
 };
+

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/ColumnMappingModal.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/ColumnMappingModal.tsx
@@ -171,7 +171,7 @@ export const ColumnMappingModal: React.FC<Props> = ({
                       <td className="py-3 px-4">
                         <Select
                           value={mapping.mappedTo}
-                          onChange={(value) => handleMappingChange(index, value)}
+                          onChange={(value) => handleMappingChange(index, value as string)}
                           options={STANDARD_FIELDS}
                           aria-label={`Map column ${mapping.originalColumn}`}
                           className={mapping.confidence < 0.5 ? 'border-yellow-500' : ''}

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/DeviceMappingModal.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/DeviceMappingModal.tsx
@@ -212,7 +212,7 @@ export const DeviceMappingModal: React.FC<Props> = ({
                           </div>
                         </td>
                         <td className="py-3 px-4">
-                          <Select
+                          <Select<string>
                             multiple
                             value={mapping.specialAreas}
                             onChange={(value) => updateMapping(index, { specialAreas: value as string[] })}


### PR DESCRIPTION
## Summary
- make Select component generic for option value types
- tighten onChange signature to accept typed values
- update consumers and tests to use exported Option interface

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx yosai_intel_dashboard/src/adapters/ui/components/upload/ColumnMappingModal.tsx yosai_intel_dashboard/src/adapters/ui/components/upload/DeviceMappingModal.tsx`
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688e51a717b88320afa5dd431c421e82