### PR TITLE
feat: add callback protocol

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
@@ -1,11 +1,12 @@
 """Unified callback utilities and registry."""
 from .events import CallbackEvent
 from .callback_registry import CallbackRegistry, ComponentCallbackManager
-from .unified_callbacks import TrulyUnifiedCallbacks
+from .unified_callbacks import CallbackHandler, TrulyUnifiedCallbacks
 
 __all__ = [
     "CallbackEvent",
     "CallbackRegistry",
     "ComponentCallbackManager",
     "TrulyUnifiedCallbacks",
+    "CallbackHandler",
 ]


### PR DESCRIPTION
## Summary
- add `CallbackHandler` protocol to describe sync and async callbacks
- use `CallbackHandler` in unified callbacks dataclasses and event methods
- re-export protocol from callbacks package for reuse

## Testing
- `pytest tests/test_callback_manager_events.py tests/test_unified_callback_coordinator.py` *(failed: ImportError: cannot import name 'Input' from 'dash')*
- `pytest tests/test_callback_manager_events.py` *(failed: NameError: redis_client is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f0c12a124832097d791d8423ecfee