### PR TITLE
Use typed callback handlers in registry

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, TYPE_CHECKING
 
 from dash import Dash
 from dash.dependencies import Input, Output, State
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .unified_callbacks import CallbackHandler
+else:  # pragma: no cover - fallback to generic callable at runtime
+    CallbackHandler = Callable[..., Any]
 
 class CallbackRegistry:
     """Minimal registry tracking registered callbacks."""
 
     def __init__(self, app: Dash | None = None) -> None:
         self.app = app
-        self.registered_callbacks: Dict[str, Callable[..., Any]] = {}
+        self.registered_callbacks: Dict[str, CallbackHandler] = {}
         self.callback_sources: Dict[str, str] = {}
 
     def handle_register(
@@ -22,7 +26,7 @@ class CallbackRegistry:
         inputs: Iterable[Input] | Input | None = None,
         states: Iterable[State] | State | None = None,
         **kwargs: Any,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> Callable[[CallbackHandler], CallbackHandler]:
         """Return a decorator registering a Dash callback if the app exists.
 
         Parameters
@@ -39,11 +43,11 @@ class CallbackRegistry:
 
         Returns
         -------
-        Callable[[Callable[..., Any]], Callable[..., Any]]
+        Callable[[CallbackHandler], CallbackHandler]
             A decorator that registers the provided function as a callback.
         """
 
-        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(func: CallbackHandler) -> CallbackHandler:
             callback_id = kwargs.get("callback_id", func.__name__)
             self.registered_callbacks[callback_id] = func
             if self.app is not None:
@@ -60,5 +64,5 @@ class ComponentCallbackManager:
         self.registry = registry
         self.component_name = self.__class__.__name__.replace("CallbackManager", "")
 
-    def register_all(self) -> None:  # pragma: no cover - interface
+    def register_all(self) -> Dict[str, CallbackHandler]:  # pragma: no cover - interface
         raise NotImplementedError

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -22,6 +22,7 @@ from typing import (
     Tuple,
     Type,
     TypeAlias,
+    TypedDict,
 
 )
 
@@ -614,7 +615,7 @@ class TrulyUnifiedCallbacks:
                 inputs: Iterable[Input] | Input | None = None,
                 states: Iterable[State] | State | None = None,
                 **kwargs: Any,
-            ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            ) -> Callable[[CallbackHandler], CallbackHandler]:
                 return self._coord.handle_register(outputs, inputs, states, **kwargs)
 
         for manager_cls in manager_classes:

--- a/yosai_intel_dashboard/src/services/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/services/upload/callbacks.py
@@ -2,16 +2,25 @@ from __future__ import annotations
 
 """Callback manager for the upload domain."""
 
-from yosai_intel_dashboard.src.core.callback_registry import CallbackRegistry, ComponentCallbackManager
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from typing import Dict
+
+from yosai_intel_dashboard.src.core.callback_registry import (
+    CallbackRegistry,
+    ComponentCallbackManager,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    CallbackHandler,
+    TrulyUnifiedCallbacks,
+)
 
 
 class UploadCallbacks(ComponentCallbackManager):
     """Register upload related callbacks using :class:`TrulyUnifiedCallbacks`."""
 
-    def register_all(self) -> None:
+    def register_all(self) -> Dict[str, CallbackHandler]:
         callbacks: TrulyUnifiedCallbacks = self.registry.callbacks
         callbacks.register_upload_callbacks()
+        return {}
 
 
 __all__ = ["UploadCallbacks"]


### PR DESCRIPTION
## Summary
- type callback registry and component registration with `CallbackHandler`
- align internal registry and upload callback manager with new handler type

## Testing
- `pytest tests/test_callback_fix.py::test_create_app_registers_callbacks -q`
- `pytest tests/test_callbacks_alias.py -q`
- `pytest tests/test_protocol_compliance.py -q` *(fails: No module named 'yosai_intel_dashboard.src.services.analytics.analytics')*

------
https://chatgpt.com/codex/tasks/task_e_688f2ac08b2c8320a92c31bc11a9f4f4