### PR TITLE
feat: add websocket metrics

### DIFF
--- a/src/websocket/metrics.py
+++ b/src/websocket/metrics.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Prometheus metrics and EventBus integration for WebSocket activity."""
+
+from prometheus_client import REGISTRY, Counter, start_http_server
+from prometheus_client.core import CollectorRegistry
+
+from typing import Any, Dict, Protocol
+
+
+class EventBusProtocol(Protocol):
+    def publish(self, event_type: str, data: Dict[str, Any], source: str | None = None) -> None: ...
+
+# Avoid duplicate registration when the module is imported multiple times.
+if "websocket_connections_total" not in REGISTRY._names_to_collectors:
+    websocket_connections_total = Counter(
+        "websocket_connections_total", "Total websocket connections"
+    )
+    websocket_reconnect_attempts_total = Counter(
+        "websocket_reconnect_attempts_total",
+        "Total websocket reconnect attempts",
+    )
+    websocket_ping_failures_total = Counter(
+        "websocket_ping_failures_total", "Total websocket ping failures"
+    )
+else:  # pragma: no cover - defensive for test imports
+    registry = CollectorRegistry()
+    websocket_connections_total = Counter(
+        "websocket_connections_total",
+        "Total websocket connections",
+        registry=registry,
+    )
+    websocket_reconnect_attempts_total = Counter(
+        "websocket_reconnect_attempts_total",
+        "Total websocket reconnect attempts",
+        registry=registry,
+    )
+    websocket_ping_failures_total = Counter(
+        "websocket_ping_failures_total",
+        "Total websocket ping failures",
+        registry=registry,
+    )
+
+_event_bus: EventBusProtocol | None = None
+
+_metrics_started = False
+
+def set_event_bus(bus: EventBusProtocol) -> None:
+    """Configure the ``EventBus`` used for publishing metric updates."""
+    global _event_bus
+    _event_bus = bus
+
+def _publish(name: str, value: float) -> None:
+    if _event_bus:
+        try:
+            _event_bus.publish("metrics_update", {name: value})
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+def start_metrics_server(port: int = 8003) -> None:
+    """Expose metrics on the given port if not already started."""
+    global _metrics_started
+    if not _metrics_started:
+        start_http_server(port)
+        _metrics_started = True
+
+def record_connection() -> None:
+    """Increment connection counter and publish update."""
+    websocket_connections_total.inc()
+    _publish(
+        "websocket_connections_total", websocket_connections_total._value.get()  # type: ignore[attr-defined]
+    )
+
+def record_reconnect_attempt() -> None:
+    """Increment reconnect counter and publish update."""
+    websocket_reconnect_attempts_total.inc()
+    _publish(
+        "websocket_reconnect_attempts_total",
+        websocket_reconnect_attempts_total._value.get(),  # type: ignore[attr-defined]
+    )
+
+def record_ping_failure() -> None:
+    """Increment ping failure counter and publish update."""
+    websocket_ping_failures_total.inc()
+    _publish(
+        "websocket_ping_failures_total",
+        websocket_ping_failures_total._value.get(),  # type: ignore[attr-defined]
+    )
+
+__all__ = [
+    "websocket_connections_total",
+    "websocket_reconnect_attempts_total",
+    "websocket_ping_failures_total",
+    "record_connection",
+    "record_reconnect_attempt",
+    "record_ping_failure",
+    "set_event_bus",
+    "start_metrics_server",
+]

--- a/tests/websocket/test_metrics.py
+++ b/tests/websocket/test_metrics.py
@@ -1,0 +1,23 @@
+from src.websocket import metrics
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.events = []
+
+    def publish(self, event_type: str, data, source=None) -> None:  # pragma: no cover - simple bus
+        self.events.append((event_type, data))
+
+
+def test_websocket_metrics_publish_updates():
+    bus = DummyBus()
+    metrics.set_event_bus(bus)
+
+    metrics.record_connection()
+    metrics.record_reconnect_attempt()
+    metrics.record_ping_failure()
+
+    assert bus.events[0][0] == "metrics_update"
+    assert bus.events[0][1]["websocket_connections_total"] == 1
+    assert bus.events[1][1]["websocket_reconnect_attempts_total"] == 1
+    assert bus.events[2][1]["websocket_ping_failures_total"] == 1


### PR DESCRIPTION
## Summary
- track websocket connections, reconnect attempts, and ping failures with Prometheus counters
- expose websocket metrics via shared server and publish updates over the event bus
- test metrics publishing through a dummy event bus

## Testing
- `pytest tests/websocket/test_metrics.py tests/websocket/test_metrics_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0d7ffa20832087a92af8fa954fb9