### PR TITLE
Record reconnect metrics for WebSocket

### DIFF
--- a/tests/websocket/test_metrics.py
+++ b/tests/websocket/test_metrics.py
@@ -19,5 +19,6 @@ def test_websocket_metrics_publish_updates():
 
     assert bus.events[0][0] == "metrics_update"
     assert bus.events[0][1]["websocket_connections_total"] == 1
+    assert bus.events[0][1]["websocket_reconnect_attempts_total"] == 0
     assert bus.events[1][1]["websocket_reconnect_attempts_total"] == 1
     assert bus.events[2][1]["websocket_ping_failures_total"] == 1

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { useWebSocket, WebSocketState } from './useWebSocket';
 import { eventBus } from '../eventBus';
+import websocket_metrics from '../metrics/websocket_metrics';
 
 jest.useFakeTimers();
 
@@ -8,6 +9,7 @@ beforeEach(() => {
   MockSocket.instances = [];
   MockSocket.instance = null;
   jest.clearAllTimers();
+  websocket_metrics.reset();
 });
 
 class MockSocket {
@@ -49,6 +51,8 @@ describe('useWebSocket', () => {
   });
 
   it('reconnects with exponential backoff', () => {
+    const events: any[] = [];
+    const off = eventBus.on('metrics_update', e => events.push(e));
     const { unmount } = renderHook(() =>
       useWebSocket('ws://test', url => new MockSocket(url) as unknown as WebSocket)
     );
@@ -62,6 +66,8 @@ describe('useWebSocket', () => {
     });
 
     expect(MockSocket.instances).toHaveLength(2);
+    expect(events[0].websocket_reconnect_attempts_total).toBe(1);
+    expect(websocket_metrics.snapshot().websocket_reconnect_attempts_total).toBe(1);
 
     act(() => {
       MockSocket.instances[1].onclose?.();
@@ -78,6 +84,7 @@ describe('useWebSocket', () => {
 
     expect(MockSocket.instances).toHaveLength(3);
 
+    off();
     unmount();
   });
 

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { defaultPool, HEARTBEAT_TIMEOUT } from './websocketPool';
+import { eventBus } from '../eventBus';
+import websocket_metrics from '../metrics/websocket_metrics';
 
 
 export const useWebSocket = (
@@ -47,6 +49,7 @@ export const useWebSocket = (
       }
       setState(WebSocketState.RECONNECTING);
       eventBus.emit('websocket_state', WebSocketState.RECONNECTING);
+      websocket_metrics.record_reconnect_attempt();
       const delay = Math.min(1000 * 2 ** attemptRef.current, 30000);
       attemptRef.current += 1;
       retryTimeout.current = setTimeout(connect, delay);

--- a/yosai_intel_dashboard/src/adapters/ui/metrics/websocket_metrics.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/metrics/websocket_metrics.ts
@@ -1,0 +1,49 @@
+import { eventBus } from '../eventBus';
+
+let websocket_connections_total = 0;
+let websocket_reconnect_attempts_total = 0;
+let websocket_ping_failures_total = 0;
+
+export const snapshot = () => ({
+  websocket_connections_total,
+  websocket_reconnect_attempts_total,
+  websocket_ping_failures_total,
+});
+
+const publish = () => {
+  eventBus.emit('metrics_update', snapshot());
+};
+
+export const record_connection = () => {
+  websocket_connections_total += 1;
+  publish();
+};
+
+export const record_reconnect_attempt = () => {
+  websocket_reconnect_attempts_total += 1;
+  publish();
+};
+
+export const record_ping_failure = () => {
+  websocket_ping_failures_total += 1;
+  publish();
+};
+
+export const reset = () => {
+  websocket_connections_total = 0;
+  websocket_reconnect_attempts_total = 0;
+  websocket_ping_failures_total = 0;
+};
+
+export const publish_snapshot = publish;
+
+const websocket_metrics = {
+  record_connection,
+  record_reconnect_attempt,
+  record_ping_failure,
+  snapshot,
+  publish_snapshot,
+  reset,
+};
+
+export default websocket_metrics;


### PR DESCRIPTION
## Summary
- track reconnection attempts via `websocket_metrics` and publish snapshots to the event bus
- expose client-side `websocket_metrics` helper for realtime metrics updates
- emit full metric snapshots from server metrics module

## Testing
- `pytest tests/websocket/test_metrics.py tests/websocket/test_metrics_provider.py`
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npx jest yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a66416c8320adc4fda36f0835bb