### PR TITLE
feat: add socket connection state and event bus

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/eventBus.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/eventBus.ts
@@ -1,0 +1,28 @@
+export type Listener<T = unknown> = (payload: T) => void;
+
+class EventBus {
+  private listeners: Map<string, Set<Listener>> = new Map();
+
+  on<T>(event: string, listener: Listener<T>): () => void {
+    const set = this.listeners.get(event) ?? new Set<Listener>();
+    set.add(listener as Listener);
+    this.listeners.set(event, set);
+    return () => this.off(event, listener);
+  }
+
+  off<T>(event: string, listener: Listener<T>): void {
+    const set = this.listeners.get(event);
+    set?.delete(listener as Listener);
+    if (set && set.size === 0) {
+      this.listeners.delete(event);
+    }
+  }
+
+  emit<T>(event: string, payload: T): void {
+    const set = this.listeners.get(event);
+    set?.forEach(listener => listener(payload));
+  }
+}
+
+export const eventBus = new EventBus();
+export default eventBus;

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
-import { useEventSocket } from './useEventSocket';
+import { useEventSocket, EventSocketState } from './useEventSocket';
+import { eventBus } from '../eventBus';
 
 class MockSocket {
   public onmessage: ((ev: { data: string }) => void) | null = null;
@@ -19,6 +20,7 @@ describe('useEventSocket', () => {
     );
 
     act(() => {
+      MockSocket.instance?.onopen?.();
       MockSocket.instance?.onmessage?.({ data: JSON.stringify({ a: 1 }) });
     });
 
@@ -26,5 +28,29 @@ describe('useEventSocket', () => {
 
     unmount();
     expect(MockSocket.instance?.close).toHaveBeenCalled();
+  });
+
+  it('emits state changes via EventBus', () => {
+    const states: EventSocketState[] = [];
+    const unsubscribe = eventBus.on('event_socket_state', (s: EventSocketState) => {
+      states.push(s);
+    });
+
+    const { unmount } = renderHook(() =>
+      useEventSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
+    );
+
+    act(() => {
+      MockSocket.instance?.onopen?.();
+    });
+
+    unmount();
+    unsubscribe();
+
+    expect(states).toEqual([
+      EventSocketState.CONNECTING,
+      EventSocketState.CONNECTED,
+      EventSocketState.DISCONNECTED,
+    ]);
   });
 });

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
@@ -1,25 +1,50 @@
 import { useEffect, useRef, useState } from 'react';
+import { eventBus } from '../eventBus';
+
+export enum EventSocketState {
+  DISCONNECTED = 'DISCONNECTED',
+  CONNECTING = 'CONNECTING',
+  CONNECTED = 'CONNECTED',
+  RECONNECTING = 'RECONNECTING',
+}
 
 export const useEventSocket = (
   url: string,
   socketFactory?: (url: string) => WebSocket,
 ) => {
   const [data, setData] = useState<string | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
+  const [state, setState] = useState<EventSocketState>(EventSocketState.DISCONNECTED);
   const wsRef = useRef<WebSocket | null>(null);
+  const stoppedRef = useRef(false);
 
   useEffect(() => {
+    stoppedRef.current = false;
+    setState(EventSocketState.CONNECTING);
+    eventBus.emit('event_socket_state', EventSocketState.CONNECTING);
     const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
     wsRef.current = ws;
 
-    ws.onopen = () => setIsConnected(true);
-    ws.onclose = () => setIsConnected(false);
+    ws.onopen = () => {
+      setState(EventSocketState.CONNECTED);
+      eventBus.emit('event_socket_state', EventSocketState.CONNECTED);
+    };
+    ws.onclose = () => {
+      if (stoppedRef.current) {
+        return;
+      }
+      setState(EventSocketState.DISCONNECTED);
+      eventBus.emit('event_socket_state', EventSocketState.DISCONNECTED);
+    };
     ws.onmessage = (ev) => setData(ev.data);
 
     return () => {
+      stoppedRef.current = true;
+      setState(EventSocketState.DISCONNECTED);
+      eventBus.emit('event_socket_state', EventSocketState.DISCONNECTED);
       ws.close();
     };
-  }, [url]);
+  }, [url, socketFactory]);
 
-  return { data, isConnected };
+  const isConnected = state === EventSocketState.CONNECTED;
+  return { data, isConnected, state };
 };


### PR DESCRIPTION
## Summary
- add simple event bus utility for UI
- track connection state in useWebSocket and useEventSocket hooks
- emit connection state changes on a shared event bus

## Testing
- `npx jest --coverage --runTestsByPath yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d7c3b188320bac862e0f868a5f0