### PR TITLE
Import TypedDict in unified callbacks

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -20,7 +20,6 @@ from typing import (
     Protocol,
     Tuple,
     Type,
-    TypedDict,
     TypeAlias,
     TypedDict,
 )


### PR DESCRIPTION
## Summary
- include `TypedDict` in `unified_callbacks` typing imports

## Testing
- `pytest tests/test_unicode_handler_full.py -q` *(fails: NameError: name 'authorize_resource' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f3b15d2208320a9a41273e336d198