### PR TITLE
feat: add execute_query connection lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,8 @@ repos:
         entry: python tools/organize_imports.py --check
         language: system
         types: [python]
+      - id: no-direct-execute-query
+        name: no direct execute_query calls
+        entry: python tools/check_execute_query.py
+        language: system
+        types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,18 @@ bandit -r .
 
 Run `isort .` to automatically sort imports before committing changes.
 
+### Database Query Helpers
+
+When executing SQL, always acquire connections using the factory context manager:
+
+```python
+with factory.get_connection() as conn:
+    execute_query(conn, sql)
+```
+
+Direct calls like `execute_query(factory.get_connection(), ...)` are flagged by
+a custom linter that runs via `make lint` and `pytest`.
+
 See [docs/test_architecture.md](docs/test_architecture.md) and
 [docs/testing_with_protocols.md](docs/testing_with_protocols.md) for details on
 the testing protocols, container builder and available test doubles.

--- a/tests/test_execute_query_lint.py
+++ b/tests/test_execute_query_lint.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_execute_query import find_violations
+
+
+def test_detects_direct_call(tmp_path):
+    code = (
+        "from database.secure_exec import execute_query\n"
+        "def bad(factory):\n"
+        "    execute_query(factory.get_connection(), 'SELECT 1')\n"
+    )
+    file = tmp_path / "bad.py"
+    file.write_text(code)
+    issues = find_violations([file])
+    assert file in issues and issues[file]
+
+
+def test_repository_has_no_direct_calls():
+    issues = find_violations([Path.cwd()])
+    assert issues == {}

--- a/tools/check_execute_query.py
+++ b/tools/check_execute_query.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Lint to ensure execute_query isn't called with factory.get_connection()."""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+def _is_factory_get_connection(call: ast.Call) -> bool:
+    return (
+        isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "factory"
+        and call.func.attr == "get_connection"
+    )
+
+
+def _check_file(path: Path) -> List[Tuple[int, int]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    issues: List[Tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "execute_query":
+                if (
+                    node.args
+                    and isinstance(node.args[0], ast.Call)
+                    and _is_factory_get_connection(node.args[0])
+                ):
+                    issues.append((node.lineno, node.col_offset))
+            elif isinstance(func, ast.Attribute) and func.attr == "execute_query":
+                if (
+                    node.args
+                    and isinstance(node.args[0], ast.Call)
+                    and _is_factory_get_connection(node.args[0])
+                ):
+                    issues.append((node.lineno, node.col_offset))
+    return issues
+
+
+def find_violations(paths: Iterable[Path]) -> Dict[Path, List[Tuple[int, int]]]:
+    result: Dict[Path, List[Tuple[int, int]]] = {}
+    for path in paths:
+        if path.is_dir():
+            for file in path.rglob("*.py"):
+                issues = _check_file(file)
+                if issues:
+                    result[file] = issues
+        elif path.is_file() and path.suffix == ".py":
+            issues = _check_file(path)
+            if issues:
+                result[path] = issues
+    return result
+
+
+def main(argv: List[str]) -> int:
+    paths = [Path(p) for p in (argv or ["."])]
+    violations = find_violations(paths)
+    if violations:
+        for file, entries in violations.items():
+            for line, col in entries:
+                print(
+                    f"{file}:{line}:{col}: avoid execute_query without 'with factory.get_connection()'"
+                )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/ops_cli.py
+++ b/tools/ops_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 import subprocess
 import sys
@@ -118,6 +120,7 @@ def format():
 def lint():
     """Run flake8 lint checks."""
     run(["flake8", "."])
+    run([sys.executable, "tools/check_execute_query.py"])
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- add AST-based linter to catch `execute_query(factory.get_connection())`
- run custom check in lint command and pre-commit
- document required `with factory.get_connection()` usage

## Testing
- `pre-commit run --files tools/check_execute_query.py tools/ops_cli.py tests/test_execute_query_lint.py CONTRIBUTING.md .pre-commit-config.yaml`
- `python tools/check_execute_query.py`
- `pytest tests/test_execute_query_lint.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb497dd5c83209f9b59f0841f1cf7