### PR TITLE
refactor: type annotate callback registry

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
@@ -1,9 +1,12 @@
 """Simplified callback registry for unified callbacks."""
+
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Iterable
 
 from dash import Dash
+from dash.dependencies import Input, Output, State
+
 
 class CallbackRegistry:
     """Minimal registry tracking registered callbacks."""
@@ -13,8 +16,33 @@ class CallbackRegistry:
         self.registered_callbacks: Dict[str, Callable[..., Any]] = {}
         self.callback_sources: Dict[str, str] = {}
 
-    def handle_register(self, outputs, inputs=None, states=None, **kwargs):
-        """Decorator registering callback on the Dash app if available."""
+    def handle_register(
+        self,
+        outputs: Output | Iterable[Output],
+        inputs: Iterable[Input] | Input | None = None,
+        states: Iterable[State] | State | None = None,
+        **kwargs: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Return a decorator registering a Dash callback if the app exists.
+
+        Parameters
+        ----------
+        outputs:
+            A Dash ``Output`` or iterable of ``Output`` objects to be produced by
+            the callback.
+        inputs:
+            Optional ``Input`` or iterable of ``Input`` objects providing
+            callback arguments.
+        states:
+            Optional ``State`` or iterable of ``State`` objects available to the
+            callback without triggering it.
+
+        Returns
+        -------
+        Callable[[Callable[..., Any]], Callable[..., Any]]
+            A decorator that registers the provided function as a callback.
+        """
+
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             callback_id = kwargs.get("callback_id", func.__name__)
             self.registered_callbacks[callback_id] = func
@@ -23,6 +51,7 @@ class CallbackRegistry:
             return func
 
         return decorator
+
 
 class ComponentCallbackManager:
     """Base class for components that register callbacks."""

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -24,8 +24,8 @@ from typing import (
 from dash import Dash
 from dash.dependencies import Input, Output, State
 
-from .events import CallbackEvent
 from .callback_registry import CallbackRegistry, ComponentCallbackManager
+from .events import CallbackEvent
 
 logger = logging.getLogger(__name__)
 
@@ -528,7 +528,13 @@ class TrulyUnifiedCallbacks:
                 super().__init__(coord.app)
                 self._coord = coord
 
-            def handle_register(self, outputs, inputs=None, states=None, **kwargs):
+            def handle_register(
+                self,
+                outputs: Output | Iterable[Output],
+                inputs: Iterable[Input] | Input | None = None,
+                states: Iterable[State] | State | None = None,
+                **kwargs: Any,
+            ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
                 return self._coord.handle_register(outputs, inputs, states, **kwargs)
 
         for manager_cls in manager_classes:


### PR DESCRIPTION
## Summary
- type annotate callback registry's handle_register method and add richer docstring
- use precise types for outputs, inputs, states in TrulyUnifiedCallbacks' internal registry

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py`
- `pytest tests/test_callback_manager.py tests/test_unified_callback_manager.py` *(fails: ImportError: cannot import name 'DatabaseManager')*

------
https://chatgpt.com/codex/tasks/task_e_688f0c16dd7483208121a11de781dcb5