### PR TITLE
feat: add optional anomaly detection

### DIFF
--- a/docs/service_builder_migration.md
+++ b/docs/service_builder_migration.md
@@ -39,9 +39,11 @@ Import validators from the `validation` package rather than accessing the
 modules directly:
 
 ```python
+from sklearn.ensemble import IsolationForest
 from validation import SecurityValidator, FileValidator
 
-validator = SecurityValidator()
+model = IsolationForest().fit([[1], [2], [3]])
+validator = SecurityValidator(anomaly_model=model)
 file_validator = FileValidator()
 ```
 
@@ -81,10 +83,12 @@ def test_health():
 
 ### Validation Rules
 ```python
+from sklearn.ensemble import IsolationForest
 from validation import SecurityValidator, FileValidator
 
 def test_validation():
-    sv = SecurityValidator()
+    model = IsolationForest().fit([[1], [2], [3]])
+    sv = SecurityValidator(anomaly_model=model)
     fv = FileValidator()
     result = sv.validate_input("SELECT 1", "query")
     assert result["valid"]

--- a/docs/validation_overview.md
+++ b/docs/validation_overview.md
@@ -37,11 +37,29 @@ if not result['valid']:
 
 SecurityValidator provides comprehensive validation including:
 - **SQL injection prevention** - Detects and blocks SQL injection attempts
-- **XSS attack prevention** - Sanitizes cross-site scripting attempts  
+- **XSS attack prevention** - Sanitizes cross-site scripting attempts
 - **Path traversal prevention** - Blocks directory traversal attacks
 - **Unicode security** - Handles surrogate characters and encoding issues
 - **File validation** - Checks file types, sizes, and malicious content
 - **Input sanitization** - Cleans and normalizes user input
+
+## Anomaly Detection
+
+`SecurityValidator` can optionally incorporate an anomaly detection model to
+score inputs. Any model with a ``predict`` method returning ``1`` for normal
+values and ``-1`` for outliers can be supplied, such as scikit-learn's
+``IsolationForest``:
+
+```python
+from sklearn.ensemble import IsolationForest
+from validation import SecurityValidator
+
+model = IsolationForest().fit([[len(s)] for s in ["ok", "normal"]])
+validator = SecurityValidator(anomaly_model=model)
+
+# Raises ValidationError if the model predicts an outlier
+validator.validate_input("suspicious")
+```
 
 ## Migration from Deprecated Classes
 

--- a/tests/test_security_validator_anomaly.py
+++ b/tests/test_security_validator_anomaly.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("CACHE_TTL", "1")
+os.environ.setdefault("CACHE_TTL_SECONDS", "1")
+os.environ.setdefault("JWKS_CACHE_TTL", "1")
+
+from validation.security_validator import SecurityValidator
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
+
+
+class DummyModel:
+    def __init__(self, result: int) -> None:
+        self.result = result
+
+    def predict(self, _):  # pragma: no cover - trivial
+        return [self.result]
+
+
+@pytest.fixture
+def normal_model():
+    return DummyModel(1)
+
+
+@pytest.fixture
+def anomalous_model():
+    return DummyModel(-1)
+
+
+def test_anomaly_model_allows_normal_input(normal_model):
+    validator = SecurityValidator(anomaly_model=normal_model)
+    assert validator.validate_input("safe") == {"valid": True, "sanitized": "safe"}
+
+
+def test_anomaly_model_rejects_outlier(anomalous_model):
+    validator = SecurityValidator(anomaly_model=anomalous_model)
+    with pytest.raises(ValidationError):
+        validator.validate_input("bad")


### PR DESCRIPTION
## Summary
- support optional IsolationForest model in `SecurityValidator`
- document anomaly detection usage and examples
- add tests covering normal and anomalous predictions

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/validation/security_validator.py docs/validation_overview.md docs/service_builder_migration.md tests/test_security_validator_anomaly.py`
- `pytest tests/test_security_validator_anomaly.py` *(fails: Cache TTL value must be a positive integer)*

------
https://chatgpt.com/codex/tasks/task_e_688e8f3e051c8320afa8ae161638a616