### PR TITLE
feat: centralize and enforce user input validation

### DIFF
--- a/tests/adapters/api/test_routes.py
+++ b/tests/adapters/api/test_routes.py
@@ -1,4 +1,10 @@
 import pytest
+import asyncio
+import importlib
+import sys
+import types
+
+from fastapi import HTTPException
 
 pytest.importorskip("api.routes")
 
@@ -6,3 +12,46 @@ pytest.importorskip("api.routes")
 def test_routes_module_importable():
     module = __import__("api.routes", fromlist=[""])
     assert module is not None
+
+
+def test_analytics_route_sanitizes_input(monkeypatch):
+    called: dict[str, str] = {}
+
+    cfg_mod = types.SimpleNamespace(get_cache_config=lambda: types.SimpleNamespace(ttl=1))
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.infrastructure.config", cfg_mod
+    )
+    analytics_router = importlib.import_module("api.analytics_router")
+
+    def fake_summary(fid: str, rng: str) -> dict:
+        called["facility_id"] = fid
+        called["range"] = rng
+        return {}
+
+    monkeypatch.setattr(
+        analytics_router._cached_service,
+        "get_analytics_summary_sync",
+        fake_summary,
+    )
+    payload = "<script>alert(1)</script>"
+    query = analytics_router.AnalyticsQuery(facility_id=payload, range="30d")
+    asyncio.run(analytics_router.get_patterns_analysis(query, None))
+    assert called["facility_id"] == "&lt;script&gt;alert(1)&lt;/script&gt;"
+
+
+def test_chart_invalid_type_returns_message(monkeypatch):
+    cfg_mod = types.SimpleNamespace(get_cache_config=lambda: types.SimpleNamespace(ttl=1))
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.infrastructure.config", cfg_mod
+    )
+    analytics_router = importlib.import_module("api.analytics_router")
+    monkeypatch.setattr(
+        analytics_router._cached_service,
+        "get_analytics_summary_sync",
+        lambda fid, rng: {},
+    )
+    payload = "<script>alert(1)</script>"
+    query = analytics_router.AnalyticsQuery()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(analytics_router.get_chart_data(payload, query, None))
+    assert exc.value.detail["message"] == "Unknown chart type"

--- a/tests/test_dash_callback_middleware.py
+++ b/tests/test_dash_callback_middleware.py
@@ -5,7 +5,6 @@ from dash import Output
 
 from yosai_intel_dashboard.src.core.dash_callback_middleware import wrap_callback
 from yosai_intel_dashboard.src.core.error_handling import error_handler
-from validation.security_validator import SecurityValidator
 
 
 def test_wrap_callback_validation(monkeypatch):
@@ -16,7 +15,7 @@ def test_wrap_callback_validation(monkeypatch):
         called["v"] = value
         return value
 
-    wrapper = wrap_callback(cb, outputs, SecurityValidator())
+    wrapper = wrap_callback(cb, outputs)
     # valid input
     assert wrapper("ok") == "ok"
     assert called["v"] == "ok"
@@ -40,7 +39,7 @@ def test_wrap_callback_error_logged(monkeypatch):
         recorded["ctx"] = context
 
     monkeypatch.setattr(error_handler, "handle_error", fake_handle_error)
-    wrapper = wrap_callback(cb, outputs, SecurityValidator())
+    wrapper = wrap_callback(cb, outputs)
     out = wrapper("ok")
     assert out is dash.no_update
     assert isinstance(recorded.get("exc"), RuntimeError)

--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -9,6 +9,7 @@ from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCa
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsService
 from yosai_intel_dashboard.src.services.security import require_permission
+from yosai_intel_dashboard.src.core.security import validate_user_input
 from shared.errors.types import ErrorCode
 
 # Routes now use an unversioned prefix and are mounted under /v1 by the
@@ -48,7 +49,9 @@ async def get_patterns_analysis(
     Fetch aggregated analytics for the requested ``facility_id`` and time ``range``
     and return the cached summary payload.
     """
-    data = _cached_service.get_analytics_summary_sync(query.facility_id, query.range)
+    facility_id = validate_user_input(query.facility_id or "", "facility_id")
+    range_val = validate_user_input(query.range or "", "range")
+    data = _cached_service.get_analytics_summary_sync(facility_id, range_val)
     return JSONResponse(content=data)
 
 
@@ -87,7 +90,10 @@ async def get_chart_data(
     - **query**: Common analytics filters including ``facility_id`` and
       reporting ``range``.
     """
-    data = _cached_service.get_analytics_summary_sync(query.facility_id, query.range)
+    chart_type = validate_user_input(chart_type, "chart_type")
+    facility_id = validate_user_input(query.facility_id or "", "facility_id")
+    range_val = validate_user_input(query.range or "", "range")
+    data = _cached_service.get_analytics_summary_sync(facility_id, range_val)
     if chart_type == "patterns":
         return JSONResponse(content={"type": "patterns", "data": data})
     if chart_type == "timeline":

--- a/yosai_intel_dashboard/src/adapters/api/explanations.py
+++ b/yosai_intel_dashboard/src/adapters/api/explanations.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from shared.errors.types import ErrorCode
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.services.security import require_permission
+from yosai_intel_dashboard.src.core.security import validate_user_input
 from yosai_intel_dashboard.src.services.analytics.analytics_service import (
     AnalyticsService,
     get_analytics_service,
@@ -20,6 +21,7 @@ async def get_explanation(
     svc: AnalyticsService = Depends(get_analytics_service),
 ):
     """Return stored SHAP explanations for a prediction."""
+    prediction_id = validate_user_input(prediction_id, "prediction_id")
     if svc.model_registry is None:
         raise http_error(ErrorCode.INTERNAL, "model registry unavailable", 500)
     record = svc.model_registry.get_explanation(prediction_id)

--- a/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
+++ b/yosai_intel_dashboard/src/adapters/api/risk_scoring.py
@@ -11,7 +11,7 @@ from app import app
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler
 from yosai_intel_dashboard.src.services.analytics.analytics_service import calculate_risk_score
 from shared.errors.types import ErrorCode
-from validation.security_validator import SecurityValidator
+from yosai_intel_dashboard.src.core.security import validate_user_input
 from yosai_framework.errors import CODE_TO_STATUS
 
 handler = ErrorHandler()
@@ -36,8 +36,9 @@ def calculate_score_endpoint(**payload):
     """Return aggregated risk score from provided values."""
     payload = payload or {}
     for key, value in payload.items():
-        check = SecurityValidator().validate_input(str(value), key)
-        if not check["valid"]:
+        try:
+            payload[key] = validate_user_input(str(value), key)
+        except Exception:
             err = handler.handle(
                 ValueError("Invalid parameter"), ErrorCategory.INVALID_INPUT
             )


### PR DESCRIPTION
## Summary
- add `validate_user_input` helper built atop `SecurityValidator`
- sanitize inbound strings across API routes, uploads and Dash callbacks
- verify sanitization logic and remediation messages via new tests

## Testing
- `pytest tests/adapters/api/test_routes.py tests/test_dash_callback_middleware.py tests/plugins/test_compliance_controller.py` *(fails: ModuleNotFoundError and other stub issues)*


------
https://chatgpt.com/codex/tasks/task_e_688f2a72ae888320846fdd0b658bb73d