### PR TITLE
Add feature flag API endpoints and CLI

### DIFF
--- a/cli/feature_flags.py
+++ b/cli/feature_flags.py
@@ -1,0 +1,112 @@
+"""CLI to manage feature flags via the API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+import requests
+
+
+def _headers(token: str | None, roles: str | None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if roles:
+        headers["X-Roles"] = roles
+    return headers
+
+
+def list_flags(api_url: str, token: str | None, roles: str | None) -> None:
+    resp = requests.get(api_url, headers=_headers(token, roles))
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def get_flag(api_url: str, name: str, token: str | None, roles: str | None) -> None:
+    resp = requests.get(f"{api_url}/{name}", headers=_headers(token, roles))
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def create_flag(
+    api_url: str, name: str, enabled: bool, token: str | None, roles: str | None
+) -> None:
+    payload = {"name": name, "enabled": enabled}
+    resp = requests.post(api_url, json=payload, headers=_headers(token, roles))
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def update_flag(
+    api_url: str, name: str, enabled: bool, token: str | None, roles: str | None
+) -> None:
+    payload = {"enabled": enabled}
+    resp = requests.put(
+        f"{api_url}/{name}", json=payload, headers=_headers(token, roles)
+    )
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def delete_flag(api_url: str, name: str, token: str | None, roles: str | None) -> None:
+    resp = requests.delete(f"{api_url}/{name}", headers=_headers(token, roles))
+    resp.raise_for_status()
+    print("deleted")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage feature flags via API")
+    parser.add_argument(
+        "--api-url",
+        default="http://localhost:8000/v1/feature-flags",
+        help="Feature flag API base URL",
+    )
+    parser.add_argument("--token", help="Bearer token for authentication")
+    parser.add_argument("--roles", help="Comma separated roles for RBAC")
+
+    sub = parser.add_subparsers(dest="command")
+
+    sp = sub.add_parser("list", help="List all feature flags")
+    sp.set_defaults(func=lambda args: list_flags(args.api_url, args.token, args.roles))
+
+    sp = sub.add_parser("get", help="Get a flag")
+    sp.add_argument("name")
+    sp.set_defaults(
+        func=lambda args: get_flag(args.api_url, args.name, args.token, args.roles)
+    )
+
+    sp = sub.add_parser("create", help="Create a flag")
+    sp.add_argument("name")
+    sp.add_argument("--enabled", action="store_true", help="Enable the flag")
+    sp.set_defaults(
+        func=lambda args: create_flag(
+            args.api_url, args.name, args.enabled, args.token, args.roles
+        )
+    )
+
+    sp = sub.add_parser("update", help="Update a flag")
+    sp.add_argument("name")
+    sp.add_argument("--enabled", action="store_true", help="Enable the flag")
+    sp.set_defaults(
+        func=lambda args: update_flag(
+            args.api_url, args.name, args.enabled, args.token, args.roles
+        )
+    )
+
+    sp = sub.add_parser("delete", help="Delete a flag")
+    sp.add_argument("name")
+    sp.set_defaults(
+        func=lambda args: delete_flag(args.api_url, args.name, args.token, args.roles)
+    )
+
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -46,3 +46,45 @@ if feature_flags.is_enabled("use_timescaledb"):
 
 Callbacks can be registered with `register_callback` to respond to
 updates.
+
+## REST API
+
+Feature flags can also be managed via the dashboard's REST API.
+
+List all flags:
+
+```bash
+curl -H "X-Roles: user" http://localhost:8000/v1/feature-flags
+```
+
+Retrieve a single flag:
+
+```bash
+curl -H "X-Roles: user" http://localhost:8000/v1/feature-flags/use_timescaledb
+```
+
+Create or update a flag (requires the `admin` role):
+
+```bash
+curl -X POST -H "X-Roles: admin" -H "Content-Type: application/json" \
+  -d '{"name": "new_feature", "enabled": true}' \
+  http://localhost:8000/v1/feature-flags
+```
+
+Delete a flag:
+
+```bash
+curl -X DELETE -H "X-Roles: admin" \
+  http://localhost:8000/v1/feature-flags/new_feature
+```
+
+## CLI Usage
+
+The repository provides a small CLI for interacting with the feature
+flag API:
+
+```bash
+python cli/feature_flags.py list --roles user
+python cli/feature_flags.py create my_flag --enabled --roles admin
+python cli/feature_flags.py delete my_flag --roles admin
+```

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -25,6 +25,7 @@ from api.analytics_router import init_cache_manager
 from api.analytics_router import router as analytics_router
 from api.explanations import router as explanations_router
 from api.monitoring_router import router as monitoring_router
+from api.routes.feature_flags import router as feature_flags_router
 from middleware.performance import TimingMiddleware
 from yosai_framework.service import BaseService
 from yosai_intel_dashboard.src.core.container import container
@@ -108,6 +109,7 @@ def create_api_app() -> "FastAPI":
     api_v1.include_router(analytics_router)
     api_v1.include_router(monitoring_router)
     api_v1.include_router(explanations_router)
+    api_v1.include_router(feature_flags_router)
 
     service.app.include_router(api_v1, dependencies=[Depends(verify_token)])
 
@@ -115,6 +117,7 @@ def create_api_app() -> "FastAPI":
     legacy_router.include_router(analytics_router)
     legacy_router.include_router(monitoring_router)
     legacy_router.include_router(explanations_router)
+    legacy_router.include_router(feature_flags_router)
 
     service.app.include_router(
         legacy_router,

--- a/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
+++ b/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage for API route modules."""

