### PR TITLE
Add configurable database query timeout

### DIFF
--- a/tests/database/test_secure_exec_timeout.py
+++ b/tests/database/test_secure_exec_timeout.py
@@ -1,0 +1,56 @@
+import pytest
+
+from database import secure_exec
+
+
+class DummyOptimizer:
+    def optimize_query(self, sql: str) -> str:
+        return sql
+
+
+class FakePGConn:
+    def __init__(self):
+        self._optimizer = DummyOptimizer()
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        return "ok"
+
+
+class FakeSQLiteConn:
+    __module__ = "sqlite3"
+
+    def __init__(self):
+        self._optimizer = DummyOptimizer()
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        if sql.startswith("SELECT"):
+            raise TimeoutError("boom")
+        return "ok"
+
+
+def test_postgres_statement_timeout(monkeypatch):
+    class DS:
+        query_timeout_seconds = 1
+
+    monkeypatch.setattr(secure_exec, "DatabaseSettings", DS)
+    conn = FakePGConn()
+    secure_exec.execute_query(conn, "SELECT 1")
+    assert conn.executed[0][0] == "SET LOCAL statement_timeout = 1000"
+    assert conn.executed[1][0] == "SELECT 1"
+    assert conn.executed[2][0] == "SET LOCAL statement_timeout = DEFAULT"
+
+
+def test_sqlite_busy_timeout_reset(monkeypatch):
+    class DS:
+        query_timeout_seconds = 2
+
+    monkeypatch.setattr(secure_exec, "DatabaseSettings", DS)
+    conn = FakeSQLiteConn()
+    with pytest.raises(TimeoutError):
+        secure_exec.execute_query(conn, "SELECT 1")
+    assert conn.executed[0][0] == "PRAGMA busy_timeout = 2000"
+    assert conn.executed[-1][0] == "PRAGMA busy_timeout = 0"

--- a/yosai_intel_dashboard/src/infrastructure/config/base.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base.py
@@ -64,6 +64,7 @@ class DatabaseConfig:
     async_pool_min_size: int = dynamic_config.get_db_pool_size()
     async_pool_max_size: int = dynamic_config.get_db_pool_size() * 2
     async_connection_timeout: int = dynamic_config.get_db_connection_timeout()
+    query_timeout_seconds: int = 600
     shrink_timeout: int = 60
     shrink_interval: int = 0
     # Use the IntelligentConnectionPool instead of the default pool

--- a/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
@@ -41,6 +41,7 @@ class DatabaseSettings(BaseModel):
     user: str = "user"
     password: str = ""
     url: str = ""
+    query_timeout_seconds: int = 600
 
 
 class SecuritySettings(BaseModel):

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -51,6 +51,7 @@ class DatabaseSettings(BaseModel):
     shrink_timeout: int = 60
     shrink_interval: int = 0
     use_intelligent_pool: bool = False
+    query_timeout_seconds: int = 600
 
     @model_validator(mode="after")
     def populate_url(cls, values: "DatabaseSettings") -> "DatabaseSettings":


### PR DESCRIPTION
## Summary
- support per-call timeouts in `execute_query` and `execute_command`
- add `query_timeout_seconds` to database configuration defaults
- cover PostgreSQL `statement_timeout` and SQLite `busy_timeout` behaviors

## Testing
- `pytest tests/database/test_secure_exec_timeout.py tests/test_execute_query_lint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0d4a16008320a8547f8d480b2d04