### PR TITLE
docs: add test migration instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,8 @@ from yosai_intel_dashboard.src.infrastructure.config.settings import Settings
 ```
 
 Run `isort .` to automatically sort imports before committing changes.
+
+## Developer Guides
+
+Refer to [docs/developer_guides.rst](docs/developer_guides.rst) for instructions on
+the test migration script and reviewing any items flagged as ``needs manual review``.

--- a/docs/developer_guides.rst
+++ b/docs/developer_guides.rst
@@ -1,0 +1,38 @@
+Developer Guides
+================
+
+Test Migration Script
+---------------------
+
+The ``tools/migrate_tests.py`` helper updates test files to the current
+import layout and adds ``pytest.importorskip`` checks for optional
+dependencies.
+
+Running
+^^^^^^^
+
+Preview changes without touching the files:
+
+.. code-block:: bash
+
+   python tools/migrate_tests.py --dry-run
+
+Remove ``--dry-run`` to apply the edits.
+
+Interpreting the Report
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Each ``Would update`` line in dry-run mode indicates a file that will be
+modified.  After applying the changes the script prints ``Updated`` for
+files it rewrote.  Any entries that could not be migrated automatically
+are grouped at the end of the output under ``needs manual review``.
+
+Reviewing Manual Items
+^^^^^^^^^^^^^^^^^^^^^^
+
+For every path listed under ``needs manual review``:
+
+#. Open the file and inspect the indicated line.
+#. Replace custom ``sys.modules`` manipulations with
+   ``safe_import`` or ``import_optional`` from ``tests.import_helpers``.
+#. Re-run the script to ensure the item no longer appears.


### PR DESCRIPTION
## Summary
- document test migration script and manual review process
- link developer guide from CONTRIBUTING

## Testing
- `pre-commit run --files CONTRIBUTING.md docs/developer_guides.rst`

------
https://chatgpt.com/codex/tasks/task_e_688e885222c48320aa7633d591722135