### PR TITLE
Add configurable monitoring alerts

### DIFF
--- a/tests/monitoring/test_alerts.py
+++ b/tests/monitoring/test_alerts.py
@@ -1,0 +1,62 @@
+import pytest
+
+from yosai_intel_dashboard.src.infrastructure.monitoring.alerts import (
+    AlertManager,
+    AlertThresholds,
+)
+
+
+class DummyNotifier:
+    def __init__(self):
+        self.messages = []
+
+    def send(self, message: str) -> None:  # pragma: no cover - simple
+        self.messages.append(message)
+
+
+def setup_alerts(monkeypatch, thresholds):
+    dummy = DummyNotifier()
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.infrastructure.monitoring.alerts.NotificationService",
+        lambda: dummy,
+    )
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.infrastructure.monitoring.alerts._load_thresholds",
+        lambda: AlertThresholds(**thresholds),
+    )
+    return dummy
+
+
+def test_metric_alert_triggers_notification(monkeypatch):
+    notifier = setup_alerts(
+        monkeypatch,
+        {"metrics": {"accuracy": 0.9}, "drift": 0.2, "error_spike": 5},
+    )
+    manager = AlertManager()
+    triggered = manager.check_metrics({"accuracy": 0.8})
+    assert triggered is True
+    assert notifier.messages
+
+
+def test_drift_and_error_alerts(monkeypatch):
+    notifier = setup_alerts(
+        monkeypatch,
+        {"metrics": {}, "drift": 0.1, "error_spike": 3},
+    )
+    manager = AlertManager()
+    drift_triggered = manager.check_drift(0.2)
+    error_triggered = manager.check_error_spike(5)
+    assert drift_triggered and error_triggered
+    assert len(notifier.messages) == 2
+
+
+def test_no_alert_when_within_threshold(monkeypatch):
+    notifier = setup_alerts(
+        monkeypatch,
+        {"metrics": {"accuracy": 0.5}, "drift": 0.5, "error_spike": 10},
+    )
+    manager = AlertManager()
+    assert manager.check_metrics({"accuracy": 0.9}) is False
+    assert manager.check_drift(0.1) is False
+    assert manager.check_error_spike(5) is False
+    assert not notifier.messages

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "start_deprecation_metrics_server",
     "InferenceDriftJob",
     "request_duration",
+    "AlertManager",
 ]
 
 
@@ -95,4 +96,8 @@ def __getattr__(name: str):
         from .request_metrics import request_duration
 
         return request_duration
+    if name == "AlertManager":
+        from .alerts import AlertManager
+
+        return AlertManager
     raise AttributeError(name)

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.py
@@ -1,0 +1,90 @@
+"""Threshold-based monitoring alerts for metrics, drift and errors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from yosai_intel_dashboard.src.services.notification_service import NotificationService
+
+
+@dataclass
+class AlertThresholds:
+    """Threshold configuration for alert checks."""
+
+    metrics: Dict[str, float] = field(default_factory=dict)
+    drift: float = 0.1
+    error_spike: int = 10
+
+
+# ------------------------------------------------------------------
+
+def _load_thresholds() -> AlertThresholds:
+    from yosai_intel_dashboard.src.infrastructure.config import get_monitoring_config
+
+    cfg = get_monitoring_config()
+    if isinstance(cfg, dict):
+        th_cfg = cfg.get("alert_thresholds", {})
+    else:
+        th_cfg = getattr(cfg, "alert_thresholds", {})
+        if hasattr(th_cfg, "model_dump"):
+            th_cfg = th_cfg.model_dump()
+    return AlertThresholds(
+        metrics=th_cfg.get("metrics", {}),
+        drift=th_cfg.get("drift", 0.1),
+        error_spike=th_cfg.get("error_spike", 10),
+    )
+
+
+class AlertManager:
+    """Evaluate metrics and dispatch notifications when thresholds are exceeded."""
+
+    def __init__(
+        self,
+        *,
+        notifier: Optional[NotificationService] = None,
+        thresholds: Optional[AlertThresholds] = None,
+    ) -> None:
+        self.notifier = notifier or NotificationService()
+        self.thresholds = thresholds or _load_thresholds()
+
+    # ------------------------------------------------------------------
+    def _notify(self, message: str) -> None:
+        try:
+            self.notifier.send(message)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    # ------------------------------------------------------------------
+    def check_metrics(self, metrics: Dict[str, float]) -> bool:
+        """Check metric values against configured thresholds."""
+        triggered = False
+        for name, value in metrics.items():
+            limit = self.thresholds.metrics.get(name)
+            if limit is not None and value < limit:
+                self._notify(f"Metric {name} below threshold: {value} < {limit}")
+                triggered = True
+        return triggered
+
+    # ------------------------------------------------------------------
+    def check_drift(self, score: float) -> bool:
+        """Check drift score against threshold."""
+        if score > self.thresholds.drift:
+            self._notify(
+                f"Drift score {score} exceeds threshold {self.thresholds.drift}"
+            )
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    def check_error_spike(self, count: int) -> bool:
+        """Check error count for spikes."""
+        if count > self.thresholds.error_spike:
+            self._notify(
+                f"Error spike detected: {count} > {self.thresholds.error_spike}"
+            )
+            return True
+        return False
+
+
+__all__ = ["AlertManager", "AlertThresholds"]

--- a/yosai_intel_dashboard/src/services/notification_service/__init__.py
+++ b/yosai_intel_dashboard/src/services/notification_service/__init__.py
@@ -1,3 +1,47 @@
-"""
-notification service package
-"""
+"""Simple notification service dispatching alerts via configured channels."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+
+class NotificationService:
+    """Dispatch messages to Slack, email or a generic webhook."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import (
+            AlertConfig,
+            AlertDispatcher,
+        )
+
+        if config is None:
+            from yosai_intel_dashboard.src.infrastructure.config import (
+                get_monitoring_config,
+            )
+
+            cfg = get_monitoring_config()
+            if isinstance(cfg, dict):
+                alert_cfg = cfg.get("alerting", {})
+            else:
+                alert_cfg = getattr(cfg, "alerting", {})
+                if hasattr(alert_cfg, "model_dump"):
+                    alert_cfg = alert_cfg.model_dump()
+        else:
+            alert_cfg = config
+
+        self._dispatcher = AlertDispatcher(
+            AlertConfig(
+                slack_webhook=alert_cfg.get("slack_webhook"),
+                email=alert_cfg.get("email"),
+                webhook_url=alert_cfg.get("webhook_url"),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    def send(self, message: str) -> None:
+        """Send an alert message through configured channels."""
+        self._dispatcher.send_alert(message)
+
+
+__all__ = ["NotificationService"]


### PR DESCRIPTION
## Summary
- implement NotificationService to dispatch messages via configured channels
- add threshold-based AlertManager for metrics, drift, and error spikes
- test alert triggering and notification dispatch

## Testing
- `pytest tests/monitoring/test_alerts.py`

------
https://chatgpt.com/codex/tasks/task_e_688e771c5a188320a13096af40d7c046