### PR TITLE
feat(pool): add shutdown support

### DIFF
--- a/tests/database/test_intelligent_pool.py
+++ b/tests/database/test_intelligent_pool.py
@@ -1,5 +1,35 @@
-from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
-from yosai_intel_dashboard.src.services.database.intelligent_connection_pool import IntelligentConnectionPool
+import importlib.util
+import types
+from pathlib import Path
+import sys
+
+exc_spec = importlib.util.spec_from_file_location(
+    "yosai_intel_dashboard.src.infrastructure.config.database_exceptions",
+    Path(__file__).resolve().parents[2]
+    / "yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py",
+)
+db_exc = importlib.util.module_from_spec(exc_spec)
+exc_spec.loader.exec_module(db_exc)
+sys.modules["yosai_intel_dashboard.src.infrastructure.config.database_exceptions"] = db_exc
+config_pkg = types.ModuleType("yosai_intel_dashboard.src.infrastructure.config")
+config_pkg.__path__ = []
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure", types.ModuleType("yosai_intel_dashboard.src.infrastructure")
+)
+sys.modules["yosai_intel_dashboard.src.infrastructure.config"] = config_pkg
+
+from yosai_intel_dashboard.src.database.intelligent_connection_pool import IntelligentConnectionPool
+
+
+class MockConnection:
+    def __init__(self):
+        self._connected = True
+
+    def health_check(self):
+        return self._connected
+
+    def close(self):
+        self._connected = False
 
 
 def factory():

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,7 +1,28 @@
 import time
 
-from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
-from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
+import importlib.util
+from pathlib import Path
+
+# Import connection_pool without triggering heavy package imports
+spec = importlib.util.spec_from_file_location(
+    "connection_pool",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/connection_pool.py",
+)
+connection_pool = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(connection_pool)
+DatabaseConnectionPool = connection_pool.DatabaseConnectionPool
+
+
+class MockConnection:
+    def __init__(self):
+        self._connected = True
+
+    def health_check(self):
+        return self._connected
+
+    def close(self):
+        self._connected = False
 
 
 def factory():

--- a/tests/test_connection_pool_threadsafe.py
+++ b/tests/test_connection_pool_threadsafe.py
@@ -1,7 +1,26 @@
 import threading
+import importlib.util
+from pathlib import Path
 
-from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
-from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
+spec = importlib.util.spec_from_file_location(
+    "connection_pool",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/connection_pool.py",
+)
+connection_pool = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(connection_pool)
+DatabaseConnectionPool = connection_pool.DatabaseConnectionPool
+
+
+class MockConnection:
+    def __init__(self):
+        self._connected = True
+
+    def health_check(self):
+        return self._connected
+
+    def close(self):
+        self._connected = False
 
 
 def factory():

--- a/tests/test_pool_shutdown.py
+++ b/tests/test_pool_shutdown.py
@@ -1,0 +1,73 @@
+import importlib.util
+import types
+from pathlib import Path
+import sys
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "connection_pool",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/connection_pool.py",
+)
+connection_pool = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(connection_pool)
+DatabaseConnectionPool = connection_pool.DatabaseConnectionPool
+
+# Stub database_exceptions to avoid heavy imports when loading IntelligentConnectionPool
+exc_spec = importlib.util.spec_from_file_location(
+    "yosai_intel_dashboard.src.infrastructure.config.database_exceptions",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py",
+)
+db_exc = importlib.util.module_from_spec(exc_spec)
+exc_spec.loader.exec_module(db_exc)
+sys.modules["yosai_intel_dashboard.src.infrastructure.config.database_exceptions"] = db_exc
+config_pkg = types.ModuleType("yosai_intel_dashboard.src.infrastructure.config")
+config_pkg.__path__ = []
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure", types.ModuleType("yosai_intel_dashboard.src.infrastructure")
+)
+sys.modules["yosai_intel_dashboard.src.infrastructure.config"] = config_pkg
+
+from yosai_intel_dashboard.src.database.intelligent_connection_pool import (
+    IntelligentConnectionPool,
+)
+
+
+class MockConnection:
+    def __init__(self):
+        self._connected = True
+
+    def health_check(self):
+        return self._connected
+
+    def close(self):
+        self._connected = False
+
+
+def factory():
+    return MockConnection()
+
+
+def test_database_pool_close_all():
+    pool = DatabaseConnectionPool(factory, initial_size=1, max_size=2, timeout=1, shrink_timeout=1)
+    active = pool.get_connection()
+    idle = pool.get_connection()
+    pool.release_connection(idle)
+    pool.close_all()
+    assert not active._connected
+    assert not idle._connected
+    with pytest.raises(TimeoutError):
+        pool.get_connection()
+
+
+def test_intelligent_pool_close_all():
+    pool = IntelligentConnectionPool(factory, min_size=1, max_size=2, timeout=1, shrink_timeout=1)
+    active = pool.get_connection()
+    idle = pool.get_connection()
+    pool.release_connection(idle)
+    pool.close_all()
+    assert not active._connected
+    assert not idle._connected
+    with pytest.raises(TimeoutError):
+        pool.get_connection()

