### PR TITLE
Add connection string parser and integrate

### DIFF
--- a/tests/database/test_connection_strings.py
+++ b/tests/database/test_connection_strings.py
@@ -1,0 +1,37 @@
+import pytest
+
+from database.utils import parse_connection_string
+
+
+def test_parse_postgres():
+    info = parse_connection_string("postgresql://user:pass@localhost:5432/db")
+    assert info.dialect == "postgresql"
+    assert info.user == "user"
+    assert info.password == "pass"
+    assert info.host == "localhost"
+    assert info.port == 5432
+    assert info.database == "db"
+    assert info.build_url() == "postgresql://user:pass@localhost:5432/db"
+
+
+def test_parse_sqlite():
+    info = parse_connection_string("sqlite:///tmp/test.db")
+    assert info.dialect == "sqlite"
+    assert info.path == "/tmp/test.db"
+    assert info.build_url() == "sqlite:///tmp/test.db"
+
+
+def test_invalid_scheme():
+    with pytest.raises(ValueError):
+        parse_connection_string("mysql://user:pass@localhost/db")
+
+
+def test_postgres_missing_db():
+    with pytest.raises(ValueError):
+        parse_connection_string("postgresql://user:pass@localhost")
+
+
+def test_build_asyncpg_url():
+    info = parse_connection_string("postgresql://user@localhost/db")
+    async_url = info.build_url("postgresql+asyncpg")
+    assert async_url == "postgresql+asyncpg://user@localhost:5432/db"

--- a/yosai_intel_dashboard/src/core/rbac.py
+++ b/yosai_intel_dashboard/src/core/rbac.py
@@ -86,9 +86,12 @@ class RBACService:
 async def create_rbac_service() -> RBACService:
     """Create and initialize :class:`RBACService` using app configuration."""
     from yosai_intel_dashboard.src.infrastructure.config import get_database_config
+    from database.utils import parse_connection_string
 
     db_cfg = get_database_config()
-    pool = await asyncpg.create_pool(dsn=db_cfg.get_connection_string())
+    dsn = db_cfg.get_connection_string()
+    parse_connection_string(dsn)
+    pool = await asyncpg.create_pool(dsn=dsn)
 
     redis_client: Optional[redis.Redis] = None
     try:

--- a/yosai_intel_dashboard/src/database/connection.py
+++ b/yosai_intel_dashboard/src/database/connection.py
@@ -5,8 +5,12 @@ from typing import Optional, Protocol
 import pandas as pd
 from opentelemetry import trace
 
-from yosai_intel_dashboard.src.infrastructure.config.database_manager import DatabaseManager, MockConnection
+from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
+    DatabaseManager,
+    MockConnection,
+)
 from database.metrics import queries_total, query_errors_total
+from database.utils import parse_connection_string
 
 
 class DatabaseConnection(Protocol):
@@ -33,12 +37,10 @@ def create_database_connection() -> DatabaseConnection:
     config_manager = get_config()
     db_config = config_manager.get_database_config()
 
+    # Validate connection string before creating manager
+    parse_connection_string(db_config.get_connection_string())
     # Create database manager with existing config
-    db_manager = DatabaseManager(
-        db_type=db_config.type,
-        connection_string=getattr(db_config, "connection_string", ""),
-        **db_config.__dict__,
-    )
+    db_manager = DatabaseManager(db_config)
 
     conn = db_manager.get_connection()
 

--- a/yosai_intel_dashboard/src/database/utils.py
+++ b/yosai_intel_dashboard/src/database/utils.py
@@ -1,0 +1,89 @@
+"""Utility helpers for database connection strings.
+
+Provides simple parsing and validation for PostgreSQL and SQLite
+connection URLs used throughout the project.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+
+@dataclass
+class ParsedConnection:
+    """Normalized representation of a database connection string."""
+
+    dialect: str
+    user: Optional[str] = None
+    password: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+    database: Optional[str] = None
+    path: Optional[str] = None
+
+    def build_url(self, override_dialect: Optional[str] = None) -> str:
+        """Reconstruct a connection URL.
+
+        Parameters
+        ----------
+        override_dialect:
+            Optional scheme to use instead of the stored ``dialect``.
+        """
+        dialect = (override_dialect or self.dialect).lower()
+        if dialect.startswith("sqlite"):
+            path = self.path or ""
+            if path.startswith("/"):
+                return f"sqlite://{path}"
+            return f"sqlite:///{path}"
+
+        if dialect.startswith("postgres"):
+            auth = ""
+            if self.user:
+                auth += self.user
+                if self.password:
+                    auth += f":{self.password}"
+                auth += "@"
+            host = self.host or ""
+            port = f":{self.port}" if self.port else ""
+            db = self.database or ""
+            return f"{dialect}://{auth}{host}{port}/{db}"
+
+        raise ValueError(f"Unsupported dialect: {dialect}")
+
+
+def parse_connection_string(url: str) -> ParsedConnection:
+    """Parse and validate *url* returning a :class:`ParsedConnection`.
+
+    Supports ``postgresql`` and ``sqlite`` style URLs.  Raises ``ValueError``
+    for unsupported schemes or missing required components.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+
+    if scheme in {"postgresql", "postgres"}:
+        if not parsed.path or parsed.path == "/":
+            raise ValueError("PostgreSQL connection string must include database name")
+        return ParsedConnection(
+            dialect="postgresql",
+            user=parsed.username,
+            password=parsed.password,
+            host=parsed.hostname or "",
+            port=parsed.port or 5432,
+            database=parsed.path.lstrip("/"),
+        )
+
+    if scheme == "sqlite":
+        # sqlite:///tmp/db.sqlite -> path="/tmp/db.sqlite"
+        path = parsed.path
+        if parsed.netloc:
+            # Handles strings like sqlite://localhost/tmp/db.sqlite
+            path = f"/{parsed.netloc}{parsed.path}"
+        if not path:
+            raise ValueError("SQLite connection string must include database path")
+        return ParsedConnection(dialect="sqlite", path=path)
+
+    raise ValueError(f"Unsupported database scheme: {parsed.scheme}")
+
+
+__all__ = ["ParsedConnection", "parse_connection_string"]

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from database.utils import parse_connection_string
+
 from .app_config import UploadConfig
 from .base import Config as DataclassConfig
 from .base import require_env_var
