### PR TITLE
feat: add redis-backed feature flag store

### DIFF
--- a/yosai_intel_dashboard/src/services/feature_flags.py
+++ b/yosai_intel_dashboard/src/services/feature_flags.py
@@ -1,105 +1,44 @@
-import asyncio
-import json
 import logging
 import os
-import threading
+import importlib.util
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Dict
 
-import aiofiles
-import aiohttp
+# Dynamically load the redis store located beside this module
+_store_path = Path(__file__).with_name("feature_flags") / "redis_store.py"
+_spec = importlib.util.spec_from_file_location("_ff_redis_store", _store_path)
+redis_store = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(redis_store)  # type: ignore[arg-type]
+RedisFeatureFlagStore = redis_store.RedisFeatureFlagStore
 
 logger = logging.getLogger(__name__)
 
 
 class FeatureFlagManager:
-    """Watch a JSON file or HTTP endpoint for feature flag updates."""
+    """Feature flag manager backed by Redis with a local cache."""
 
-    def __init__(self, source: str | None = None, poll_interval: float = 5.0) -> None:
-        self.source = source or os.getenv("FEATURE_FLAG_SOURCE", "feature_flags.json")
-        self.poll_interval = poll_interval
-        self._flags: Dict[str, bool] = {}
-        self._callbacks: List[Callable[[Dict[str, bool]], Any]] = []
-        self._stop = threading.Event()
-        self._thread: threading.Thread | None = None
-        self._last_mtime: float | None = None
-        asyncio.run(self.load_flags())
-
-    async def load_flags_async(self) -> None:
-        """Asynchronously load flags from the configured source."""
-
-        data: Dict[str, Any] = {}
-        if self.source.startswith("http://") or self.source.startswith("https://"):
-            try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.source, timeout=2) as resp:
-
-                        resp.raise_for_status()
-                        data = await resp.json()
-            except Exception as exc:  # pragma: no cover - network failures
-                logger.warning("Failed to fetch flags from %s: %s", self.source, exc)
-                return
-        else:
-            path = Path(self.source)
-            if not path.is_file():
-                return
-            mtime = path.stat().st_mtime
-            if self._last_mtime and mtime == self._last_mtime:
-                return
-            self._last_mtime = mtime
-            try:
-                async with aiofiles.open(path) as fh:
-                    content = await fh.read()
-                    data = json.loads(content)
-            except Exception as exc:  # pragma: no cover - bad file
-                logger.warning("Failed to read %s: %s", path, exc)
-                return
-
-        if isinstance(data, dict):
-            new_flags = {k: bool(v) for k, v in data.items()}
-            if new_flags != self._flags:
-                self._flags = new_flags
-                for cb in list(self._callbacks):
-                    try:
-                        cb(self._flags.copy())
-                    except Exception as exc:  # pragma: no cover - callback errors
-                        logger.warning("Feature flag callback failed: %s", exc)
-
-    def load_flags(self) -> None:
-        """Synchronous wrapper for :meth:`load_flags_async`."""
-        asyncio.run(self.load_flags_async())
+    def __init__(self, redis_url: str | None = None) -> None:
+        redis_url = redis_url or os.getenv("FEATURE_FLAG_REDIS_URL", "redis://localhost:6379/0")
+        self._store = RedisFeatureFlagStore(redis_url=redis_url)
+        # expose the cache for tests that monkeypatch _flags
+        self._flags = self._store._flags
 
     def start(self) -> None:
-        """Start background watcher for flag changes."""
-        if self._thread and self._thread.is_alive():
-            return
-
-        self._stop.clear()
-        self._thread = threading.Thread(target=self._watch, daemon=True)
-        self._thread.start()
+        """Start the background Pub/Sub listener."""
+        self._store.start()
 
     def stop(self) -> None:
-        """Stop the background watcher."""
-        if self._thread:
-            self._stop.set()
-            self._thread.join()
-
-    def _watch(self) -> None:
-        while not self._stop.is_set():
-            asyncio.run(self.load_flags_async())
-            if self._stop.wait(self.poll_interval):
-                break
+        """Stop the background Pub/Sub listener."""
+        self._store.stop()
 
     def is_enabled(self, name: str, default: bool = False) -> bool:
-        """Return True if *name* flag is enabled."""
-        return self._flags.get(name, default)
+        return self._store.get_flag(name, default)
 
-    def register_callback(self, cb: Callable[[Dict[str, bool]], Any]) -> None:
-        """Register *cb* to be called when flags change."""
-        self._callbacks.append(cb)
+    def set_flag(self, name: str, value: bool) -> None:
+        self._store.set_flag(name, value)
 
     def get_all(self) -> Dict[str, bool]:
