### PR TITLE
Add websocket metrics for connections and ping failures

### DIFF
--- a/tests/test_websocket_server.py
+++ b/tests/test_websocket_server.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 import sys
 import types
+from collections import deque
 from pathlib import Path
+
+from src.websocket import metrics as websocket_metrics
 
 
 def _load_server():
@@ -14,13 +19,17 @@ def _load_server():
     for name in pkg_names:
         sys.modules.setdefault(name, types.ModuleType(name))
     events_mod = types.ModuleType("yosai_intel_dashboard.src.core.events")
+
     class EventBus:
         def __init__(self, *a, **kw):
             pass
+
         def publish(self, *a, **kw):
             pass
+
         def subscribe(self, *a, **kw):
             pass
+
     events_mod.EventBus = EventBus
     sys.modules["yosai_intel_dashboard.src.core.events"] = events_mod
     path = (
@@ -57,13 +66,21 @@ class DummyWS:
     async def close(self):
         self.closed = True
 
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
 
 class DummyBus:
     def __init__(self) -> None:
         self.subs = {}
+
     def publish(self, event_type, data):
         for h in self.subs.get(event_type, []):
             h(data)
+
     def subscribe(self, event_type, handler):
         self.subs.setdefault(event_type, []).append(handler)
 
@@ -75,6 +92,11 @@ def _create_server(event_bus: DummyBus) -> AnalyticsWebSocketServer:
     server = AnalyticsWebSocketServer(event_bus, ping_interval=0.01, ping_timeout=0.01)
     AnalyticsWebSocketServer._run = original
     return server
+
+
+class DummyPool:
+    async def release(self, ws):
+        pass
 
 
 def test_ping_client_publishes_alive():
@@ -94,7 +116,20 @@ def test_ping_client_closes_on_timeout():
     server = _create_server(bus)
     ws = DummyWS(False)
     server.clients.add(ws)  # ensure removal
+    start = websocket_metrics.websocket_ping_failures_total._value.get()
     asyncio.run(server._ping_client(ws))
     assert events and events[0]["status"] == "timeout"
     assert ws.closed
     assert ws not in server.clients
+    assert websocket_metrics.websocket_ping_failures_total._value.get() == start + 1
+
+
+def test_handler_records_connection_metric():
+    bus = DummyBus()
+    server = _create_server(bus)
+    server.pool = DummyPool()
+    server._queue = deque()
+    ws = DummyWS()
+    start = websocket_metrics.websocket_connections_total._value.get()
+    asyncio.run(server._handler(ws))
+    assert websocket_metrics.websocket_connections_total._value.get() == start + 1

--- a/tests/websocket/test_metrics.py
+++ b/tests/websocket/test_metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from src.websocket import metrics
 
 
@@ -5,19 +7,24 @@ class DummyBus:
     def __init__(self) -> None:
         self.events = []
 
-    def publish(self, event_type: str, data, source=None) -> None:  # pragma: no cover - simple bus
+    def publish(
+        self, event_type: str, data, source=None
+    ) -> None:  # pragma: no cover - simple bus
         self.events.append((event_type, data))
 
 
 def test_websocket_metrics_publish_updates():
     bus = DummyBus()
     metrics.set_event_bus(bus)
+    start_conn = metrics.websocket_connections_total._value.get()
+    start_reconnect = metrics.websocket_reconnect_attempts_total._value.get()
+    start_ping = metrics.websocket_ping_failures_total._value.get()
 
     metrics.record_connection()
     metrics.record_reconnect_attempt()
     metrics.record_ping_failure()
 
     assert bus.events[0][0] == "metrics_update"
-    assert bus.events[0][1]["websocket_connections_total"] == 1
-    assert bus.events[1][1]["websocket_reconnect_attempts_total"] == 1
-    assert bus.events[2][1]["websocket_ping_failures_total"] == 1
+    assert bus.events[0][1]["websocket_connections_total"] == start_conn + 1
+    assert bus.events[1][1]["websocket_reconnect_attempts_total"] == start_reconnect + 1
+    assert bus.events[2][1]["websocket_ping_failures_total"] == start_ping + 1


### PR DESCRIPTION
## Summary
- record websocket connections and ping failures in websocket server
- test websocket metrics counters for new connections and ping timeouts

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/websocket_server.py tests/test_websocket_server.py tests/websocket/test_metrics.py`
- `pytest tests/test_websocket_server.py tests/websocket/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2a607c508320aa864e0bf1522e4f