### PR TITLE
feat: auto-apply common database indexes

### DIFF
--- a/tests/database/test_index_optimizer.py
+++ b/tests/database/test_index_optimizer.py
@@ -1,4 +1,5 @@
-from yosai_intel_dashboard.src.services.database.index_optimizer import IndexOptimizer
+from yosai_intel_dashboard.src.database.index_optimizer import IndexOptimizer
+from yosai_intel_dashboard.src.database import index_optimizer as idx_mod
 
 
 def make_sqlite_conn(indexes=None):
@@ -21,20 +22,24 @@ def make_sqlite_conn(indexes=None):
     return SQLiteConnection(indexes)
 
 
-def test_recommend_new_index():
+def test_recommend_new_index(monkeypatch):
     conn = make_sqlite_conn(["idx_existing"])
+    monkeypatch.setattr(idx_mod, "execute_query", lambda c, q, p=None: c.execute_query(q, p))
+    monkeypatch.setattr(idx_mod, "execute_command", lambda c, q, p=None: c.execute_command(q, p))
     opt = IndexOptimizer(conn)
     stmts = opt.recommend_new_indexes("tbl", ["col1", "col2"])
     assert stmts == ["CREATE INDEX idx_tbl_col1_col2 ON tbl (col1, col2)"]
 
 
-def test_analyze_index_usage_handles_error():
+def test_analyze_index_usage_handles_error(monkeypatch):
     class BadConn:
         __name__ = "SQLiteConnection"
 
         def execute_query(self, query, params=None):
             raise RuntimeError("boom")
 
+    monkeypatch.setattr(idx_mod, "execute_query", lambda c, q, p=None: c.execute_query(q, p))
+    monkeypatch.setattr(idx_mod, "execute_command", lambda c, q, p=None: c.execute_command(q, p))
     opt = IndexOptimizer(BadConn())
     assert opt.analyze_index_usage() == []
 
@@ -62,8 +67,19 @@ class PostgreSQLConnection:
 
 def test_postgres_usage_and_recommend(monkeypatch):
     conn = PostgreSQLConnection()
+    monkeypatch.setattr(idx_mod, "execute_query", lambda c, q, p=None: c.execute_query(q, p))
+    monkeypatch.setattr(idx_mod, "execute_command", lambda c, q, p=None: c.execute_command(q, p))
     opt = IndexOptimizer(conn)
     stats = opt.analyze_index_usage()
     assert stats and stats[0]["index_name"] == "idx_tbl_col1"
     stmts = opt.recommend_new_indexes("tbl", ["col1", "col2"])
     assert not stmts  # index already exists
+
+
+def test_apply_recommendations_executes_statements(monkeypatch):
+    conn = make_sqlite_conn([])
+    monkeypatch.setattr(idx_mod, "execute_query", lambda c, q, p=None: c.execute_query(q, p))
+    monkeypatch.setattr(idx_mod, "execute_command", lambda c, q, p=None: c.execute_command(q, p))
+    opt = IndexOptimizer(conn)
+    opt.apply_recommendations("tbl", ["col1"])
+    assert ("CREATE INDEX idx_tbl_col1 ON tbl (col1)", None) in conn.executed

--- a/yosai_intel_dashboard/src/core/di/bootstrap.py
+++ b/yosai_intel_dashboard/src/core/di/bootstrap.py
@@ -1,9 +1,15 @@
 """Container bootstrap utilities."""
 from __future__ import annotations
 
+import logging
+
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from startup.service_registration import register_all_application_services
 from startup.registry_startup import register_optional_services
+from startup.service_registration import register_all_application_services
+from config.common_indexes import COMMON_INDEXES
+from yosai_intel_dashboard.src.database.index_optimizer import IndexOptimizer
+
+logger = logging.getLogger(__name__)
 
 
 def bootstrap_container() -> ServiceContainer:
@@ -11,6 +17,17 @@ def bootstrap_container() -> ServiceContainer:
     container = ServiceContainer()
     register_all_application_services(container)
     register_optional_services()
+
+    # Ensure common indexes exist. Failures are logged but do not prevent
+    # startup since this is a best-effort optimization.
+    try:
+        optimizer = IndexOptimizer()
+        for table, column_sets in COMMON_INDEXES.items():
+            for cols in column_sets:
+                optimizer.apply_recommendations(table, cols)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Failed to apply common index recommendations: %s", exc)
+
     return container
 
 __all__ = ["bootstrap_container"]

--- a/yosai_intel_dashboard/src/infrastructure/config/common_indexes.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/common_indexes.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Mapping, Sequence, Tuple
+
+# Mapping of table names to sequences of column groups that should be indexed.
+# Each column group is a tuple of column names representing a single index.
+COMMON_INDEXES: Mapping[str, Sequence[Tuple[str, ...]]] = {
+    # Example entries. Extend as needed for application tables.
+    "events": [("user_id",), ("facility_id", "created_at")],
+}
+
+__all__ = ["COMMON_INDEXES"]

--- a/yosai_intel_dashboard/src/services/index_optimizer_cli.py
+++ b/yosai_intel_dashboard/src/services/index_optimizer_cli.py
@@ -7,7 +7,6 @@ import json
 from typing import Sequence
 
 from database.index_optimizer import IndexOptimizer
-from database.secure_exec import execute_command
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -34,8 +33,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             return
         for sql in statements:
             print(f"Executing: {sql}")
-            execute_command(optimizer.connection, sql)
-            print("Created")
+        optimizer.apply_recommendations(args.table, args.columns)
+        print("Created")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- extend IndexOptimizer with ability to apply recommended indexes
- add common index config and ensure indexes at startup
- update index optimizer CLI and tests

## Testing
- `pytest tests/database/test_index_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_688f0d47f9bc83209703a6672fe12f70