### PR TITLE
feat: add contextual validation for inputs

### DIFF
--- a/tests/validation/test_security_validator_injections.py
+++ b/tests/validation/test_security_validator_injections.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from validation.security_validator import SecurityValidator
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "input_type,payload",
+    [
+        ("sql", "1; DROP TABLE users"),
+        ("nosql", '{"$where":"this.password==\'a\'"}'),
+        ("ldap", "*)(uid=*))(|(uid=*"),
+        ("xpath", "' or 1=1 or 'x'='x"),
+        ("command", "whoami && rm -rf /"),
+    ],
+)
+def test_injection_patterns_raise(input_type, payload):
+    validator = SecurityValidator()
+    with pytest.raises(ValidationError):
+        validator.validate_input(payload, input_type=input_type)
+
+
+def test_html_is_escaped():
+    validator = SecurityValidator()
+    result = validator.validate_input("<b>bold</b>", input_type="html")
+    assert result["sanitized"] == "&lt;b&gt;bold&lt;/b&gt;"
+
+
+def test_json_validates_and_canonicalizes():
+    validator = SecurityValidator()
+    result = validator.validate_input('{"a":1}', input_type="json")
+    assert result["sanitized"] == '{"a": 1}'
+
+
+def test_json_invalid_raises():
+    validator = SecurityValidator()
+    with pytest.raises(ValidationError):
+        validator.validate_input('{"a":1,}', input_type="json")


### PR DESCRIPTION
## Summary
- map input types to validation rules and sanitizers
- add keyword-only `input_type` argument selecting contextual rules
- test various injection patterns across SQL, NoSQL, LDAP, XPath, command, HTML, and JSON

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/validation/security_validator.py tests/validation/test_security_validator_injections.py`
- `pytest tests/validation/test_security_validator_injections.py` *(fails: Cache TTL values must be positive)*

------
https://chatgpt.com/codex/tasks/task_e_688e8f3cb4c08320a7e44e198f7d653f