### PR TITLE
refactor: enforce CallbackHandler protocol

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -22,6 +22,7 @@ from typing import (
     Tuple,
     Type,
     TypeAlias,
+    TypedDict,
 
 )
 
@@ -34,7 +35,6 @@ from .events import CallbackEvent
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
-CallbackHandler: TypeAlias = Callable[..., Any]
 Outputs: TypeAlias = Output | tuple[Output, ...]
 Inputs: TypeAlias = Input | tuple[Input, ...] | None
 States: TypeAlias = State | tuple[State, ...] | None
@@ -350,7 +350,7 @@ class TrulyUnifiedCallbacks:
             self._event_callbacks[event].sort(key=lambda c: c.priority)
 
     # ------------------------------------------------------------------
-    def unregister_event(self, event: CallbackEvent, func: Callable[..., Any]) -> None:
+    def unregister_event(self, event: CallbackEvent, func: CallbackHandler) -> None:
         """Remove a previously registered event callback.
 
         Thread-safe via an internal ``RLock``.
@@ -434,7 +434,7 @@ class TrulyUnifiedCallbacks:
         tasks = [asyncio.create_task(_run(cb)) for cb in callbacks]
         return await asyncio.gather(*tasks) if tasks else []
 
-    def get_event_callbacks(self, event: CallbackEvent) -> List[Callable[..., Any]]:
+    def get_event_callbacks(self, event: CallbackEvent) -> List[CallbackHandler]:
         """Return registered callbacks for *event*.
 
         Thread-safe via an internal ``RLock``.
@@ -614,7 +614,7 @@ class TrulyUnifiedCallbacks:
                 inputs: Iterable[Input] | Input | None = None,
                 states: Iterable[State] | State | None = None,
                 **kwargs: Any,
-            ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            ) -> Callable[[CallbackHandler], CallbackHandler]:
                 return self._coord.handle_register(outputs, inputs, states, **kwargs)
 
         for manager_cls in manager_classes:


### PR DESCRIPTION
## Summary
- drop `CallbackHandler` type alias and rely on protocol definition
- type callback APIs with `CallbackHandler` protocol rather than bare callables

## Testing
- `pytest tests/test_callback_manager.py::test_thread_safe_registration_and_trigger -q` *(fails: NameError: name 'redis_client' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f2abc73508320a8ef9ffb0893b0c7