### PR TITLE
Add DB health status model and endpoint

### DIFF
--- a/factories/__init__.py
+++ b/factories/__init__.py
@@ -1,0 +1,24 @@
+"""Factory helpers for the dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+
+from .db_health import DBHealthStatus
+
+
+def health_check() -> DBHealthStatus:
+    """Return database health status synchronously.
+
+    Wraps the asynchronous ``services.common.async_db.health_check``
+    so that call sites (like Flask endpoints) can retrieve the
+    status without needing an event loop.
+    """
+
+    from yosai_intel_dashboard.src.services.common import async_db as _async_db
+
+    return asyncio.run(_async_db.health_check())
+
+
+__all__ = ["DBHealthStatus", "health_check"]
+

--- a/factories/db_health.py
+++ b/factories/db_health.py
@@ -1,0 +1,16 @@
+"""Pydantic models used by factory helpers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class DBHealthStatus(BaseModel):
+    """Schema representing database health information."""
+
+    healthy: bool
+    details: dict
+
+
+__all__ = ["DBHealthStatus"]
+

--- a/tests/test_db_health_endpoint.py
+++ b/tests/test_db_health_endpoint.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+from flask import Flask
+
+import factories
+import sys
+import types
+
+secret_stub = types.SimpleNamespace(validate_secrets=lambda: {})
+sys.modules["yosai_intel_dashboard.src.core.secret_manager"] = secret_stub
+
+spec = importlib.util.spec_from_file_location(
+    "health_module",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "core"
+    / "app_factory"
+    / "health.py",
+)
+health_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(health_module)  # type: ignore
+register_health_endpoints = health_module.register_health_endpoints
+
+
+def test_db_health_endpoint(monkeypatch):
+    app = Flask(__name__)
+    dummy_status = factories.DBHealthStatus(healthy=True, details={"info": "ok"})
+    monkeypatch.setattr(factories, "health_check", lambda: dummy_status)
+    monkeypatch.setattr(health_module, "db_health_check", lambda: dummy_status)
+
+    register_health_endpoints(app)
+    client = app.test_client()
+    resp = client.get("/health/db")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"healthy": True, "details": {"info": "ok"}}
+

--- a/yosai_intel_dashboard/src/core/app_factory/health.py
+++ b/yosai_intel_dashboard/src/core/app_factory/health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from yosai_intel_dashboard.src.core.secret_manager import validate_secrets
+from factories import health_check as db_health_check
 
 
 def register_health_endpoints(server: Any, progress_events: Any | None = None) -> None:
@@ -12,6 +13,12 @@ def register_health_endpoints(server: Any, progress_events: Any | None = None) -
     def health():
         """Basic health check."""
         return {"status": "ok"}, 200
+
+    @server.route("/health/db", methods=["GET"])
+    def health_db():
+        """Database connectivity check."""
+        status = db_health_check()
+        return status.model_dump(), 200
 
     @server.route("/health/secrets", methods=["GET"])
     def health_secrets():


### PR DESCRIPTION
## Summary
- add reusable `DBHealthStatus` schema
- expose database health via `/health/db` endpoint
- return `DBHealthStatus` from async DB health check and wrap with sync factory

## Testing
- `pytest tests/test_async_db.py::test_health_check tests/test_async_db.py::test_health_check_failure tests/test_db_health_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb4b27ac083209e0e62687f2051f1