### PR TITLE
feat: add centralized configuration service

### DIFF
--- a/src/common/base.py
+++ b/src/common/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Base classes used across demo components."""
+
+from .config import ConfigProvider, ConfigService
+
+
+class BaseComponent:
+    """Base class that provides access to the application configuration."""
+
+    def __init__(self, config: ConfigProvider | None = None) -> None:
+        # If no config supplied use defaults loaded from the environment.
+        self._config: ConfigProvider = config or ConfigService()
+
+    @property
+    def config(self) -> ConfigProvider:
+        """Configuration accessor for subclasses."""
+        return self._config
+
+
+__all__ = ["BaseComponent"]

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Lightweight configuration service.
+
+The :class:`ConfigService` loads configuration values from the environment
+(or a provided mapping) and exposes them as read‑only properties.  It acts as a
+central place for runtime settings used by small demo components within the
+``src`` package.  Instances are immutable which prevents accidental mutation of
+settings during tests.
+"""
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol
+import os
+
+
+class ConfigProvider(Protocol):
+    """Protocol describing the configuration attributes used by components."""
+
+    @property
+    def metrics_interval(self) -> float: ...
+
+    @property
+    def ping_interval(self) -> float: ...
+
+    @property
+    def ping_timeout(self) -> float: ...
+
+
+@dataclass(frozen=True)
+class ConfigService(ConfigProvider):
+    """Simple immutable configuration container."""
+
+    _settings: Mapping[str, Any]
+
+    def __init__(self, settings: Mapping[str, Any] | None = None) -> None:
+        if settings is None:
+            settings = {
+                "metrics_interval": float(os.getenv("METRICS_INTERVAL", "1.0")),
+                "ping_interval": float(os.getenv("PING_INTERVAL", "30.0")),
+                "ping_timeout": float(os.getenv("PING_TIMEOUT", "10.0")),
+            }
+        object.__setattr__(self, "_settings", MappingProxyType(dict(settings)))
+
+    # Expose settings via properties for convenient, type‑checked access
+    @property
+    def metrics_interval(self) -> float:
+        return float(self._settings["metrics_interval"])
+
+    @property
+    def ping_interval(self) -> float:
+        return float(self._settings["ping_interval"])
+
+    @property
+    def ping_timeout(self) -> float:
+        return float(self._settings["ping_timeout"])
+
+
+__all__ = ["ConfigService", "ConfigProvider"]

--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import threading
 from typing import Any, Dict, Protocol
 
+from src.common.base import BaseComponent
+from src.common.config import ConfigProvider
+
 
 class EventBusProtocol(Protocol):
     def publish(self, event_type: str, data: Dict[str, Any]) -> None: ...
@@ -18,12 +21,19 @@ def generate_sample_metrics() -> Dict[str, Any]:
     }
 
 
-class MetricsProvider:
+class MetricsProvider(BaseComponent):
     """Publish metrics updates to an event bus periodically."""
 
-    def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+    def __init__(
+        self,
+        event_bus: EventBusProtocol,
+        config: ConfigProvider | None = None,
+        interval: float | None = None,
+    ) -> None:
+        super().__init__(config)
         self.event_bus = event_bus
-        self.interval = interval
+        # allow explicit override but fall back to configured interval
+        self.interval = interval if interval is not None else self.config.metrics_interval
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -12,6 +12,7 @@ import dash
 import dash_bootstrap_components as dbc
 import pytest
 from dash import dcc, html
+from src.common.config import ConfigService
 
 from tests.import_helpers import import_optional, safe_import
 
@@ -147,8 +148,9 @@ def test_plugin_upload_event_sse_ws(
         AnalyticsWebSocketServer,
     )
 
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
     ws_server = AnalyticsWebSocketServer(
-        event_bus=event_bus, host="127.0.0.1", port=8765
+        event_bus=event_bus, host="127.0.0.1", port=8765, config=cfg
     )
 
     messages: list[str] = []

--- a/tests/integration/test_websocket_event_flow.py
+++ b/tests/integration/test_websocket_event_flow.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import websockets
+from src.common.config import ConfigService
 
 
 def _load_server():
@@ -66,7 +67,8 @@ ws_module, AnalyticsWebSocketServer, EventBus = _load_server()
 @pytest.fixture
 def websocket_server():
     event_bus = EventBus()
-    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8770)
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
+    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8770, config=cfg)
     server.pool = ws_module.WebSocketConnectionPool()
     server._queue = deque()
     time.sleep(0.05)

--- a/tests/integration/test_websocket_events.py
+++ b/tests/integration/test_websocket_events.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import websockets
+from src.common.config import ConfigService
 
 
 def _load_server():
@@ -63,7 +64,8 @@ AnalyticsWebSocketServer, EventBus = _load_server()
 
 def test_websocket_events_broadcast():
     event_bus = EventBus()
-    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8766)
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
+    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8766, config=cfg)
     try:
 
         async def runner():

--- a/tests/integration/test_websocket_updates.py
+++ b/tests/integration/test_websocket_updates.py
@@ -4,6 +4,8 @@ import types
 import time
 from pathlib import Path
 
