### PR TITLE
feat: support tiered rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,8 +919,11 @@ defaults:
 
 
 - `PBKDF2_ITERATIONS` – password hashing iterations
- - `RATE_LIMIT_REQUESTS` – number of requests allowed per window
-- `RATE_LIMIT_WINDOW` – rate limit window in minutes
+- `RATE_LIMIT_REQUESTS` – number of requests allowed per window for the default tier
+- `RATE_LIMIT_WINDOW` – rate limit window in minutes for the default tier
+- `RATE_LIMIT_<TIER>_REQUESTS` – per-tier request limit override
+- `RATE_LIMIT_<TIER>_WINDOW` – per-tier window override in minutes
+- `RATE_LIMIT_<TIER>_BURST` – optional burst capacity for the tier
 - `MAX_UPLOAD_MB` – maximum allowed upload size
 - `DB_POOL_SIZE` – database connection pool size
 - `DB_INITIAL_POOL_SIZE` – starting number of pooled connections

--- a/docs/rate_limit.md
+++ b/docs/rate_limit.md
@@ -22,3 +22,30 @@ The middleware exposes remaining quota via the following headers:
 
 Rate limit metrics are exported alongside existing gateway metrics and can be
 visualized using the default Prometheus dashboard.
+
+## Application Tier Limits
+
+The dynamic configuration layer supports per-tier API limits with optional
+burst capacity:
+
+```yaml
+security:
+  rate_limits:
+    free:
+      requests: 100
+      window_minutes: 1
+    pro:
+      requests: 1000
+      window_minutes: 1
+      burst: 200
+```
+
+Each tier can be overridden at runtime using environment variables:
+
+```bash
+export RATE_LIMIT_PRO_REQUESTS=1500
+export RATE_LIMIT_PRO_BURST=300
+```
+
+The helper `get_rate_limit(tier)` returns the final `limit`, `window`, and
+`burst` values after all overrides.

--- a/tests/test_rate_limit_tiers.py
+++ b/tests/test_rate_limit_tiers.py
@@ -1,0 +1,32 @@
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager
+
+
+def test_tiered_rate_limit_env_override(tmp_path, monkeypatch):
+    yaml_text = """
+security:
+  rate_limits:
+    free:
+      requests: 100
+      window_minutes: 1
+      burst: 10
+    pro:
+      requests: 1000
+      window_minutes: 1
+"""
+    path = tmp_path / "c.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
+    required = {
+        "SECRET_KEY": "s",
+        "DB_PASSWORD": "pwd",
+        "AUTH0_CLIENT_ID": "cid",
+        "AUTH0_CLIENT_SECRET": "secret",
+        "AUTH0_DOMAIN": "dom",
+        "AUTH0_AUDIENCE": "aud",
+    }
+    for k, v in required.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("RATE_LIMIT_PRO_BURST", "50")
+    cfg = DynamicConfigManager()
+    assert cfg.get_rate_limit("free") == {"limit": 100, "window": 1, "burst": 10}
+    assert cfg.get_rate_limit("pro")["burst"] == 50

--- a/yosai_intel_dashboard/src/infrastructure/config/config.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/config.yaml
@@ -29,6 +29,14 @@ security:
     - .json
     - .xlsx
     - .xls
+  rate_limits:
+    free:
+      requests: 100
+      window_minutes: 1
+    pro:
+      requests: 1000
+      window_minutes: 1
+      burst: 200
 
 sample_files:
   csv_path: "data/sample_data.csv"

--- a/yosai_intel_dashboard/src/infrastructure/config/constants.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/constants.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict
 
 # Default chunk size used across services when reading or uploading large files
 DEFAULT_CHUNK_SIZE: int = 50_000
@@ -79,6 +80,15 @@ class FileProcessingLimits:
 
 
 @dataclass
+class RateLimitConfig:
+    """Configuration for a single API tier rate limit."""
+
+    requests: int
+    window_minutes: int
+    burst: int = 0
+
+
+@dataclass
 class SecurityConstants:
     """Security related default values with large file support."""
 
@@ -86,6 +96,9 @@ class SecurityConstants:
     salt_bytes: int = 32
     rate_limit_requests: int = 200
     rate_limit_window_minutes: int = 1
+    rate_limits: Dict[str, RateLimitConfig] = field(
+        default_factory=lambda: {"default": RateLimitConfig(200, 1, 0)}
+    )
     max_upload_mb: int = 500  # Changed from 100 to 500
     max_file_size_mb: int = 500  # Added for consistency
     max_analysis_mb: int = 1000  # Added for large file processing

--- a/yosai_intel_dashboard/src/infrastructure/config/production.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/production.yaml
@@ -49,7 +49,15 @@ security:
     - ${FRONTEND_URL:https://dashboard.yourdomain.com}
     - ${API_URL:https://api.yourdomain.com}
   rate_limiting_enabled: ${RATE_LIMITING:true}
-  rate_limit_per_minute: ${RATE_LIMIT:120}
+  rate_limits:
+    free:
+      requests: ${RATE_LIMIT_FREE_REQUESTS:60}
+      window_minutes: ${RATE_LIMIT_FREE_WINDOW:1}
+      burst: ${RATE_LIMIT_FREE_BURST:0}
+    pro:
+      requests: ${RATE_LIMIT_PRO_REQUESTS:120}
+      window_minutes: ${RATE_LIMIT_PRO_WINDOW:1}
+      burst: ${RATE_LIMIT_PRO_BURST:20}
 
 analytics:
   cache_timeout_seconds: ${ANALYTICS_CACHE_TIMEOUT:600}

--- a/yosai_intel_dashboard/src/infrastructure/config/staging.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/staging.yaml
@@ -30,7 +30,14 @@ security:
   cors_enabled: true
   cors_origins: []
   rate_limiting_enabled: true
-  rate_limit_per_minute: 1000
+  rate_limits:
+    basic:
+      requests: 1000
+      window_minutes: 1
+    premium:
+      requests: 2000
+      window_minutes: 1
+      burst: 100
 
 sample_files:
   csv_path: "data/sample_data.csv"


### PR DESCRIPTION
## Summary
- load per-tier rate limit settings with optional bursts
- expose `get_rate_limit(tier)` to surface limit, window and burst
- document tiered rate limit environment overrides and add tests

## Testing
- `pytest tests/test_dynamic_config_validation.py tests/test_rate_limit_tiers.py -q`
- `pytest tests/test_security_validator.py -q` *(fails: SecurityValidator.__init__() missing arg 'rate_limit'; redis_client undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a9028f48320b9bbcc019bea522c