### PR TITLE
feat: add resilient feature flag manager

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,14 +1,18 @@
 # Feature Flag Management
 
 The dashboard can toggle experimental services on and off at runtime. A
-small manager watches a JSON file or remote endpoint and exposes the
-current flag values to the application.
+small manager watches a JSON file, Redis instance or remote HTTP
+endpoint and exposes the current flag values to the application. Each
+flag has a **fallback** value used when dependencies cannot be resolved
+or the remote store is unavailable.
 
 ## Configuring the Source
 
 Set the `FEATURE_FLAG_SOURCE` environment variable to either a file path
 or an HTTP(S) URL that returns a JSON object. If unset, the manager
-looks for `feature_flags.json` in the working directory.
+looks for `feature_flags.json` in the working directory. Alternatively,
+configure `FEATURE_FLAG_REDIS_URL` to load flags from Redis (key
+`feature_flags`).
 
 ```bash
 # Local file
@@ -18,19 +22,23 @@ export FEATURE_FLAG_SOURCE=/etc/yosai/flags.json
 export FEATURE_FLAG_SOURCE=https://config.example.com/flags
 ```
 
-The file or endpoint should return a simple mapping of flag names to
-boolean values:
+The file/endpoint/Redis value should return flag definitions. Each
+definition may specify the current `enabled` value, a `fallback` value
+and optional dependencies:
 
 ```json
 {
-  "use_timescaledb": true,
-  "use_kafka_events": false,
-  "use_analytics_microservice": true
+  "use_timescaledb": {"enabled": true, "fallback": false},
+  "use_kafka_events": {"enabled": false, "fallback": false},
+  "use_analytics_microservice": {"enabled": true, "fallback": false}
 }
 ```
 
 Changes are detected automatically and any registered callbacks are
-invoked so services can hot‑reload their configuration.
+invoked so services can hot‑reload their configuration. The last
+evaluated flag set is persisted to `feature_flags_cache.json` and loaded
+on startup before contacting Redis or other sources. If the remote store
+is unreachable the cached values are used and a warning is logged.
 
 ## Querying Flags
 

