### PR TITLE
Add WebSocket connection pool and integrate with analytics broadcast

### DIFF
--- a/yosai_intel_dashboard/src/services/websocket_pool.py
+++ b/yosai_intel_dashboard/src/services/websocket_pool.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Set
+
+from websockets import WebSocketServerProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class WebSocketConnectionPool:
+    """Pool managing active ``WebSocketServerProtocol`` connections.
+
+    Connections are added to the pool when acquired and removed when released.
+    The pool can broadcast a message to all active connections, removing any
+    dead ones encountered during send operations.
+    """
+
+    def __init__(self) -> None:
+        self._connections: Set[WebSocketServerProtocol] = set()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, websocket: WebSocketServerProtocol) -> None:
+        """Add a websocket connection to the pool."""
+        async with self._lock:
+            self._connections.add(websocket)
+
+    async def release(self, websocket: WebSocketServerProtocol) -> None:
+        """Remove a websocket connection from the pool."""
+        async with self._lock:
+            self._connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        """Broadcast ``message`` to all active connections."""
+        async with self._lock:
+            connections = set(self._connections)
+        for ws in connections:
+            try:
+                await ws.send(message)
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.debug("Dropping websocket due to send error: %s", exc)
+                await self.release(ws)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._connections)
+
+
+__all__ = ["WebSocketConnectionPool"]

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
 import threading
-from typing import Optional, Set
+from typing import Optional
 
 from websockets import WebSocketServerProtocol, serve
 
 from yosai_intel_dashboard.src.core.events import EventBus
+
+from .websocket_pool import WebSocketConnectionPool
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +27,7 @@ class AnalyticsWebSocketServer:
         self.host = host
         self.port = port
         self.event_bus = event_bus or EventBus()
-        self.clients: Set[WebSocketServerProtocol] = set()
+        self.pool = WebSocketConnectionPool()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -32,14 +36,14 @@ class AnalyticsWebSocketServer:
         logger.info("WebSocket server started on ws://%s:%s", self.host, self.port)
 
     async def _handler(self, websocket: WebSocketServerProtocol) -> None:
-        self.clients.add(websocket)
+        await self.pool.acquire(websocket)
         try:
             async for _ in websocket:
                 pass  # Server is broadcast-only
         except Exception as exc:  # pragma: no cover - connection errors
             logger.debug("WebSocket connection error: %s", exc)
         finally:
-            self.clients.discard(websocket)
+            await self.pool.release(websocket)
 
     async def _serve(self) -> None:
         self._loop = asyncio.get_running_loop()
@@ -49,18 +53,10 @@ class AnalyticsWebSocketServer:
     def _run(self) -> None:
         asyncio.run(self._serve())
 
-    async def _broadcast_async(self, message: str) -> None:
-        for ws in set(self.clients):
-            try:
-                await ws.send(message)
-            except Exception as exc:  # pragma: no cover - drop dead clients
-                logger.debug("Failed sending to client: %s", exc)
-                self.clients.discard(ws)
-
     def broadcast(self, data: dict) -> None:
         message = json.dumps(data)
         if self._loop is not None:
-            asyncio.run_coroutine_threadsafe(self._broadcast_async(message), self._loop)
+            asyncio.run_coroutine_threadsafe(self.pool.broadcast(message), self._loop)
 
     def stop(self) -> None:
         """Stop the server thread and event loop."""


### PR DESCRIPTION
## Summary
- add `WebSocketConnectionPool` to manage websocket acquisition and broadcast
- update `AnalyticsWebSocketServer` to use pool for client tracking and event-bus broadcasts

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/websocket_pool.py yosai_intel_dashboard/src/services/websocket_server.py` *(fails: mypy errors in unrelated modules)*
- `pytest tests/integration/test_sample_plugin_upload.py -k plugin_upload_event_sse_ws -q` *(fails: SyntaxError in test file)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d7782e88320925a30e274d2ab04