### PR TITLE
Add resource ID authorization validation

### DIFF
--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -95,3 +95,12 @@ def test_malicious_query_rejected():
     client = app.test_client()
     resp = client.get("/?q=%3Cscript%3E")
     assert resp.status_code == 400
+
+
+def test_resource_id_authorization():
+    def deny(user, resource_id):
+        return False
+
+    validator = SecurityValidator(authorize_resource=deny)
+    with pytest.raises(ValidationError):
+        validator.validate_resource_id("alice", "secret-id")

--- a/tests/stubs/services/upload/controllers/upload_controller.py
+++ b/tests/stubs/services/upload/controllers/upload_controller.py
@@ -1,3 +1,13 @@
+from typing import Any
+
+from validation.security_validator import SecurityValidator
+
+
 class UnifiedUploadController:
-    def parse_upload(self, contents: str, filename: str):
+    def __init__(self, validator: SecurityValidator | None = None) -> None:
+        self._validator = validator or SecurityValidator()
+
+    def parse_upload(self, contents: str, filename: str, user: Any | None = None):
+        if user is not None:
+            self._validator.validate_resource_id(user, filename)
         return None

--- a/yosai_intel_dashboard/src/core/domain/entities/access_events.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/access_events.py
@@ -25,7 +25,9 @@ class AccessEventModel(BaseModel):
     """Model for access control events with full type safety"""
 
     @monitor_query_performance()
-    def get_data(self, filters: Dict[str, Any] | None = None) -> pd.DataFrame:
+    def get_data(
+        self, filters: Dict[str, Any] | None = None, user: Any | None = None
+    ) -> pd.DataFrame:
         """Get access events with optional filtering"""
 
         base_query = """
@@ -60,10 +62,14 @@ class AccessEventModel(BaseModel):
             params.append(filters["end_date"])
 
         if "person_id" in filters:
+            if user is not None:
+                _sql_validator.validate_resource_id(user, filters["person_id"])
             base_query += " AND person_id = %s"
             params.append(filters["person_id"])
 
         if "door_id" in filters:
+            if user is not None:
+                _sql_validator.validate_resource_id(user, filters["door_id"])
             base_query += " AND door_id = %s"
             params.append(filters["door_id"])
 

--- a/yosai_intel_dashboard/src/services/upload/controllers/upload_controller.py
+++ b/yosai_intel_dashboard/src/services/upload/controllers/upload_controller.py
@@ -2,9 +2,10 @@ import base64
 import io
 import json
 import logging
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import pandas as pd
+from validation.security_validator import SecurityValidator
 
 logger = logging.getLogger(__name__)
 
@@ -12,14 +13,20 @@ logger = logging.getLogger(__name__)
 class UnifiedUploadController:
     """Handle core upload parsing logic independent of Dash."""
 
-    def __init__(self) -> None:
+    def __init__(self, validator: SecurityValidator | None = None) -> None:
         self._progress = 0
         self._files: List[str] = []
+        self._validator = validator or SecurityValidator()
 
-    def parse_upload(self, contents: str, filename: str) -> Optional[pd.DataFrame]:
+    def parse_upload(
+        self, contents: str, filename: str, user: Any | None = None
+    ) -> Optional[pd.DataFrame]:
         """Return parsed DataFrame from uploaded *contents*."""
         if not contents or not filename:
             return None
+
+        if user is not None:
+            self._validator.validate_resource_id(user, filename)
 
         try:
             _type, content_string = contents.split(",", 1)


### PR DESCRIPTION
## Summary
- add IDORRule to `SecurityValidator` with `validate_resource_id` helper
- validate resource IDs in upload and access event controllers
- test unauthorized resource access fails validation

## Testing
- `pytest tests/security/test_validators.py::test_resource_id_authorization -q`
- `pytest tests/security/test_validators.py -q` *(fails: NameError: import_optional, TypedDict)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a7437508320b171d4da373ac0dc