### PR TITLE
Add Redis-backed query caching

### DIFF
--- a/yosai_intel_dashboard/src/database/query_cache.py
+++ b/yosai_intel_dashboard/src/database/query_cache.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Simple query result cache backed by Redis."""
+
+import asyncio
+import os
+from typing import Any, Optional
+
+from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, RedisCacheManager
+
+
+class QueryCache:
+    """Cache wrapper for database query results."""
+
+    def __init__(
+        self,
+        cache_manager: Optional[RedisCacheManager] = None,
+        *,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        ttl: Optional[int] = None,
+    ) -> None:
+        cfg = CacheConfig()
+        if host is not None:
+            cfg.host = host
+        if port is not None:
+            cfg.port = port
+        self.ttl = ttl if ttl is not None else int(os.getenv("QUERY_CACHE_TTL", cfg.timeout_seconds))
+        self.cache = cache_manager or RedisCacheManager(cfg)
+        asyncio.run(self.cache.start())
+
+    def get(self, key: str):
+        """Return cached value for ``key`` or ``None``."""
+        return asyncio.run(self.cache.get(key))
+
+    def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store ``value`` under ``key`` for ``ttl`` seconds."""
+        asyncio.run(self.cache.set(key, value, ttl or self.ttl))
+
+    def clear(self) -> None:
+        """Remove all cache entries."""
+        asyncio.run(self.cache.clear())
+
+    def stop(self) -> None:
+        """Release cache resources."""
+        asyncio.run(self.cache.stop())
+
+
+__all__ = ["QueryCache"]

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -1,13 +1,40 @@
-"""Secure wrappers for database execution."""
+"""Secure wrappers for database execution with optional query caching."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from typing import Any, Iterable, Optional
 
 from database.types import DBRows
+from database.query_cache import QueryCache
+from yosai_intel_dashboard.src.core.cache_manager import RedisCacheManager
 
 logger = logging.getLogger(__name__)
+
+_QUERY_CACHE: QueryCache | None = None
+
+
+def get_query_cache(
+    cache_manager: RedisCacheManager | None = None,
+    *,
+    ttl: int | None = None,
+) -> QueryCache:
+    """Return a shared :class:`QueryCache` instance.
+
+    Parameters
+    ----------
+    cache_manager:
+        Optional custom :class:`RedisCacheManager` to use as backend.
+    ttl:
+        Optional time-to-live override for cached results in seconds.
+    """
+
+    global _QUERY_CACHE
+    if _QUERY_CACHE is None or cache_manager is not None or ttl is not None:
+        _QUERY_CACHE = QueryCache(cache_manager=cache_manager, ttl=ttl)
+    return _QUERY_CACHE
 
 
 def _infer_db_type(obj: Any) -> str:
@@ -46,28 +73,56 @@ def _validate_params(params: Optional[Iterable[Any]]) -> Optional[tuple]:
     raise TypeError("params must be a tuple/list or None")
 
 
-def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
-    """Validate, optimize and execute a SELECT query on ``conn``."""
+def execute_query(
+    conn: Any,
+    sql: str,
+    params: Optional[Iterable[Any]] = None,
+    *,
+    optimize: bool = True,
+):
+    """Validate, optionally optimize and execute a SELECT query with caching."""
 
     if not isinstance(sql, str):
         raise TypeError("sql must be a string")
     p = _validate_params(params)
-    optimized_sql = _get_optimizer(conn).optimize_query(sql)
-    logger.debug("Executing query: %s", optimized_sql)
+
+    cache = get_query_cache()
+    key_data = {
+        "sql": sql,
+        "params": list(p) if p is not None else [],
+        "opt": optimize,
+    }
+    cache_key = hashlib.sha256(
+        json.dumps(key_data, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    executable_sql = (
+        _get_optimizer(conn).optimize_query(sql) if optimize else sql
+    )
+    logger.debug("Executing query: %s", executable_sql)
     if hasattr(conn, "execute_query"):
-        return conn.execute_query(optimized_sql, p)
-    if hasattr(conn, "execute"):
+        result = conn.execute_query(executable_sql, p)
+    elif hasattr(conn, "execute"):
         if p is not None:
-            return conn.execute(optimized_sql, p)
-        return conn.execute(optimized_sql)
-    raise AttributeError("Object has no execute or execute_query method")
+            result = conn.execute(executable_sql, p)
+        else:
+            result = conn.execute(executable_sql)
+    else:
+        raise AttributeError("Object has no execute or execute_query method")
+
+    cache.set(cache_key, result)
+    return result
 
 
 def execute_secure_query(conn: Any, sql: str, params: Iterable[Any]) -> DBRows:
     """Execute a parameterized SELECT query enforcing provided params."""
     if params is None:
         raise ValueError("params must be provided for execute_secure_query")
-    return execute_query(conn, sql, params)
+    return execute_query(conn, sql, params, optimize=False)
 
 
 def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
@@ -86,4 +141,4 @@ def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None)
     raise AttributeError("Object has no execute or execute_command method")
 
 
-__all__ = ["execute_query", "execute_command", "execute_secure_query"]
+__all__ = ["execute_query", "execute_command", "execute_secure_query", "get_query_cache"]


### PR DESCRIPTION
## Summary
- add `QueryCache` built on `RedisCacheManager` for database caching
- cache results in `secure_exec.execute_query` with configurable TTL
- expose `get_query_cache` helper for custom cache managers

## Testing
- `python - <<'PY'
import asyncpg, redis.asyncio, pytest, sys
sys.exit(pytest.main(['tests/database/test_query_optimizer.py','tests/database/test_sql_injection.py','tests/test_secure_db.py','tests/test_execute_query_lint.py']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f0d43e3b48320a6b909b432309ae6