### PR TITLE
feat: enhance event socket reliability

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { eventBus } from '../eventBus';
+import { HEARTBEAT_TIMEOUT } from './websocketPool';
 
 export enum EventSocketState {
   DISCONNECTED = 'DISCONNECTED',
@@ -17,31 +18,50 @@ export const useEventSocket = (
   const [state, setState] = useState<EventSocketState>(EventSocketState.DISCONNECTED);
   const wsRef = useRef<WebSocket | null>(null);
   const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heartbeatTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attemptRef = useRef(0);
   const stoppedRef = useRef(false);
 
   const connect = () => {
+    setState(EventSocketState.CONNECTING);
+    eventBus.emit('event_socket_state', EventSocketState.CONNECTING);
 
     const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
     wsRef.current = ws;
 
+    const resetHeartbeat = () => {
+      if (heartbeatTimeout.current) {
+        clearTimeout(heartbeatTimeout.current);
+      }
+      heartbeatTimeout.current = setTimeout(() => ws.close(), HEARTBEAT_TIMEOUT);
+    };
+    resetHeartbeat();
+    if (typeof (ws as any).on === 'function') {
+      (ws as any).on('ping', () => {
+        (ws as any).pong?.();
+        resetHeartbeat();
+      });
+    }
+
     ws.onopen = () => {
-      setIsConnected(true);
+      setState(EventSocketState.CONNECTED);
+      eventBus.emit('event_socket_state', EventSocketState.CONNECTED);
       attemptRef.current = 0;
     };
     ws.onclose = () => {
-      setIsConnected(false);
-      if (!stoppedRef.current) {
-        let delay = Math.min(1000 * 2 ** attemptRef.current, 30000);
-        if (jitter) {
-          delay += Math.random() * 1000;
-        }
-        attemptRef.current += 1;
-        retryTimeout.current = setTimeout(connect, delay);
+      if (stoppedRef.current) {
+        return;
       }
-
+      setState(EventSocketState.RECONNECTING);
+      eventBus.emit('event_socket_state', EventSocketState.RECONNECTING);
+      let delay = Math.min(1000 * 2 ** attemptRef.current, 30000);
+      if (jitter) {
+        delay += Math.random() * 1000;
+      }
+      attemptRef.current += 1;
+      retryTimeout.current = setTimeout(connect, delay);
     };
-    ws.onmessage = (ev) => setData(ev.data);
+    ws.onmessage = ev => setData(ev.data as string);
   };
 
   const cleanup = () => {
@@ -49,7 +69,12 @@ export const useEventSocket = (
     if (retryTimeout.current) {
       clearTimeout(retryTimeout.current);
     }
+    if (heartbeatTimeout.current) {
+      clearTimeout(heartbeatTimeout.current);
+    }
     wsRef.current?.close();
+    setState(EventSocketState.DISCONNECTED);
+    eventBus.emit('event_socket_state', EventSocketState.DISCONNECTED);
   };
 
   useEffect(() => {
@@ -61,7 +86,8 @@ export const useEventSocket = (
     };
   }, [url, socketFactory, jitter]);
 
-  return { data, isConnected, cleanup };
+  const isConnected = state === EventSocketState.CONNECTED;
+  return { data, isConnected, state, cleanup };
 
 };
 


### PR DESCRIPTION
## Summary
- add state tracking and exponential reconnect w/ heartbeat for `useEventSocket`
- broadcast event socket connection state changes via `eventBus`
- cover event bus and heartbeat behaviours in `useEventSocket` tests

## Testing
- `npx jest yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts --runInBand --testEnvironment=jsdom` *(fails: Jest failed to parse a file)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a620aa08320b875a79b2a85860e