### PR TITLE
Add resource filters for feature flag audit logs

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/monitoring/missing_dependencies.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/missing_dependencies.py
@@ -1,0 +1,13 @@
+"""Stub prometheus counter for optional dependency tracking."""
+
+
+class _Counter:
+    def labels(self, **kwargs):  # pragma: no cover - simple stub
+        return self
+
+    def inc(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+missing_dependencies = _Counter()
+

--- a/yosai_intel_dashboard/src/services/feature_flags/audit.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/audit.py
@@ -1,0 +1,101 @@
+"""Feature flag audit helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
+
+# This module expects an audit logger instance to be provided by the
+# application. Tests inject a dummy logger by assigning to this variable.
+audit_logger: Optional[ComplianceAuditLogger] = None
+
+
+def log_feature_flag_created(
+    name: str,
+    new_value: Any,
+    *,
+    actor_user_id: str,
+    reason: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Record creation of a feature flag."""
+    if audit_logger is None:
+        return
+
+    metadata = {"new_value": new_value, "reason": reason, "timestamp": timestamp}
+    audit_logger.log_action(
+        actor_user_id=actor_user_id,
+        action_type="FEATURE_FLAG_CREATED",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Feature flag {name} created",
+        metadata=metadata,
+    )
+
+
+def log_feature_flag_updated(
+    name: str,
+    *,
+    old_value: Any,
+    new_value: Any,
+    actor_user_id: str,
+    reason: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Record an update to a feature flag."""
+    if audit_logger is None:
+        return
+
+    metadata = {
+        "old_value": old_value,
+        "new_value": new_value,
+        "reason": reason,
+        "timestamp": timestamp,
+    }
+    audit_logger.log_action(
+        actor_user_id=actor_user_id,
+        action_type="FEATURE_FLAG_UPDATED",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Feature flag {name} updated",
+        metadata=metadata,
+    )
+
+
+def log_feature_flag_deleted(
+    name: str,
+    *,
+    old_value: Any,
+    actor_user_id: str,
+    reason: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Record deletion of a feature flag."""
+    if audit_logger is None:
+        return
+
+    metadata = {"old_value": old_value, "reason": reason, "timestamp": timestamp}
+    audit_logger.log_action(
+        actor_user_id=actor_user_id,
+        action_type="FEATURE_FLAG_DELETED",
+        resource_type="feature_flag",
+        resource_id=name,
+        description=f"Feature flag {name} deleted",
+        metadata=metadata,
+    )
+
+
+def get_feature_flag_audit_history(name: str, limit: int = 50) -> List[Dict[str, Any]]:
+    """Retrieve recent audit log entries for a feature flag."""
+    if audit_logger is None:
+        return []
+
+    logs = audit_logger.search_audit_logs(
+        resource_type="feature_flag",
+        resource_id=name,
+        limit=limit,
+    )
+    return logs[:limit] if logs else []
+


### PR DESCRIPTION
## Summary
- add resource filters to audit log search
- expose feature flag audit helpers using resource-scoped queries
- test feature flag audit history limit enforcement

## Testing
- `pytest tests/test_feature_flag_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3a3d21bc8320894e39a93f586fa6