### PR TITLE
feat: add websocket heartbeat

### DIFF
--- a/tests/test_websocket_data_provider.py
+++ b/tests/test_websocket_data_provider.py
@@ -1,14 +1,60 @@
+import importlib.util
+import sys
 import time
+import types
+from pathlib import Path
 
-from yosai_intel_dashboard.src.core.events import EventBus
-from yosai_intel_dashboard.src.services.websocket_data_provider import WebSocketDataProvider
+
+def _load_provider():
+    pkg_names = [
+        "yosai_intel_dashboard",
+        "yosai_intel_dashboard.src",
+        "yosai_intel_dashboard.src.core",
+        "yosai_intel_dashboard.src.services",
+    ]
+    for name in pkg_names:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    proto_mod = types.ModuleType("yosai_intel_dashboard.src.core.interfaces.protocols")
+    class EventBusProtocol:
+        pass
+    proto_mod.EventBusProtocol = EventBusProtocol
+    sys.modules["yosai_intel_dashboard.src.core.interfaces.protocols"] = proto_mod
+    analytics_mod = types.ModuleType("yosai_intel_dashboard.src.services.analytics_summary")
+    analytics_mod.generate_sample_analytics = lambda: {"x": 1}
+    sys.modules["yosai_intel_dashboard.src.services.analytics_summary"] = analytics_mod
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "services"
+        / "websocket_data_provider.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "yosai_intel_dashboard.src.services.websocket_data_provider",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module.WebSocketDataProvider
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self._subs = {}
+    def publish(self, event_type, data):
+        for h in self._subs.get(event_type, []):
+            h(data)
+    def subscribe(self, event_type, handler):
+        self._subs.setdefault(event_type, []).append(handler)
 
 
 def test_websocket_data_provider_publishes():
-    bus = EventBus()
+    Provider = _load_provider()
+    bus = DummyBus()
     events = []
     bus.subscribe("analytics_update", lambda d: events.append(d))
-    provider = WebSocketDataProvider(bus, interval=0.01)
+    provider = Provider(bus, interval=0.01)
     time.sleep(0.05)
     provider.stop()
     assert events

--- a/tests/test_websocket_server.py
+++ b/tests/test_websocket_server.py
@@ -1,0 +1,100 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_server():
+    pkg_names = [
+        "yosai_intel_dashboard",
+        "yosai_intel_dashboard.src",
+        "yosai_intel_dashboard.src.core",
+    ]
+    for name in pkg_names:
+        sys.modules.setdefault(name, types.ModuleType(name))
+    events_mod = types.ModuleType("yosai_intel_dashboard.src.core.events")
+    class EventBus:
+        def __init__(self, *a, **kw):
+            pass
+        def publish(self, *a, **kw):
+            pass
+        def subscribe(self, *a, **kw):
+            pass
+    events_mod.EventBus = EventBus
+    sys.modules["yosai_intel_dashboard.src.core.events"] = events_mod
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "services"
+        / "websocket_server.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "yosai_intel_dashboard.src.services.websocket_server",
+        path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module.AnalyticsWebSocketServer
+
+
+AnalyticsWebSocketServer = _load_server()
+
+
+class DummyWS:
+    def __init__(self, respond: bool = True):
+        self.respond = respond
+        self.closed = False
+
+    def ping(self):
+        fut = asyncio.Future()
+        if self.respond:
+            fut.set_result(None)
+        return fut
+
+    async def close(self):
+        self.closed = True
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.subs = {}
+    def publish(self, event_type, data):
+        for h in self.subs.get(event_type, []):
+            h(data)
+    def subscribe(self, event_type, handler):
+        self.subs.setdefault(event_type, []).append(handler)
+
+
+def _create_server(event_bus: DummyBus) -> AnalyticsWebSocketServer:
+    # avoid starting actual websocket server
+    original = AnalyticsWebSocketServer._run
+    AnalyticsWebSocketServer._run = lambda self: None  # type: ignore
+    server = AnalyticsWebSocketServer(event_bus, ping_interval=0.01, ping_timeout=0.01)
+    AnalyticsWebSocketServer._run = original
+    return server
+
+
+def test_ping_client_publishes_alive():
+    bus = DummyBus()
+    events = []
+    bus.subscribe("websocket_heartbeat", lambda d: events.append(d))
+    server = _create_server(bus)
+    ws = DummyWS(True)
+    asyncio.run(server._ping_client(ws))
+    assert events and events[0]["status"] == "alive"
+
+
+def test_ping_client_closes_on_timeout():
+    bus = DummyBus()
+    events = []
+    bus.subscribe("websocket_heartbeat", lambda d: events.append(d))
+    server = _create_server(bus)
+    ws = DummyWS(False)
+    server.clients.add(ws)  # ensure removal
+    asyncio.run(server._ping_client(ws))
+    assert events and events[0]["status"] == "timeout"
+    assert ws.closed
+    assert ws not in server.clients

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts
@@ -14,9 +14,17 @@ class MockSocket {
   public onopen: (() => void) | null = null;
   public onclose: (() => void) | null = null;
   public close = jest.fn();
+  public pong = jest.fn();
+  private handlers: Record<string, Function> = {};
   constructor(public url: string) {
     MockSocket.instance = this;
     MockSocket.instances.push(this);
+  }
+  on(evt: string, handler: Function) {
+    this.handlers[evt] = handler;
+  }
+  trigger(evt: string) {
+    this.handlers[evt]?.();
   }
   static instance: MockSocket | null = null;
   static instances: MockSocket[] = [];
@@ -87,5 +95,33 @@ describe('useWebSocket', () => {
     });
 
     expect(MockSocket.instances).toHaveLength(1);
+  });
+
+  it('responds to ping with pong and resets heartbeat', () => {
+    const { unmount } = renderHook(() =>
+      useWebSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(29999);
+    });
+    expect(MockSocket.instance?.close).not.toHaveBeenCalled();
+
+    act(() => {
+      MockSocket.instance?.trigger('ping');
+    });
+    expect(MockSocket.instance?.pong).toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(29999);
+    });
+    expect(MockSocket.instance?.close).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+    expect(MockSocket.instance?.close).toHaveBeenCalled();
+
+    unmount();
   });
 });

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/websocketPool.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/websocketPool.ts
@@ -1,0 +1,40 @@
+export const HEARTBEAT_TIMEOUT = 30000;
+
+type Factory = (url: string) => WebSocket;
+
+export class WebSocketPool {
+  private sockets = new Map<string, WebSocket>();
+
+  constructor(private factory: Factory = url => new WebSocket(url)) {}
+
+  get(url: string): WebSocket {
+    let ws = this.sockets.get(url);
+    if (!ws || ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+      ws = this.factory(url);
+      this.sockets.set(url, ws);
+      this.setupHeartbeat(ws, url);
+      ws.addEventListener?.('close', () => {
+        this.sockets.delete(url);
+      });
+    }
+    return ws;
+  }
+
+  private setupHeartbeat(ws: any, url: string) {
+    if (ws.__hbListener) return;
+    ws.__hbListener = true;
+    const reset = () => {
+      clearTimeout(ws.__hbTimeout);
+      ws.__hbTimeout = setTimeout(() => ws.close(), HEARTBEAT_TIMEOUT);
+    };
+    reset();
+    if (typeof ws.on === 'function') {
+      ws.on('ping', () => {
+        ws.pong?.();
+        reset();
+      });
+    }
+  }
+}
+
+export const defaultPool = new WebSocketPool();

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -19,12 +19,17 @@ class AnalyticsWebSocketServer:
         event_bus: Optional[EventBus] = None,
         host: str = "0.0.0.0",
         port: int = 6789,
