### PR TITLE
feat: add batch execution support

### DIFF
--- a/tests/database/test_connection_factory.py
+++ b/tests/database/test_connection_factory.py
@@ -105,6 +105,13 @@ def load_dbm_modules():
         db_pkg.secure_exec.execute_command = (
             lambda conn, cmd, params=None: conn.execute_command(cmd, params)
         )
+        db_pkg.secure_exec.execute_batch = (
+            lambda conn, cmd, params_seq: (
+                conn.execute_batch(cmd, params_seq)
+                if hasattr(conn, "execute_batch")
+                else conn.executemany(cmd, params_seq)
+            )
+        )
         db_pkg.types = types.ModuleType("database.types")
         class DatabaseConnection: ...
         db_pkg.types.DatabaseConnection = DatabaseConnection
@@ -370,6 +377,9 @@ def test_retry_with_exponential_backoff(monkeypatch):
         def close(self):
             pass
 
+        def execute_batch(self, command, params_seq):
+             pass
+
     conn = FlakyConn()
 
     class Pool:
@@ -417,6 +427,9 @@ def test_unicode_query_parameter_handling(monkeypatch):
             return True
 
         def close(self):
+            pass
+
+        def execute_batch(self, command, params_seq):
             pass
 
     conn = Conn()

--- a/tests/database/test_database_manager_retry.py
+++ b/tests/database/test_database_manager_retry.py
@@ -118,6 +118,9 @@ class FailingConnection:
     def execute_command(self, cmd, params=None):
         pass
 
+    def execute_batch(self, cmd, params_seq):
+        pass
+
     def health_check(self):
         self.health_calls += 1
         return self.health_calls > self.health_failures

--- a/tests/database/test_database_service_error.py
+++ b/tests/database/test_database_service_error.py
@@ -118,6 +118,9 @@ class BadQueryConnection:
     def execute_command(self, cmd, params=None):
         pass
 
+    def execute_batch(self, cmd, params_seq):
+        pass
+
     def health_check(self):
         return True
 

--- a/tests/database/test_index_optimizer.py
+++ b/tests/database/test_index_optimizer.py
@@ -18,6 +18,9 @@ def make_sqlite_conn(indexes=None):
         def execute_command(self, command, params=None):
             self.executed.append((command, params))
 
+        def execute_batch(self, command, params_seq):
+            self.executed.append((command, list(params_seq)))
+
     return SQLiteConnection(indexes)
 
 

--- a/tests/database/test_multi_database_factories.py
+++ b/tests/database/test_multi_database_factories.py
@@ -26,6 +26,9 @@ class SQLiteConn:
     def execute_command(self, command: str, params: tuple | None = None) -> None:
         pass
 
+    def execute_batch(self, command: str, params_seq):
+        pass
+
     def health_check(self) -> bool:
         return True
 
@@ -41,6 +44,9 @@ class DummyPostgres:
         return []
 
     def execute_command(self, command: str, params: tuple | None = None) -> None:
+        pass
+
+    def execute_batch(self, command: str, params_seq):
         pass
 
     def health_check(self) -> bool:

--- a/tests/database/test_types.py
+++ b/tests/database/test_types.py
@@ -20,6 +20,9 @@ def _create_dummy_conn():
         def execute_command(self, *args, **kwargs):
             return None
 
+        def execute_batch(self, *args, **kwargs):
+            return None
+
         def health_check(self) -> bool:  # pragma: no cover - simple stub
             return True
 

--- a/tests/repositories/test_repositories.py
+++ b/tests/repositories/test_repositories.py
@@ -33,6 +33,12 @@ class _SQLiteConn:
         self.conn.commit()
         return cur.rowcount
 
+    def execute_batch(self, command: str, params_seq):
+        cur = self.conn.cursor()
+        cur.executemany(self._adapt(command), params_seq)
+        self.conn.commit()
+        return cur.rowcount
+
     def health_check(self) -> bool:
         try:
             self.conn.execute("SELECT 1")