+from src.common.config import ConfigService
+
 
 def _load_provider():
     pkg_names = [
@@ -63,7 +65,12 @@ class DummyBus:
 def test_websocket_data_provider_integration():
     Provider = _load_provider()
     bus = DummyBus()
-    provider = Provider(bus, interval=0.01)
+    cfg = ConfigService({
+        'metrics_interval': 0.01,
+        'ping_interval': 0.01,
+        'ping_timeout': 0.01,
+    })
+    provider = Provider(bus, config=cfg)
     time.sleep(0.05)
     provider.stop()
     assert any(e[0] == "analytics_update" for e in bus.events)

--- a/tests/test_websocket_data_provider.py
+++ b/tests/test_websocket_data_provider.py
@@ -4,6 +4,8 @@ import time
 import types
 from pathlib import Path
 
+from src.common.config import ConfigService
+
 
 def _load_provider():
     pkg_names = [
@@ -54,7 +56,12 @@ def test_websocket_data_provider_publishes():
     bus = DummyBus()
     events = []
     bus.subscribe("analytics_update", lambda d: events.append(d))
-    provider = Provider(bus, interval=0.01)
+    cfg = ConfigService({
+        'metrics_interval': 0.01,
+        'ping_interval': 0.01,
+        'ping_timeout': 0.01,
+    })
+    provider = Provider(bus, config=cfg)
     time.sleep(0.05)
     provider.stop()
     assert events

--- a/tests/test_websocket_server.py
+++ b/tests/test_websocket_server.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import threading
 
 from src.websocket import metrics as websocket_metrics
+from src.common.config import ConfigService
 
 
 def _load_server():
@@ -93,7 +94,12 @@ def _create_server(event_bus: DummyBus) -> AnalyticsWebSocketServer:
     # avoid starting actual websocket server
     original = AnalyticsWebSocketServer._run
     AnalyticsWebSocketServer._run = lambda self: None  # type: ignore
-    server = AnalyticsWebSocketServer(event_bus, ping_interval=0.01, ping_timeout=0.01)
+    cfg = ConfigService({
+        'metrics_interval': 0.01,
+        'ping_interval': 0.01,
+        'ping_timeout': 0.01,
+    })
+    server = AnalyticsWebSocketServer(event_bus, config=cfg)
     AnalyticsWebSocketServer._run = original
     return server
 

--- a/tests/unit/test_websocket_server.py
+++ b/tests/unit/test_websocket_server.py
@@ -8,6 +8,8 @@ import time
 import types
 from pathlib import Path
 
+from src.common.config import ConfigService
+
 
 
 class DummyEventBus:
@@ -100,7 +102,8 @@ def _run_client(port: int, expected: int) -> list[dict]:
 
 def test_buffered_events_flushed_on_client_connect() -> None:
     event_bus = EventBus()
-    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8766)
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
+    server = AnalyticsWebSocketServer(event_bus=event_bus, host="127.0.0.1", port=8766, config=cfg)
 
     time.sleep(0.1)
 
@@ -118,8 +121,9 @@ def test_buffered_events_flushed_on_client_connect() -> None:
 
 def test_queue_bound() -> None:
     event_bus = EventBus()
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
     server = AnalyticsWebSocketServer(
-        event_bus=event_bus, host="127.0.0.1", port=8767, queue_size=2
+        event_bus=event_bus, host="127.0.0.1", port=8767, queue_size=2, config=cfg
     )
 
     time.sleep(0.1)
@@ -138,11 +142,13 @@ def test_queue_bound() -> None:
 
 def test_compressed_broadcast() -> None:
     event_bus = EventBus()
+    cfg = ConfigService({'metrics_interval':0.01,'ping_interval':0.01,'ping_timeout':0.01})
     server = AnalyticsWebSocketServer(
         event_bus=event_bus,
         host="127.0.0.1",
         port=8768,
         compression_threshold=10,
+        config=cfg,
     )
 
     time.sleep(0.1)

--- a/tests/websocket/test_metrics_provider.py
+++ b/tests/websocket/test_metrics_provider.py
@@ -1,6 +1,7 @@
 import time
 
 from src.websocket.metrics_provider import MetricsProvider
+from src.common.config import ConfigService
 
 
 class DummyBus:
@@ -19,7 +20,12 @@ def test_metrics_provider_publishes_updates():
     bus = DummyBus()
     events = []
     bus.subscribe('metrics_update', lambda data: events.append(data))
-    provider = MetricsProvider(bus, interval=0.01)
+    cfg = ConfigService({
+        'metrics_interval': 0.01,
+        'ping_interval': 0.01,
+        'ping_timeout': 0.01,
+    })
+    provider = MetricsProvider(bus, config=cfg)
     time.sleep(0.05)
     provider.stop()
     assert events

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -8,14 +8,23 @@ from typing import Any, Dict
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from yosai_intel_dashboard.src.services.analytics_summary import generate_sample_analytics
+from src.common.base import BaseComponent
+from src.common.config import ConfigProvider
 
 
-class WebSocketDataProvider:
+class WebSocketDataProvider(BaseComponent):
     """Publish sample analytics updates to an event bus periodically."""
 
-    def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+    def __init__(
+        self,
+        event_bus: EventBusProtocol,
+        *,
+        config: ConfigProvider | None = None,
+        interval: float | None = None,
+    ) -> None:
+        super().__init__(config)
         self.event_bus = event_bus
-        self.interval = interval
+        self.interval = interval if interval is not None else self.config.metrics_interval
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()


### PR DESCRIPTION
## Summary
- add `ConfigService` providing immutable runtime settings via properties
- introduce `BaseComponent` and inject config into websocket services
- update tests to use a mocked config service

## Testing
- `pytest tests/api/test_metrics_endpoints.py tests/websocket/test_metrics.py tests/websocket/test_metrics_provider.py tests/test_websocket_server.py tests/test_websocket_data_provider.py tests/integration/test_websocket_updates.py tests/integration/test_websocket_event_flow.py tests/integration/test_websocket_events.py tests/unit/test_websocket_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3e7237fc8320ad5cf27bc2c5ba23