### PR TITLE
Add coverage for monitoring, drift, explainability and persistence

### DIFF
--- a/tests/integration/test_model_registry_persistence.py
+++ b/tests/integration/test_model_registry_persistence.py
@@ -1,0 +1,66 @@
+import importlib.util
+import types
+from pathlib import Path
+import os
+
+import pytest
+
+os.environ.setdefault("CACHE_TTL", "1")
+
+
+class DummyS3:
+    def upload_file(self, *a, **k):
+        pass
+
+    def download_file(self, *a, **k):
+        pass
+
+
+class DummyRun:
+    def __init__(self):
+        self.info = types.SimpleNamespace(run_id="run")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyMlflow:
+    def start_run(self):
+        return DummyRun()
+
+    def log_metric(self, *a, **k):
+        pass
+
+    def log_artifact(self, *a, **k):
+        pass
+
+    def set_tracking_uri(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "models"
+        / "ml"
+        / "model_registry.py"
+    )
+    spec = importlib.util.spec_from_file_location("model_registry", path)
+    mr = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(mr)
+    monkeypatch.setattr(mr, "mlflow", DummyMlflow())
+    return mr.ModelRegistry("sqlite:///:memory:", bucket="bucket", s3_client=DummyS3())
+
+
+def test_log_explanation_persists(registry):
+    registry.log_explanation("pred1", "model", "1.0", {"shap_values": [1, 2]})
+    rec = registry.get_explanation("pred1")
+    assert rec["model_name"] == "model"
+    assert rec["explanation"]["shap_values"] == [1, 2]

--- a/tests/integration/test_prometheus_request_metrics.py
+++ b/tests/integration/test_prometheus_request_metrics.py
@@ -1,0 +1,15 @@
+import os
+
+from prometheus_client import generate_latest
+
+os.environ.setdefault("CACHE_TTL", "1")
+
+from yosai_intel_dashboard.src.infrastructure.monitoring.request_metrics import (
+    request_duration,
+)
+
+
+def test_request_duration_metric_exposed():
+    request_duration.observe(0.2)
+    metrics = generate_latest(request_duration)
+    assert b"api_request_duration_seconds_count" in metrics

--- a/tests/integration/test_websocket_updates.py
+++ b/tests/integration/test_websocket_updates.py
@@ -1,0 +1,69 @@
+import importlib.util
+import sys
+import types
+import time
+from pathlib import Path
+
+
+def _load_provider():
+    pkg_names = [
+        "yosai_intel_dashboard",
+        "yosai_intel_dashboard.src",
+        "yosai_intel_dashboard.src.core",
+        "yosai_intel_dashboard.src.core.interfaces",
+        "yosai_intel_dashboard.src.services",
+    ]
+    for name in pkg_names:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    proto_mod = types.ModuleType("yosai_intel_dashboard.src.core.interfaces.protocols")
+    class EventBusProtocol:
+        pass
+    proto_mod.EventBusProtocol = EventBusProtocol
+    sys.modules[
+        "yosai_intel_dashboard.src.core.interfaces.protocols"
+    ] = proto_mod
+
+    analytics_mod = types.ModuleType(
+        "yosai_intel_dashboard.src.services.analytics_summary"
+    )
+    analytics_mod.generate_sample_analytics = lambda: {"x": 1}
+    sys.modules[
+        "yosai_intel_dashboard.src.services.analytics_summary"
+    ] = analytics_mod
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "services"
+        / "websocket_data_provider.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "yosai_intel_dashboard.src.services.websocket_data_provider",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module.WebSocketDataProvider
+
+
+class DummyBus:
+    def __init__(self):
+        self.events = []
+
+    def publish(self, event_type, data):
+        self.events.append((event_type, data))
+
+    def subscribe(self, event_type, handler):
+        pass
+
+
+def test_websocket_data_provider_integration():
+    Provider = _load_provider()
+    bus = DummyBus()
+    provider = Provider(bus, interval=0.01)
+    time.sleep(0.05)
+    provider.stop()
+    assert any(e[0] == "analytics_update" for e in bus.events)

