### PR TITLE
feat: add logging to connection factory and pool

### DIFF
--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -58,6 +58,14 @@ Prometheus scrapes metrics from `/metrics` using the sample
 memory and request charts. Logs can be forwarded to Elasticsearch through
 `logging/logstash.conf` and visualized with Kibana.
 
+## Database Connection Logging
+
+The database connection factory logs warnings whenever connection attempts are
+retried and records errors if all retries are exhausted. The connection pool
+also emits warnings when it expands or drops unhealthy connections, including
+current pool sizes. Operators should monitor these log messages to diagnose
+connectivity issues early.
+
 ## Canary Deployments
 
 Production releases use a short canary phase before rolling out fully. The CI/CD pipeline first applies manifests from `k8s/canary` which deploy a single replica alongside the existing deployment. Kubernetes waits for the canary pod to become ready.

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -29,6 +29,7 @@ from .secure_config_manager import SecureConfigManager
 from .secure_db import execute_secure_query
 from .unicode_handler import UnicodeHandler
 from .unified_loader import UnifiedLoader
+from .database_connection_factory import DatabaseConnectionFactory
 
 
 def create_config_manager(
@@ -133,6 +134,7 @@ __all__ = [
     "RetrainingConfig",
     "execute_secure_query",
     "UnicodeHandler",
+    "DatabaseConnectionFactory",
 ]
 
 

--- a/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from typing import Callable, List, Tuple
 
 from database.types import DatabaseConnection
+
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseConnectionPool:
@@ -42,7 +46,13 @@ class DatabaseConnectionPool:
                 return
             usage = (self._active - len(self._pool)) / self._max_size
             if usage >= self._threshold and self._max_size < self._max_pool_size:
-                self._max_size = min(self._max_size * 2, self._max_pool_size)
+                new_size = min(self._max_size * 2, self._max_pool_size)
+                logger.warning(
+                    "Expanding connection pool to %d due to usage %.2f",
+                    new_size,
+                    usage,
+                )
+                self._max_size = new_size
 
     def _shrink_idle_connections(self) -> None:
         with self._lock:
@@ -53,6 +63,9 @@ class DatabaseConnectionPool:
                     now - ts > self._shrink_timeout
                     and self._max_size > self._initial_size
                 ):
+                    logger.warning(
+                        "Closing idle connection after %.2fs", now - ts
+                    )
                     conn.close()
                     self._active -= 1
                     self._max_size -= 1
@@ -71,6 +84,7 @@ class DatabaseConnectionPool:
                 if self._pool:
                     conn, _ = self._pool.pop()
                     if not conn.health_check():
+                        logger.warning("Discarding unhealthy connection")
                         conn.close()
                         self._active -= 1
                         continue
@@ -82,6 +96,11 @@ class DatabaseConnectionPool:
                     return conn
 
             if time.time() >= deadline:
+                logger.error(
+                    "Timed out waiting for database connection (active=%d, pool=%d)",
+                    self._active,
+                    len(self._pool),
+                )
                 raise TimeoutError("No available connection in pool")
 
             time.sleep(0.05)
@@ -90,11 +109,15 @@ class DatabaseConnectionPool:
         with self._lock:
             self._shrink_idle_connections()
             if not conn.health_check():
+                logger.warning("Dropping unhealthy connection on release")
                 conn.close()
                 self._active -= 1
                 return
 
             if len(self._pool) >= self._max_size:
+                logger.warning(
+                    "Connection pool full; closing returned connection"
+                )
                 conn.close()
                 self._active -= 1
             else:
@@ -108,6 +131,9 @@ class DatabaseConnectionPool:
                 conn, ts = self._pool.pop()
                 if not conn.health_check():
                     healthy = False
+                    logger.warning(
+                        "Removing unhealthy idle connection during health check"
+                    )
                     conn.close()
                     self._active -= 1
                     if self._max_size > self._initial_size:

--- a/yosai_intel_dashboard/src/infrastructure/config/database_connection_factory.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_connection_factory.py
@@ -1,0 +1,94 @@
+"""Factory for creating database connections with retry and pooling support."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .connection_pool import DatabaseConnectionPool
+from .connection_retry import ConnectionRetryManager, RetryConfig
+from .database_exceptions import ConnectionRetryExhausted, DatabaseError
+from .database_manager import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class _RetryLogger:
+    """Callback handler that logs retry events."""
+
+    def __init__(self, max_attempts: int) -> None:
+        self.max_attempts = max_attempts
+
+    def on_retry(self, attempt: int, delay: float) -> None:  # pragma: no cover - simple logging
+        logger.warning(
+            "Database connection attempt %d/%d failed; retrying in %.2fs",
+            attempt,
+            self.max_attempts,
+            delay,
+        )
+
+    def on_success(self) -> None:  # pragma: no cover - simple logging
+        logger.info("Database connection established")
+
+    def on_failure(self) -> None:  # pragma: no cover - simple logging
+        logger.error(
+            "Database connection failed after %d attempts", self.max_attempts
+        )
+
+
+class DatabaseConnectionFactory:
+    """Create database connections with retry and optional pooling."""
+
+    def __init__(
+        self,
+        manager: DatabaseManager,
+        retry_config: Optional[RetryConfig] = None,
+    ) -> None:
+        self._manager = manager
+        self._retry_config = retry_config or RetryConfig()
+        self._retry = ConnectionRetryManager(
+            self._retry_config, callbacks=_RetryLogger(self._retry_config.max_attempts)
+        )
+
+    def _create_connection_with_retry(self):
+        try:
+            return self._retry.run_with_retry(self._manager._create_connection)  # type: ignore[attr-defined]
+        except ConnectionRetryExhausted as exc:  # pragma: no cover - defensive
+            logger.error("Exhausted retries creating database connection: %s", exc)
+            raise
+        except DatabaseError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Unexpected error creating database connection: %s", exc)
+            raise DatabaseError(str(exc)) from exc
+
+    def create_pool(
+        self,
+        initial_size: int,
+        max_size: int,
+        timeout: int,
+        shrink_timeout: int,
+    ) -> DatabaseConnectionPool:
+        """Create a connection pool using the retrying connection factory."""
+
+        pool = DatabaseConnectionPool(
+            self._create_connection_with_retry,
+            initial_size,
+            max_size,
+            timeout,
+            shrink_timeout,
+        )
+        logger.info(
+            "Created connection pool initial_size=%d max_size=%d",
+            initial_size,
+            max_size,
+        )
+        return pool
+
+    def create_connection(self):
+        """Create a single database connection using retry strategy."""
+
+        return self._create_connection_with_retry()
+
+
+__all__ = ["DatabaseConnectionFactory"]


### PR DESCRIPTION
## Summary
- add database connection factory with retry logging and pooling support
- emit warnings/errors from connection pool events
- document database connection logging for operators

## Testing
- `pytest` *(fails: 231 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688eb482eda48320a7b003f4b0f70985