### PR TITLE
feat: add reconnect with backoff to event socket

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts
@@ -1,6 +1,14 @@
 import { renderHook, act } from '@testing-library/react';
 import { useEventSocket } from './useEventSocket';
 
+jest.useFakeTimers();
+
+beforeEach(() => {
+  MockSocket.instances = [];
+  MockSocket.instance = null;
+  jest.clearAllTimers();
+});
+
 class MockSocket {
   public onmessage: ((ev: { data: string }) => void) | null = null;
   public onopen: (() => void) | null = null;
@@ -8,14 +16,20 @@ class MockSocket {
   public close = jest.fn();
   constructor(public url: string) {
     MockSocket.instance = this;
+    MockSocket.instances.push(this);
   }
   static instance: MockSocket | null = null;
+  static instances: MockSocket[] = [];
 }
 
 describe('useEventSocket', () => {
   it('receives websocket messages', () => {
     const { result, unmount } = renderHook(() =>
-      useEventSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
+      useEventSocket(
+        'ws://test',
+        (url) => new MockSocket(url) as unknown as WebSocket,
+        false,
+      ),
     );
 
     act(() => {
@@ -26,5 +40,93 @@ describe('useEventSocket', () => {
 
     unmount();
     expect(MockSocket.instance?.close).toHaveBeenCalled();
+  });
+
+  it('reconnects with exponential backoff', () => {
+    const { unmount } = renderHook(() =>
+      useEventSocket(
+        'ws://test',
+        (url) => new MockSocket(url) as unknown as WebSocket,
+        false,
+      ),
+    );
+
+    act(() => {
+      MockSocket.instances[0].onclose?.();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(MockSocket.instances).toHaveLength(2);
+
+    act(() => {
+      MockSocket.instances[1].onclose?.();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(MockSocket.instances).toHaveLength(2);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(MockSocket.instances).toHaveLength(3);
+
+    unmount();
+  });
+
+  it('applies jitter when enabled', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const { unmount } = renderHook(() =>
+      useEventSocket(
+        'ws://test',
+        (url) => new MockSocket(url) as unknown as WebSocket,
+      ),
+    );
+
+    act(() => {
+      MockSocket.instances[0].onclose?.();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1499);
+    });
+
+    expect(MockSocket.instances).toHaveLength(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(MockSocket.instances).toHaveLength(2);
+
+    unmount();
+    (Math.random as jest.Mock).mockRestore();
+  });
+
+  it('stops retries after cleanup', () => {
+    const { unmount } = renderHook(() =>
+      useEventSocket(
+        'ws://test',
+        (url) => new MockSocket(url) as unknown as WebSocket,
+        false,
+      ),
+    );
+
+    act(() => {
+      MockSocket.instances[0].onclose?.();
+    });
+
+    unmount();
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(MockSocket.instances).toHaveLength(1);
   });
 });

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
@@ -3,23 +3,55 @@ import { useEffect, useRef, useState } from 'react';
 export const useEventSocket = (
   url: string,
   socketFactory?: (url: string) => WebSocket,
+  jitter: boolean = true,
 ) => {
   const [data, setData] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+  const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptRef = useRef(0);
+  const stoppedRef = useRef(false);
 
-  useEffect(() => {
+  const connect = () => {
     const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
     wsRef.current = ws;
 
-    ws.onopen = () => setIsConnected(true);
-    ws.onclose = () => setIsConnected(false);
+    ws.onopen = () => {
+      setIsConnected(true);
+      attemptRef.current = 0;
+    };
+    ws.onclose = () => {
+      setIsConnected(false);
+      if (!stoppedRef.current) {
+        let delay = Math.min(1000 * 2 ** attemptRef.current, 30000);
+        if (jitter) {
+          delay += Math.random() * 1000;
+        }
+        attemptRef.current += 1;
+        retryTimeout.current = setTimeout(connect, delay);
+      }
+    };
     ws.onmessage = (ev) => setData(ev.data);
+  };
+
+  const cleanup = () => {
+    stoppedRef.current = true;
+    if (retryTimeout.current) {
+      clearTimeout(retryTimeout.current);
+    }
+    wsRef.current?.close();
+  };
+
+  useEffect(() => {
+    stoppedRef.current = false;
+    connect();
 
     return () => {
-      ws.close();
+      cleanup();
     };
-  }, [url]);
+  }, [url, socketFactory, jitter]);
 
-  return { data, isConnected };
+  return { data, isConnected, cleanup };
 };
+
+export default useEventSocket;


### PR DESCRIPTION
## Summary
- add exponential backoff and optional jitter to useEventSocket hook
- add comprehensive tests for reconnection, jitter, and cleanup

## Testing
- `npm test` *(fails: Cannot find module 'yosai_intel_dashboard/src/adapters/ui/package.json')*
- `node node_modules/react-scripts/scripts/test.js --runTestsByPath yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts` *(fails: No tests found)*
- `pytest -q` *(fails: Interrupted: 256 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_688f0d76334c8320a56005019dde0f0f