### PR TITLE
feat: add database connection factory config

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -18,12 +18,13 @@ from .protocols import (
     ConfigTransformerProtocol,
     ConfigValidatorProtocol,
 )
+from .pydantic_models import DatabaseConnectionFactoryConfig
 from .schema import (
     AppSettings,
     ConfigSchema,
     DatabaseSettings,
-    SecuritySettings,
     RetrainingSettings,
+    SecuritySettings,
 )
 from .secure_config_manager import SecureConfigManager
 from .secure_db import execute_secure_query
@@ -81,6 +82,11 @@ def get_database_config() -> DatabaseSettings:
     return get_config().get_database_config()
 
 
+def get_database_connection_factory_config() -> DatabaseConnectionFactoryConfig:
+    """Get database connection factory configuration"""
+    return get_config().get_database_connection_factory_config()
+
+
 def get_security_config() -> SecuritySettings:
     """Get security configuration"""
     return get_config().get_security_config()
@@ -99,6 +105,7 @@ __all__ = [
     "ConfigSchema",
     "AppSettings",
     "DatabaseSettings",
+    "DatabaseConnectionFactoryConfig",
     "SecuritySettings",
     "RetrainingSettings",
     "UploadConfig",
@@ -121,6 +128,7 @@ __all__ = [
     # Convenience getters
     "get_app_config",
     "get_database_config",
+    "get_database_connection_factory_config",
     "get_security_config",
     "get_plugin_config",
     # Dynamic configuration

--- a/yosai_intel_dashboard/src/infrastructure/config/config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config.py
@@ -3,18 +3,17 @@
 Simplified Configuration System
 Replaces: config/yaml_config.py, config/unified_config.py, config/validator.py
 """
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 
-import yaml
-
-from .base import (
-    CacheConfig,
-    Config,
-)
-from .config_transformer import ConfigTransformer
+from .base import CacheConfig, Config
+from .config_manager import ConfigManager, create_config_manager
+from .pydantic_models import DatabaseConnectionFactoryConfig
 from .schema import (
     AnalyticsSettings,
     AppSettings,
+    ConfigSchema,
     DatabaseSettings,
     MonitoringSettings,
     SampleFilesSettings,
@@ -23,7 +22,7 @@ from .schema import (
 )
 
 # Global configuration instance
-_config_manager: Optional["ConfigManager"] = None
+_config_manager: Optional[ConfigManager] = None
 
 
 def get_config() -> "ConfigManager":
@@ -87,6 +86,11 @@ def get_secret_validation_config() -> SecretValidationSettings:
     return get_config().get_secret_validation_config()
 
 
+def get_database_connection_factory_config() -> DatabaseConnectionFactoryConfig:
+    """Get database connection factory configuration"""
+    return get_config().get_database_connection_factory_config()
+
+
 def get_plugin_config(name: str) -> Dict[str, Any]:
     """Get configuration for a specific plugin"""
     return get_config().get_plugin_config(name)
@@ -99,6 +103,7 @@ __all__ = [
     "ConfigSchema",
     "AppSettings",
     "DatabaseSettings",
+    "DatabaseConnectionFactoryConfig",
     "SecuritySettings",
     "SampleFilesSettings",
     "AnalyticsSettings",
@@ -117,10 +122,6 @@ __all__ = [
     "get_monitoring_config",
     "get_cache_config",
     "get_secret_validation_config",
+    "get_database_connection_factory_config",
     "get_plugin_config",
 ]
-
-# Use new implementation by default
-from .config_manager import ConfigManager as ConfigManager
-from .config_manager import get_config as get_config
-from .config_manager import reload_config as reload_config


### PR DESCRIPTION
## Summary
- add `DatabaseConnectionFactoryConfig` with retry settings and pool validation
- parse new database connection factory config in `ConfigManager`
- expose `get_database_connection_factory_config` helper

## Testing
- `pre-commit run --files config/pydantic_models.py config/config_manager.py config/config.py config/__init__.py` *(fails: mypy returning many repository-wide typing errors)*
- `pytest tests/test_config_loader.py tests/test_config_validator.py -q` *(fails: Cache TTL values must be positive)*

------
https://chatgpt.com/codex/tasks/task_e_688eb48427008320971fb0a1aa07e67f