--- a/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
+++ b/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Set
 
 from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionValidationFailed
 from database.types import DatabaseConnection
@@ -69,6 +69,7 @@ class IntelligentConnectionPool:
 
         self._pool: List[Tuple[DatabaseConnection, float]] = []
         self._active = 0
+        self._in_use: Set[DatabaseConnection] = set()
         self.circuit_breaker = CircuitBreaker(failure_threshold, recovery_timeout)
         self.metrics: Dict[str, Any] = {
             "acquired": 0,
@@ -132,6 +133,7 @@ class IntelligentConnectionPool:
                     self.metrics["acquired"] += 1
                     self.metrics["acquire_times"].append(time.time() - start)
                     self.circuit_breaker.record_success()
+                    self._in_use.add(conn)
                     self._condition.notify()
                     return conn
 
@@ -148,6 +150,7 @@ class IntelligentConnectionPool:
                     self.metrics["acquired"] += 1
                     self.metrics["acquire_times"].append(time.time() - start)
                     self.circuit_breaker.record_success()
+                    self._in_use.add(conn)
                     self._condition.notify()
                     return conn
 
@@ -162,11 +165,17 @@ class IntelligentConnectionPool:
     def release_connection(self, conn: DatabaseConnection) -> None:
         with self._condition:
             self._shrink_idle_connections()
+            self._in_use.discard(conn)
             if not conn.health_check():
                 conn.close()
                 self._active -= 1
                 self.metrics["failed"] += 1
                 self.circuit_breaker.record_failure()
+                return
+
+            if self._max_size == 0:
+                conn.close()
+                self._condition.notify()
                 return
 
             if len(self._pool) >= self._max_size:
@@ -209,6 +218,20 @@ class IntelligentConnectionPool:
         data["active"] = self._active
         data["max_size"] = self._max_size
         return data
+
+    # ------------------------------------------------------------------
+    def close_all(self) -> None:
+        """Close all connections and prevent further use."""
+        with self._condition:
+            for conn, _ in self._pool:
+                conn.close()
+            self._pool.clear()
+            for conn in list(self._in_use):
+                conn.close()
+            self._in_use.clear()
+            self._active = 0
+            self._max_size = 0
+            self._condition.notify_all()
 
 
 __all__ = ["IntelligentConnectionPool", "CircuitBreaker"]

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -311,6 +311,14 @@ class ThreadSafeDatabaseManager(DatabaseManager):
             if self._pool:
                 self._pool.release_connection(conn)
 
+    def close(self) -> None:  # type: ignore[override]
+        """Close all pooled connections."""
+        with self._lock:
+            if self._pool:
+                self._pool.close_all()
+                self._pool = None
+        super().close()
+
 
 # Factory function
 def create_database_manager(config: DatabaseSettings) -> DatabaseManager:
@@ -403,3 +411,8 @@ class EnhancedPostgreSQLManager(DatabaseManager):
                 self.pool.release_connection(conn)
 
         return self.retry_manager.run_with_retry(run)
+
+    def close(self) -> None:  # type: ignore[override]
+        """Close all pool connections."""
+        self.pool.close_all()
+        super().close()


### PR DESCRIPTION
## Summary
- track active connections and add `close_all` to connection pools
- ensure database managers close pools during shutdown
- cover shutdown behaviour with tests

## Testing
- `pytest tests/test_connection_pool.py tests/test_connection_pool_threadsafe.py tests/test_enhanced_connection_pool.py tests/database/test_intelligent_pool.py tests/test_pool_shutdown.py`

------
https://chatgpt.com/codex/tasks/task_e_688eb4baad508320b3ce1236703b7c96