### PR TITLE
feat: allow overrides for pooled retries

### DIFF
--- a/tests/test_retry_strategy_overrides.py
+++ b/tests/test_retry_strategy_overrides.py
@@ -1,0 +1,71 @@
+import time
+
+from yosai_intel_dashboard.src.database.retry_strategy import RetryStrategy
+from yosai_intel_dashboard.src.database._pooled_connection import _PooledConnection
+
+
+class DummyConn:
+    def __init__(self, failures: int) -> None:
+        self.failures = failures
+        self.calls = 0
+
+    def work(self) -> str:
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise RuntimeError("boom")
+        return "ok"
+
+    # Pool compatibility
+    def health_check(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+class DummyPool:
+    def __init__(self, conn: DummyConn) -> None:
+        self.conn = conn
+
+    def get_connection(self) -> DummyConn:
+        return self.conn
+
+    def release_connection(self, conn: DummyConn) -> None:
+        pass
+
+
+def test_defaults_used(monkeypatch):
+    """Without overrides, strategy defaults drive retries."""
+    conn = DummyConn(failures=2)
+    pool = DummyPool(conn)
+    strategy = RetryStrategy(attempts=3, backoff=1)
+    pc = _PooledConnection(pool, strategy)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.database.retry_strategy.time.sleep",
+        lambda s: sleeps.append(s),
+    )
+
+    assert pc.call(lambda c: c.work()) == "ok"
+    assert conn.calls == 3
+    assert sleeps == [1, 2]
+
+
+def test_overrides(monkeypatch):
+    """Overrides for attempts and backoff are honoured."""
+    conn = DummyConn(failures=4)
+    pool = DummyPool(conn)
+    # defaults would fail; overrides ensure success
+    strategy = RetryStrategy(attempts=2, backoff=1)
+    pc = _PooledConnection(pool, strategy)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.database.retry_strategy.time.sleep",
+        lambda s: sleeps.append(s),
+    )
+
+    assert pc.call(lambda c: c.work(), attempts=5, backoff=2) == "ok"
+    assert conn.calls == 5
+    assert sleeps == [2, 4, 8, 16]

--- a/yosai_intel_dashboard/src/database/_pooled_connection.py
+++ b/yosai_intel_dashboard/src/database/_pooled_connection.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Connection wrapper that applies :class:`RetryStrategy` to operations.
+
+The class is internal (note the leading underscore) and is primarily used in
+tests.  It acquires a connection from a pool for each attempt and releases it
+back to the pool when finished.  Calls can supply override ``attempts`` and
+``backoff`` values which are forwarded to :class:`RetryStrategy.run`.
+"""
+
+from typing import Any, Callable, TypeVar
+
+from .retry_strategy import RetryStrategy
+
+T = TypeVar("T")
+
+
+class _PooledConnection:
+    def __init__(self, pool: Any, retry: RetryStrategy | None = None) -> None:
+        self._pool = pool
+        self._retry = retry or RetryStrategy()
+
+    def call(
+        self,
+        op: Callable[[Any], T],
+        *,
+        attempts: int | None = None,
+        backoff: float | None = None,
+    ) -> T:
+        """Execute ``op`` with a connection from the pool.
+
+        ``op`` is a callable that receives a single connection argument.  The
+        retry behaviour can be tuned per-call using ``attempts`` and
+        ``backoff``.
+        """
+
+        def use_conn() -> T:
+            conn = self._pool.get_connection()
+            try:
+                return op(conn)
+            finally:
+                self._pool.release_connection(conn)
+
+        return self._retry.run(use_conn, attempts=attempts, backoff=backoff)
+
+
+__all__ = ["_PooledConnection"]

--- a/yosai_intel_dashboard/src/database/retry_strategy.py
+++ b/yosai_intel_dashboard/src/database/retry_strategy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Simple retry helper used by pooled connections.
+
+The :class:`RetryStrategy` encapsulates retry logic with exponential
+backoff.  It exposes a :meth:`run` method that executes a callable and
+will retry on failure.  Individual calls may override the configured
+``attempts`` and ``backoff`` values.
+"""
+
+from dataclasses import dataclass
+import time
+from typing import Callable, TypeVar, Any
+
+T = TypeVar("T")
+
+
+@dataclass
+class RetryStrategy:
+    """Retry callable with exponential backoff."""
+
+    attempts: int = 3
+    backoff: float = 0.1
+
+    def run(
+        self,
+        func: Callable[[], T],
+        *,
+        attempts: int | None = None,
+        backoff: float | None = None,
+    ) -> T:
+        """Run ``func`` applying the retry strategy.
+
+        Parameters
+        ----------
+        func:
+            Zero-argument callable to execute.
+        attempts:
+            Optional override for the number of attempts.
+        backoff:
+            Optional override for the initial backoff delay.
+        """
+
+        max_attempts = attempts if attempts is not None else self.attempts
+        delay = backoff if backoff is not None else self.backoff
+
+        if max_attempts <= 0:
+            raise ValueError("attempts must be positive")
+
+        for attempt in range(max_attempts):
+            try:
+                return func()
+            except Exception:
+                if attempt == max_attempts - 1:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+
+
+__all__ = ["RetryStrategy"]


### PR DESCRIPTION
## Summary
- add `RetryStrategy` helper with per-call override support
- allow `_PooledConnection` to forward retry overrides
- test default vs overridden retry behaviour

## Testing
- `pytest tests/test_retry_strategy_overrides.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb4944d448320ac7ab3afaefa4f19