### PR TITLE
feat: monitor database query performance

### DIFF
--- a/tests/database/test_secure_exec_performance.py
+++ b/tests/database/test_secure_exec_performance.py
@@ -1,0 +1,43 @@
+import logging
+import time
+
+import pytest
+
+from database import secure_exec
+
+
+def _histogram_sum(hist):
+    for metric in hist.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_sum"):
+                return sample.value
+    return 0
+
+
+@pytest.mark.skipif(
+    secure_exec.query_execution_seconds is None,
+    reason="prometheus_client is not installed",
+)
+def test_execute_query_records_metrics_and_logs(monkeypatch, caplog):
+    class Recorder:
+        def execute(self, sql, params=None):  # type: ignore[no-untyped-def]
+            time.sleep(0.01)
+            return []
+
+    class NoopOptimizer:
+        def optimize_query(self, sql):  # type: ignore[no-untyped-def]
+            return sql
+
+    monkeypatch.setattr(secure_exec, "_get_optimizer", lambda _: NoopOptimizer())
+    conn = Recorder()
+    monkeypatch.setattr(secure_exec, "SLOW_QUERY_THRESHOLD", 0.0)
+    secure_exec.query_metrics.clear()
+
+    start_sum = _histogram_sum(secure_exec.query_execution_seconds)
+    with caplog.at_level(logging.WARNING):
+        secure_exec.execute_query(conn, "SELECT 1")
+
+    assert secure_exec.query_metrics, "execution time should be recorded"
+    assert any("Slow query" in r.message for r in caplog.records)
+    end_sum = _histogram_sum(secure_exec.query_execution_seconds)
+    assert end_sum > start_sum

--- a/yosai_intel_dashboard/src/database/metrics.py
+++ b/yosai_intel_dashboard/src/database/metrics.py
@@ -4,11 +4,16 @@ Import ``queries_total`` and ``query_errors_total`` to track how many
 database queries were executed and how many failed.
 """
 
-from prometheus_client import Counter, Gauge
+from prometheus_client import Counter, Gauge, Histogram
 
 queries_total = Counter("database_queries_total", "Total database queries executed")
 query_errors_total = Counter(
     "database_query_errors_total", "Total database query errors"
+)
+
+query_execution_seconds = Histogram(
+    "database_query_execution_seconds",
+    "Time spent executing database queries",
 )
 
 # Connection pool metrics
@@ -28,6 +33,7 @@ health_check_retries_total = Counter(
 __all__ = [
     "queries_total",
     "query_errors_total",
+    "query_execution_seconds",
     "pool_utilization",
     "health_check_failures_total",
     "health_check_retries_total",

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -3,11 +3,31 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 from typing import Any, Iterable, Optional
 
+try:  # optional import to avoid heavy dependency chain
+    from core.performance import PerformanceThresholds
+except Exception:  # pragma: no cover - default if core package unavailable
+    class PerformanceThresholds:  # type: ignore[misc]
+        SLOW_QUERY_SECONDS = 1.0
+
+from database.performance_analyzer import DatabasePerformanceAnalyzer
 from database.types import DBRows
 
+try:  # optional Prometheus integration
+    from database.metrics import query_execution_seconds
+except Exception:  # pragma: no cover - metrics are optional
+    query_execution_seconds = None  # type: ignore
+
 logger = logging.getLogger(__name__)
+
+performance_analyzer = DatabasePerformanceAnalyzer()
+query_metrics = performance_analyzer.query_metrics
+SLOW_QUERY_THRESHOLD = float(
+    os.getenv("DB_SLOW_QUERY_THRESHOLD", PerformanceThresholds.SLOW_QUERY_SECONDS)
+)
 
 
 def _infer_db_type(obj: Any) -> str:
@@ -54,13 +74,22 @@ def execute_query(conn: Any, sql: str, params: Optional[Iterable[Any]] = None):
     p = _validate_params(params)
     optimized_sql = _get_optimizer(conn).optimize_query(sql)
     logger.debug("Executing query: %s", optimized_sql)
-    if hasattr(conn, "execute_query"):
-        return conn.execute_query(optimized_sql, p)
-    if hasattr(conn, "execute"):
-        if p is not None:
-            return conn.execute(optimized_sql, p)
-        return conn.execute(optimized_sql)
-    raise AttributeError("Object has no execute or execute_query method")
+    start = time.perf_counter()
+    try:
+        if hasattr(conn, "execute_query"):
+            return conn.execute_query(optimized_sql, p)
+        if hasattr(conn, "execute"):
+            if p is not None:
+                return conn.execute(optimized_sql, p)
+            return conn.execute(optimized_sql)
+        raise AttributeError("Object has no execute or execute_query method")
+    finally:
+        elapsed = time.perf_counter() - start
+        performance_analyzer.analyze_query_performance(optimized_sql, elapsed)
+        if elapsed > SLOW_QUERY_THRESHOLD:
+            logger.warning("Slow query (%.6f s): %s", elapsed, optimized_sql)
+        if query_execution_seconds is not None:
+            query_execution_seconds.observe(elapsed)
 
 
 def execute_secure_query(conn: Any, sql: str, params: Iterable[Any]) -> DBRows:
@@ -77,13 +106,28 @@ def execute_command(conn: Any, sql: str, params: Optional[Iterable[Any]] = None)
     p = _validate_params(params)
     optimized_sql = _get_optimizer(conn).optimize_query(sql)
     logger.debug("Executing command: %s", optimized_sql)
-    if hasattr(conn, "execute_command"):
-        return conn.execute_command(optimized_sql, p)
-    if hasattr(conn, "execute"):
-        if p is not None:
-            return conn.execute(optimized_sql, p)
-        return conn.execute(optimized_sql)
-    raise AttributeError("Object has no execute or execute_command method")
+    start = time.perf_counter()
+    try:
+        if hasattr(conn, "execute_command"):
+            return conn.execute_command(optimized_sql, p)
+        if hasattr(conn, "execute"):
+            if p is not None:
+                return conn.execute(optimized_sql, p)
+            return conn.execute(optimized_sql)
+        raise AttributeError("Object has no execute or execute_command method")
+    finally:
+        elapsed = time.perf_counter() - start
+        performance_analyzer.analyze_query_performance(optimized_sql, elapsed)
+        if elapsed > SLOW_QUERY_THRESHOLD:
+            logger.warning("Slow query (%.6f s): %s", elapsed, optimized_sql)
+        if query_execution_seconds is not None:
+            query_execution_seconds.observe(elapsed)
 
 
-__all__ = ["execute_query", "execute_command", "execute_secure_query"]
+__all__ = [
+    "execute_query",
+    "execute_command",
+    "execute_secure_query",
+    "query_metrics",
+    "performance_analyzer",
+]


### PR DESCRIPTION
## Summary
- track database query performance and log slow queries
- expose Prometheus histogram for query execution times
- add test for performance metrics

## Testing
- `PYTHONPATH=./yosai_intel_dashboard/src python -m pytest tests/database/test_query_optimizer.py tests/test_execute_query_lint.py tests/database/test_secure_exec_performance.py` *(fails: ImportError: cannot import name 'DatabaseManager')*
- `PYTHONPATH=./yosai_intel_dashboard/src python -m pytest tests/database/test_secure_exec_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_688f0d4b65608320b944ef7ff518e557