--- a/tests/test_feature_flag_fallback.py
+++ b/tests/test_feature_flag_fallback.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from yosai_intel_dashboard.src.services.feature_flags import FeatureFlagManager
+
+
+def test_redis_unavailable_uses_cache_and_fallback(tmp_path, caplog):
+    cache = tmp_path / "feature_flags_cache.json"
+    cache.write_text(json.dumps({"use_analytics_microservice": True}))
+
+    mgr = FeatureFlagManager(
+        source=None,
+        redis_url="redis://localhost:1",  # unreachable
+        cache_file=cache,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert mgr.is_enabled("use_analytics_microservice") is True
+        assert mgr.is_enabled("use_kafka_events") is False
+    assert any("fallback mode" in r.message for r in caplog.records)
+
+
+def test_dependency_failure_returns_fallback(caplog):
+    mgr = FeatureFlagManager(source=None, redis_url=None)
+    mgr._definitions["a"] = {
+        "enabled": True,
+        "fallback": False,
+        "requires": ["missing"],
+    }
+    with caplog.at_level(logging.WARNING):
+        mgr._recompute_flags()
+        assert mgr.is_enabled("a") is False
+    assert any("Failed to evaluate feature flag a" in r.message for r in caplog.records)

--- a/tests/test_migration_adapter.py
+++ b/tests/test_migration_adapter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 import os
 import pathlib
@@ -6,21 +8,28 @@ import types
 from typing import Any
 
 import pandas as pd
-from tests.import_helpers import safe_import, import_optional
+
+from tests.import_helpers import import_optional, safe_import
 
 # Provide a lightweight stub for services.interfaces to avoid heavy imports
 stub_pkg = types.ModuleType("services")
 stub_interfaces = types.ModuleType("services.interfaces")
 
+safe_import("services", lambda: stub_pkg)
+
 # Load the feature flag module so adapter imports succeed
 flags_spec = importlib.util.spec_from_file_location(
     "services.feature_flags",
-    pathlib.Path(__file__).resolve().parents[1] / "services" / "feature_flags.py",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "services"
+    / "feature_flags.py",
 )
 flags_module = importlib.util.module_from_spec(flags_spec)
 flags_spec.loader.exec_module(flags_module)
 stub_pkg.feature_flags = flags_module
-safe_import('services.feature_flags', flags_module)
+safe_import("services.feature_flags", lambda: flags_module)
 
 # Minimal registry stub
 registry_stub = types.ModuleType("services.registry")
@@ -33,7 +42,7 @@ class ServiceDiscovery:
 
 registry_stub.ServiceDiscovery = ServiceDiscovery
 stub_pkg.registry = registry_stub
-safe_import('services.registry', registry_stub)
+safe_import("services.registry", lambda: registry_stub)
 
 # Minimal resilience.circuit_breaker stub
 resilience_pkg = types.ModuleType("services.resilience")
@@ -53,8 +62,8 @@ cb_module.CircuitBreaker = CircuitBreaker
 cb_module.CircuitBreakerOpen = CircuitBreakerOpen
 resilience_pkg.circuit_breaker = cb_module
 stub_pkg.resilience = resilience_pkg
-safe_import('services.resilience', resilience_pkg)
-safe_import('services.resilience.circuit_breaker', cb_module)
+safe_import("services.resilience", lambda: resilience_pkg)
+safe_import("services.resilience.circuit_breaker", lambda: cb_module)
 
 
 class AnalyticsServiceProtocol:
@@ -62,12 +71,13 @@ class AnalyticsServiceProtocol:
 
 
 stub_interfaces.AnalyticsServiceProtocol = AnalyticsServiceProtocol
-safe_import('services', stub_pkg)
-safe_import('services.interfaces', stub_interfaces)
+safe_import("services.interfaces", lambda: stub_interfaces)
 
 spec = importlib.util.spec_from_file_location(
     "migration_adapter",
     pathlib.Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
     / "services"
     / "migration"
     / "adapter.py",

--- a/yosai_intel_dashboard/src/services/feature_flags.py
+++ b/yosai_intel_dashboard/src/services/feature_flags.py
@@ -1,39 +1,92 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Set
 
 import aiofiles
 import aiohttp
 
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover - fallback if redis not installed
+    redis = None  # type: ignore
+
+
 logger = logging.getLogger(__name__)
 
 
-class FeatureFlagManager:
-    """Watch a JSON file or HTTP endpoint for feature flag updates."""
+# Default flag definitions with fallbacks. Additional flags may be provided at
+# runtime from Redis or a JSON source. Each definition contains a "fallback"
+# value and optional list of dependencies under "requires".
+FLAG_DEFINITIONS: Dict[str, Dict[str, Any]] = {
+    "use_kafka_events": {"fallback": False, "requires": []},
+    "use_timescaledb": {"fallback": False, "requires": []},
+    "use_analytics_microservice": {"fallback": False, "requires": []},
+}
 
-    def __init__(self, source: str | None = None, poll_interval: float = 5.0) -> None:
+
+class FeatureFlagManager:
+    """Watch a JSON file, HTTP endpoint or Redis for feature flag updates."""
+
+    def __init__(
+        self,
+        source: str | None = None,
+        poll_interval: float = 5.0,
+        redis_url: str | None = None,
+        cache_file: str | Path | None = None,
+    ) -> None:
         self.source = source or os.getenv("FEATURE_FLAG_SOURCE", "feature_flags.json")
         self.poll_interval = poll_interval
+        self.redis_url = redis_url or os.getenv("FEATURE_FLAG_REDIS_URL")
+        self.redis_key = os.getenv("FEATURE_FLAG_REDIS_KEY", "feature_flags")
+        self.cache_file = Path(
+            cache_file or os.getenv("FEATURE_FLAG_CACHE", "feature_flags_cache.json")
+        )
+        # ``_definitions`` holds flag metadata including fallbacks and dependencies
+        self._definitions: Dict[str, Dict[str, Any]] = json.loads(
+            json.dumps(FLAG_DEFINITIONS)
+        )
+        # ``_flags`` holds the last evaluated values for quick lookup
         self._flags: Dict[str, bool] = {}
         self._callbacks: List[Callable[[Dict[str, bool]], Any]] = []
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._last_mtime: float | None = None
-        asyncio.run(self.load_flags())
+        self._fallback_mode = False
+        self._warned_fallback = False
+        self._redis: redis.Redis | None = None
 
+        # Load cached flags before attempting any remote fetches
+        self._load_cache()
+        self._recompute_flags()
+        self.load_flags()
+
+    # ------------------------------------------------------------------
     async def load_flags_async(self) -> None:
-        """Asynchronously load flags from the configured source."""
+        """Asynchronously load flags from Redis, HTTP or file sources."""
 
         data: Dict[str, Any] = {}
-        if self.source.startswith("http://") or self.source.startswith("https://"):
+        if self.redis_url and redis is not None:
+            try:
+                if self._redis is None:
+                    self._redis = redis.from_url(self.redis_url, decode_responses=True)
+                raw = await self._redis.get(self.redis_key)
+                data = json.loads(raw) if raw else {}
+            except Exception as exc:  # pragma: no cover - network failures
+                self._fallback_mode = True
+                logger.warning("Failed to fetch flags from Redis: %s", exc)
+                return
+        elif self.source and (
+            self.source.startswith("http://") or self.source.startswith("https://")
+        ):
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(self.source, timeout=2) as resp:
-
                         resp.raise_for_status()
                         data = await resp.json()
             except Exception as exc:  # pragma: no cover - network failures
@@ -56,19 +109,29 @@ class FeatureFlagManager:
                 return
 
         if isinstance(data, dict):
-            new_flags = {k: bool(v) for k, v in data.items()}
-            if new_flags != self._flags:
-                self._flags = new_flags
-                for cb in list(self._callbacks):
-                    try:
-                        cb(self._flags.copy())
-                    except Exception as exc:  # pragma: no cover - callback errors
-                        logger.warning("Feature flag callback failed: %s", exc)
+            for name, value in data.items():
+                definition = self._definitions.setdefault(name, {"fallback": False})
+                if isinstance(value, dict):
+                    definition["enabled"] = bool(
+                        value.get("enabled", value.get("value", False))
+                    )
+                    if "fallback" in value:
+                        definition["fallback"] = bool(value["fallback"])
+                    if "requires" in value:
+                        definition["requires"] = list(value["requires"])
+                else:
+                    definition["enabled"] = bool(value)
+            self._recompute_flags()
+            await self._save_cache()
+            self._fallback_mode = False
+            self._warned_fallback = False
 
+    # ------------------------------------------------------------------
     def load_flags(self) -> None:
         """Synchronous wrapper for :meth:`load_flags_async`."""
         asyncio.run(self.load_flags_async())
 
+    # ------------------------------------------------------------------
     def start(self) -> None:
         """Start background watcher for flag changes."""
         if self._thread and self._thread.is_alive():
@@ -78,29 +141,103 @@ class FeatureFlagManager:
         self._thread = threading.Thread(target=self._watch, daemon=True)
         self._thread.start()
 
+    # ------------------------------------------------------------------
     def stop(self) -> None:
         """Stop the background watcher."""
         if self._thread:
             self._stop.set()
             self._thread.join()
 
+    # ------------------------------------------------------------------
     def _watch(self) -> None:
         while not self._stop.is_set():
             asyncio.run(self.load_flags_async())
             if self._stop.wait(self.poll_interval):
                 break
 
+    # ------------------------------------------------------------------
     def is_enabled(self, name: str, default: bool = False) -> bool:
         """Return True if *name* flag is enabled."""
-        return self._flags.get(name, default)
 
+        if self._fallback_mode and not self._warned_fallback:
+            logger.warning("FeatureFlagManager operating in fallback mode")
+            self._warned_fallback = True
+
+        if name in self._flags:
+            return self._flags[name]
+
+        definition = self._definitions.get(name)
+        if definition is not None:
+            return bool(definition.get("fallback", default))
+        return default
+
+    # ------------------------------------------------------------------
     def register_callback(self, cb: Callable[[Dict[str, bool]], Any]) -> None:
         """Register *cb* to be called when flags change."""
         self._callbacks.append(cb)
 
+    # ------------------------------------------------------------------
     def get_all(self) -> Dict[str, bool]:
         return self._flags.copy()
 
+    # ------------------------------------------------------------------
+    def _resolve(self, name: str, seen: Set[str]) -> bool:
+        if name in seen:
+            raise RuntimeError("circular dependency detected")
+        seen.add(name)
+        definition = self._definitions.get(name, {})
+        enabled = bool(definition.get("enabled", definition.get("fallback", False)))
+        requires = definition.get("requires", [])
+        for dep in requires:
+            if dep not in self._definitions:
+                raise KeyError(f"missing dependency {dep}")
+            if not self._resolve(dep, seen):
+                return bool(definition.get("fallback", False))
+        return enabled
+
+    # ------------------------------------------------------------------
+    def _recompute_flags(self) -> None:
+        new_flags: Dict[str, bool] = {}
+        for name in self._definitions:
+            try:
+                new_flags[name] = self._resolve(name, set())
+            except Exception as exc:  # pragma: no cover - defensive
+                fallback = bool(self._definitions[name].get("fallback", False))
+                logger.warning("Failed to evaluate feature flag %s: %s", name, exc)
+                new_flags[name] = fallback
+
+        if new_flags != self._flags:
+            self._flags = new_flags
+            for cb in list(self._callbacks):
+                try:
+                    cb(self._flags.copy())
+                except Exception as exc:  # pragma: no cover - callback errors
+                    logger.warning("Feature flag callback failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    def _load_cache(self) -> None:
+        try:
+            if self.cache_file.is_file():
+                content = self.cache_file.read_text()
+                cached = json.loads(content)
+                self._flags = {k: bool(v) for k, v in cached.items()}
+                for name, val in self._flags.items():
+                    self._definitions.setdefault(name, {"fallback": False})[
+                        "enabled"
+                    ] = val
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to load feature flag cache: %s", exc)
+
+    # ------------------------------------------------------------------
+    async def _save_cache(self) -> None:
+        try:
+            async with aiofiles.open(self.cache_file, "w") as fh:
+                await fh.write(json.dumps(self._flags))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to persist feature flag cache: %s", exc)
+
 
 # Global feature flag manager
-feature_flags = FeatureFlagManager()
+feature_flags = FeatureFlagManager(
+    redis_url=os.getenv("FEATURE_FLAG_REDIS_URL"),
+)


### PR DESCRIPTION
## Summary
- expand feature flag manager with fallbacks, Redis support, and disk cache
- document fallback and caching behaviour
- add tests for fallback evaluation

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/feature_flags.py docs/feature_flags.md tests/test_feature_flag_fallback.py tests/test_migration_adapter.py`
- `pytest tests/test_feature_flag_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2ae29974832088c89b4d29e73592