### PR TITLE
Graceful fallback for plugin and analytics adapters

### DIFF
--- a/docs/analytics_service.md
+++ b/docs/analytics_service.md
@@ -19,6 +19,13 @@ manager.run_full_pipeline(raw_data)
 finally emit a `pipeline_complete` event using
 `TrulyUnifiedCallbacks`.
 
+## Degraded Mode
+
+When the analytics microservice cannot be reached the
+``AnalyticsServiceAdapter`` now logs the exception via ``ErrorHandler`` and
+returns an empty result. Callers should treat an empty dictionary as a signal to
+display placeholder analytics in the UI.
+
 ## Removing Legacy Details
 
 Previous documentation describing individual service classes has been removed.

--- a/docs/column_verification.md
+++ b/docs/column_verification.md
@@ -5,6 +5,10 @@ It relies on **Dash** and **dash-bootstrap-components** for rendering and uses
 `pandas` to inspect uploaded files. Optional AI suggestions come from the
 `ComponentPluginAdapter` so plugins can provide smarter mappings.
 
+If the plugin service is unreachable the adapter now returns an empty mapping
+and records the error via ``ErrorHandler``. UI components should detect this
+case and display a placeholder instead of AI powered suggestions.
+
 ## Usage
 
 Call `register_callbacks` during application startup to enable the interactive

--- a/yosai_intel_dashboard/src/components/__init__.py
+++ b/yosai_intel_dashboard/src/components/__init__.py
@@ -1,0 +1,6 @@
+"""Component-level helpers and adapters."""
+
+from .plugin_adapter import ComponentPluginAdapter
+
+__all__ = ["ComponentPluginAdapter"]
+

--- a/yosai_intel_dashboard/src/components/plugin_adapter.py
+++ b/yosai_intel_dashboard/src/components/plugin_adapter.py
@@ -1,0 +1,105 @@
+"""Adapter for optional AI plugins.
+
+This adapter communicates with a plugin service if available. Network
+failures are swallowed and logged via :class:`ErrorHandler` so callers receive
+empty results instead of exceptions. This allows UI components to display
+placeholder states when the plugin backend is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import pandas as pd
+import requests
+
+from yosai_intel_dashboard.src.error_handling import ErrorHandler
+
+
+class ComponentPluginAdapter:
+    """Thin HTTP client for plugin-provided AI helpers."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        handler: ErrorHandler | None = None,
+    ) -> None:
+        self.base_url = base_url or os.getenv(
+            "PLUGIN_SERVICE_URL", "http://localhost:8003"
+        )
+        self.error_handler = handler or ErrorHandler()
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _post(self, path: str, payload: Dict[str, Any]) -> Any:
+        try:
+            resp = requests.post(
+                f"{self.base_url}{path}", json=payload, timeout=2
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - network failures
+            self.error_handler.handle(exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def suggest_columns(self, df: pd.DataFrame) -> Dict[str, str]:
+        """Return simple column rename suggestions.
+
+        The plugin service is asked for suggestions based on the provided
+        DataFrame. If the request fails an empty mapping is returned.
+        """
+
+        result = self._post(
+            "/v1/ai/suggest-columns", {"columns": list(df.columns)}
+        )
+        if isinstance(result, dict):
+            return {k: str(v) for k, v in result.items()}
+        return {}
+
+    def get_ai_column_suggestions(
+        self, df: pd.DataFrame, filename: str
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return detailed AI suggestions for column mappings."""
+
+        result = self._post(
+            "/v1/ai/column-suggestions",
+            {"columns": list(df.columns), "filename": filename},
+        )
+        if isinstance(result, dict):
+            return result
+        return {}
+
+    def save_verified_mappings(
+        self, filename: str, mappings: Dict[str, str], metadata: Dict[str, Any]
+    ) -> bool:
+        """Persist user-confirmed column mappings."""
+
+        result = self._post(
+            "/v1/ai/save-mappings",
+            {"filename": filename, "mappings": mappings, "metadata": metadata},
+        )
+        return bool(result)
+
+    def get_ai_plugin(self):
+        """Return an instance of the AI plugin if it can be imported."""
+
+        try:
+            from yosai_intel_dashboard.src.adapters.api.plugins.ai_classification.plugin import (
+                AIClassificationPlugin,
+            )
+
+            plugin = AIClassificationPlugin()
+            plugin.start()
+            return plugin
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self.error_handler.handle(exc)
+            return None
+
+
+__all__ = ["ComponentPluginAdapter"]
+


### PR DESCRIPTION
## Summary
- cache existing flags when feature flag HTTP fetch fails
- add ComponentPluginAdapter with safe defaults when plugin service unavailable
- handle analytics microservice outages with ErrorHandler and empty responses
- document degraded modes for plugin and analytics UI components

## Testing
- `pytest tests/test_migration_adapter.py tests/integration/test_microservice_adapters.py` *(fails: FileNotFoundError: services/feature_flags.py; AttributeError: module 'httpx' has no attribute 'Response')*
- `pytest tests/test_ai_column_mapper_adapter.py` *(fails: ModuleNotFoundError: yosai_intel_dashboard.src.services.mapping)*

------
https://chatgpt.com/codex/tasks/task_e_688f2aa607d08320910cae7e2ac9b1ef