### PR TITLE
Add integration test for auth login flow

### DIFF
--- a/tests/integration/test_auth_integration.py
+++ b/tests/integration/test_auth_integration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+# Reuse stubbed auth application fixture
+from tests.integration.test_auth_flow import auth_app as _auth_app
+
+auth_app = _auth_app
+
+
+@pytest.mark.integration
+def test_login_and_protected_access(auth_app) -> None:
+    """Login sets session and allows protected endpoint access."""
+
+    client = auth_app.test_client()
+
+    # Access to protected route should redirect to login before authentication
+    resp = client.get("/protected")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["Location"]
+
+    # Begin login flow
+    resp = client.get("/login")
+    assert resp.status_code == 302
+
+    # Simulate callback with token exchange
+    resp = client.get("/callback?code=fake")
+    assert resp.status_code == 302
+
+    # Session data should be set
+    with client.session_transaction() as sess:
+        assert sess["user_id"] == "user123"
+        assert sess["roles"] == ["admin"]
+
+    # Protected endpoint accessible after login
+    resp = client.get("/protected")
+    assert resp.status_code == 200
+    assert resp.data == b"ok"


### PR DESCRIPTION
## Summary
- refactor auth flow test into reusable `auth_app` fixture with stubs
- add integration test covering login flow and protected endpoint access

## Testing
- `pre-commit run black --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`
- `pre-commit run isort --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`
- `pre-commit run flake8 --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`
- `pre-commit run import-style-check --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`
- `pre-commit run no-direct-execute-query --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`
- `pre-commit run bandit --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py` *(fails: Issue B110 in analyzers/style_analyzer.py)*
- `pre-commit run mypy --files tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py` *(fails: multiple type errors across repository)*
- `pytest tests/integration/test_auth_integration.py tests/integration/test_auth_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2a234e7883209f3caf689d0d2fbc