### PR TITLE
feat(error): allow user comments in manual reports

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx
@@ -38,6 +38,28 @@ test('shows fallback UI and posts error report', () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/error-report', expect.any(Object));
 });
 
+test('includes user comments when reporting issue', () => {
+  const ThrowError = () => {
+    throw new Error('boom');
+  };
+
+  render(
+    <ErrorBoundary>
+      <ThrowError />
+    </ErrorBoundary>
+  );
+
+  const originalPrompt = window.prompt;
+  (window as any).prompt = jest.fn().mockReturnValue('It failed after clicking');
+  fireEvent.click(screen.getByText('Report Issue'));
+
+  expect((window as any).prompt).toHaveBeenCalled();
+  expect(global.fetch).toHaveBeenCalledTimes(2);
+  const payload = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+  expect(payload.comments).toBe('It failed after clicking');
+  window.prompt = originalPrompt;
+});
+
 test('retry resets error boundary', () => {
   let shouldThrow = true;
   const ProblemChild = () => {

--- a/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.tsx
@@ -45,13 +45,15 @@ class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, ErrorBo
   handleReport() {
     const { error, errorInfo } = this.state;
     if (!error) return;
+    const comments = window.prompt('Please describe what happened (optional):') || '';
     fetch('/api/error-report', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         message: error.message,
         stack: error.stack,
-        componentStack: errorInfo?.componentStack
+        componentStack: errorInfo?.componentStack,
+        comments
       })
     }).catch((err) => console.error('Failed to report error', err));
   }


### PR DESCRIPTION
## Summary
- prompt for optional comments before resubmitting error reports
- include user comments in error payload
- test that manual report sends user comments

## Testing
- `npm test -- ErrorBoundary.test.tsx` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npx jest --env=jsdom yosai_intel_dashboard/src/adapters/ui/components/ErrorBoundary.test.tsx` *(fails: SyntaxError: Unexpected token, expected "," (11:17))*

------
https://chatgpt.com/codex/tasks/task_e_688e5bc44fec83209dcba47d66ef59ba