### PR TITLE
feat: add retry strategy support for db connection factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ The `/v1/plugins/performance` endpoint exposes metrics for dashboards.
 - Supports PostgreSQL, SQLite, and Mock databases
 - Type-safe connection management
 - Retry logic via `connection_retry.py` with exponential backoff
+- Customizable retry strategies via `DatabaseConnectionFactory`
  - Safe Unicode handling using `UnicodeSQLProcessor` for queries and
    `UnicodeProcessor` for parameters
 - Connection pooling through `connection_pool.py`
@@ -1037,6 +1038,22 @@ from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
 )
 manager = EnhancedPostgreSQLManager(DatabaseConfig(type="postgresql"))
 manager.execute_query_with_retry("SELECT 1")
+```
+
+Custom retry strategies can be supplied to the connection factory:
+
+```python
+from config.database_connection_factory import DatabaseConnectionFactory
+from config.database_manager import DatabaseSettings
+
+class NoDelayStrategy:
+    def run_with_retry(self, func):
+        return func()
+
+factory = DatabaseConnectionFactory(
+    DatabaseSettings(type="mock"), retry_strategy=NoDelayStrategy()
+)
+conn = factory.create()
 ```
 
 ### Models Layer (`models/`)

--- a/tests/test_database_connection_factory.py
+++ b/tests/test_database_connection_factory.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+import types
+
+
+def test_custom_retry_strategy_used():
+    module_name = "yosai_intel_dashboard.src.infrastructure.config.database_manager"
+    stub_module = types.ModuleType(module_name)
+
+    class MockConnection:
+        def health_check(self) -> bool:  # pragma: no cover - simple stub
+            return True
+
+        def close(self) -> None:  # pragma: no cover - simple stub
+            pass
+
+    class StubManager:
+        def __init__(self, config) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def get_connection(self):  # pragma: no cover - simple stub
+            return MockConnection()
+
+    stub_module.DatabaseManager = StubManager
+    stub_module.MockConnection = MockConnection
+    sys.modules[module_name] = stub_module
+
+    db_conn_module_name = "yosai_intel_dashboard.src.database.connection"
+    db_conn_module = types.ModuleType(db_conn_module_name)
+    sys.modules[db_conn_module_name] = db_conn_module
+    sys.modules["database.connection"] = db_conn_module
+
+    query_opt_name = "yosai_intel_dashboard.src.services.query_optimizer"
+    sys.modules[query_opt_name] = types.ModuleType(query_opt_name)
+
+    from yosai_intel_dashboard.src.infrastructure.config import (
+        database_connection_factory as dcf,
+    )
+
+    class StubStrategy:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_with_retry(self, func):  # type: ignore[override]
+            self.calls += 1
+            return func()
+
+    cfg = object()
+    strategy = StubStrategy()
+    factory = dcf.DatabaseConnectionFactory(cfg, retry_strategy=strategy)
+    conn = factory.create()
+    assert isinstance(conn, MockConnection)
+    assert strategy.calls == 1

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -9,6 +9,7 @@ from .config_manager import ConfigManager, get_config, reload_config
 from .config_transformer import ConfigTransformer
 from .config_validator import ConfigValidator, ValidationResult
 from .constants import CSSConstants, PerformanceConstants, SecurityConstants
+from .database_connection_factory import DatabaseConnectionFactory, RetryStrategy
 from .dynamic_config import DynamicConfigManager, dynamic_config
 from .environment_processor import EnvironmentProcessor
 from .hierarchical_loader import HierarchicalLoader
@@ -22,8 +23,8 @@ from .schema import (
     AppSettings,
     ConfigSchema,
     DatabaseSettings,
-    SecuritySettings,
     RetrainingSettings,
+    SecuritySettings,
 )
 from .secure_config_manager import SecureConfigManager
 from .secure_db import execute_secure_query
@@ -133,6 +134,8 @@ __all__ = [
     "RetrainingConfig",
     "execute_secure_query",
     "UnicodeHandler",
+    "DatabaseConnectionFactory",
+    "RetryStrategy",
 ]
 
 

--- a/yosai_intel_dashboard/src/infrastructure/config/database_connection_factory.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_connection_factory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Factory for creating database connections with pluggable retry support."""
+
+from typing import TYPE_CHECKING, Callable, Protocol, TypeVar
+
+from database.types import DatabaseConnection
+
+from .connection_retry import ConnectionRetryManager
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .schema import DatabaseSettings  # noqa: F401
+
+T = TypeVar("T")
+
+
+class RetryStrategy(Protocol):
+    """Protocol for retry strategies used by the factory."""
+
+    def run_with_retry(self, func: Callable[[], T]) -> T: ...
+
+
+class DatabaseConnectionFactory:
+    """Create database connections using an optional :class:`RetryStrategy`."""
+
+    def __init__(
+        self,
+        config: "DatabaseSettings",
+        *,
+        retry_strategy: RetryStrategy | None = None,
+    ) -> None:
+        from .database_manager import DatabaseManager
+
+        self._config = config
+        self._retry_strategy = retry_strategy or ConnectionRetryManager()
+        self._manager = DatabaseManager(config)
+
+    def create(self) -> DatabaseConnection:
+        """Create a connection using the configured retry strategy."""
+
+        def _connect() -> DatabaseConnection:
+            return self._manager.get_connection()
+
+        return self._retry_strategy.run_with_retry(_connect)


### PR DESCRIPTION
## Summary
- allow DatabaseConnectionFactory to accept pluggable RetryStrategy
- document how to plug in custom retry strategies
- add test showing stub strategy injection

## Testing
- `SKIP=bandit,mypy pre-commit run --files README.md yosai_intel_dashboard/src/infrastructure/config/database_connection_factory.py yosai_intel_dashboard/src/infrastructure/config/__init__.py tests/test_database_connection_factory.py`
- `pytest tests/test_database_connection_factory.py -q`
- `pytest tests/test_database_connection_factory.py tests/test_connection_pool.py tests/test_database_config.py tests/test_connection_pool_threadsafe.py tests/test_enhanced_database_manager.py tests/database/test_performance_analyzer.py tests/database/test_database_manager_retry.py -q` *(fails: Cache TTL values must be ...)*

------
https://chatgpt.com/codex/tasks/task_e_688eb4b72eec8320a04d223908e42e10