### PR TITLE
Add resiliency fallbacks for registry clients and service discovery

### DIFF
--- a/tests/test_service_discovery.py
+++ b/tests/test_service_discovery.py
@@ -1,0 +1,70 @@
+import asyncio
+from unittest.mock import MagicMock
+
+from yosai_intel_dashboard.src.services.registry import ServiceDiscovery
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    async def json(self):
+        return self._data
+
+
+class DummySession:
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+        self.closed = False
+
+    def get(self, url, params=None, headers=None, timeout=None):  # type: ignore[override]
+        if self._exc:
+            raise self._exc
+        return self._response
+
+    async def close(self):
+        self.closed = True
+
+
+def test_resolve_async_cache(monkeypatch):
+    handler = MagicMock()
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.services.registry.ErrorHandler", lambda: handler
+    )
+    monkeypatch.setattr(
+        "aiohttp.ClientSession",
+        lambda: DummySession(DummyResponse([{"Service": {"Address": "a", "Port": 1}}])),
+    )
+    sd = ServiceDiscovery("http://registry")
+    addr = asyncio.run(sd.resolve_async("svc"))
+    assert addr == "a:1"
+    sd.session = DummySession(exc=RuntimeError("boom"))
+    addr2 = asyncio.run(sd.resolve_async("svc"))
+    assert addr2 == "a:1"
+    assert handler.handle.called
+
+
+def test_resolve_async_env(monkeypatch):
+    handler = MagicMock()
+    monkeypatch.setattr(
+        "yosai_intel_dashboard.src.services.registry.ErrorHandler", lambda: handler
+    )
+    monkeypatch.setenv("FOO_SERVICE_URL", "env:1234")
+    monkeypatch.setattr(
+        "aiohttp.ClientSession", lambda: DummySession(exc=RuntimeError("boom"))
+    )
+    sd = ServiceDiscovery("http://registry")
+    addr = asyncio.run(sd.resolve_async("foo"))
+    assert addr == "env:1234"
+    assert handler.handle.called

--- a/yosai_intel_dashboard/src/core/async_utils/async_batch.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_batch.py
@@ -8,6 +8,7 @@ import psutil
 
 from yosai_intel_dashboard.src.core.performance import (
     MetricType,
+    PerformanceProfiler,
     get_performance_monitor,
 )
 

--- a/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_circuit_breaker.py
@@ -8,6 +8,7 @@ import psutil
 
 from yosai_intel_dashboard.src.core.performance import (
     MetricType,
+    PerformanceProfiler,
     get_performance_monitor,
 )
 

--- a/yosai_intel_dashboard/src/core/async_utils/async_retry.py
+++ b/yosai_intel_dashboard/src/core/async_utils/async_retry.py
@@ -10,6 +10,7 @@ import psutil
 
 from yosai_intel_dashboard.src.core.performance import (
     MetricType,
+    PerformanceProfiler,
     get_performance_monitor,
 )
 

--- a/yosai_intel_dashboard/src/services/common/schema_registry.py
+++ b/yosai_intel_dashboard/src/services/common/schema_registry.py
@@ -6,11 +6,16 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import aiohttp
 
 from monitoring.data_quality_monitor import get_data_quality_monitor
+from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler
+from yosai_intel_dashboard.src.services.resilience.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
 
 
 @dataclass
@@ -29,6 +34,12 @@ class SchemaRegistryClient:
         self.url = (
             url or os.getenv("SCHEMA_REGISTRY_URL", "http://localhost:8081")
         ).rstrip("/")
+        self._schema_cache: Dict[Tuple[str, str], SchemaInfo] = {}
+        self._id_cache: Dict[int, SchemaInfo] = {}
+        self._lock = asyncio.Lock()
+        self._cb = CircuitBreaker(3, 30, "schema_registry")
+        self._retries = 3
+        self._error_handler = ErrorHandler()
 
     # ------------------------------------------------------------------
     async def _get_async(self, path: str) -> Any:
@@ -66,20 +77,78 @@ class SchemaRegistryClient:
     async def get_schema_async(
         self, subject: str, version: int | str = "latest"
     ) -> SchemaInfo:
-        data = await self._get_async(f"/subjects/{subject}/versions/{version}")
-        return SchemaInfo(
-            id=data["id"], version=data["version"], schema=json.loads(data["schema"])
-        )
+        key = (subject, str(version))
+        async with self._lock:
+            cached = self._schema_cache.get(key)
+            if cached is not None:
+                return cached
 
-    @lru_cache(maxsize=64)
+        for attempt in range(self._retries):
+            try:
+                async with self._cb:
+                    data = await self._get_async(
+                        f"/subjects/{subject}/versions/{version}"
+                    )
+                info = SchemaInfo(
+                    id=data["id"],
+                    version=data["version"],
+                    schema=json.loads(data["schema"]),
+                )
+                async with self._lock:
+                    self._schema_cache[key] = info
+                    self._id_cache[info.id] = info
+                return info
+            except CircuitBreakerOpen as exc:
+                self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+                if cached is not None:
+                    return cached
+                raise
+            except Exception as exc:
+                self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+                if attempt + 1 == self._retries:
+                    if cached is not None:
+                        return cached
+                    raise
+                await asyncio.sleep(0.1 * (attempt + 1))
+
+        return cached  # pragma: no cover - loop exit
+
     def get_schema(self, subject: str, version: int | str = "latest") -> SchemaInfo:
         return asyncio.run(self.get_schema_async(subject, version))
 
     async def get_schema_by_id_async(self, schema_id: int) -> SchemaInfo:
-        data = await self._get_async(f"/schemas/ids/{schema_id}")
-        return SchemaInfo(id=schema_id, version=-1, schema=json.loads(data["schema"]))
+        async with self._lock:
+            cached = self._id_cache.get(schema_id)
+            if cached is not None:
+                return cached
 
-    @lru_cache(maxsize=64)
+        for attempt in range(self._retries):
+            try:
+                async with self._cb:
+                    data = await self._get_async(f"/schemas/ids/{schema_id}")
+                info = SchemaInfo(
+                    id=schema_id,
+                    version=-1,
+                    schema=json.loads(data["schema"]),
+                )
+                async with self._lock:
+                    self._id_cache[schema_id] = info
+                return info
+            except CircuitBreakerOpen as exc:
+                self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+                if cached is not None:
+                    return cached
+                raise
+            except Exception as exc:
+                self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+                if attempt + 1 == self._retries:
+                    if cached is not None:
+                        return cached
+                    raise
+                await asyncio.sleep(0.1 * (attempt + 1))
+
+        return cached  # pragma: no cover
+
     def get_schema_by_id(self, schema_id: int) -> SchemaInfo:
         return asyncio.run(self.get_schema_by_id_async(schema_id))
 


### PR DESCRIPTION
## Summary
- cache last-known schemas and return them when schema registry calls fail
- preserve active model versions when registry unreachable
- fall back to cached or env-provided service addresses and log via error handler

## Testing
- `pytest tests/test_schema_registry.py tests/test_model_registry_async.py tests/test_service_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2aa51eac8320a43441f2f0e272d4