### PR TITLE
Add feature flag audit logging and routes

### DIFF
--- a/tests/test_migration_adapter.py
+++ b/tests/test_migration_adapter.py
@@ -15,7 +15,12 @@ stub_interfaces = types.ModuleType("services.interfaces")
 # Load the feature flag module so adapter imports succeed
 flags_spec = importlib.util.spec_from_file_location(
     "services.feature_flags",
-    pathlib.Path(__file__).resolve().parents[1] / "services" / "feature_flags.py",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "services"
+    / "feature_flags"
+    / "__init__.py",
 )
 flags_module = importlib.util.module_from_spec(flags_spec)
 flags_spec.loader.exec_module(flags_module)

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -25,6 +25,7 @@ from api.analytics_router import init_cache_manager
 from api.analytics_router import router as analytics_router
 from api.explanations import router as explanations_router
 from api.monitoring_router import router as monitoring_router
+from api.routes import router as feature_flags_router
 from middleware.performance import TimingMiddleware
 from yosai_framework.service import BaseService
 from yosai_intel_dashboard.src.core.container import container
@@ -108,6 +109,7 @@ def create_api_app() -> "FastAPI":
     api_v1.include_router(analytics_router)
     api_v1.include_router(monitoring_router)
     api_v1.include_router(explanations_router)
+    api_v1.include_router(feature_flags_router)
 
     service.app.include_router(api_v1, dependencies=[Depends(verify_token)])
 

--- a/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
+++ b/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
@@ -1,0 +1,9 @@
+"""Additional API routers."""
+from fastapi import APIRouter
+
+from .feature_flags import router as feature_flags_router
+
+router = APIRouter()
+router.include_router(feature_flags_router)
+
+__all__ = ["router", "feature_flags_router"]

--- a/yosai_intel_dashboard/src/adapters/api/routes/feature_flags.py
+++ b/yosai_intel_dashboard/src/adapters/api/routes/feature_flags.py
@@ -1,0 +1,23 @@
+"""Feature flag audit routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+
+from yosai_intel_dashboard.src.services.feature_flags.audit import (
+    get_feature_flag_audit_history,
+)
+from yosai_intel_dashboard.src.services.security import require_permission
+
+router = APIRouter(prefix="/feature-flags", tags=["feature-flags"])
+
+
+@router.get("/{name}/audit")
+async def feature_flag_audit_history(
+    name: str,
+    limit: int = Query(100, ge=1, le=1000),
+    _: None = Depends(require_permission("feature_flags.read")),
+) -> JSONResponse:
+    """Return audit history for a feature flag."""
+    history = get_feature_flag_audit_history(name, limit)
+    return JSONResponse({"flag": name, "history": history})

--- a/yosai_intel_dashboard/src/services/feature_flags/__init__.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/__init__.py
@@ -23,7 +23,7 @@ class FeatureFlagManager:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._last_mtime: float | None = None
-        asyncio.run(self.load_flags())
+        self.load_flags()
 
     async def load_flags_async(self) -> None:
         """Asynchronously load flags from the configured source."""

--- a/yosai_intel_dashboard/src/services/feature_flags/audit.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/audit.py
@@ -1,0 +1,89 @@
+"""Feature flag audit logging utilities."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from plugins.compliance_plugin.services.audit_logger import ComplianceAuditLogger
+from yosai_intel_dashboard.src.core.container import container
+
+
+def _get_audit_logger() -> ComplianceAuditLogger:
+    """Retrieve the global :class:`ComplianceAuditLogger` instance."""
+    if container.has("compliance_audit_logger"):
+        return container.get("compliance_audit_logger")
+    return container.get("audit_logger")
+
+
+def log_feature_flag_created(
+    name: str, new_value: bool, user_id: str, reason: str
+) -> str:
+    """Log creation of a feature flag."""
+    logger = _get_audit_logger()
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return logger.log_action(
+        actor_user_id=user_id,
+        action_type="FEATURE_FLAG_CREATE",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Created feature flag '{name}'",
+        metadata={
+            "old_value": None,
+            "new_value": new_value,
+            "reason": reason,
+            "timestamp": timestamp,
+        },
+    )
+
+
+def log_feature_flag_updated(
+    name: str, old_value: bool, new_value: bool, user_id: str, reason: str
+) -> str:
+    """Log update of a feature flag."""
+    logger = _get_audit_logger()
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return logger.log_action(
+        actor_user_id=user_id,
+        action_type="FEATURE_FLAG_UPDATE",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Updated feature flag '{name}'",
+        metadata={
+            "old_value": old_value,
+            "new_value": new_value,
+            "reason": reason,
+            "timestamp": timestamp,
+        },
+    )
+
+
+def log_feature_flag_deleted(
+    name: str, old_value: bool, user_id: str, reason: str
+) -> str:
+    """Log deletion of a feature flag."""
+    logger = _get_audit_logger()
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return logger.log_action(
+        actor_user_id=user_id,
+        action_type="FEATURE_FLAG_DELETE",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Deleted feature flag '{name}'",
+        metadata={
+            "old_value": old_value,
+            "new_value": None,
+            "reason": reason,
+            "timestamp": timestamp,
+        },
+    )
+
+
+def get_feature_flag_audit_history(name: str, limit: int = 100) -> List[Dict[str, Any]]:
+    """Return audit log entries for a feature flag."""
+    logger = _get_audit_logger()
+    logs = logger.search_audit_logs(limit=limit)
+    return [
+        log
+        for log in logs
+        if log.get("resource_type") == "feature_flag" and log.get("resource_id") == name
+    ]


### PR DESCRIPTION
## Summary
- add ComplianceAuditLogger helpers for feature flag create/update/delete events
- expose `/feature-flags/{name}/audit` route to fetch audit history
- wire new router into API application

## Testing
- `pytest -q` *(fails: TypedDict not defined and missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688f2ae117388320a25891c9ebddfc3f