--- a/tests/repositories/test_sql_injection_repo.py
+++ b/tests/repositories/test_sql_injection_repo.py
@@ -111,6 +111,11 @@ class RecordingConn:
         self.last_params = params
         return 0
 
+    def execute_batch(self, command, params_seq):
+        self.last_query = command
+        self.last_params = params_seq
+        return 0
+
     def health_check(self):
         return True
 

--- a/tests/services/test_optimized_queries.py
+++ b/tests/services/test_optimized_queries.py
@@ -1,5 +1,6 @@
 import sqlite3
 from datetime import datetime
+from typing import Iterable
 from importlib import util
 from pathlib import Path
 
@@ -29,6 +30,11 @@ class _Conn:
         cur.execute(command.replace("%s", "?"), params or ())
         self.conn.commit()
         return cur.rowcount
+
+    def execute_batch(self, command: str, params_seq: Iterable[tuple]):
+        cur = self.conn.cursor()
+        cur.executemany(command.replace("%s", "?"), params_seq)
+        self.conn.commit()
 
     def health_check(self) -> bool:
         try:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -27,6 +27,9 @@ class MockConnection:
     def execute_command(self, command, params=None):
         return None
 
+    def execute_batch(self, command, params_seq):
+        return None
+
     def health_check(self):
         return self._connected
 

--- a/tests/test_connection_pool_timeout.py
+++ b/tests/test_connection_pool_timeout.py
@@ -26,6 +26,9 @@ class MockConnection:
     def execute_command(self, command, params=None):
         return None
 
+    def execute_batch(self, command, params_seq):
+        return None
+
     def health_check(self):
         return self._connected
 

--- a/tests/test_database_analytics_service.py
+++ b/tests/test_database_analytics_service.py
@@ -20,6 +20,9 @@ class FakeConnection:
             ]
         return []
 
+    def execute_batch(self, command, params_seq):
+        return None
+
 
 class FakeDBManager:
     def get_connection(self):

--- a/tests/test_enhanced_connection_pool.py
+++ b/tests/test_enhanced_connection_pool.py
@@ -52,6 +52,9 @@ class MockConnection:
     def execute_command(self, command, params=None):
         return None
 
+    def execute_batch(self, command, params_seq):
+        return None
+
     def health_check(self):
         return self._connected
 

--- a/tests/test_protocol_compliance.py
+++ b/tests/test_protocol_compliance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Protocol, assert_type, runtime_checkable
+from typing import Any, Callable, Dict, Iterable, List, Protocol, assert_type, runtime_checkable
 
 import pandas as pd
 import pytest
@@ -71,6 +71,9 @@ class DummyDatabase(DatabaseProtocol):
         return pd.DataFrame()
 
     def execute_command(self, command: str, params: tuple | None = None) -> None:
+        pass
+
+    def execute_batch(self, command: str, params_seq: Iterable[tuple]) -> None:
         pass
 
     def begin_transaction(self) -> Any:

--- a/tests/test_secure_db.py
+++ b/tests/test_secure_db.py
@@ -12,6 +12,10 @@ class DummyConn:
         self.called_with = (query, params)
         return "ok"
 
+    def execute_batch(self, command: str, params_seq):
+        self.called_with = (command, list(params_seq))
+        return "ok"
+
 
 def test_execute_secure_query_basic():
     conn = DummyConn()

--- a/tests/test_secure_query_wrapper.py
+++ b/tests/test_secure_query_wrapper.py
@@ -19,6 +19,10 @@ class DummyConn:
         self.last = (query, params)
         return 1
 
+    def execute_batch(self, command: str, params_seq):
+        self.last = (command, list(params_seq))
+        return 1
+
 
 def test_execute_secure_sql_basic():
     conn = DummyConn()

--- a/tests/test_security_patterns.py
+++ b/tests/test_security_patterns.py
@@ -13,6 +13,9 @@ def test_analyze_failed_access_returns_expected_keys(monkeypatch):
         def execute_command(self, *a, **kw):
             return 0
 
