### PR TITLE
feat: add DatabaseConfig serialization

### DIFF
--- a/tests/test_database_config_serialization.py
+++ b/tests/test_database_config_serialization.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from cryptography.fernet import Fernet
+
+
+def _load_database_config():
+    """Load DatabaseConfig without importing the heavy config package."""
+
+    # Ensure real cryptography module is used
+    sys.modules.pop("cryptography", None)
+    sys.modules.pop("cryptography.fernet", None)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    config_dir = (
+        repo_root / "yosai_intel_dashboard" / "src" / "infrastructure" / "config"
+    )
+
+    package_name = "_temp_config"
+    pkg = ModuleType(package_name)
+    pkg.__path__ = [str(config_dir)]
+    sys.modules[package_name] = pkg
+
+    import optional_dependencies
+
+    optional_dependencies._fallbacks.pop("cryptography.fernet", None)
+    optional_dependencies._fallbacks.pop("cryptography", None)
+
+    # Stub minimal dependencies to avoid heavy imports
+    core_exc = ModuleType("yosai_intel_dashboard.src.core.exceptions")
+
+    class ConfigurationError(Exception):
+        pass
+
+    core_exc.ConfigurationError = ConfigurationError
+    sys.modules["yosai_intel_dashboard.src.core.exceptions"] = core_exc
+
+    dynamic = ModuleType(f"{package_name}.dynamic_config")
+
+    class _DummyDynamicConfig:
+        @staticmethod
+        def get_db_connection_timeout() -> int:
+            return 1
+
+        @staticmethod
+        def get_db_pool_size() -> int:
+            return 1
+
+    dynamic.dynamic_config = _DummyDynamicConfig()
+    sys.modules[f"{package_name}.dynamic_config"] = dynamic
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.base",
+        config_dir / "base.py",
+        submodule_search_locations=[str(config_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None  # for type checkers
+    spec.loader.exec_module(module)
+    return module.DatabaseConfig
+
+
+DatabaseConfig = _load_database_config()
+
+
+def test_database_config_round_trip():
+    cfg = DatabaseConfig(
+        type="postgresql",
+        host="db",
+        port=5432,
+        name="test",
+        user="u",
+        password="pw",
+    )
+    cfg_dict = cfg.to_dict()
+    new_cfg = DatabaseConfig.from_dict(cfg_dict)
+    assert new_cfg == cfg
+
+
+def test_database_config_exclude_password():
+    cfg = DatabaseConfig(password="secret")
+    cfg_dict = cfg.to_dict(include_password=False)
+    assert "password" not in cfg_dict
+    new_cfg = DatabaseConfig.from_dict(cfg_dict)
+    assert new_cfg.password == ""
+
+
+def test_database_config_encrypt_round_trip():
+    key = Fernet.generate_key().decode()
+    cfg = DatabaseConfig(password="topsecret")
+    cfg_dict = cfg.to_dict(fernet_key=key)
+    new_cfg = DatabaseConfig.from_dict(cfg_dict, fernet_key=key)
+    assert new_cfg == cfg

--- a/yosai_intel_dashboard/src/infrastructure/config/base.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import os
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
+from optional_dependencies import import_optional
 from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .app_config import UploadConfig
@@ -18,6 +19,9 @@ from .constants import (
     DEFAULT_DB_PORT,
 )
 from .dynamic_config import dynamic_config
+
+fernet_mod = import_optional("cryptography.fernet")
+Fernet = getattr(fernet_mod, "Fernet", None)
 
 
 def require_env_var(name: str) -> str:
@@ -94,6 +98,80 @@ class DatabaseConfig:
         if self.type == "sqlite":
             return f"sqlite:///{self.name}"
         return f"mock://{self.name}"
+
+    # ------------------------------------------------------------------
+    def to_dict(
+        self,
+        *,
+        include_password: bool = True,
+        fernet_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Serialize configuration to a dictionary.
+
+        Parameters
+        ----------
+        include_password:
+            If ``False``, the password field is omitted from the result.
+        fernet_key:
+            When provided, the password will be encrypted using this key.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary representation of the configuration.
+        """
+
+        data = asdict(self)
+
+        if not include_password:
+            data.pop("password", None)
+            return data
+
+        if fernet_key and data.get("password"):
+            if not Fernet:
+                raise ConfigurationError(
+                    "cryptography package is required for encryption"
+                )
+            key_bytes = (
+                fernet_key.encode() if isinstance(fernet_key, str) else fernet_key
+            )
+            f = Fernet(key_bytes)
+            data["password"] = f.encrypt(data["password"].encode()).decode()
+
+        return data
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        *,
+        fernet_key: Optional[str] = None,
+    ) -> "DatabaseConfig":
+        """Create :class:`DatabaseConfig` from a dictionary.
+
+        Parameters
+        ----------
+        data:
+            Serialized configuration produced by :meth:`to_dict`.
+        fernet_key:
+            If provided, the password field will be decrypted using this key.
+        """
+
+        params = dict(data)
+
+        if fernet_key and params.get("password"):
+            if not Fernet:
+                raise ConfigurationError(
+                    "cryptography package is required for decryption"
+                )
+            key_bytes = (
+                fernet_key.encode() if isinstance(fernet_key, str) else fernet_key
+            )
+            f = Fernet(key_bytes)
+            params["password"] = f.decrypt(params["password"].encode()).decode()
+
+        return cls(**params)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add `to_dict` and `from_dict` helpers for `DatabaseConfig`
- allow optional password encryption or omission when serializing
- cover DatabaseConfig serialization round-trips with tests

## Testing
- `SKIP=bandit,mypy pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/base.py tests/test_database_config_serialization.py`
- `pytest tests/test_database_config_serialization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688eb49d9038832080541a6fd38ef01b