### PR TITLE
feat: add pool exhausted error

### DIFF
--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -3,6 +3,7 @@ import pytest
 from config import DatabaseSettings
 from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import PoolExhaustedError
 from tests.config import FakeConfiguration
 from tests.import_helpers import safe_import, import_optional
 
@@ -26,7 +27,7 @@ def test_database_config_default_pool_sizes():
     )
 
     conns = [pool.get_connection() for _ in range(cfg.max_pool_size)]
-    with pytest.raises(TimeoutError):
+    with pytest.raises(PoolExhaustedError):
         pool.get_connection()
     for c in conns:
         pool.release_connection(c)

--- a/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
+++ b/yosai_intel_dashboard/src/database/intelligent_connection_pool.py
@@ -6,7 +6,10 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Tuple
 
-from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import ConnectionValidationFailed
+from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import (
+    ConnectionValidationFailed,
+    PoolExhaustedError,
+)
 from database.types import DatabaseConnection
 
 
@@ -155,7 +158,7 @@ class IntelligentConnectionPool:
                 if remaining <= 0:
                     self.metrics["timeouts"] += 1
                     self.circuit_breaker.record_failure()
-                    raise TimeoutError("No available connection in pool")
+                    raise PoolExhaustedError("No available connection in pool")
                 self._condition.wait(timeout=remaining)
 
     # ------------------------------------------------------------------

--- a/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
@@ -5,6 +5,7 @@ import time
 from typing import Callable, List, Tuple
 
 from database.types import DatabaseConnection
+from .database_exceptions import PoolExhaustedError
 
 
 class DatabaseConnectionPool:
@@ -82,7 +83,7 @@ class DatabaseConnectionPool:
                     return conn
 
             if time.time() >= deadline:
-                raise TimeoutError("No available connection in pool")
+                raise PoolExhaustedError("No available connection in pool")
 
             time.sleep(0.05)
 

--- a/yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_exceptions.py
@@ -15,6 +15,10 @@ class ConnectionValidationFailed(DatabaseError):
     """Raised when a connection health check fails."""
 
 
+class PoolExhaustedError(DatabaseError):
+    """Raised when a connection cannot be acquired within the timeout."""
+
+
 class UnicodeEncodingError(DatabaseError):
     """Raised when invalid Unicode is detected during SQL encoding."""
 
@@ -27,5 +31,6 @@ __all__ = [
     "DatabaseError",
     "ConnectionRetryExhausted",
     "ConnectionValidationFailed",
+    "PoolExhaustedError",
     "UnicodeEncodingError",
 ]


### PR DESCRIPTION
## Summary
- add PoolExhaustedError for connection pool timeouts
- raise PoolExhaustedError when connections can't be acquired
- update tests to expect PoolExhaustedError

## Testing
- `pytest tests/test_database_config.py -q` *(fails: Cache TTL values must be positive)*

------
https://chatgpt.com/codex/tasks/task_e_688eb4b3a2008320a5d320247d3b4d10