+        ping_interval: float = 30.0,
+        ping_timeout: float = 10.0,
     ) -> None:
         self.host = host
         self.port = port
         self.event_bus = event_bus or EventBus()
         self.clients: Set[WebSocketServerProtocol] = set()
+        self.ping_interval = ping_interval
+        self.ping_timeout = ping_timeout
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._heartbeat_task: asyncio.Task | None = None
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
         if self.event_bus:
@@ -44,7 +49,34 @@ class AnalyticsWebSocketServer:
     async def _serve(self) -> None:
         self._loop = asyncio.get_running_loop()
         async with serve(self._handler, self.host, self.port):
+            self._heartbeat_task = asyncio.create_task(self._heartbeat())
             await asyncio.Event().wait()
+
+    async def _ping_client(self, ws: WebSocketServerProtocol) -> None:
+        try:
+            pong_waiter = ws.ping()
+            await asyncio.wait_for(pong_waiter, timeout=self.ping_timeout)
+            if self.event_bus:
+                self.event_bus.publish(
+                    "websocket_heartbeat",
+                    {"client": id(ws), "status": "alive"},
+                )
+        except asyncio.TimeoutError:
+            if self.event_bus:
+                self.event_bus.publish(
+                    "websocket_heartbeat",
+                    {"client": id(ws), "status": "timeout"},
+                )
+            try:
+                await ws.close()
+            finally:
+                self.clients.discard(ws)
+
+    async def _heartbeat(self) -> None:
+        while True:
+            await asyncio.sleep(self.ping_interval)
+            for ws in set(self.clients):
+                await self._ping_client(ws)
 
     def _run(self) -> None:
         asyncio.run(self._serve())
@@ -65,6 +97,8 @@ class AnalyticsWebSocketServer:
     def stop(self) -> None:
         """Stop the server thread and event loop."""
         if self._loop is not None:
+            if self._heartbeat_task is not None:
+                self._loop.call_soon_threadsafe(self._heartbeat_task.cancel)
             self._loop.call_soon_threadsafe(self._loop.stop)
             self._thread.join(timeout=1)
 


### PR DESCRIPTION
## Summary
- add periodic ping task to websocket server and publish heartbeat events
- add websocket pooling with automatic pong replies
- handle heartbeat resets in `useWebSocket` hook

## Testing
- `pytest tests/test_websocket_server.py tests/test_websocket_data_provider.py tests/websocket/test_metrics_provider.py -q`
- `npm test --workspaces=false -- yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d79ed988320bead0dca1515b859