--- a/tests/models/test_model_registry_versioning.py
+++ b/tests/models/test_model_registry_versioning.py
@@ -1,0 +1,83 @@
+import importlib.util
+import types
+from pathlib import Path
+import os
+
+import pytest
+
+os.environ.setdefault("CACHE_TTL", "1")
+
+
+class DummyS3:
+    def upload_file(self, *a, **k):
+        pass
+
+    def download_file(self, *a, **k):
+        pass
+
+
+class DummyRun:
+    def __init__(self):
+        self.info = types.SimpleNamespace(run_id="run")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyMlflow:
+    def start_run(self):
+        return DummyRun()
+
+    def log_metric(self, *a, **k):
+        pass
+
+    def log_artifact(self, *a, **k):
+        pass
+
+    def set_tracking_uri(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def registry(monkeypatch, tmp_path):
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "models"
+        / "ml"
+        / "model_registry.py"
+    )
+    spec = importlib.util.spec_from_file_location("model_registry", path)
+    mr = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(mr)
+    monkeypatch.setattr(mr, "mlflow", DummyMlflow())
+    return mr.ModelRegistry(
+        f"sqlite:///{tmp_path}/db.sqlite",
+        bucket="bucket",
+        s3_client=DummyS3(),
+        metric_thresholds={"acc": 0.05},
+    )
+
+
+def test_version_bumping(monkeypatch, tmp_path, registry):
+    p1 = tmp_path / "m1.bin"
+    p1.write_text("a")
+    r1 = registry.register_model("m", str(p1), {"acc": 0.8}, "h1")
+    assert r1.version == "0.1.0"
+    registry.set_active_version("m", r1.version)
+
+    p2 = tmp_path / "m2.bin"
+    p2.write_text("b")
+    r2 = registry.register_model("m", str(p2), {"acc": 0.86}, "h2")
+    assert r2.version == "0.2.0"
+    registry.set_active_version("m", r2.version)
+
+    p3 = tmp_path / "m3.bin"
+    p3.write_text("c")
+    r3 = registry.register_model("m", str(p3), {"acc": 0.84}, "h3")
+    assert r3.version == "0.2.1"

