### PR TITLE
feat: improve select accessibility

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx
@@ -6,9 +6,28 @@ const options = [
   { value: 'b', label: 'B' }
 ];
 
-test('calls onChange with selected value', () => {
+test('calls onChange with selected value and manages aria attributes', () => {
   const onChange = jest.fn();
-  render(<Select value="" onChange={onChange} options={options} />);
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'a' } });
+  render(<Select id="test" value="" onChange={onChange} options={options} placeholder="pick" />);
+  const select = screen.getByRole('combobox');
+
+  // aria-expanded toggles on focus/blur
+  expect(select).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.focus(select);
+  expect(select).toHaveAttribute('aria-expanded', 'true');
+
+  fireEvent.change(select, { target: { value: 'a' } });
   expect(onChange).toHaveBeenCalledWith('a');
+  expect(select).toHaveAttribute('aria-activedescendant', 'test-option-a');
+
+  fireEvent.blur(select);
+  expect(select).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('applies listbox role and aria-multiselectable for multiple select', () => {
+  const onChange = jest.fn();
+  render(<Select id="multi" value={[]} onChange={onChange} options={options} multiple />);
+  const listbox = screen.getByRole('listbox');
+  expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
+  expect(screen.getAllByRole('option')).toHaveLength(options.length);
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Select.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId, useState } from 'react';
 
 interface Option { value: string; label: string; }
 interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
@@ -8,28 +8,80 @@ interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
   multiple?: boolean;
   placeholder?: string;
   className?: string;
+  label?: string;
 }
 
-export const Select: React.FC<Props> = ({ value, onChange, options, multiple = false, placeholder, className='', ...rest }) => {
+export const Select: React.FC<Props> = ({
+  value,
+  onChange,
+  options,
+  multiple = false,
+  placeholder,
+  className = '',
+  label,
+  id,
+  onFocus,
+  onBlur,
+  ...rest
+}) => {
+  const generatedId = useId();
+  const selectId = id || generatedId;
+  const [expanded, setExpanded] = useState(false);
+
+  const handleFocus = (e: React.FocusEvent<HTMLSelectElement>) => {
+    setExpanded(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLSelectElement>) => {
+    setExpanded(false);
+    onBlur?.(e);
+  };
+
+  const activeDescendant =
+    !multiple && typeof value === 'string' && value !== ''
+      ? `${selectId}-option-${value}`
+      : undefined;
+
   return (
-    <select
-      multiple={multiple}
-      value={value}
-      {...rest}
-      onChange={(e) => {
-        if (multiple) {
-          const selected = Array.from(e.target.selectedOptions).map(o => o.value);
-          onChange(selected);
-        } else {
-          onChange(e.target.value);
-        }
-      }}
-      className={`border rounded-md px-2 py-1 ${className}`}
-    >
-      {!multiple && placeholder && <option value="">{placeholder}</option>}
-      {options.map(opt => (
-        <option key={opt.value} value={opt.value}>{opt.label}</option>
-      ))}
-    </select>
+    <>
+      {label && (
+        <label htmlFor={selectId} className="sr-only">
+          {label}
+        </label>
+      )}
+      <select
+        id={selectId}
+        multiple={multiple}
+        value={value}
+        role={multiple ? 'listbox' : 'combobox'}
+        aria-expanded={expanded}
+        aria-activedescendant={activeDescendant}
+        aria-multiselectable={multiple || undefined}
+        {...rest}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={(e) => {
+          if (multiple) {
+            const selected = Array.from(e.target.selectedOptions).map((o) => o.value);
+            onChange(selected);
+          } else {
+            onChange(e.target.value);
+          }
+        }}
+        className={`border rounded-md px-2 py-1 ${className}`}
+      >
+        {!multiple && placeholder && (
+          <option role="option" id={`${selectId}-option-`} value="">
+            {placeholder}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option role="option" id={`${selectId}-option-${opt.value}`} key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- enhance Select component with WAI-ARIA roles, expanded state, active-descendant tracking, and optional hidden labels
- test Select for aria attributes and listbox/multiselect behavior

## Testing
- `npx jest yosai_intel_dashboard/src/adapters/ui/components/shared/Select.test.tsx` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688e51a893a48320997855378c38eaa8