### PR TITLE
Add query and parameter encoding utilities

### DIFF
--- a/tests/test_unicode_processor_functions.py
+++ b/tests/test_unicode_processor_functions.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "unicode_processor",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py",
+)
+unicode_processor = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(unicode_processor)  # type: ignore[attr-defined]
+encode_query = unicode_processor.encode_query
+encode_params = unicode_processor.encode_params
+
+
+def test_encode_query_surrogate_pair():
+    text = chr(0xD83D) + chr(0xDC36)  # dog face
+    assert encode_query(text) == "🐶"
+
+
+def test_encode_query_bytes():
+    q = b"SELECT \xf0\x9f\x90\xb6"
+    assert encode_query(q) == "SELECT 🐶"
+
+
+def test_encode_params_mixed_encodings():
+    params = ["ok", b"\xf0\x9f\x92\xa9", {"x": "bad" + chr(0xD800)}]
+    result = encode_params(params)
+    assert result[0] == "ok"
+    assert result[1] == "💩"
+    assert result[2]["x"] == "bad"

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py
@@ -11,9 +11,10 @@ from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
 
 from .unicode_processor import (
     FileUnicodeHandler,
-    QueryUnicodeHandler,
     UnicodeSecurityValidator,
 )
+from .unicode_processor import encode_params as _encode_params
+from .unicode_processor import encode_query as _encode_query
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +44,7 @@ class UnicodeHandler:
         *,
         on_surrogate: Callable[[str], None] | None = None,
     ) -> str:
-        return QueryUnicodeHandler.handle_unicode_query(
-            query,
-            processor=self.processor,
-            on_surrogate=on_surrogate,
-        )
+        return _encode_query(query, processor=self.processor, on_surrogate=on_surrogate)
 
     def encode_params(
         self,
@@ -55,10 +52,8 @@ class UnicodeHandler:
         *,
         on_surrogate: Callable[[str], None] | None = None,
     ) -> Any:
-        return QueryUnicodeHandler.handle_query_parameters(
-            params,
-            processor=self.processor,
-            on_surrogate=on_surrogate,
+        return _encode_params(
+            params, processor=self.processor, on_surrogate=on_surrogate
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose `encode_query` and `encode_params` wrappers for SQL sanitization
- update UnicodeHandler to use new helpers and support byte inputs
- cover surrogate pairs and mixed encodings in tests

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py yosai_intel_dashboard/src/infrastructure/config/unicode_handler.py tests/test_unicode_processor_functions.py`
- `pytest tests/test_unicode_processor_functions.py`
- `pytest tests/test_unicode_processor_functions.py tests/test_unicode_handler_class.py tests/test_unicode_handler.py tests/test_unicode_handling.py` *(fails: ImportError: cannot import name 'Config' from partially initialized module 'yosai_intel_dashboard.src.infrastructure.config.base')*


------
https://chatgpt.com/codex/tasks/task_e_688eb488ef488320bafe22aec1b4f371