### PR TITLE
feat: add searchable select

### DIFF
--- a/docs/Select.md
+++ b/docs/Select.md
@@ -12,6 +12,7 @@ The `Select` component is a styled wrapper around the native `<select>` element.
 | `multiple` | `boolean` | Enables multi-select mode. |
 | `placeholder` | `string` | Placeholder text for single select. |
 | `className` | `string` | Additional CSS classes. |
+| `searchable` | `boolean` | Adds an internal search input to filter options. |
 | `...rest` | `SelectHTMLAttributes` | Any other native `<select>` props (e.g. `aria-label`). |
 
 ## Searchable Example
@@ -24,26 +25,16 @@ const fruits = [
 ];
 
 function SearchableSelect() {
-  const [query, setQuery] = React.useState('');
   const [value, setValue] = React.useState('');
-  const filtered = fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase()));
   return (
-    <div>
-      <input
-        aria-label="Search options"
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-        placeholder="Search..."
-        className="mb-2 border px-2 py-1"
-      />
-      <Select
-        aria-label="Fruit"
-        options={filtered}
-        value={value}
-        onChange={setValue}
-        placeholder="Pick a fruit"
-      />
-    </div>
+    <Select
+      aria-label="Fruit"
+      options={fruits}
+      value={value}
+      onChange={setValue}
+      placeholder="Pick a fruit"
+      searchable
+    />
   );
 }
 ```

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Select } from '../yosai_intel_dashboard/src/adapters/ui/components/shared/Select';
+import { Select } from '../yosai_intel_dashboard/src/adapters/ui/components/select/Select';
 
 const fruitOptions = [
   { value: 'apple', label: 'Apple' },
@@ -38,22 +38,11 @@ export const Playground: Story = {
   },
   render: (args) => {
     const [value, setValue] = React.useState(args.value as string);
-    const [query, setQuery] = React.useState('');
-    const filtered = (args.options || []).filter(o =>
-      o.label.toLowerCase().includes(query.toLowerCase())
-    );
     return (
       <div>
-        <input
-          aria-label="Search options"
-          placeholder="Search..."
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          className="mb-2 border px-2 py-1"
-        />
         <Select
           {...args}
-          options={filtered}
+          searchable
           value={value}
           onChange={setValue}
           onKeyDown={e => console.log('Key pressed', e.key)}
@@ -65,7 +54,8 @@ export const Playground: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Includes a search field and logs key presses to demonstrate keyboard interaction.'
+        story:
+          'Use arrow keys to navigate options, type in the search box to filter, and press Enter or Space to select.'
       }
     }
   }
@@ -89,7 +79,8 @@ export const MultiSelect: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Use standard keyboard modifiers (Shift, Ctrl/Command) for multi-selection.'
+        story:
+          'Hold Ctrl/Command or Shift while clicking or using arrow keys to select multiple items.'
       }
     }
   }

--- a/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx
@@ -22,3 +22,11 @@ test('handles multiple selection', () => {
   });
   expect(onChange).toHaveBeenCalledWith(['a', 'b']);
 });
+
+test('filters options when searchable', () => {
+  render(<Select value="" onChange={() => {}} options={options} searchable />);
+  const search = screen.getByRole('textbox', { name: /search options/i });
+  fireEvent.change(search, { target: { value: 'b' } });
+  expect(screen.queryByText('A')).not.toBeInTheDocument();
+  expect(screen.getByText('B')).toBeInTheDocument();
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/select/Select.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/select/Select.tsx
@@ -12,6 +12,10 @@ export interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectE
   multiple?: boolean;
   placeholder?: string;
   className?: string;
+  /**
+   * Enables an internal search box that filters the available options.
+   */
+  searchable?: boolean;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -21,8 +25,16 @@ export const Select: React.FC<SelectProps> = ({
   multiple = false,
   placeholder,
   className = '',
+  searchable = false,
   ...rest
 }) => {
+  const [query, setQuery] = React.useState('');
+  const filtered = React.useMemo(() => {
+    return options.filter(o =>
+      o.label.toLowerCase().includes(query.toLowerCase())
+    );
+  }, [options, query]);
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (multiple) {
       const selected = Array.from(e.target.selectedOptions).map(o => o.value);
@@ -32,7 +44,7 @@ export const Select: React.FC<SelectProps> = ({
     }
   };
 
-  return (
+  const renderSelect = (
     <select
       multiple={multiple}
       value={value}
@@ -41,12 +53,30 @@ export const Select: React.FC<SelectProps> = ({
       {...rest}
     >
       {!multiple && placeholder && <option value="">{placeholder}</option>}
-      {options.map(opt => (
+      {filtered.map(opt => (
         <option key={opt.value} value={opt.value}>
           {opt.label}
         </option>
       ))}
     </select>
+  );
+
+  if (!searchable) {
+    return renderSelect;
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="Search..."
+        aria-label="Search options"
+        className="mb-2 border px-2 py-1"
+      />
+      {renderSelect}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `searchable` prop to Select for filtering options
- update Select story to use built-in search and document keyboard/multi-select behavior
- cover searchable filtering with new tests and docs

## Testing
- `npm test -- --testPathPattern=select/Select` *(fails: Cannot find module '.../package.json')*
- `npx jest yosai_intel_dashboard/src/adapters/ui/components/select/Select.test.tsx` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688e5bc33fdc83208a3b983074ce98d0