### PR TITLE
Add compliance framework integration guide

### DIFF
--- a/plugins/compliance_plugin/COMPLETE COMPLIANCE FRAMEWORK INTEGRATION GUIDE
+++ b/plugins/compliance_plugin/COMPLETE COMPLIANCE FRAMEWORK INTEGRATION GUIDE
@@ -1,0 +1,93 @@
+# Complete Compliance Framework Integration Guide
+
+## Overview of GDPR and APPI Frameworks
+
+### GDPR
+- Protects personal data of EU residents.
+- Requires lawful basis for processing and mandates data subject rights.
+
+### APPI
+- Governs handling of personal information in Japan.
+- Emphasizes user consent, purpose limitation, and cross-border data transfer rules.
+
+## Step-by-Step Integration Instructions
+1. Enable the `compliance_plugin` in your settings.
+2. Apply database migrations to create compliance tables.
+3. Configure API routes for compliance operations.
+4. Update services to call plugin hooks for data events.
+5. Write tests and run the compliance test suite.
+
+## Database Schema for Compliance Tables
+```sql
+CREATE TABLE consent_records (
+    id SERIAL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    consent_given BOOLEAN NOT NULL,
+    given_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE audit_log (
+    id SERIAL PRIMARY KEY,
+    user_id UUID,
+    action TEXT NOT NULL,
+    details JSONB,
+    created_at TIMESTAMP NOT NULL
+);
+```
+
+## API Endpoints for Compliance Operations
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/api/compliance/consent` | Record user consent |
+| `GET`  | `/api/compliance/portability/<user_id>` | Export user data |
+| `DELETE` | `/api/compliance/delete/<user_id>` | Remove user data |
+
+## Code Examples
+
+### Consent Management
+```python
+from plugins.compliance_plugin import consent
+consent.record(user_id, granted=True)
+```
+
+### Data Retention
+```python
+from plugins.compliance_plugin import retention
+retention.schedule_cleanup(days=30)
+```
+
+### Right to Deletion
+```python
+from plugins.compliance_plugin import erasure
+erasure.delete_user(user_id)
+```
+
+### Data Portability
+```python
+from plugins.compliance_plugin import portability
+archive = portability.export_user(user_id)
+```
+
+### Audit Logging
+```python
+from plugins.compliance_plugin import audit
+audit.log(user_id, action="download", details={"size": 512})
+```
+
+## Configuration Examples
+```yaml
+compliance_plugin:
+  enabled: true
+  retention_period_days: 30
+  audit_sink: s3://compliance-logs
+```
+
+## Testing Guidelines
+- Run `pytest tests/compliance_plugin`.
+- Verify API endpoints with integration tests.
+- Confirm database migrations apply cleanly in staging.
+
+## Troubleshooting
+- **Missing Tables**: Ensure migrations ran successfully.
+- **Permission Errors**: Verify service accounts have access to compliance tables.
+- **Incorrect Exports**: Check audit logs for data processing steps.


### PR DESCRIPTION
## Summary
- add `plugins/compliance_plugin` directory
- provide comprehensive compliance framework integration guide with GDPR/APPI overview, integration steps, schema, API and code examples, configuration, testing, and troubleshooting

## Testing
- `pytest -q` *(fails: NameError: name 'pytest' is not defined in tests/conftest.py)*
- `python - <<'PY'
import openapi
print(openapi.GenerateIntegrationGuide().splitlines()[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_688e602aebac8320a0c67a84cd6aba8c