### PR TITLE
feat: add prepared statement support

### DIFF
--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -38,6 +38,16 @@ class DatabaseProtocol(Protocol):
         ...
 
     @abstractmethod
+    def prepare_statement(self, name: str, query: str) -> None:
+        """Prepare ``query`` for later execution."""
+        ...
+
+    @abstractmethod
+    def execute_prepared(self, name: str, params: tuple) -> pd.DataFrame:
+        """Execute a previously prepared statement."""
+        ...
+
+    @abstractmethod
     def begin_transaction(self) -> Any:
         """Begin database transaction."""
         ...

--- a/yosai_intel_dashboard/src/database/connection.py
+++ b/yosai_intel_dashboard/src/database/connection.py
@@ -10,6 +10,7 @@ from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
 )
 from database.metrics import queries_total, query_errors_total
 from database.utils import parse_connection_string
+from database.types import DBRows
 
 
 
@@ -22,6 +23,14 @@ class DatabaseConnection(Protocol):
 
     def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
         """Execute INSERT/UPDATE/DELETE"""
+        ...
+
+    def prepare_statement(self, name: str, query: str) -> None:
+        """Prepare ``query`` under ``name`` for later execution."""
+        ...
+
+    def execute_prepared(self, name: str, params: tuple) -> DBRows:
+        """Execute a previously prepared statement."""
         ...
 
     def health_check(self) -> bool:
@@ -63,6 +72,19 @@ def create_database_connection() -> DatabaseConnection:
                 queries_total.inc()
                 try:
                     return conn.execute_command(command, params)
+                except Exception:
+                    query_errors_total.inc()
+                    raise
+
+        def prepare_statement(self, name: str, query: str) -> None:
+            with tracer.start_as_current_span("prepare_statement"):
+                return conn.prepare_statement(name, query)
+
+        def execute_prepared(self, name: str, params: tuple) -> DBRows:
+            with tracer.start_as_current_span("execute_prepared"):
+                queries_total.inc()
+                try:
+                    return conn.execute_prepared(name, params)
                 except Exception:
                     query_errors_total.inc()
                     raise

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -86,4 +86,43 @@ def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None)
     raise AttributeError("Object has no execute or execute_command method")
 
 
-__all__ = ["execute_query", "execute_command", "execute_secure_query"]
+def prepare_statement(conn: Any, name: str, sql: str) -> None:
+    """Prepare ``sql`` on ``conn`` under identifier ``name``."""
+    if not isinstance(name, str) or not isinstance(sql, str):
+        raise TypeError("name and sql must be strings")
+    optimized_sql = _get_optimizer(conn).optimize_query(sql)
+    logger.debug("Preparing statement %s: %s", name, optimized_sql)
+    if hasattr(conn, "prepare_statement"):
+        conn.prepare_statement(name, optimized_sql)
+        return
+    cache = getattr(conn, "_prepared_statements", None)
+    if cache is None:
+        cache = {}
+        try:
+            setattr(conn, "_prepared_statements", cache)
+        except Exception:
+            pass
+    cache[name] = optimized_sql
+
+
+def execute_prepared(conn: Any, name: str, params: Optional[Iterable[Any]] = None):
+    """Execute a previously prepared statement."""
+    p = _validate_params(params)
+    if hasattr(conn, "execute_prepared"):
+        return conn.execute_prepared(name, p if p is not None else tuple())
+    cache = getattr(conn, "_prepared_statements", {})
+    sql = cache.get(name)
+    if sql is None:
+        raise AttributeError(f"Statement {name!r} has not been prepared")
+    if sql.lstrip().lower().startswith("select"):
+        return execute_query(conn, sql, p)
+    return execute_command(conn, sql, p)
+
+
+__all__ = [
+    "execute_query",
+    "execute_command",
+    "execute_secure_query",
+    "prepare_statement",
+    "execute_prepared",
+]

--- a/yosai_intel_dashboard/src/database/types.py
+++ b/yosai_intel_dashboard/src/database/types.py
@@ -27,6 +27,14 @@ class DatabaseConnection(Protocol):
         """Execute a command (INSERT, UPDATE, DELETE)"""
         ...
 
+    def prepare_statement(self, name: str, query: str) -> None:
+        """Prepare ``query`` under ``name`` for later execution."""
+        ...
+
+    def execute_prepared(self, name: str, params: tuple) -> DBRows:
+        """Execute a previously prepared statement."""
+        ...
+
     def health_check(self) -> bool:
         """Verify database connectivity"""
         ...


### PR DESCRIPTION
## Summary
- extend database protocols with prepare/execute_prepared APIs
- add prepared statement caching for sqlite and postgresql connections
- expose secure wrappers for preparing and executing statements

## Testing
- `python -m py_compile yosai_intel_dashboard/src/database/types.py yosai_intel_dashboard/src/database/connection.py yosai_intel_dashboard/src/database/secure_exec.py yosai_intel_dashboard/src/core/protocols/__init__.py yosai_intel_dashboard/src/infrastructure/database/database_connection_factory.py`
- `pytest tests/database/test_connection_factory.py tests/test_connection_pool.py -q` *(fails: No module named 'config.circuit_breaker')*

------
https://chatgpt.com/codex/tasks/task_e_688f0d46c1fc8320b766f696030fd3b9