### PR TITLE
docs: generate API reference from OpenAPI

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,229 @@
+# API Reference
+
+## Health-Check Endpoints
+
+
+### `GET /health`
+
+**Summary:** Health
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+async def health():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/health
+```
+
+
+### `GET /health/live`
+
+**Summary:** Health Live
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health/live")
+async def health_live():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/health/live", methods=["GET"])
+def health_live():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/health/live
+```
+
+
+### `GET /health/ready`
+
+**Summary:** Health Ready
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health/ready")
+async def health_ready():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/health/ready", methods=["GET"])
+def health_ready():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/health/ready
+```
+
+
+### `GET /health/startup`
+
+**Summary:** Health Startup
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health/startup")
+async def health_startup():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/health/startup", methods=["GET"])
+def health_startup():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/health/startup
+```
+
+## Metrics Endpoints
+
+
+### `GET /v1/metrics/drift`
+
+**Summary:** Return sample drift statistics.
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/v1/metrics/drift")
+async def v1_metrics_drift():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/v1/metrics/drift", methods=["GET"])
+def v1_metrics_drift():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/v1/metrics/drift
+```
+
+
+### `GET /v1/metrics/feature-importance`
+
+**Summary:** Return sample feature importances.
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/v1/metrics/feature-importance")
+async def v1_metrics_feature_importance():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/v1/metrics/feature-importance", methods=["GET"])
+def v1_metrics_feature_importance():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/v1/metrics/feature-importance
+```
+
+
+### `GET /v1/metrics/performance`
+
+**Summary:** Return sample performance metrics.
+
+**FastAPI**
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/v1/metrics/performance")
+async def v1_metrics_performance():
+    ...
+```
+
+**Flask**
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route("/v1/metrics/performance", methods=["GET"])
+def v1_metrics_performance():
+    return jsonify()
+```
+
+**curl**
+```bash
+curl -X GET http://localhost:8000/v1/metrics/performance
+```

--- a/scripts/generate_api_reference.py
+++ b/scripts/generate_api_reference.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate Markdown API reference from OpenAPI spec."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+SPEC_PATH = Path("docs/openapi.json")
+OUTPUT_PATH = Path("docs/api_reference.md")
+
+# Additional endpoints not present in the base spec
+EXTRA_PATHS = {
+    "/v1/metrics/performance": {
+        "get": {"summary": "Return sample performance metrics."}
+    },
+    "/v1/metrics/drift": {"get": {"summary": "Return sample drift statistics."}},
+    "/v1/metrics/feature-importance": {
+        "get": {"summary": "Return sample feature importances."}
+    },
+}
+
+
+def load_spec() -> dict:
+    spec = json.loads(SPEC_PATH.read_text(encoding="utf-8"))
+    spec.setdefault("paths", {}).update(EXTRA_PATHS)
+    return spec
+
+
+def endpoint_block(method: str, path: str, summary: str) -> str:
+    method_upper = method.upper()
+    function_name = path.strip("/").replace("/", "_").replace("-", "_") or "root"
+    return dedent(
+        f"""
+        ### `{method_upper} {path}`
+
+        **Summary:** {summary}
+
+        **FastAPI**
+        ```python
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        @app.{method}("{path}")
+        async def {function_name}():
+            ...
+        ```
+
+        **Flask**
+        ```python
+        from flask import Flask, jsonify
+
+        app = Flask(__name__)
+
+        @app.route("{path}", methods=["{method_upper}"])
+        def {function_name}():
+            return jsonify()
+        ```
+
+        **curl**
+        ```bash
+        curl -X {method_upper} http://localhost:8000{path}
+        ```
+        """
+    )
+
+
+def build_doc(spec: dict) -> str:
+    health_blocks: list[str] = []
+    metrics_blocks: list[str] = []
+
+    for path, methods in sorted(spec.get("paths", {}).items()):
+        for method, meta in methods.items():
+            summary = meta.get("summary", "").strip() or ""
+            block = endpoint_block(method, path, summary)
+            if path.startswith("/v1/metrics"):
+                metrics_blocks.append(block)
+            else:
+                health_blocks.append(block)
+
+    lines = ["# API Reference\n"]
+    if health_blocks:
+        lines.append("## Health-Check Endpoints\n")
+        lines.extend(health_blocks)
+    if metrics_blocks:
+        lines.append("## Metrics Endpoints\n")
+        lines.extend(metrics_blocks)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    spec = load_spec()
+    OUTPUT_PATH.write_text(build_doc(spec), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script that converts the OpenAPI spec into markdown
- generate API reference including health and metrics endpoints with Python and curl examples

## Testing
- `pytest tests/api/test_metrics_endpoints.py tests/test_secret_health.py`

------
https://chatgpt.com/codex/tasks/task_e_688e8f5839e88320b1d0a08ba0db0b04