@@ -51,7 +53,19 @@ class DatabaseSettings(BaseModel):
 
     @model_validator(mode="after")
     def populate_url(cls, values: "DatabaseSettings") -> "DatabaseSettings":
-        if not values.url:
+        if values.url:
+            info = parse_connection_string(values.url)
+            values.type = info.dialect
+            if info.dialect == "sqlite":
+                values.name = info.path.lstrip("/") if info.path else values.name
+            else:
+                values.host = info.host or values.host
+                values.port = info.port or values.port
+                values.name = info.database or values.name
+                values.user = info.user or values.user
+                values.password = info.password or values.password
+            values.url = info.build_url()
+        else:
             if values.type == "sqlite":
                 values.url = f"sqlite:///{values.name}"
             elif values.type == "postgresql":
@@ -75,14 +89,8 @@ class DatabaseSettings(BaseModel):
         return values
 
     def get_connection_string(self) -> str:  # pragma: no cover - util
-        if self.type == "postgresql":
-            return (
-                f"postgresql://{self.user}:{self.password}"
-                f"@{self.host}:{self.port}/{self.name}"
-            )
-        if self.type == "sqlite":
-            return f"sqlite:///{self.name}"
-        return f"mock://{self.name}"
+        parse_connection_string(self.url)
+        return self.url
 
 
 class SecuritySettings(BaseModel):

--- a/yosai_intel_dashboard/src/services/analytics/async_repository.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_repository.py
@@ -13,15 +13,17 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from yosai_intel_dashboard.src.infrastructure.config import get_database_config
+from database.utils import parse_connection_string
 from yosai_intel_dashboard.src.services.timescale.models import AccessEvent, Base
 
 # ---------------------------------------------------------------------------
 # Engine and session factory
 # ---------------------------------------------------------------------------
 _db_cfg = get_database_config()
-_async_url = _db_cfg.get_connection_string().replace(
-    "postgresql://", "postgresql+asyncpg://"
-)
+_conn_str = _db_cfg.get_connection_string()
+# Validate connection string and construct async variant
+parse_connection_string(_conn_str)
+_async_url = _conn_str.replace("postgresql://", "postgresql+asyncpg://")
 engine: AsyncEngine = create_async_engine(
     _async_url,
     pool_size=_db_cfg.async_pool_min_size,

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ConfigDict
 
 from analytics import anomaly_detection, feature_extraction, security_patterns
 from yosai_intel_dashboard.src.infrastructure.config import get_database_config
+from database.utils import parse_connection_string
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CACHE_HOST, DEFAULT_CACHE_PORT
 from yosai_intel_dashboard.src.infrastructure.config.config_loader import load_service_config
 from yosai_intel_dashboard.src.core.security import RateLimiter
@@ -193,8 +194,10 @@ async def _startup() -> None:
         raise RuntimeError("invalid JWT secret")
 
     cfg = get_database_config()
+    dsn = cfg.get_connection_string()
+    parse_connection_string(dsn)
     pool = await create_pool(
-        cfg.get_connection_string(),
+        dsn,
         min_size=cfg.initial_pool_size,
         max_size=cfg.max_pool_size,
         timeout=cfg.connection_timeout,


### PR DESCRIPTION
## Summary
- add utility to parse and validate PostgreSQL/SQLite connection strings
- parse and normalize connection URLs in configuration
- validate DSNs in services and add tests for connection string formats

## Testing
- `pytest tests/database/test_connection_strings.py -q`
- `pytest tests/database -q` *(fails: Cache TTL values must be positive; ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.database'; ModuleNotFoundError: No module named 'distributed'; ModuleNotFoundError: No module named 'asyncpg.utils';* `

------
https://chatgpt.com/codex/tasks/task_e_688eb4a358648320913803dc727affb3