### PR TITLE
refactor: centralize dependency injection with base component

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,4 @@
+"""Common utilities for dependency injection components."""
+from .base import BaseComponent, LoggingMixin, EventDispatchMixin, handle_deprecated
+
+__all__ = ["BaseComponent", "LoggingMixin", "EventDispatchMixin", "handle_deprecated"]

--- a/src/common/base.py
+++ b/src/common/base.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Base component and mixins providing simple dependency injection."""
+
+from typing import Any, Mapping
+import logging
+import types
+import warnings
+from functools import wraps
+
+
+class BaseComponent:
+    """Store provided dependencies as immutable attributes."""
+
+    def __init__(self, **dependencies: Any) -> None:  # noqa: D401 - simple container
+        for name, value in dependencies.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(
+            self, "_dependencies", types.MappingProxyType(dict(dependencies))
+        )
+
+    def __setattr__(self, key: str, value: Any) -> None:  # pragma: no cover - simple
+        if key in getattr(self, "_dependencies", {}):
+            raise AttributeError(f"Dependency '{key}' is immutable")
+        object.__setattr__(self, key, value)
+
+
+def handle_deprecated(*param_names: str):
+    """Allow positional args for backwards compat with a warning."""
+
+    def decorator(init):
+        @wraps(init)
+        def wrapped(self, *args, **kwargs):
+            if args:
+                warnings.warn(
+                    f"Positional arguments for {self.__class__.__name__} are deprecated; "
+                    "use keyword arguments instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                for arg, name in zip(args, param_names):
+                    kwargs.setdefault(name, arg)
+            return init(self, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+class LoggingMixin:
+    """Provide a simple logging helper."""
+
+    logger: logging.Logger | None = None
+
+    def log(self, level: int, msg: str, *args, **kwargs) -> None:
+        logger = self.logger or logging.getLogger(self.__class__.__name__)
+        logger.log(level, msg, *args, **kwargs)
+
+
+class EventDispatchMixin:
+    """Mixin requiring an ``event_bus`` dependency for dispatching."""
+
+    event_bus: Any
+
+    def dispatch_event(self, event_type: str, data: Mapping[str, Any]) -> None:
+        if not hasattr(self, "event_bus"):
+            raise AttributeError("event_bus dependency required")
+        self.event_bus.publish(event_type, data)

--- a/yosai_intel_dashboard/src/services/publishing_service.py
+++ b/yosai_intel_dashboard/src/services/publishing_service.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from src.common import BaseComponent, EventDispatchMixin, handle_deprecated
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from yosai_intel_dashboard.src.services.analytics.protocols import PublishingProtocol
 from yosai_intel_dashboard.src.services.analytics.publisher import Publisher
 
 
-class PublishingService(PublishingProtocol):
+class PublishingService(EventDispatchMixin, BaseComponent, PublishingProtocol):
     """Service wrapping :class:`Publisher` for event dispatch."""
 
-    def __init__(self, event_bus: EventBusProtocol | None = None) -> None:
+    @handle_deprecated("event_bus")
+    def __init__(self, *, event_bus: EventBusProtocol | None = None) -> None:
+        super().__init__(event_bus=event_bus)
         self._publisher = Publisher(event_bus)
 
     def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -2,20 +2,26 @@ from __future__ import annotations
 
 """Simple background publisher for analytics WebSocket demos."""
 
+import logging
 import threading
-import time
 from typing import Any, Dict
 
+from src.common import (
+    BaseComponent,
+    EventDispatchMixin,
+    LoggingMixin,
+    handle_deprecated,
+)
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from yosai_intel_dashboard.src.services.analytics_summary import generate_sample_analytics
 
 
-class WebSocketDataProvider:
+class WebSocketDataProvider(EventDispatchMixin, LoggingMixin, BaseComponent):
     """Publish sample analytics updates to an event bus periodically."""
 
-    def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
-        self.event_bus = event_bus
-        self.interval = interval
+    @handle_deprecated("event_bus", "interval")
+    def __init__(self, *, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+        super().__init__(event_bus=event_bus, interval=interval)
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -23,7 +29,8 @@ class WebSocketDataProvider:
     def _run(self) -> None:
         while not self._stop.is_set():
             payload: Dict[str, Any] = generate_sample_analytics()
-            self.event_bus.publish("analytics_update", payload)
+            self.dispatch_event("analytics_update", payload)
+            self.log(logging.DEBUG, "analytics_update dispatched")
             self._stop.wait(self.interval)
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- add BaseComponent with logging and event dispatch mixins
- refactor providers and services to use BaseComponent and deprecation wrapper

## Testing
- `python -m py_compile src/common/base.py src/websocket/metrics_provider.py yosai_intel_dashboard/src/services/websocket_data_provider.py yosai_intel_dashboard/src/services/publishing_service.py`
- `pytest -q 2>&1 | tail -n 20` *(fails: Missing dependencies and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f3e70f4848320a30b578929af059f