### PR TITLE
Add secret scanning

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,8 +56,27 @@ jobs:
           name: snyk-results
           path: snyk-results.json
 
+  secret-scan:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install detect-secrets
+      - name: Run secret scan
+        run: |
+          python scripts/security_scan_secrets.py || exit 1
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: secret-scan-report
+          path: secret-scan-report.json
+
   release:
-    needs: [trivy-scan, snyk-scan]
+    needs: [trivy-scan, snyk-scan, secret-scan]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,374 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "/workspace/yosai_intel_dashboard_fresh/.secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 1063
+      }
+    ],
+    "docker-compose.dev.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.dev.yml",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "docs/async_driver_evaluation.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/async_driver_evaluation.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "docs/operations.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/operations.md",
+        "hashed_secret": "0b6d3b35c49598a07075f80e4ff883a3d9fb1bf5",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "docs/secret_management.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/secret_management.md",
+        "hashed_secret": "e8d4a2f731a2b37fcb169639d14ccb9350952d59",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "docs/timescale_integration.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/timescale_integration.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "feature_store/feature_store.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "feature_store/feature_store.yaml",
+        "hashed_secret": "f37a74d82869756054661d6501b29cdfec0fdb38",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "k8s/microservices/secrets/analytics-service-secret.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "k8s/microservices/secrets/analytics-service-secret.yaml",
+        "hashed_secret": "827f076409fb3c1f4d000d1bd420556f26ac0b69",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "k8s/microservices/secrets/api-gateway-secret.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "k8s/microservices/secrets/api-gateway-secret.yaml",
+        "hashed_secret": "23f24a48d90e7086c51bddf431f01b6ef2be5023",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "k8s/microservices/secrets/event-ingestion-secret.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "k8s/microservices/secrets/event-ingestion-secret.yaml",
+        "hashed_secret": "bd69aaa42abf8ad83b47f42648c49503d81cd89f",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "load-tests/docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "load-tests/docker-compose.yml",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/database/test_connection_strings.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/database/test_connection_strings.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/database/test_connection_strings.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "tests/integration/test_auth_flow.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_auth_flow.py",
+        "hashed_secret": "e5d3db477707ed7e063c4cc9f87449633c3337c4",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_auth_flow.py",
+        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "tests/integration/test_rbac_endpoints.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_rbac_endpoints.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 132
+      }
+    ],
+    "tests/test_config_loader.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config_loader.py",
+        "hashed_secret": "fca268ae2442d5cabc3e12d87b349adf8bf7d76c",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "tests/test_database_config_serialization.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_database_config_serialization.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 78
+      }
+    ],
+    "tests/test_rbac.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_rbac.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/test_secure_config_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_secure_config_manager.py",
+        "hashed_secret": "d481604f2aacecc116fc823d5712dadb17fc1e01",
+        "is_verified": false,
+        "line_number": 107
+      }
+    ],
+    "yosai_intel_dashboard/src/infrastructure/config/production.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/production.yaml",
+        "hashed_secret": "95c3aa6f169f232f863191565e009c361c16f59d",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/production.yaml",
+        "hashed_secret": "dea007630085f60e4fd74d9660727420eb527313",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "yosai_intel_dashboard/src/infrastructure/config/staging.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/staging.yaml",
+        "hashed_secret": "95c3aa6f169f232f863191565e009c361c16f59d",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/staging.yaml",
+        "hashed_secret": "dea007630085f60e4fd74d9660727420eb527313",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "yosai_intel_dashboard/src/infrastructure/config/test.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/test.yaml",
+        "hashed_secret": "95c3aa6f169f232f863191565e009c361c16f59d",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/infrastructure/config/test.yaml",
+        "hashed_secret": "dea007630085f60e4fd74d9660727420eb527313",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "yosai_intel_dashboard/src/services/analytics_microservice/app.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/services/analytics_microservice/app.py",
+        "hashed_secret": "cb2cf2b2fb4cebc5cf2aa9f22c3eb91e2a11a849",
+        "is_verified": false,
+        "line_number": 103
+      }
+    ],
+    "yosai_intel_dashboard/src/services/security/jwt_service.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "yosai_intel_dashboard/src/services/security/jwt_service.py",
+        "hashed_secret": "cb2cf2b2fb4cebc5cf2aa9f22c3eb91e2a11a849",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ]
+  },
+  "generated_at": "2025-08-03T09:27:38Z"
+}

--- a/scripts/security_scan_secrets.py
+++ b/scripts/security_scan_secrets.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Scan the repository for secrets using detect-secrets.
+
+This wrapper ensures a shared workflow for secret scanning. It will
+compare the current state of the repository against the stored baseline
+and exit with a non-zero status if new secrets are detected.
+
+If the baseline does not exist yet, it will be generated automatically.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE_PATH = REPO_ROOT / ".secrets.baseline"
+REPORT_PATH = REPO_ROOT / "secret-scan-report.json"
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def generate_baseline() -> None:
+    result = _run(["detect-secrets", "scan", str(REPO_ROOT)])
+    BASELINE_PATH.write_text(result.stdout)
+    print(f"Baseline created at {BASELINE_PATH}")
+
+
+def main() -> int:
+    if not BASELINE_PATH.exists():
+        generate_baseline()
+        return 0
+
+    result = _run(
+        [
+            "detect-secrets",
+            "scan",
+            "--baseline",
+            str(BASELINE_PATH),
+            str(REPO_ROOT),
+        ]
+    )
+
+    REPORT_PATH.write_text(result.stdout or "{}")
+
+    if result.returncode != 0:
+        print("Potential secrets detected. See secret-scan-report.json for details.")
+        print(
+            "Remove the secrets or run 'detect-secrets audit .secrets.baseline' "
+            "to update the baseline if these are false positives."
+        )
+    else:
+        print("No new secrets detected.")
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add detect-secrets wrapper to scan repository and manage baseline
- include secret-scan job in CI pipeline
- check in baseline for secret detection

## Testing
- `pre-commit run --files .github/workflows/pipeline.yml scripts/security_scan_secrets.py .secrets.baseline` *(fails: bandit issues across repository)*
- `pre-commit run black --files scripts/security_scan_secrets.py`
- `pre-commit run isort --files scripts/security_scan_secrets.py`
- `pre-commit run flake8 --files scripts/security_scan_secrets.py`
- `pre-commit run mypy --files scripts/security_scan_secrets.py`
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a758f28832090b307f320105e63