-        return self._flags.copy()
+        return self._store.get_all()
 
 
 # Global feature flag manager

--- a/yosai_intel_dashboard/src/services/feature_flags/redis_store.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/redis_store.py
@@ -1,0 +1,141 @@
+import asyncio
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Dict
+
+import redis.asyncio as redis
+
+logger = logging.getLogger(__name__)
+
+
+class ReadWriteLock:
+    """A simple reader-writer lock."""
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._readers = 0
+
+    @contextmanager
+    def read_lock(self):
+        with self._cond:
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._cond:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._cond.notify_all()
+
+    @contextmanager
+    def write_lock(self):
+        with self._cond:
+            while self._readers > 0:
+                self._cond.wait()
+            self._readers = -1
+        try:
+            yield
+        finally:
+            with self._cond:
+                self._readers = 0
+                self._cond.notify_all()
+
+
+class RedisFeatureFlagStore:
+    """Persist feature flags in Redis with a local in-memory cache."""
+
+    def __init__(
+        self,
+        redis_url: str = "redis://localhost:6379/0",
+        prefix: str = "feature_flag:",
+        channel: str = "feature_flags:updates",
+    ) -> None:
+        self.redis_url = redis_url
+        self.prefix = prefix
+        self.channel = channel
+        self._redis: redis.Redis = redis.from_url(redis_url, decode_responses=True)
+        self._flags: Dict[str, bool] = {}
+        self._lock = ReadWriteLock()
+        self._pubsub_thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def _key(self, name: str) -> str:
+        return f"{self.prefix}{name}"
+
+    async def _load_all(self) -> None:
+        keys = await self._redis.keys(f"{self.prefix}*")
+        data: Dict[str, bool] = {}
+        for key in keys:
+            name = key[len(self.prefix) :]
+            val = await self._redis.hget(key, "enabled")
+            data[name] = bool(int(val)) if val is not None else False
+        with self._lock.write_lock():
+            self._flags = data
+
+    def start(self) -> None:
+        """Start Pub/Sub listener and warm the cache."""
+        if self._pubsub_thread and self._pubsub_thread.is_alive():
+            return
+        asyncio.run(self._load_all())
+        self._stop.clear()
+        self._pubsub_thread = threading.Thread(target=self._run_listener, daemon=True)
+        self._pubsub_thread.start()
+
+    def stop(self) -> None:
+        """Stop the Pub/Sub listener."""
+        if self._pubsub_thread:
+            self._stop.set()
+            self._pubsub_thread.join()
+            self._pubsub_thread = None
+        asyncio.run(self._redis.close())
+
+    def _run_listener(self) -> None:
+        asyncio.run(self._listener())
+
+    async def _listener(self) -> None:
+        pubsub = self._redis.pubsub()
+        await pubsub.subscribe(self.channel)
+        try:
+            while not self._stop.is_set():
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True, timeout=1.0
+                )
+                if message is None:
+                    continue
+                name = message.get("data")
+                if not isinstance(name, str):
+                    continue
+                val = await self._redis.hget(self._key(name), "enabled")
+                if val is None:
+                    continue
+                flag = bool(int(val))
+                with self._lock.write_lock():
+                    self._flags[name] = flag
+        finally:
+            await pubsub.unsubscribe(self.channel)
+            await pubsub.close()
+
+    def get_flag(self, name: str, default: bool = False) -> bool:
+        with self._lock.read_lock():
+            if name in self._flags:
+                return self._flags[name]
+        val = asyncio.run(self._redis.hget(self._key(name), "enabled"))
+        if val is None:
+            return default
+        flag = bool(int(val))
+        with self._lock.write_lock():
+            self._flags[name] = flag
+        return flag
+
+    def set_flag(self, name: str, value: bool) -> None:
+        asyncio.run(
+            self._redis.hset(self._key(name), mapping={"enabled": int(value)})
+        )
+        with self._lock.write_lock():
+            self._flags[name] = value
+        asyncio.run(self._redis.publish(self.channel, name))
+
+    def get_all(self) -> Dict[str, bool]:
+        with self._lock.read_lock():
+            return dict(self._flags)


### PR DESCRIPTION
## Summary
- add RedisFeatureFlagStore with pub/sub and read/write cached access
- refactor FeatureFlagManager to use Redis-backed store and expose start/stop listener

## Testing
- `pytest tests/test_redis_asyncio_import.py -q`
- `pytest tests/test_redis_asyncio_import.py tests/test_redis_cache_fallback.py tests/test_redis_cache_json.py -q` *(fails: fixture 'fake_dash' not found, ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688f2adca2f483209c518b3a9f282b9f