### PR TITLE
Add prepared statement cache with LRU eviction

### DIFF
--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -154,7 +154,13 @@ func main() {
 			return c.ConsecutiveFailures >= uint32(t)
 		},
 	}
-	engCore, err := engine.NewRuleEngineWithSettings(db, dbSettings)
+	cacheSize := 64
+	if v := os.Getenv("RULE_ENGINE_STMT_CACHE_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cacheSize = n
+		}
+	}
+	engCore, err := engine.NewRuleEngineWithSettings(db, dbSettings, cacheSize)
 	if err != nil {
 		tracing.Logger.Fatalf("failed to init rule engine: %v", err)
 	}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -5,6 +5,7 @@ go 1.23.8
 require github.com/gorilla/mux v1.8.1
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/WSG23/resilience v0.0.0
 	github.com/WSG23/yosai-framework v0.0.0
 	github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors v0.0.0
@@ -13,6 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/consul/api v1.32.1
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.22.0
@@ -54,7 +56,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.5 // indirect
-	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hashicorp/serf v0.10.2 // indirect
 	github.com/linkedin/goavro/v2 v2.14.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
@@ -202,6 +204,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/gateway/internal/engine/stmt_cache.go
+++ b/gateway/internal/engine/stmt_cache.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/sirupsen/logrus"
+)
+
+// StmtCache caches prepared statements with LRU eviction.
+type StmtCache struct {
+	db   *sql.DB
+	mu   sync.Mutex
+	lru  *lru.Cache
+	hits uint64
+	miss uint64
+}
+
+// NewStmtCache creates a new prepared statement cache with the given size.
+func NewStmtCache(db *sql.DB, size int) (*StmtCache, error) {
+	cache, err := lru.NewWithEvict(size, func(key, value interface{}) {
+		if stmt, ok := value.(*sql.Stmt); ok {
+			_ = stmt.Close()
+		}
+		logrus.WithField("query", key).Debug("evicted prepared statement")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &StmtCache{db: db, lru: cache}, nil
+}
+
+// Get returns a prepared statement for the query, preparing and caching it if necessary.
+func (c *StmtCache) Get(ctx context.Context, query string) (*sql.Stmt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if stmt, ok := c.lru.Get(query); ok {
+		c.hits++
+		logrus.WithField("query", query).Debug("prepared statement cache hit")
+		return stmt.(*sql.Stmt), nil
+	}
+
+	c.miss++
+	logrus.WithField("query", query).Debug("prepared statement cache miss")
+	stmt, err := c.db.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	c.lru.Add(query, stmt)
+	return stmt, nil
+}
+
+// Hits returns the number of cache hits.
+func (c *StmtCache) Hits() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits
+}
+
+// Misses returns the number of cache misses.
+func (c *StmtCache) Misses() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.miss
+}

--- a/gateway/internal/engine/stmt_cache_test.go
+++ b/gateway/internal/engine/stmt_cache_test.go
@@ -1,0 +1,58 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestStmtCacheLRU(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	cache, err := NewStmtCache(db, 2)
+	if err != nil {
+		t.Fatalf("NewStmtCache: %v", err)
+	}
+
+	ctx := context.Background()
+
+	mock.ExpectPrepare("SELECT 1")
+	if _, err := cache.Get(ctx, "SELECT 1"); err != nil {
+		t.Fatalf("first query: %v", err)
+	}
+
+	mock.ExpectPrepare("SELECT 2")
+	if _, err := cache.Get(ctx, "SELECT 2"); err != nil {
+		t.Fatalf("second query: %v", err)
+	}
+
+	if _, err := cache.Get(ctx, "SELECT 1"); err != nil {
+		t.Fatalf("hit query: %v", err)
+	}
+
+	mock.ExpectPrepare("SELECT 3")
+	if _, err := cache.Get(ctx, "SELECT 3"); err != nil {
+		t.Fatalf("third query: %v", err)
+	}
+
+	mock.ExpectPrepare("SELECT 2")
+	if _, err := cache.Get(ctx, "SELECT 2"); err != nil {
+		t.Fatalf("evicted query: %v", err)
+	}
+
+	if cache.Hits() != 1 {
+		t.Errorf("expected 1 hit, got %d", cache.Hits())
+	}
+	if cache.Misses() != 4 {
+		t.Errorf("expected 4 misses, got %d", cache.Misses())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add LRU-based prepared statement cache with hit/miss logging
- allow configuring cache size for rule engine via env var
- test statement cache behavior under high query diversity

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688eb4adb014832099af806bca692ac9