--- a/tests/test_explainability_feature_importance.py
+++ b/tests/test_explainability_feature_importance.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+from yosai_intel_dashboard.src.services.explainability_service import ExplainabilityService
+
+
+def test_feature_importance_with_coefficients():
+    X = pd.DataFrame({"a": [0, 1, 0, 1], "b": [1, 0, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = LogisticRegression().fit(X, y)
+    svc = ExplainabilityService()
+    svc.register_model("demo", model, background_data=X)
+    imp = svc.feature_importance("demo", X)
+    assert set(imp.keys()) == {"a", "b"}

--- a/tests/test_explainability_visualize_model.py
+++ b/tests/test_explainability_visualize_model.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+from yosai_intel_dashboard.src.services.explainability_service import ExplainabilityService
+
+shap = pytest.importorskip("shap")
+if not hasattr(shap.plots, "save"):
+    pytest.skip("shap.plots.save not available", allow_module_level=True)
+
+
+def test_visualize_model_creates_file(tmp_path):
+    X = pd.DataFrame({"a": [0, 1, 0, 1], "b": [1, 0, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = LogisticRegression().fit(X, y)
+    svc = ExplainabilityService()
+    svc.register_model("demo", model, background_data=X)
+    out = tmp_path / "plot.png"
+    svc.visualize_model("demo", X, out)
+    assert out.exists()

--- a/tests/test_model_ab_tester_metrics.py
+++ b/tests/test_model_ab_tester_metrics.py
@@ -1,0 +1,41 @@
+import os
+import types
+
+os.environ.setdefault("CACHE_TTL", "1")
+
+from yosai_intel_dashboard.src.services.ab_testing import ModelABTester
+
+
+def test_record_metrics_updates_internal_and_prom(monkeypatch, tmp_path):
+    registry = types.SimpleNamespace(get_model=lambda *a, **k: None, download_artifact=lambda *a, **k: None)
+    tester = ModelABTester(
+        "model",
+        registry,
+        weights={},
+        weights_file=tmp_path / "w.json",
+        model_dir=tmp_path / "models",
+    )
+
+    class DummyMetric:
+        def __init__(self):
+            self.count = 0
+
+        def labels(self, *a):
+            return self
+
+        def inc(self, val=1):
+            self.count += val
+
+        def observe(self, val):
+            self.count += 1
+
+    dummy = DummyMetric()
+    monkeypatch.setattr(tester, "_prom_counts", dummy)
+    monkeypatch.setattr(tester, "_prom_success", dummy)
+    monkeypatch.setattr(tester, "_prom_latency", dummy)
+
+    tester._record_metrics("1", True, 0.2)
+    assert tester.metrics["1"]["count"] == 1
+    assert tester.metrics["1"]["success"] == 1
+    assert tester.metrics["1"]["latency_sum"] == 0.2
+    assert dummy.count >= 2

--- a/tests/test_model_registry_drift.py
+++ b/tests/test_model_registry_drift.py
@@ -1,0 +1,58 @@
+import importlib.util
+import os
+import types
+from pathlib import Path
+
+import pandas as pd
+
+os.environ.setdefault("CACHE_TTL", "1")
+os.environ.setdefault("CACHE_TTL_SECONDS", "1")
+os.environ.setdefault("JWKS_CACHE_TTL", "1")
+
+path = (
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "models"
+    / "ml"
+    / "model_registry.py"
+)
+spec = importlib.util.spec_from_file_location("model_registry", path)
+mr = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(mr)
+ModelRegistry = mr.ModelRegistry
+
+
+class DummyS3:
+    def upload_file(self, *a, **k):
+        pass
+
+    def download_file(self, *a, **k):
+        pass
+
+
+def test_get_drift_metrics_uses_compute_psi(monkeypatch):
+    registry = ModelRegistry("sqlite:///:memory:", bucket="b", s3_client=DummyS3())
+    base = pd.DataFrame({"a": [0, 1, 2]})
+    cur = pd.DataFrame({"a": [1, 2, 3]})
+    registry.log_features("m", base)
+    registry.log_features("m", cur)
+
+    called = {}
+
+    def fake_compute_psi(baseline, current, bins=10):
+        called["baseline"] = baseline
+        called["current"] = current
+        called["bins"] = bins
+        return {"a": 0.1}
+
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.services.monitoring.drift.compute_psi",
+        fake_compute_psi,
+    )
+
+    metrics = registry.get_drift_metrics("m")
+    assert called["baseline"].equals(base)
+    assert called["current"].equals(cur)
+    assert metrics == {"a": 0.1}

--- a/tests/test_performance_budget_system.py
+++ b/tests/test_performance_budget_system.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+os.environ.setdefault("CACHE_TTL", "1")
+os.environ.setdefault("CACHE_TTL_SECONDS", "1")
+os.environ.setdefault("JWKS_CACHE_TTL", "1")
+
+
+def _load_system():
+    pkg_names = [
+        "yosai_intel_dashboard",
+        "yosai_intel_dashboard.src",
+        "yosai_intel_dashboard.src.core",
+        "yosai_intel_dashboard.src.core.monitoring",
+    ]
+    for name in pkg_names:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    perf_mod = types.ModuleType("yosai_intel_dashboard.src.core.performance")
+    perf_mod.get_performance_monitor = lambda: types.SimpleNamespace(metrics=[])
+    sys.modules["yosai_intel_dashboard.src.core.performance"] = perf_mod
+
+    uem_mod = types.ModuleType(
+        "yosai_intel_dashboard.src.core.monitoring.user_experience_metrics"
+    )
+    class AlertDispatcher:
+        pass
+    uem_mod.AlertDispatcher = AlertDispatcher
+    sys.modules[
+        "yosai_intel_dashboard.src.core.monitoring.user_experience_metrics"
+    ] = uem_mod
+
+    path = Path(__file__).resolve().parents[1] / "yosai_intel_dashboard" / "src" / "core" / "monitoring" / "performance_budget_system.py"
+    spec = importlib.util.spec_from_file_location(
+        "yosai_intel_dashboard.src.core.monitoring.performance_budget_system",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module.PerformanceBudgetSystem
+
+
+def test_alert_triggered_on_budget_exceeded():
+    System = _load_system()
+    calls = []
+    dispatcher = types.SimpleNamespace(send_alert=lambda msg: calls.append(msg))
+    system = System({"latency": 1.0}, dispatcher)
+    system.check_metric("latency", 1.5)
+    system.check_metric("latency", 0.5)
+    assert calls == ["latency exceeded budget: 1.50 > 1.00"]

--- a/tests/test_real_time_performance_tracker.py
+++ b/tests/test_real_time_performance_tracker.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+os.environ.setdefault("CACHE_TTL", "1")
+os.environ.setdefault("CACHE_TTL_SECONDS", "1")
+os.environ.setdefault("JWKS_CACHE_TTL", "1")
+
+
+def _load_tracker(perf):
+    pkg_names = [
+        "yosai_intel_dashboard",
+        "yosai_intel_dashboard.src",
+        "yosai_intel_dashboard.src.core",
+        "yosai_intel_dashboard.src.core.monitoring",
+    ]
+    for name in pkg_names:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    base_model_mod = types.ModuleType("yosai_intel_dashboard.src.core.base_model")
+    class BaseModel:
+        def __init__(self, *a, **k):
+            pass
+    base_model_mod.BaseModel = BaseModel
+    performance_mod = types.ModuleType("yosai_intel_dashboard.src.core.performance")
+    class MetricType:
+        FILE_PROCESSING = "fp"
+        EXECUTION_TIME = "et"
+    performance_mod.MetricType = MetricType
+    performance_mod.get_performance_monitor = lambda: perf
+    sys.modules["yosai_intel_dashboard.src.core.base_model"] = base_model_mod
+    sys.modules["yosai_intel_dashboard.src.core.performance"] = performance_mod
+
+    path = Path(__file__).resolve().parents[1] / "yosai_intel_dashboard" / "src" / "core" / "monitoring" / "real_time_performance_tracker.py"
+    spec = importlib.util.spec_from_file_location(
+        "yosai_intel_dashboard.src.core.monitoring.real_time_performance_tracker",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module.RealTimePerformanceTracker, performance_mod.MetricType
+
+
+def test_tracker_records_latency_and_throughput():
+    calls = []
+    perf = types.SimpleNamespace(
+        record_metric=lambda n, v, t, metadata=None: calls.append((n, v, t, metadata))
+    )
+    Tracker, MetricType = _load_tracker(perf)
+    tracker = Tracker()
+    tracker.record_upload_speed(5.0, 2.0)
+    tracker.record_callback_duration("cb", 0.25)
+    assert (
+        "upload.speed_mb_s",
+        2.5,
+        MetricType.FILE_PROCESSING,
+        {"file_size_mb": 5.0, "duration_sec": 2.0},
+    ) in calls
+    assert (
+        "callback.cb.duration",
+        0.25,
+        MetricType.EXECUTION_TIME,
+        None,
+    ) in calls


### PR DESCRIPTION
## Summary
- expand monitoring tests for latency/throughput and alert budgets
- cover feature importance, drift metrics and model versioning
- add integration checks for Prometheus metrics, WebSocket provider and registry persistence

## Testing
- `CACHE_TTL=1 CACHE_TTL_SECONDS=1 JWKS_CACHE_TTL=1 pytest tests/test_real_time_performance_tracker.py tests/test_model_registry_drift.py tests/test_explainability_feature_importance.py tests/test_explainability_visualize_model.py tests/test_performance_budget_system.py tests/test_model_ab_tester_metrics.py tests/models/test_model_registry_versioning.py tests/integration/test_prometheus_request_metrics.py tests/integration/test_websocket_updates.py tests/integration/test_model_registry_persistence.py`

------
https://chatgpt.com/codex/tasks/task_e_688e7723a9208320a106c8cd8ccd822d