### PR TITLE
feat: allow mock database via env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,9 @@ Use the provided environment template for tests:
 ```bash
 cp .env.test .env
 ```
+Set `USE_MOCK_DB=1` to force the configuration factory to use a lightweight
+mock database instead of a real database connection. This is helpful when
+running tests or developing locally without a database server.
 For minimal CI environments you can run `./scripts/install_test_deps.sh` which
 only installs the Python dependencies required for the tests.
 ### Test Requirements

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,6 +95,10 @@ Factory class for creating database connections.
 - `create_connection(config) -> DatabaseConnection`: Create database connection
 - `test_connection(config) -> bool`: Test database connectivity
 
+For local testing or development, set the `USE_MOCK_DB` environment variable to
+force the factory to return a `MockDatabaseManager` instead of a real database
+connection.
+
 ## Analytics Service
 
 ### `AnalyticsService`

--- a/tests/test_database_factory.py
+++ b/tests/test_database_factory.py
@@ -1,0 +1,63 @@
+import pytest
+from types import SimpleNamespace, ModuleType
+import sys
+
+
+def test_mock_db_enabled(monkeypatch):
+    """Factory uses MockDatabaseManager when USE_MOCK_DB is set."""
+    monkeypatch.setenv("USE_MOCK_DB", "1")
+    monkeypatch.setenv("CACHE_TTL_SECONDS", "1")
+    monkeypatch.setenv("JWKS_CACHE_TTL", "1")
+    dummy_perf = ModuleType("performance")
+    dummy_perf.cache_monitor = None
+    dummy_perf.MetricType = type("MetricType", (), {})
+    dummy_perf.PerformanceThresholds = type(
+        "PerformanceThresholds", (), {"SLOW_QUERY_SECONDS": 1}
+    )
+    dummy_perf.get_performance_monitor = lambda: type(
+        "Monitor", (), {"record_metric": lambda *a, **k: None}
+    )()
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.core.performance", dummy_perf
+    )
+
+    from yosai_intel_dashboard.src.core.plugins.config.factories import (
+        DatabaseManagerFactory,
+    )
+    from yosai_intel_dashboard.src.core.plugins.config.database_manager import (
+        MockDatabaseManager,
+    )
+
+    config = SimpleNamespace(type="postgresql")
+    manager = DatabaseManagerFactory.create_manager(config)
+    assert isinstance(manager, MockDatabaseManager)
+
+
+def test_mock_db_disabled(monkeypatch):
+    """Factory falls back to SQLite when USE_MOCK_DB is not set."""
+    monkeypatch.delenv("USE_MOCK_DB", raising=False)
+    monkeypatch.setenv("CACHE_TTL_SECONDS", "1")
+    monkeypatch.setenv("JWKS_CACHE_TTL", "1")
+    dummy_perf = ModuleType("performance")
+    dummy_perf.cache_monitor = None
+    dummy_perf.MetricType = type("MetricType", (), {})
+    dummy_perf.PerformanceThresholds = type(
+        "PerformanceThresholds", (), {"SLOW_QUERY_SECONDS": 1}
+    )
+    dummy_perf.get_performance_monitor = lambda: type(
+        "Monitor", (), {"record_metric": lambda *a, **k: None}
+    )()
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.core.performance", dummy_perf
+    )
+
+    from yosai_intel_dashboard.src.core.plugins.config.factories import (
+        DatabaseManagerFactory,
+    )
+    from yosai_intel_dashboard.src.core.plugins.config.database_manager import (
+        SQLiteDatabaseManager,
+    )
+
+    config = SimpleNamespace(type="sqlite")
+    manager = DatabaseManagerFactory.create_manager(config)
+    assert isinstance(manager, SQLiteDatabaseManager)

--- a/yosai_intel_dashboard/src/core/plugins/config/factories.py
+++ b/yosai_intel_dashboard/src/core/plugins/config/factories.py
@@ -3,14 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Callable, Dict, List, Type
-
-from yosai_intel_dashboard.src.core.hierarchical_cache_manager import (
-    HierarchicalCacheManager,
-)
-from yosai_intel_dashboard.src.core.intelligent_multilevel_cache import (
-    IntelligentMultiLevelCache,
-)
 
 from .interfaces import ICacheManager, IDatabaseManager
 
@@ -36,6 +30,7 @@ class DatabaseManagerFactory:
         # Import here to avoid circular imports
         from .database_manager import (
             AsyncPostgreSQLManager,
+            MockDatabaseManager,
             SQLiteDatabaseManager,
         )
 
@@ -45,8 +40,13 @@ class DatabaseManagerFactory:
                 {
                     "postgresql": AsyncPostgreSQLManager,
                     "sqlite": SQLiteDatabaseManager,
+                    "mock": MockDatabaseManager,
                 }
             )
+
+        if os.getenv("USE_MOCK_DB"):
+            logger.info("USE_MOCK_DB set - using MockDatabaseManager")
+            return MockDatabaseManager(database_config)
 
         db_type = getattr(database_config, "type", "sqlite")
 
@@ -84,6 +84,12 @@ class CacheManagerFactory:
             AdvancedRedisCacheManager,
             MemoryCacheManager,
             RedisCacheManager,
+        )
+        from yosai_intel_dashboard.src.core.hierarchical_cache_manager import (
+            HierarchicalCacheManager,
+        )
+        from yosai_intel_dashboard.src.core.intelligent_multilevel_cache import (
+            IntelligentMultiLevelCache,
         )
 
         # Register default managers if not already registered


### PR DESCRIPTION
## Summary
- allow DatabaseManagerFactory to swap in a MockDatabaseManager when USE_MOCK_DB is set
- document USE_MOCK_DB for development and testing
- add tests for mock database fallback logic

## Testing
- `pytest tests/test_database_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb48e5ed8832085b198b612b6f2ab