### PR TITLE
refactor: make Select generic

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -1,14 +1,14 @@
 # Select
 
-The `Select` component is a styled wrapper around the native `<select>` element. It supports single and multiple selection while remaining accessible and keyboard friendly.
+The `Select` component is a styled wrapper around the native `<select>` element. It supports single and multiple selection while remaining accessible and keyboard friendly. The component is generic (`Select<T extends string>`) and exports an `Option<T>` type for strongly typed option values.
 
 ## Props
 
 | Prop | Type | Description |
 | ---- | ---- | ----------- |
-| `value` | `string | string[]` | The current selection. |
-| `onChange` | `(value: any) => void` | Callback fired when the selection changes. |
-| `options` | `{ value: string; label: string }[]` | Available choices. |
+| `value` | `T | T[]` | The current selection. |
+| `onChange` | `(value: T | T[]) => void` | Callback fired when the selection changes. |
+| `options` | `Option<T>[]` | Available choices. |
 | `multiple` | `boolean` | Enables multi-select mode. |
 | `placeholder` | `string` | Placeholder text for single select. |
 | `className` | `string` | Additional CSS classes. |

--- a/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Select } from './Select';
+import { Select, Option } from './Select';
 
-const options = [
+const options: Option<'a' | 'b'>[] = [
   { value: 'a', label: 'A' },
   { value: 'b', label: 'B' }
 ];

--- a/yosai_intel_dashboard/src/adapters/ui/components/select/Select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/select/Select.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 
-interface Option {
-  value: string;
+export interface Option<T extends string> {
+  value: T;
   label: string;
 }
 
-export interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'value' | 'onChange'> {
-  value: string | string[];
-  onChange: (value: string | string[]) => void;
-  options: Option[];
+export interface SelectProps<T extends string = string>
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'value' | 'onChange'> {
+  value: T | T[];
+  onChange: (value: T | T[]) => void;
+  options: Option<T>[];
   multiple?: boolean;
   placeholder?: string;
   className?: string;
 }
 
-export const Select: React.FC<SelectProps> = ({
+export const Select = <T extends string,>({
   value,
   onChange,
   options,
@@ -22,13 +23,13 @@ export const Select: React.FC<SelectProps> = ({
   placeholder,
   className = '',
   ...rest
-}) => {
+}: SelectProps<T>) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (multiple) {
-      const selected = Array.from(e.target.selectedOptions).map(o => o.value);
-      onChange(selected);
+      const selected = Array.from(e.target.selectedOptions).map(o => o.value as T);
+      onChange(selected as T[]);
     } else {
-      onChange(e.target.value);
+      onChange(e.target.value as T);
     }
   };
 


### PR DESCRIPTION
## Summary
- refactor Select to accept typed options and export Option
- update Select tests for new generic types
- document generic option types and onChange signature

## Testing
- `npm test` (fails: react-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_688e5ba5b5748320b19b32d91023c29c