### PR TITLE
docs: add database manager factory migration guide

### DIFF
--- a/deprecation.yml
+++ b/deprecation.yml
@@ -6,3 +6,7 @@
   deprecated_since: 1.5.0
   removal_version: 2.1.0
   migration_path: docs/migration/new-dashboard.md
+- component: database-manager
+  deprecated_since: 2.4.0
+  removal_version: 3.0.0
+  migration_path: docs/migration/database_manager_to_factory.md

--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -8,9 +8,11 @@ This document summarizes features scheduled for removal and links to their migra
 |-----------|-----------------|-----------------|----------------|
 | legacy-auth | 1.2.0 | 2.0.0 | [Legacy Auth Migration](migration/legacy-auth.md) |
 | old-dashboard | 1.5.0 | 2.1.0 | [New Dashboard Migration](migration/new-dashboard.md) |
+| database-manager | 2.4.0 | 3.0.0 | [Database Manager to Factory Migration](migration/database_manager_to_factory.md) |
 
 - [Legacy Auth Migration](migration/legacy-auth.md)
 - [New Dashboard Migration](migration/new-dashboard.md)
+- [Database Manager to Factory Migration](migration/database_manager_to_factory.md)
 
 
 This section will detail user impact and remediation steps.

--- a/docs/migration/database_manager_to_factory.md
+++ b/docs/migration/database_manager_to_factory.md
@@ -1,0 +1,46 @@
+# Database Manager to Factory Migration
+
+The legacy `DatabaseManager` has been replaced by the `DatabaseManagerFactory` to simplify configuration and improve extensibility. This guide outlines how to migrate existing code to the new factory based approach.
+
+## Legacy Usage
+
+```python
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, DatabaseSettings
+
+settings = DatabaseSettings(type="sqlite", name="analytics.db")
+db = DatabaseManager(settings)
+result = db.execute_query("SELECT 1")
+db.close_connection()
+```
+
+## New Usage
+
+```python
+from yosai_intel_dashboard.src.core.plugins.config.factories import DatabaseManagerFactory
+from yosai_intel_dashboard.src.infrastructure.config.schema import DatabaseSettings
+
+settings = DatabaseSettings(type="sqlite", name="analytics.db")
+db = DatabaseManagerFactory.create_manager(settings)
+result = db.execute_query("SELECT 1")
+db.close_connection()
+```
+
+## Interface Mapping
+
+| Legacy Interface | Factory API | Notes |
+|------------------|-------------|-------|
+| `DatabaseManager(settings)` | `DatabaseManagerFactory.create_manager(settings)` | Factory selects appropriate manager implementation based on configuration. |
+| `get_connection()` | `get_connection()` | Method name unchanged. |
+| `test_connection()` | `test_connection()` | Method name unchanged. |
+| `execute_query(query, params=None)` | `execute_query(query, params=None)` | Method name unchanged. |
+| `close_connection()` | `close_connection()` | Method name unchanged. |
+
+## Deprecations
+
+- Direct instantiation of `DatabaseManager`.
+- `ThreadSafeDatabaseManager`.
+- `create_database_manager` helper function.
+
+These components are deprecated as of version **2.4.0** and are scheduled for removal in version **3.0.0**.
+
+See the [Deprecation Timeline](../deprecation_timeline.md) for important dates.


### PR DESCRIPTION
## Summary
- document migration from DatabaseManager to DatabaseManagerFactory
- add deprecation timeline entry for legacy DatabaseManager

## Testing
- `pre-commit run --files docs/migration/database_manager_to_factory.md docs/deprecation_timeline.md deprecation.yml`
- `pytest tests/docs/test_documentation_examples.py -q` *(fails: Cache TTL value must be positive)*

------
https://chatgpt.com/codex/tasks/task_e_688eb49a90888320aadb2680cba3574c