### PR TITLE
refactor: use connection factory in migrations

### DIFF
--- a/migration_tests/test_migration_cli.py
+++ b/migration_tests/test_migration_cli.py
@@ -5,7 +5,17 @@ import types
 
 import pytest
 
-SERVICES_PATH = pathlib.Path(__file__).resolve().parents[1] / "services"
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+SERVICES_PATH = ROOT / "yosai_intel_dashboard" / "src" / "services"
+
+# Stub out heavy optional dependencies
+dash_stub = types.ModuleType("dash")
+dash_stub.Dash = object
+sys.modules.setdefault("dash", dash_stub)
+deps_stub = types.ModuleType("dash.dependencies")
+deps_stub.Input = deps_stub.Output = deps_stub.State = object
+sys.modules.setdefault("dash.dependencies", deps_stub)
 services_pkg = types.ModuleType("services")
 services_pkg.__path__ = [str(SERVICES_PATH)]
 sys.modules.setdefault("services", services_pkg)

--- a/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncIterator, List
+from typing import AsyncIterator, List, Callable, Awaitable
 
 import asyncpg
 from yosai_intel_dashboard.src.infrastructure.config.constants import MIGRATION_CHUNK_SIZE
@@ -14,8 +14,13 @@ class AnalyticsMigration(MigrationStrategy):
     TABLE = "analytics_results"
     CHUNK_SIZE = MIGRATION_CHUNK_SIZE
 
-    def __init__(self, target_dsn: str) -> None:
-        super().__init__(self.TABLE, target_dsn)
+    def __init__(
+        self,
+        target_dsn: str,
+        *,
+        pool_factory: Callable[..., Awaitable[asyncpg.Pool]] | None = None,
+    ) -> None:
+        super().__init__(self.TABLE, target_dsn, pool_factory=pool_factory)
 
     async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
         start = 0

--- a/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncIterator, List
+from typing import AsyncIterator, List, Callable, Awaitable
 
 import asyncpg
 from yosai_intel_dashboard.src.infrastructure.config.constants import DataProcessingLimits
@@ -14,8 +14,13 @@ class EventsMigration(MigrationStrategy):
     TABLE = "access_events"
     CHUNK_SIZE = DataProcessingLimits.DEFAULT_QUERY_LIMIT
 
-    def __init__(self, target_dsn: str) -> None:
-        super().__init__(self.TABLE, target_dsn)
+    def __init__(
+        self,
+        target_dsn: str,
+        *,
+        pool_factory: Callable[..., Awaitable[asyncpg.Pool]] | None = None,
+    ) -> None:
+        super().__init__(self.TABLE, target_dsn, pool_factory=pool_factory)
 
     async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
         start = 0

--- a/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncIterator, List
+from typing import AsyncIterator, List, Callable, Awaitable
 
 import asyncpg
 from yosai_intel_dashboard.src.infrastructure.config.constants import MIGRATION_CHUNK_SIZE
@@ -14,8 +14,13 @@ class GatewayMigration(MigrationStrategy):
     TABLE = "gateway_logs"
     CHUNK_SIZE = MIGRATION_CHUNK_SIZE
 
-    def __init__(self, target_dsn: str) -> None:
-        super().__init__(self.TABLE, target_dsn)
+    def __init__(
+        self,
+        target_dsn: str,
+        *,
+        pool_factory: Callable[..., Awaitable[asyncpg.Pool]] | None = None,
+    ) -> None:
+        super().__init__(self.TABLE, target_dsn, pool_factory=pool_factory)
 
     async def run(self, source_pool: asyncpg.Pool) -> AsyncIterator[int]:
         start = 0


### PR DESCRIPTION
## Summary
- support dependency-injected asyncpg pool creation for migration manager and strategies
- accept optional pool factories in analytics, events, and gateway migration strategies
- adjust migration tests to build pools via factory and stub heavy dependencies

## Testing
- `pytest migration_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb4868a688320b9ed5e798f0afad0