### PR TITLE
feat: unify database result typing

### DIFF
--- a/tests/database/test_types.py
+++ b/tests/database/test_types.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import assert_type
+
+from database.types import DBRow, DBRows
+
+
+# Stub heavy dependencies to avoid circular imports during test collection
+import sys
+import types
+
+dummy_conn = types.ModuleType("database.connection")
+
+
+def _create_dummy_conn():
+    class _Dummy:
+        def execute_query(self, *args, **kwargs):
+            return []
+
+        def execute_command(self, *args, **kwargs):
+            return None
+
+        def health_check(self) -> bool:  # pragma: no cover - simple stub
+            return True
+
+    return _Dummy()
+
+
+dummy_conn.create_database_connection = _create_dummy_conn
+sys.modules.setdefault("database.connection", dummy_conn)
+
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
+    MockConnection,
+    SQLiteConnection,
+)
+from yosai_intel_dashboard.src.infrastructure.config.schema import DatabaseSettings
+
+
+def test_mock_connection_returns_dbrows() -> None:
+    conn = MockConnection()
+    rows = conn.execute_query("SELECT 1")
+    assert isinstance(rows, list)
+    assert rows and isinstance(rows[0], dict)
+    assert_type(rows, DBRows)
+    assert_type(rows[0], DBRow)
+
+
+def test_sqlite_connection_returns_dbrows(tmp_path) -> None:
+    cfg = DatabaseSettings(name=str(tmp_path / "test.db"), type="sqlite")
+    conn = SQLiteConnection(cfg)
+    conn.execute_command("CREATE TABLE test (id INTEGER)")
+    conn.execute_command("INSERT INTO test (id) VALUES (1)")
+    rows = conn.execute_query("SELECT id FROM test")
+    assert rows == [{"id": 1}]
+    assert_type(rows, DBRows)
+    assert_type(rows[0], DBRow)

--- a/yosai_intel_dashboard/src/core/plugins/config/database_manager.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/database_manager.py
@@ -4,7 +4,7 @@ import logging
 import sqlite3
 from typing import Any, Dict, Optional
 
-import pandas as pd
+from database.types import DBRows
 
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_DB_HOST, DEFAULT_DB_PORT
 
@@ -38,10 +38,10 @@ class MockDatabaseManager(IDatabaseManager):
         self._connected = False
         logger.info("Mock database connection closed")
 
-    def execute_query(self, query: str, params: Optional[Dict] = None) -> Any:
+    def execute_query(self, query: str, params: Optional[Dict] = None) -> DBRows:
         """Execute mock query"""
         logger.debug(f"Mock query executed: {query}")
-        return f"Mock result for: {query}"
+        return [{"result": f"Mock result for: {query}"}]
 
 
 class SQLiteDatabaseManager(IDatabaseManager):
@@ -100,7 +100,7 @@ class SQLiteDatabaseManager(IDatabaseManager):
         self.connection = None
         logger.info("SQLite connection closed")
 
-    def execute_query(self, query: str, params: Optional[Dict] = None) -> Any:
+    def execute_query(self, query: str, params: Optional[Dict] = None) -> DBRows:
         """Execute SQLite query"""
         result = self.get_connection()
         if not result.success or not result.connection:
@@ -112,11 +112,9 @@ class SQLiteDatabaseManager(IDatabaseManager):
             cur = conn.cursor()
             cur.execute(query, params or [])
             if cur.description:
-                rows = [dict(row) for row in cur.fetchall()]
-                df = pd.DataFrame(rows)
-                return df
+                return [dict(row) for row in cur.fetchall()]
             conn.commit()
-            return cur.rowcount
+            return []
         except Exception as e:
             logger.error(f"SQLite query failed: {e}")
             raise

--- a/yosai_intel_dashboard/src/core/plugins/config/interfaces.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/interfaces.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from database.types import DBRows
+
 
 @dataclass
 class ConnectionResult:
@@ -34,7 +36,7 @@ class IDatabaseManager(ABC):
         pass
 
     @abstractmethod
-    def execute_query(self, query: str, params: Optional[Dict] = None) -> Any:
+    def execute_query(self, query: str, params: Optional[Dict] = None) -> DBRows:
         """Execute database query"""
         pass
 

