### PR TITLE
feat: add api versioning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,10 @@ sequenceDiagram
 
 ## API Versioning
 
-All endpoints are prefixed with a version such as `/v1`.
+All routes are grouped under a versioned prefix such as `/v1`.
+Unversioned paths remain temporarily available for backward compatibility but
+return a `Warning` header and are marked as deprecated. Future releases will
+introduce `/v2` endpoints following the same pattern.
 The Go `versioning` module provides `VersionManager` middleware that extracts
 the version from the request path and attaches metadata to the context. The
 manager can mark versions as `active`, `deprecated`, or `sunset` to control

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os
 
-from fastapi import Depends, HTTPException, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Response as FastAPIResponse, status
 from fastapi.middleware.wsgi import WSGIMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -89,11 +89,32 @@ def create_api_app() -> "FastAPI":
     settings = get_security_config()
     CORS(app, origins=settings.cors_origins)
 
+    # Helper dependency used for deprecated unversioned routes
+    def add_deprecation_warning(response: FastAPIResponse) -> None:
+        response.headers[
+            "Warning"
+        ] = "299 - Deprecated API path; please use versioned '/v1' routes"
+
     # Third-party analytics demo endpoints (FastAPI router)
-    service.app.include_router(analytics_router, dependencies=[Depends(verify_token)])
     service.app.add_event_handler("startup", init_cache_manager)
-    service.app.include_router(monitoring_router, dependencies=[Depends(verify_token)])
-    service.app.include_router(explanations_router, dependencies=[Depends(verify_token)])
+
+    api_v1 = APIRouter(prefix="/v1")
+    api_v1.include_router(analytics_router)
+    api_v1.include_router(monitoring_router)
+    api_v1.include_router(explanations_router)
+
+    service.app.include_router(api_v1, dependencies=[Depends(verify_token)])
+
+    legacy_router = APIRouter()
+    legacy_router.include_router(analytics_router)
+    legacy_router.include_router(monitoring_router)
+    legacy_router.include_router(explanations_router)
+
+    service.app.include_router(
+        legacy_router,
+        dependencies=[Depends(verify_token), Depends(add_deprecation_warning)],
+        deprecated=True,
+    )
 
     # Core upload and mapping endpoints
     err_handler = (

--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -11,7 +11,10 @@ from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsS
 from yosai_intel_dashboard.src.services.security import require_permission
 from shared.errors.types import ErrorCode
 
-router = APIRouter(prefix="/api/v1/analytics", tags=["analytics"])
+# Routes now use an unversioned prefix and are mounted under /v1 by the
+# adapter. This simplifies preparing future versions while keeping unversioned
+# paths available for backward compatibility.
+router = APIRouter(prefix="/analytics", tags=["analytics"])
 
 cfg = get_cache_config()
 _cache_manager = InMemoryCacheManager(CacheConfig(timeout_seconds=cfg.ttl))

--- a/yosai_intel_dashboard/src/adapters/api/explanations.py
+++ b/yosai_intel_dashboard/src/adapters/api/explanations.py
@@ -8,7 +8,9 @@ from yosai_intel_dashboard.src.services.analytics.analytics_service import (
     get_analytics_service,
 )
 
-router = APIRouter(prefix="/api/v1/explanations", tags=["explanations"])
+# Use an unversioned prefix so the adapter can mount the router under /v1 and
+# also expose deprecated legacy paths without duplication here.
+router = APIRouter(prefix="/explanations", tags=["explanations"])
 
 
 @router.get("/{prediction_id}")

--- a/yosai_intel_dashboard/src/adapters/api/monitoring_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/monitoring_router.py
@@ -7,7 +7,9 @@ from fastapi import APIRouter, Query
 
 from yosai_intel_dashboard.src.services.timescale.manager import TimescaleDBManager
 
-router = APIRouter(prefix="/v1/model-monitoring", tags=["model-monitoring"])
+# Expose routes without a version so the adapter can mount them under /v1 and
+# also offer deprecated legacy access.
+router = APIRouter(prefix="/model-monitoring", tags=["model-monitoring"])
 
 
 @router.get("/{model_name}")


### PR DESCRIPTION
## Summary
- group API routers under a new `/v1` namespace
- expose legacy unversioned routes with deprecation warnings
- update API documentation for versioned paths

## Testing
- `pytest tests/analytics/test_async_api.py -q` *(fails: NameError: name 'pytest' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e68011a488320a137979de37b8dc8