### PR TITLE
Ensure thread-safe connection pool acquisition

### DIFF
--- a/tests/test_connection_pool_threadsafe.py
+++ b/tests/test_connection_pool_threadsafe.py
@@ -1,7 +1,29 @@
-import threading
+from __future__ import annotations
 
-from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
-from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
+import importlib.util
+import threading
+import time
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "connection_pool",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard/src/infrastructure/config/connection_pool.py",
+)
+connection_pool = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(connection_pool)  # type: ignore[attr-defined]
+DatabaseConnectionPool = connection_pool.DatabaseConnectionPool
+
+
+class MockConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def health_check(self) -> bool:
+        return not self.closed
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def factory():
@@ -13,9 +35,14 @@ def test_pool_thread_safety():
         factory, initial_size=1, max_size=3, timeout=10, shrink_timeout=10
     )
     results = []
+    max_active = []
+    lock = threading.Lock()
 
     def worker():
         conn = pool.get_connection()
+        with lock:
+            max_active.append(pool._active)
+        time.sleep(0.05)
         results.append(conn)
         pool.release_connection(conn)
 
@@ -26,4 +53,27 @@ def test_pool_thread_safety():
         t.join()
 
     assert len(results) == 10
-    assert pool._active <= pool._max_pool_size
+    assert max(max_active) <= pool._max_pool_size
+
+
+def test_pool_blocks_until_connection_available():
+    pool = DatabaseConnectionPool(
+        factory, initial_size=1, max_size=1, timeout=5, shrink_timeout=10
+    )
+
+    def worker():
+        conn = pool.get_connection()
+        time.sleep(0.1)
+        pool.release_connection(conn)
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    start = time.time()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    duration = time.time() - start
+
+    # With only one connection available, the total duration should reflect
+    # sequential access by each thread.
+    assert duration >= 0.25

--- a/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/connection_pool.py
@@ -8,7 +8,13 @@ from database.types import DatabaseConnection
 
 
 class DatabaseConnectionPool:
-    """Connection pool that can grow and shrink based on usage."""
+    """Connection pool that can grow and shrink based on usage.
+
+    This class is thread-safe: access to the internal state is
+    synchronised by a re-entrant lock and a condition variable which
+    allows threads to block while waiting for a connection to become
+    available.
+    """
 
     def __init__(
         self,
@@ -19,7 +25,10 @@ class DatabaseConnectionPool:
         shrink_timeout: int,
         threshold: float = 0.8,
     ) -> None:
+        # Re-entrant lock protects all mutable internal state.  A dedicated
+        # condition is used to signal threads waiting for a connection.
         self._lock = threading.RLock()
+        self._condition = threading.Condition(self._lock)
         self._factory = factory
         self._initial_size = initial_size
         self._max_pool_size = max(max_size, initial_size)
@@ -37,33 +46,41 @@ class DatabaseConnectionPool:
             self._active += 1
 
     def _maybe_expand(self) -> None:
-        with self._lock:
-            if self._max_size == 0:
-                return
-            usage = (self._active - len(self._pool)) / self._max_size
-            if usage >= self._threshold and self._max_size < self._max_pool_size:
-                self._max_size = min(self._max_size * 2, self._max_pool_size)
+        """Increase ``_max_size`` if current usage exceeds the threshold.
+
+        Caller must hold ``_lock`` before invoking this method.
+        """
+        if self._max_size == 0:
+            return
+        usage = (self._active - len(self._pool)) / self._max_size
+        if usage >= self._threshold and self._max_size < self._max_pool_size:
+            self._max_size = min(self._max_size * 2, self._max_pool_size)
 
     def _shrink_idle_connections(self) -> None:
-        with self._lock:
-            now = time.time()
-            new_pool: List[Tuple[DatabaseConnection, float]] = []
-            for conn, ts in self._pool:
-                if (
-                    now - ts > self._shrink_timeout
-                    and self._max_size > self._initial_size
-                ):
-                    conn.close()
-                    self._active -= 1
-                    self._max_size -= 1
-                else:
-                    new_pool.append((conn, ts))
-            self._pool = new_pool
+        """Remove idle connections that have exceeded ``shrink_timeout``.
+
+        Caller must hold ``_lock`` before invoking this method.
+        """
+        now = time.time()
+        new_pool: List[Tuple[DatabaseConnection, float]] = []
+        for conn, ts in self._pool:
+            if now - ts > self._shrink_timeout and self._max_size > self._initial_size:
+                conn.close()
+                self._active -= 1
+                self._max_size -= 1
+            else:
+                new_pool.append((conn, ts))
+        self._pool = new_pool
 
     def get_connection(self) -> DatabaseConnection:
+        """Acquire a connection from the pool in a thread-safe manner.
+
+        Threads block on the condition variable until a connection is
+        available or the ``timeout`` expires.
+        """
         deadline = time.time() + self._timeout
-        while True:
-            with self._lock:
+        with self._condition:
+            while True:
                 self._shrink_idle_connections()
                 # Check if pool usage is high before handing out a connection
                 self._maybe_expand()
@@ -81,27 +98,33 @@ class DatabaseConnectionPool:
                     self._active += 1
                     return conn
 
-            if time.time() >= deadline:
-                raise TimeoutError("No available connection in pool")
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise TimeoutError("No available connection in pool")
 
-            time.sleep(0.05)
+                # Wait a short interval to allow other threads to release
+                # connections while respecting the overall timeout.
+                self._condition.wait(timeout=min(0.05, remaining))
 
     def release_connection(self, conn: DatabaseConnection) -> None:
-        with self._lock:
+        """Return a connection to the pool and notify waiting threads."""
+        with self._condition:
             self._shrink_idle_connections()
             if not conn.health_check():
                 conn.close()
                 self._active -= 1
-                return
-
-            if len(self._pool) >= self._max_size:
+            elif len(self._pool) >= self._max_size:
                 conn.close()
                 self._active -= 1
             else:
                 self._pool.append((conn, time.time()))
+            # Wake one waiting thread (if any) since the pool size or
+            # availability may have changed.
+            self._condition.notify()
 
     def health_check(self) -> bool:
-        with self._lock:
+        """Check the health of all idle connections."""
+        with self._condition:
             temp: List[Tuple[DatabaseConnection, float]] = []
             healthy = True
             while self._pool:


### PR DESCRIPTION
## Summary
- use a condition variable to coordinate connection acquisition and release
- add threading-based tests verifying concurrent access and blocking behavior
- document thread safety guarantees

## Testing
- `SKIP=bandit,mypy pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/connection_pool.py tests/test_connection_pool_threadsafe.py`
- `pytest tests/test_connection_pool_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb4acc0ac832086fde21c2bb88bd0