### PR TITLE
feat: add model performance tracker with drift detection

### DIFF
--- a/tests/monitoring/test_model_performance_tracker.py
+++ b/tests/monitoring/test_model_performance_tracker.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
+
+from monitoring.model_performance_tracker import ModelPerformanceTracker
+
+
+def test_metric_collection():
+    tracker = ModelPerformanceTracker()
+    snap = tracker.record_batch([1, 0, 1, 1], [1, 0, 0, 1], latency=0.2)
+    assert snap.accuracy == pytest.approx(0.75)
+    assert snap.f1 == pytest.approx(0.8)
+    assert snap.throughput == pytest.approx(20.0)
+    assert len(tracker.metrics_history) == 1
+
+
+def test_drift_calculation():
+    tracker = ModelPerformanceTracker()
+    base = pd.DataFrame({"a": [0, 1, 0, 1]})
+    current = pd.DataFrame({"a": [0, 0, 0, 0]})
+    drift = tracker.calculate_drift(base, current)
+    assert "a" in drift
+    assert set(drift["a"].keys()) == {"psi", "ks", "wasserstein"}
+
+
+def test_feature_importance_tracking():
+    tracker = ModelPerformanceTracker(drift_threshold=0.1)
+    baseline = {"f1": 0.5, "f2": 0.5}
+    assert not tracker.update_feature_importance(baseline)
+    changed = {"f1": 0.7, "f2": 0.3}
+    assert tracker.update_feature_importance(changed)
+    assert len(tracker.feature_importance_history) == 2

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "ModelMonitoringService",
     "ModelMetrics",
     "get_model_performance_monitor",
+    "ModelPerformanceTracker",
     "RealTimeUIMonitor",
     "get_ui_monitor",
     "check_cluster_health",
@@ -67,6 +68,10 @@ def __getattr__(name: str):
         )
 
         return locals()[name]
+    if name == "ModelPerformanceTracker":
+        from .model_performance_tracker import ModelPerformanceTracker
+
+        return ModelPerformanceTracker
     if name == "ModelMonitoringService":
         from .model_monitoring_service import ModelMonitoringService
 

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_tracker.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_tracker.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Track model metrics, latency, and feature importance with drift detection."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from yosai_intel_dashboard.src.services.monitoring.drift import detect_drift
+
+
+@dataclass
+class MetricSnapshot:
+    """Persisted metrics for a batch of predictions."""
+
+    accuracy: float
+    precision: float
+    recall: float
+    f1: float
+    latency: float
+    throughput: float
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+class ModelPerformanceTracker:
+    """Collect model metrics and feature importance over time."""
+
+    def __init__(self, *, drift_threshold: float = 0.1) -> None:
+        self.drift_threshold = drift_threshold
+        self.metrics_history: List[MetricSnapshot] = []
+        self.feature_importance_history: List[Dict[str, float]] = []
+        self.baseline_importance: Optional[Dict[str, float]] = None
+
+    # ------------------------------------------------------------------
+    def record_batch(
+        self, y_true: Sequence[int], y_pred: Sequence[int], *, latency: float
+    ) -> MetricSnapshot:
+        """Record metrics for a batch of predictions."""
+        y_true_arr = np.asarray(y_true)
+        y_pred_arr = np.asarray(y_pred)
+        if y_true_arr.size == 0:
+            raise ValueError("y_true cannot be empty")
+        tp = int(np.logical_and(y_true_arr == 1, y_pred_arr == 1).sum())
+        tn = int(np.logical_and(y_true_arr == 0, y_pred_arr == 0).sum())
+        fp = int(np.logical_and(y_true_arr == 0, y_pred_arr == 1).sum())
+        fn = int(np.logical_and(y_true_arr == 1, y_pred_arr == 0).sum())
+
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        accuracy = (tp + tn) / y_true_arr.size
+        f1 = (
+            2 * precision * recall / (precision + recall)
+            if (precision + recall)
+            else 0.0
+        )
+        throughput = y_pred_arr.size / latency if latency > 0 else 0.0
+
+        snapshot = MetricSnapshot(
+            accuracy=accuracy,
+            precision=precision,
+            recall=recall,
+            f1=f1,
+            latency=latency,
+            throughput=throughput,
+        )
+        self.metrics_history.append(snapshot)
+        return snapshot
+
+    # ------------------------------------------------------------------
+    def calculate_drift(
+        self, baseline: pd.DataFrame, current: pd.DataFrame
+    ) -> Dict[str, Dict[str, float]]:
+        """Return drift metrics for ``current`` compared to ``baseline``."""
+        return detect_drift(baseline, current)
+
+    # ------------------------------------------------------------------
+    def update_feature_importance(self, importances: Dict[str, float]) -> bool:
+        """Persist feature importances and detect drift from the baseline."""
+        self.feature_importance_history.append(importances.copy())
+        if self.baseline_importance is None:
+            self.baseline_importance = importances.copy()
+            return False
+        for feature, base_value in self.baseline_importance.items():
+            current_value = importances.get(feature, 0.0)
+            if base_value == 0.0:
+                diff = abs(current_value - base_value)
+            else:
+                diff = abs(current_value - base_value) / base_value
+            if diff > self.drift_threshold:
+                return True
+        return False
+
+
+__all__ = ["ModelPerformanceTracker", "MetricSnapshot"]


### PR DESCRIPTION
## Summary
- add `ModelPerformanceTracker` for capturing F1, latency, throughput and drift via KS/PSI/Wasserstein
- expose tracker in monitoring package
- test metric capture, drift calculation and feature importance tracking

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_tracker.py yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py tests/monitoring/test_model_performance_tracker.py`
- `pytest tests/monitoring/test_model_performance_tracker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e771badf4832094063ad4102e6bbc