--- a/yosai_intel_dashboard/src/adapters/api/routes/feature_flags.py
+++ b/yosai_intel_dashboard/src/adapters/api/routes/feature_flags.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel
+
+from yosai_intel_dashboard.src.services.feature_flags import feature_flags
+from yosai_intel_dashboard.src.services.security import require_role
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/feature-flags", tags=["feature-flags"])
+
+
+class FeatureFlag(BaseModel):
+    name: str
+    enabled: bool
+
+
+class FeatureFlagUpdate(BaseModel):
+    enabled: bool
+
+
+# ---------------------------------------------------------------------------
+
+
+def _persist_flags() -> None:
+    """Persist current flags to the source file when possible."""
+    source = feature_flags.source
+    if source.startswith("http://") or source.startswith("https://"):
+        return
+    path = Path(source)
+    try:
+        path.write_text(json.dumps(feature_flags.get_all(), indent=2))
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Failed to write feature flags: %s", exc)
+
+
+@router.get("/")
+async def list_feature_flags(_: None = Depends(require_role("user"))):
+    """Return all feature flags."""
+    return feature_flags.get_all()
+
+
+@router.get("/{name}")
+async def get_feature_flag(name: str, _: None = Depends(require_role("user"))):
+    """Return a single feature flag by *name*."""
+    flags = feature_flags.get_all()
+    if name not in flags:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="flag not found"
+        )
+    return {"name": name, "enabled": flags[name]}
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_feature_flag(
+    flag: FeatureFlag, _: None = Depends(require_role("admin"))
+):
+    """Create a new feature flag."""
+    flags = feature_flags.get_all()
+    if flag.name in flags:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="flag exists")
+    feature_flags._flags[flag.name] = flag.enabled
+    _persist_flags()
+    return flag
+
+
+@router.put("/{name}")
+async def update_feature_flag(
+    name: str, flag: FeatureFlagUpdate, _: None = Depends(require_role("admin"))
+):
+    """Update an existing feature flag."""
+    if name not in feature_flags.get_all():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="flag not found"
+        )
+    feature_flags._flags[name] = flag.enabled
+    _persist_flags()
+    return {"name": name, "enabled": flag.enabled}
+
+
+@router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_feature_flag(name: str, _: None = Depends(require_role("admin"))):
+    """Delete a feature flag."""
+    if name not in feature_flags.get_all():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="flag not found"
+        )
+    del feature_flags._flags[name]
+    _persist_flags()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- add `/feature-flags` API with list/get/create/update/delete operations and RBAC
- expose feature flag routes via API adapter
- add CLI utility for managing feature flags through API
- document feature flag API and CLI usage

## Testing
- `pre-commit run --files api/routes/__init__.py api/routes/feature_flags.py api/adapter.py cli/feature_flags.py docs/feature_flags.md`
- `pytest tests/test_rbac.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2ae6f65c8320b44ab37f5a12c6e3