### PR TITLE
Add security validator rules for deserialization and SSRF

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,13 +1,35 @@
-# Secure Database Queries
+# Security Protections
+
+This project implements safeguards aligned with the OWASP Top 10 categories.
+
+## Injection
+
+- Parameterized queries are required for all database access to avoid SQL injection.
+- `SecurityValidator` applies `SQLRule` and `XSSRule` to block SQL injection and cross-site scripting payloads.
+
+## Authentication
+
+Authentication mechanisms enforce strong credential and session management. Tokens and session IDs are protected and validated on every request to minimize the risk of broken authentication.
+
+## Sensitive Data Exposure
+
+Secrets and personal data are stored using encrypted channels and secret management tooling. Configuration files avoid embedding credentials directly and rely on secure storage.
+
+## Insecure Deserialization
+
+`InsecureDeserializationRule` rejects input containing patterns such as `pickle.loads` or YAML object tags that could trigger unsafe object deserialization.
+
+## Server-Side Request Forgery (SSRF)
+
+`SSRFRule` blocks URLs referencing internal hosts (e.g., `127.0.0.1`, `169.254.169.254`, `10.x.x.x`) or dangerous schemes like `file://`, reducing the risk of internal network access.
+
+## Secure Database Queries
 
 To reduce the risk of SQL injection vulnerabilities:
 
-- Always use parameterized queries with placeholders like `%s` or `?` rather than
-  formatting values into query strings.
-- Prefer the `execute_query` and `execute_command` helpers which enforce
-  parameter validation.
+- Always use parameterized queries with placeholders like `%s` or `?` rather than formatting values into query strings.
+- Prefer the `execute_query` and `execute_command` helpers which enforce parameter validation.
 - Never concatenate untrusted input with SQL keywords or table names.
 - Validate user-supplied data types before executing a query.
 
-Following these practices ensures that user input is passed separately from the
-SQL statement, preventing malicious injections.
+Following these practices ensures that user input is passed separately from the SQL statement, preventing malicious injections.

--- a/tests/test_security_validator.py
+++ b/tests/test_security_validator.py
@@ -1,15 +1,12 @@
-import html
-
 import pytest
-
-from validation.security_validator import SecurityValidator
-
+from yosai_intel_dashboard.src.infrastructure.validation.security_validator import (
+    SecurityValidator,
+)
 
 def test_sql_injection_validation():
     validator = SecurityValidator()
     with pytest.raises(Exception):
-        validator.validate_input("1; DROP TABLE users")
-
+        validator.validate_input('1; DROP TABLE users')
 
 def test_main_validation_orchestration():
     validator = SecurityValidator()
@@ -17,10 +14,19 @@ def test_main_validation_orchestration():
     with pytest.raises(Exception):
         validator.validate_input(value, "comment")
 
-
 def test_validate_file_upload_rules():
     validator = SecurityValidator()
-    valid = validator.validate_file_upload("ok.csv", b"a,b\n1,2")
-    assert valid["valid"]
+    valid = validator.validate_file_upload('ok.csv', b'a,b\n1,2')
+    assert valid['valid']
     with pytest.raises(Exception):
-        validator.validate_file_upload("bad.csv", b"=cmd()")
+        validator.validate_file_upload('bad.csv', b'=cmd()')
+
+def test_insecure_deserialization_detection():
+    validator = SecurityValidator()
+    with pytest.raises(Exception):
+        validator.validate_input('pickle.loads(data)')
+
+def test_ssrf_detection():
+    validator = SecurityValidator()
+    with pytest.raises(Exception):
+        validator.validate_input('http://127.0.0.1/admin')


### PR DESCRIPTION
## Summary
- guard against insecure deserialization and SSRF via new validation rules
- document OWASP protections and new validator hooks
- add tests demonstrating the new security patterns

## Testing
- `pytest tests/test_security_validator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8f45c9408320ab020e35af86f759