--- a/yosai_intel_dashboard/src/database/baseline_metrics.py
+++ b/yosai_intel_dashboard/src/database/baseline_metrics.py
@@ -9,10 +9,11 @@ historical performance metrics.
 """
 
 import logging
-from typing import Dict, List
+from typing import Dict
 
 from database.connection import create_database_connection
 from database.secure_exec import execute_command
+from database.types import DBRows
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class BaselineMetricsDB:
     # ------------------------------------------------------------------
     def get_baseline(self, entity_type: str, entity_id: str) -> Dict[str, float]:
         try:
-            rows: List[Dict] = execute_query(
+            rows: DBRows = execute_query(
                 self.conn,
                 f"SELECT metric, value FROM {self.table_name} WHERE entity_type=? AND entity_id=?",
                 (entity_type, entity_id),

--- a/yosai_intel_dashboard/src/database/index_optimizer.py
+++ b/yosai_intel_dashboard/src/database/index_optimizer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 """Helpers for analyzing and creating database indexes."""
 
 import logging
-from typing import Any, Dict, List, Sequence
+from typing import Any, List, Sequence
+
+from database.types import DBRows
 
 from .connection import create_database_connection
 from .secure_exec import execute_query
@@ -18,7 +20,7 @@ class IndexOptimizer:
         self.connection = connection or create_database_connection()
 
     # ------------------------------------------------------------------
-    def analyze_index_usage(self) -> List[Dict[str, Any]]:
+    def analyze_index_usage(self) -> DBRows:
         """Return index usage statistics for supported databases."""
         try:
             conn = self.connection
@@ -45,10 +47,10 @@ class IndexOptimizer:
             index_name = f"idx_{table}_{'_'.join(columns)}"
             existing: List[str] = []
             if conn_name == "SQLiteConnection":
-                rows = execute_query(conn, "PRAGMA index_list(?)", (table,))
+                rows: DBRows = execute_query(conn, "PRAGMA index_list(?)", (table,))
                 existing = [row.get("name") for row in rows]
             elif conn_name == "PostgreSQLConnection":
-                rows = execute_query(
+                rows: DBRows = execute_query(
                     conn,
                     "SELECT indexname FROM pg_indexes WHERE tablename=%s",
                     (table,),

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterable, Optional
 
+from database.types import DBRows
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +20,9 @@ def _validate_params(params: Optional[Iterable[Any]]) -> Optional[tuple]:
     raise TypeError("params must be a tuple/list or None")
 
 
-def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
+def execute_query(
+    conn: Any, sql: str, params: Optional[Iterable[Any]] = None
+) -> DBRows:
     """Validate and execute a SELECT query on the given connection."""
     if not isinstance(sql, str):
         raise TypeError("sql must be a string")
@@ -33,7 +37,7 @@ def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
     raise AttributeError("Object has no execute or execute_query method")
 
 
-def execute_secure_query(conn: Any, sql: str, params: Iterable[Any]) -> Any:
+def execute_secure_query(conn: Any, sql: str, params: Iterable[Any]) -> DBRows:
     """Execute a parameterized SELECT query enforcing provided params."""
     if params is None:
         raise ValueError("params must be provided for execute_secure_query")

--- a/yosai_intel_dashboard/src/database/types.py
+++ b/yosai_intel_dashboard/src/database/types.py
@@ -6,13 +6,20 @@ The :class:`DatabaseConnection` protocol describes the minimal interface
 expected by the connection pools and helpers in this package.
 """
 
-from typing import Any, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol
+
+
+# ---------------------------------------------------------------------------
+# Result type aliases
+# ---------------------------------------------------------------------------
+DBRow = Dict[str, Any]
+DBRows = List[DBRow]
 
 
 class DatabaseConnection(Protocol):
     """Protocol for database connections"""
 
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> Any:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> DBRows:
         """Execute a query and return results"""
         ...
 
@@ -25,4 +32,4 @@ class DatabaseConnection(Protocol):
         ...
 
 
-__all__ = ["DatabaseConnection"]
+__all__ = ["DBRow", "DBRows", "DatabaseConnection"]

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
 from database.query_optimizer import DatabaseQueryOptimizer
 from database.secure_exec import execute_command, execute_query
-from database.types import DatabaseConnection
+from database.types import DBRows, DatabaseConnection
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints
     from .connection_pool import DatabaseConnectionPool
@@ -36,7 +36,7 @@ class MockConnection:
         self._connected = True
         logger.info("Mock database connection created")
 
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> list:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> DBRows:
         """Execute mock query"""
         logger.debug(f"Mock query: {query}")
         return [{"id": 1, "result": "mock_data"}]
@@ -80,7 +80,7 @@ class SQLiteConnection:
             logger.error(f"Failed to connect to SQLite: {e}")
             raise DatabaseError(f"SQLite connection failed: {e}") from e
 
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> list:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> DBRows:
         """Execute SQLite query"""
         if not self._connection:
             raise DatabaseError("No database connection")
@@ -173,7 +173,7 @@ class PostgreSQLConnection:
             logger.error(f"Failed to connect to PostgreSQL: {e}")
             raise DatabaseError(f"PostgreSQL connection failed: {e}") from e
 
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> list:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> DBRows:
         """Execute PostgreSQL query"""
         if not self._connection:
             raise DatabaseError("No database connection")
@@ -361,7 +361,7 @@ class EnhancedPostgreSQLManager(DatabaseManager):
             self.config.shrink_timeout,
         )
 
-    def execute_query_with_retry(self, query: str, params: Optional[Dict] = None):
+    def execute_query_with_retry(self, query: str, params: Optional[Dict] = None) -> DBRows:
         encoded_query = UnicodeSQLProcessor.encode_query(query)
         optimized_query = self.optimizer.optimize_query(encoded_query)
 


### PR DESCRIPTION
## Summary
- define `DBRow` and `DBRows` aliases and update `DatabaseConnection` protocol
- standardize connection implementations and helpers to return typed rows
- add tests ensuring connections return `DBRows`

## Testing
- `pytest tests/database/test_types.py -q`
- `pytest -q` *(fails: Cache TTL values must be positive)*

------
https://chatgpt.com/codex/tasks/task_e_688eb49bd07c83209d70e90428ecbc92