+        def execute_batch(self, *a, **kw):
+            return 0
+
         def health_check(self) -> bool:
             return True
 

--- a/tests/utils/query_recorder.py
+++ b/tests/utils/query_recorder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 
 class QueryRecordingConnection:
@@ -17,6 +17,10 @@ class QueryRecordingConnection:
     def execute_command(self, command: str, params: Optional[tuple] = None):
         self.statements.append(command)
         return self._base.execute_command(command, params)
+
+    def execute_batch(self, command: str, params_seq: Iterable[tuple]):
+        self.statements.append(command)
+        return self._base.execute_batch(command, params_seq)
 
     def __getattr__(self, item: str) -> Any:
         return getattr(self._base, item)

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Protocol,
@@ -35,6 +36,11 @@ class DatabaseProtocol(Protocol):
     @abstractmethod
     def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
         """Execute a command (INSERT, UPDATE, DELETE)"""
+        ...
+
+    @abstractmethod
+    def execute_batch(self, command: str, params_seq: Iterable[tuple]) -> None:
+        """Execute a command across multiple parameter sets"""
         ...
 
     @abstractmethod

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -46,6 +46,15 @@ def _validate_params(params: Optional[Iterable[Any]]) -> Optional[tuple]:
     raise TypeError("params must be a tuple/list or None")
 
 
+def _validate_params_seq(params_seq: Iterable[Iterable[Any]]) -> tuple[tuple[Any, ...], ...]:
+    if not isinstance(params_seq, Iterable):
+        raise TypeError("params_seq must be an iterable of parameter sequences")
+    validated = []
+    for params in params_seq:
+        validated.append(_validate_params(params) or ())
+    return tuple(validated)
+
+
 def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
     """Validate, optimize and execute a SELECT query on ``conn``."""
 
@@ -86,4 +95,20 @@ def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None)
     raise AttributeError("Object has no execute or execute_command method")
 
 
-__all__ = ["execute_query", "execute_command", "execute_secure_query"]
+def execute_batch(conn: Any, sql: str, params_seq: Iterable[Iterable[Any]]):
+    """Validate, optimize and execute a batch command on ``conn``."""
+    if not isinstance(sql, str):
+        raise TypeError("sql must be a string")
+    if params_seq is None:
+        raise ValueError("params_seq must be provided")
+    p_seq = _validate_params_seq(params_seq)
+    optimized_sql = _get_optimizer(conn).optimize_query(sql)
+    logger.debug("Executing batch command: %s", optimized_sql)
+    if hasattr(conn, "execute_batch"):
+        return conn.execute_batch(optimized_sql, p_seq)
+    if hasattr(conn, "executemany"):
+        return conn.executemany(optimized_sql, p_seq)
+    raise AttributeError("Object has no execute_batch or executemany method")
+
+
+__all__ = ["execute_query", "execute_command", "execute_secure_query", "execute_batch"]

--- a/yosai_intel_dashboard/src/database/types.py
+++ b/yosai_intel_dashboard/src/database/types.py
@@ -6,7 +6,7 @@ The :class:`DatabaseConnection` protocol describes the minimal interface
 expected by the connection pools and helpers in this package.
 """
 
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Dict, Iterable, List, Optional, Protocol
 
 
 # ---------------------------------------------------------------------------
@@ -25,6 +25,10 @@ class DatabaseConnection(Protocol):
 
     def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
         """Execute a command (INSERT, UPDATE, DELETE)"""
+        ...
+
+    def execute_batch(self, command: str, params_seq: Iterable[tuple]) -> None:
+        """Execute a command against multiple parameter sets"""
         ...
 
     def health_check(self) -> bool:


### PR DESCRIPTION
## Summary
- extend database protocols and connection wrappers with execute_batch
- implement secure batch execution helper and database-specific executemany use

## Testing
- `pytest` *(fails: NameError: name 'redis_client' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d456e888320a368d760af4556fa