### PR TITLE
feat: improve select accessibility

### DIFF
--- a/docs/select_accessibility.md
+++ b/docs/select_accessibility.md
@@ -1,0 +1,25 @@
+# Accessible Select Component
+
+The custom `Select` component implements the [combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) pattern. It exposes a search input linked to a list of options to provide screen‑reader friendly autocomplete behaviour.
+
+## Roles and States
+
+- The search input uses `role="combobox"` and manages `aria-expanded` to reflect whether the option list is visible.
+- The option list is rendered as a `role="listbox"` with an `id` referenced by the input's `aria-controls`.
+- Each option is rendered with `role="option"`. The currently highlighted option is communicated through `aria-activedescendant` on the combobox.
+- When `multiple` is enabled, the listbox exposes `aria-multiselectable="true"`.
+- A hidden `role="status"` region announces the number of available results for screen readers.
+
+## Usage
+
+```tsx
+<Select
+  value={value}
+  onChange={setValue}
+  options={options}
+  multiple
+  placeholder="Search…"
+/>```
+
+The component filters options as the user types and automatically updates all ARIA attributes to keep assistive technologies informed.
+

--- a/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
@@ -9,16 +9,48 @@ const options = [
 test('calls onChange with selected value', () => {
   const onChange = jest.fn();
   render(<Select value="" onChange={onChange} options={options} />);
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'a' } });
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  const option = screen.getByRole('option', { name: 'A' });
+  fireEvent.mouseDown(option);
   expect(onChange).toHaveBeenCalledWith('a');
 });
 
 test('handles multiple selection', () => {
   const onChange = jest.fn();
   render(<Select value={[]} onChange={onChange} options={options} multiple />);
-  const select = screen.getByRole('listbox');
-  fireEvent.change(select, {
-    target: { selectedOptions: [{ value: 'a' }, { value: 'b' }] }
-  });
-  expect(onChange).toHaveBeenCalledWith(['a', 'b']);
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  fireEvent.mouseDown(screen.getByRole('option', { name: 'A' }));
+  fireEvent.mouseDown(screen.getByRole('option', { name: 'B' }));
+  expect(onChange).toHaveBeenLastCalledWith(['a', 'b']);
+});
+
+test('manages aria attributes', () => {
+  render(<Select value="" onChange={() => {}} options={options} />);
+  const input = screen.getByRole('combobox');
+  expect(input).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.focus(input);
+  const listbox = screen.getByRole('listbox');
+  expect(input).toHaveAttribute('aria-controls', listbox.id);
+  fireEvent.keyDown(input, { key: 'ArrowDown' });
+  const firstOption = screen.getByRole('option', { name: 'A' });
+  expect(input).toHaveAttribute('aria-activedescendant', firstOption.id);
+});
+
+test('sets aria-multiselectable when multiple', () => {
+  render(<Select value={[]} onChange={() => {}} options={options} multiple />);
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  const listbox = screen.getByRole('listbox');
+  expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
+});
+
+test('announces number of results', () => {
+  render(<Select value="" onChange={() => {}} options={options} />);
+  const status = screen.getByRole('status');
+  expect(status).toHaveTextContent('2 results available');
+  const input = screen.getByRole('combobox');
+  fireEvent.change(input, { target: { value: 'A' } });
+  expect(status).toHaveTextContent('1 results available');
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/select.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Select } from '../select/Select';
 
 const options = [{ value: '1', label: 'One' }];
 
-test('renders unified select', () => {
+test('renders accessible combobox', () => {
   render(<Select value="" onChange={() => {}} options={options} />);
-  expect(screen.getByRole('combobox')).toBeInTheDocument();
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  const listbox = screen.getByRole('listbox');
+  expect(input).toHaveAttribute('aria-controls', listbox.id);
+  expect(screen.getAllByRole('option')).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- render custom select with combobox/listbox/option roles
- link search input and listbox via aria-controls and announce results
- add accessibility tests and documentation

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `pytest` *(fails: NameError: name 'pytest' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e5bbebae48320b6446e5b8caf193e