### PR TITLE
Add feature flag monitoring metrics and alerts

### DIFF
--- a/dashboards/grafana/feature_flags.json
+++ b/dashboards/grafana/feature_flags.json
@@ -1,0 +1,41 @@
+{
+  "uid": "feature-flags",
+  "title": "Feature Flag Metrics",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Flag Evaluations",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "feature_flag_evaluations_total", "legendFormat": "evaluations"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Cache Refreshes",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "feature_flag_cache_refreshes_total", "legendFormat": "refreshes"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Variant Hits",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "feature_flag_variant_hits_total", "legendFormat": "{{variant}}"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Fallback Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(feature_flag_fallback_total[5m]) / rate(feature_flag_evaluations_total[5m])",
+          "legendFormat": "fallback_rate"
+        }
+      ]
+    }
+  ]
+}

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -29,7 +29,11 @@ __all__ = [
     "InferenceDriftJob",
     "request_duration",
     "ABTest",
-
+    "flag_evaluations",
+    "variant_hits",
+    "cache_refreshes",
+    "flag_fallbacks",
+    "missing_dependencies",
 ]
 
 
@@ -47,7 +51,7 @@ def __getattr__(name: str):
         "record_avro_failure",
         "record_compatibility_failure",
     }:
-        from .data_quality_monitor import (
+        from .data_quality_monitor import (  # noqa: F401
             DataQualityMetrics,
             DataQualityMonitor,
             avro_decoding_failures,
@@ -68,7 +72,7 @@ def __getattr__(name: str):
         "register_health_check",
         "setup_health_checks",
     }:
-        from ..discovery.health_check import (
+        from ..discovery.health_check import (  # noqa: F401
             health_check,
             health_check_router,
             register_health_check,
@@ -81,7 +85,7 @@ def __getattr__(name: str):
         "ModelMetrics",
         "get_model_performance_monitor",
     }:
-        from .model_performance_monitor import (
+        from .model_performance_monitor import (  # noqa: F401
             ModelMetrics,
             ModelPerformanceMonitor,
             get_model_performance_monitor,
@@ -97,7 +101,7 @@ def __getattr__(name: str):
 
         return ModelMonitoringService
     if name in {"RealTimeUIMonitor", "get_ui_monitor"}:
-        from .ui_monitor import RealTimeUIMonitor, get_ui_monitor
+        from .ui_monitor import RealTimeUIMonitor, get_ui_monitor  # noqa: F401
 
         return locals()[name]
     if name in {
@@ -105,7 +109,7 @@ def __getattr__(name: str):
         "record_deprecated_call",
         "start_deprecation_metrics_server",
     }:
-        from .prometheus.deprecation import (
+        from .prometheus.deprecation import (  # noqa: F401
             deprecated_calls,
             record_deprecated_call,
             start_deprecation_metrics_server,
@@ -124,5 +128,21 @@ def __getattr__(name: str):
         from .ab_testing import ABTest
 
         return ABTest
+    if name in {
+        "flag_evaluations",
+        "variant_hits",
+        "cache_refreshes",
+        "flag_fallbacks",
+        "missing_dependencies",
+    }:
+        from .flag_metrics import (  # noqa: F401
+            cache_refreshes,
+            flag_evaluations,
+            flag_fallbacks,
+            missing_dependencies,
+            variant_hits,
+        )
+
+        return locals()[name]
 
     raise AttributeError(name)

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/alerts.yml
@@ -24,3 +24,22 @@ groups:
           summary: A performance budget was exceeded
           channels: performance-alerts
 
+  - name: feature-flags
+    rules:
+      - alert: HighFeatureFlagFallbackRate
+        expr: rate(feature_flag_fallback_total[5m]) / rate(feature_flag_evaluations_total[5m]) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High feature flag fallback rate detected
+          channels: performance-alerts
+      - alert: MissingOptionalDependencies
+        expr: optional_dependency_missing_total > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Optional dependency missing
+          channels: performance-alerts
+

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/flag_metrics.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/flag_metrics.py
@@ -1,0 +1,64 @@
+"""Prometheus counters for feature flag performance."""
+
+from __future__ import annotations
+
+from prometheus_client import REGISTRY, Counter
+from prometheus_client.core import CollectorRegistry
+
+if "feature_flag_evaluations_total" not in REGISTRY._names_to_collectors:
+    flag_evaluations = Counter(
+        "feature_flag_evaluations_total", "Number of feature flag evaluations"
+    )
+    variant_hits = Counter(
+        "feature_flag_variant_hits_total",
+        "Number of feature flag variant hits",
+        ["variant"],
+    )
+    cache_refreshes = Counter(
+        "feature_flag_cache_refreshes_total", "Number of feature flag cache refreshes"
+    )
+    flag_fallbacks = Counter(
+        "feature_flag_fallback_total", "Number of times default flag values were used"
+    )
+    missing_dependencies = Counter(
+        "optional_dependency_missing_total",
+        "Times an optional dependency was missing",
+        ["dependency"],
+    )
+else:  # pragma: no cover - defensive in tests
+    registry = CollectorRegistry()
+    flag_evaluations = Counter(
+        "feature_flag_evaluations_total",
+        "Number of feature flag evaluations",
+        registry=registry,
+    )
+    variant_hits = Counter(
+        "feature_flag_variant_hits_total",
+        "Number of feature flag variant hits",
+        ["variant"],
+        registry=registry,
+    )
+    cache_refreshes = Counter(
+        "feature_flag_cache_refreshes_total",
+        "Number of feature flag cache refreshes",
+        registry=registry,
+    )
+    flag_fallbacks = Counter(
+        "feature_flag_fallback_total",
+        "Number of times default flag values were used",
+        registry=registry,
+    )
+    missing_dependencies = Counter(
+        "optional_dependency_missing_total",
+        "Times an optional dependency was missing",
+        ["dependency"],
+        registry=registry,
+    )
+
+__all__ = [
+    "flag_evaluations",
+    "variant_hits",
+    "cache_refreshes",
+    "flag_fallbacks",
+    "missing_dependencies",
+]


### PR DESCRIPTION
## Summary
- add Prometheus counters for flag evaluations, variants, refreshes and fallbacks
- surface flag performance on Grafana and alert on fallback rate or missing deps
- log variant hits, cache refreshes and fallback usage

## Testing
- `pre-commit run --files optional_dependencies.py monitoring/flag_metrics.py monitoring/__init__.py monitoring/ab_testing.py monitoring/alerts.yml yosai_intel_dashboard/src/services/feature_flags.py dashboards/grafana/feature_flags.json`


------
https://chatgpt.com/codex/tasks/task_e_688f2ae5cef88320a05686f211a95d32