### PR TITLE
docs: add websocket endpoint reference

### DIFF
--- a/docs/websocket_endpoints.md
+++ b/docs/websocket_endpoints.md
@@ -1,0 +1,47 @@
+# WebSocket Endpoints
+
+## Analytics Broadcast Server
+
+- **Path:** `ws://<host>:6789/`
+- **Message schema:**
+  ```json
+  {
+    "type": "object",
+    "description": "Analytics update data",
+    "additionalProperties": true
+  }
+  ```
+  Example message:
+  ```json
+  {
+    "status": "ok",
+    "data_summary": {"total_records": 120}
+  }
+  ```
+- **Connection requirements:** No authentication. Clients connect and receive
+  JSON messages for each `analytics_update` event published on the internal
+  event bus.
+
+## `/ws/analytics`
+
+- **Path:** `/ws/analytics`
+- **Message schema:**
+  ```json
+  {
+    "type": "object",
+    "description": "Analytics update data",
+    "additionalProperties": true
+  }
+  ```
+  Example message:
+  ```json
+  {
+    "status": "ok",
+    "data_summary": {"total_records": 120}
+  }
+  ```
+- **Connection requirements:** Clients must include the header
+  `X-Permissions: analytics.read` during the WebSocket handshake. Each
+  `analytics_update` event from the internal event bus is forwarded to the
+  connected client as a JSON message.
+


### PR DESCRIPTION
## Summary
- document analytics broadcast server and FastAPI websocket endpoint

## Testing
- `pre-commit run --files docs/websocket_endpoints.md`
- `pytest tests/analytics/test_async_api.py -k test_websocket_updates -q` *(fails: SyntaxError)*
- `pytest tests/websocket/test_metrics_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e8f561fb48320994e0a10e50b679f