### PR TITLE
feat: add compressed websocket broadcast

### DIFF
--- a/tests/unit/test_websocket_server.py
+++ b/tests/unit/test_websocket_server.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 import json
 import sys
-import types
 import time
+import types
+from pathlib import Path
 
 
 class DummyEventBus:
@@ -21,7 +24,12 @@ class DummyEventBus:
         self._subs.append((event_type, handler))
         return f"sub-{len(self._subs)}"
 
-    def get_event_history(self, event_type: str | None = None, limit: int = 100) -> list[dict]:
+    def unsubscribe(self, sub_id: str) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def get_event_history(
+        self, event_type: str | None = None, limit: int = 100
+    ) -> list[dict]:
         history = (
             self._history
             if event_type is None
@@ -40,17 +48,30 @@ core_pkg.__path__ = []
 events_module = types.ModuleType("yosai_intel_dashboard.src.core.events")
 events_module.EventBus = DummyEventBus
 
+services_pkg = types.ModuleType("yosai_intel_dashboard.src.services")
+services_pkg.__path__ = [
+    str(
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "services"
+    )
+]
+
 sys.modules["yosai_intel_dashboard"] = root_pkg
 sys.modules["yosai_intel_dashboard.src"] = src_pkg
 sys.modules["yosai_intel_dashboard.src.core"] = core_pkg
 sys.modules["yosai_intel_dashboard.src.core.events"] = events_module
+sys.modules["yosai_intel_dashboard.src.services"] = services_pkg
 
 # Load the websocket server module directly
 spec = importlib.util.spec_from_file_location(
-    "analytics_ws_server", "yosai_intel_dashboard/src/services/websocket_server.py"
+    "yosai_intel_dashboard.src.services.websocket_server",
+    "yosai_intel_dashboard/src/services/websocket_server.py",
 )
 ws_module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
+sys.modules[spec.name] = ws_module
 spec.loader.exec_module(ws_module)
 AnalyticsWebSocketServer = ws_module.AnalyticsWebSocketServer
 EventBus = ws_module.EventBus  # type: ignore
@@ -64,6 +85,10 @@ def _run_client(port: int, expected: int) -> list[dict]:
         async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:
             for _ in range(expected):
                 msg = await asyncio.wait_for(ws.recv(), timeout=1)
+                if isinstance(msg, bytes):
+                    import gzip
+
+                    msg = gzip.decompress(msg).decode("utf-8")
                 received.append(json.loads(msg))
         return received
 
@@ -109,3 +134,22 @@ def test_queue_bound() -> None:
 
     server.stop()
 
+
+def test_compressed_broadcast() -> None:
+    event_bus = EventBus()
+    server = AnalyticsWebSocketServer(
+        event_bus=event_bus,
+        host="127.0.0.1",
+        port=8768,
+        compression_threshold=10,
+    )
+
+    time.sleep(0.1)
+
+    payload = {"data": "x" * 100}
+    event_bus.publish("analytics_update", payload)
+
+    messages = _run_client(8768, 1)
+    assert messages[0] == payload
+
+    server.stop()

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 import json
 import logging
 import threading
 from collections import deque
-from typing import Optional, Set, Deque
-
+from typing import Deque, Optional, Set
 
 from websockets import WebSocketServerProtocol, serve
 
-from yosai_intel_dashboard.src.core.events import EventBus
 from src.websocket import metrics as websocket_metrics
+from yosai_intel_dashboard.src.core.events import EventBus
 
 from .websocket_pool import WebSocketConnectionPool
 
@@ -28,7 +28,8 @@ class AnalyticsWebSocketServer:
         port: int = 6789,
         ping_interval: float = 30.0,
         ping_timeout: float = 10.0,
-
+        queue_size: int = 0,
+        compression_threshold: int | None = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -36,6 +37,10 @@ class AnalyticsWebSocketServer:
         self.clients: Set[WebSocketServerProtocol] = set()
         self.ping_interval = ping_interval
         self.ping_timeout = ping_timeout
+
+        self.pool = WebSocketConnectionPool()
+        self._queue: Deque[dict] = deque(maxlen=queue_size or None)
+        self.compression_threshold = compression_threshold
 
         self._loop: asyncio.AbstractEventLoop | None = None
         self._heartbeat_task: asyncio.Task | None = None
@@ -50,6 +55,7 @@ class AnalyticsWebSocketServer:
 
     async def _handler(self, websocket: WebSocketServerProtocol) -> None:
         self.clients.add(websocket)
+        await self.pool.acquire(websocket)
         if self._queue:
             queued = list(self._queue)
             self._queue.clear()
@@ -115,6 +121,11 @@ class AnalyticsWebSocketServer:
         else:
             self._queue.append(data)
 
+    async def _broadcast_async(self, message: str) -> None:
+        payload: str | bytes = message
+        if self.compression_threshold and len(message) > self.compression_threshold:
+            payload = gzip.compress(message.encode("utf-8"))
+        await self.pool.broadcast(payload)
 
     def stop(self) -> None:
         """Stop the server thread and event loop."""


### PR DESCRIPTION
## Summary
- support optional gzip compression for websocket broadcast payloads
- ensure websocket clients decompress compressed messages
- add unit/integration tests for compressed websocket broadcasts

## Testing
- `pre-commit run --files tests/integration/test_websocket_events.py tests/unit/test_websocket_server.py yosai_intel_dashboard/src/services/websocket_server.py`
- `pytest tests/unit/test_websocket_server.py tests/integration/test_websocket_events.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2a5f39a08320b09d7673ccf8253c