### PR TITLE
feat: add circuit breaker to service clients

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -29,6 +29,8 @@ __all__ = [
     "InferenceDriftJob",
     "request_duration",
     "ABTest",
+    "circuit_breaker_state",
+    "start_metrics_server",
 
 ]
 
@@ -124,5 +126,12 @@ def __getattr__(name: str):
         from .ab_testing import ABTest
 
         return ABTest
+    if name in {"circuit_breaker_state", "start_metrics_server"}:
+        from yosai_intel_dashboard.src.services.resilience.metrics import (
+            circuit_breaker_state,
+            start_metrics_server,
+        )
+
+        return locals()[name]
 
     raise AttributeError(name)

--- a/yosai_intel_dashboard/src/services/common/model_registry.py
+++ b/yosai_intel_dashboard/src/services/common/model_registry.py
@@ -6,6 +6,13 @@ from typing import Optional
 
 import aiohttp
 
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+from yosai_intel_dashboard.src.error_handling.core import ErrorHandler
+from yosai_intel_dashboard.src.error_handling.exceptions import ErrorCategory
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,6 +24,8 @@ class ModelRegistry:
             base_url or os.getenv("MODEL_REGISTRY_URL", "http://localhost:8080")
         ).rstrip("/")
         self._session: aiohttp.ClientSession | None = None
+        self._circuit_breaker = CircuitBreaker(5, 30, name="model_registry")
+        self._error_handler = ErrorHandler()
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -29,13 +38,17 @@ class ModelRegistry:
         """Return the active version for *model_name* or *default* if lookup fails."""
         try:
             session = await self._get_session()
-            async with session.get(
-                f"{self.base_url}/models/{model_name}/active",
-                timeout=aiohttp.ClientTimeout(total=2),
-            ) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
-                return data.get("version", default)
+            async with self._circuit_breaker:
+                async with session.get(
+                    f"{self.base_url}/models/{model_name}/active",
+                    timeout=aiohttp.ClientTimeout(total=2),
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    return data.get("version", default)
+        except CircuitBreakerOpen as exc:
+            self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+            return default
         except Exception as exc:  # pragma: no cover - network failures
             logger.warning("model registry lookup failed for %s: %s", model_name, exc)
             return default

--- a/yosai_intel_dashboard/src/services/feature_flags.py
+++ b/yosai_intel_dashboard/src/services/feature_flags.py
@@ -9,6 +9,13 @@ from typing import Any, Callable, Dict, List
 import aiofiles
 import aiohttp
 
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+from yosai_intel_dashboard.src.error_handling.core import ErrorHandler
+from yosai_intel_dashboard.src.error_handling.exceptions import ErrorCategory
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +30,8 @@ class FeatureFlagManager:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._last_mtime: float | None = None
+        self._circuit_breaker = CircuitBreaker(5, 30, name="feature_flags")
+        self._error_handler = ErrorHandler()
         asyncio.run(self.load_flags())
 
     async def load_flags_async(self) -> None:
@@ -31,11 +40,14 @@ class FeatureFlagManager:
         data: Dict[str, Any] = {}
         if self.source.startswith("http://") or self.source.startswith("https://"):
             try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.source, timeout=2) as resp:
-
-                        resp.raise_for_status()
-                        data = await resp.json()
+                async with self._circuit_breaker:
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(self.source, timeout=2) as resp:
+                            resp.raise_for_status()
+                            data = await resp.json()
+            except CircuitBreakerOpen as exc:  # pragma: no cover - circuit open
+                self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+                return
             except Exception as exc:  # pragma: no cover - network failures
                 logger.warning("Failed to fetch flags from %s: %s", self.source, exc)
                 return

--- a/yosai_intel_dashboard/src/services/registry.py
+++ b/yosai_intel_dashboard/src/services/registry.py
@@ -9,6 +9,12 @@ from typing import Any, Dict, Optional
 import aiohttp
 
 from tracing import propagate_context
+from yosai_intel_dashboard.src.core.async_utils.async_circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+from yosai_intel_dashboard.src.error_handling.core import ErrorHandler
+from yosai_intel_dashboard.src.error_handling.exceptions import ErrorCategory
 
 from .base_database_service import BaseDatabaseService
 
@@ -55,24 +61,30 @@ class ServiceDiscovery:
         )
         self.base_url = url.rstrip("/")
         self.session = aiohttp.ClientSession()
+        self._circuit_breaker = CircuitBreaker(5, 30, name="service_discovery")
+        self._error_handler = ErrorHandler()
 
     async def resolve_async(self, name: str) -> Optional[str]:
         """Return ``host:port`` for *name* or ``None`` if lookup fails."""
         try:
             headers: Dict[str, str] = {}
             propagate_context(headers)
-            async with self.session.get(
-                f"{self.base_url}/v1/health/service/{name}",
-                params={"passing": 1},
-                headers=headers,
-                timeout=2,
-            ) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
-                if not data:
-                    return None
-                svc = data[0]["Service"]
-                return f"{svc['Address']}:{svc['Port']}"
+            async with self._circuit_breaker:
+                async with self.session.get(
+                    f"{self.base_url}/v1/health/service/{name}",
+                    params={"passing": 1},
+                    headers=headers,
+                    timeout=2,
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    if not data:
+                        return None
+                    svc = data[0]["Service"]
+                    return f"{svc['Address']}:{svc['Port']}"
+        except CircuitBreakerOpen as exc:  # pragma: no cover - circuit open
+            self._error_handler.handle(exc, ErrorCategory.UNAVAILABLE)
+            return None
         except Exception as exc:  # pragma: no cover - network failures
             logger.warning("Service discovery failed for '%s': %s", name, exc)
             return None


### PR DESCRIPTION
## Summary
- add async circuit breakers to schema registry and model registry clients
- harden feature flag, service discovery, and rest client calls with breakers
- export circuit breaker state metrics via monitoring package

## Testing
- `pytest` *(fails: module 'httpx' has no attribute 'Response' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688f2aa224888320a92c8755e4906624