### PR TITLE
Introduce reusable EventBus and integrate websocket metrics

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,5 @@
+"""Common utilities for the simplified dashboard package."""
+
+from .events import EventBus, EventPublisher
+
+__all__ = ["EventBus", "EventPublisher"]

--- a/src/common/events.py
+++ b/src/common/events.py
@@ -1,0 +1,65 @@
+"""Thread-safe in-memory event bus and publisher utilities."""
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from threading import RLock
+from types import MappingProxyType
+from typing import Any, Callable, Dict, Mapping
+
+
+class EventBus:
+    """Simple thread-safe event bus.
+
+    Subscribers are stored by event type. ``emit`` makes a defensive copy of
+    the payload and exposes it as an immutable mapping to subscribers to avoid
+    accidental mutation of shared state.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, Dict[str, Callable[[Mapping[str, Any]], None]]] = defaultdict(dict)
+        self._lock = RLock()
+        self._counter = 0
+
+    def subscribe(self, event_type: str, handler: Callable[[Mapping[str, Any]], None]) -> str:
+        """Register ``handler`` to be called when ``event_type`` is emitted.
+
+        Returns a subscription identifier that can be used to unsubscribe later.
+        """
+        with self._lock:
+            self._counter += 1
+            token = f"{event_type}:{self._counter}"
+            self._subscribers[event_type][token] = handler
+            return token
+
+    def unsubscribe(self, token: str) -> None:
+        """Remove a previously registered handler using its subscription token."""
+        with self._lock:
+            for event_type, handlers in list(self._subscribers.items()):
+                if token in handlers:
+                    del handlers[token]
+                    if not handlers:
+                        del self._subscribers[event_type]
+                    break
+
+    def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        """Publish ``payload`` to all subscribers of ``event_type``."""
+        with self._lock:
+            handlers = list(self._subscribers.get(event_type, {}).values())
+        immutable_payload = MappingProxyType(deepcopy(dict(payload)))
+        for handler in handlers:
+            handler(immutable_payload)
+
+
+class EventPublisher:
+    """Mixin providing convenience methods for publishing events."""
+
+    def __init__(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+
+    def publish_event(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        """Publish an event via the configured ``EventBus``."""
+        self._event_bus.emit(event_type, payload)
+
+
+__all__ = ["EventBus", "EventPublisher"]

--- a/src/websocket/metrics.py
+++ b/src/websocket/metrics.py
@@ -1,15 +1,12 @@
+"""Prometheus metrics and EventBus integration for WebSocket activity."""
 from __future__ import annotations
 
-"""Prometheus metrics and EventBus integration for WebSocket activity."""
+from typing import Dict
 
 from prometheus_client import REGISTRY, Counter, start_http_server
 from prometheus_client.core import CollectorRegistry
 
-from typing import Any, Dict, Protocol
-
-
-class EventBusProtocol(Protocol):
-    def publish(self, event_type: str, data: Dict[str, Any], source: str | None = None) -> None: ...
+from src.common.events import EventBus, EventPublisher
 
 # Avoid duplicate registration when the module is imported multiple times.
 if "websocket_connections_total" not in REGISTRY._names_to_collectors:
@@ -41,32 +38,44 @@ else:  # pragma: no cover - defensive for test imports
         registry=registry,
     )
 
-_event_bus: EventBusProtocol | None = None
+
+class WebSocketMetrics(EventPublisher):
+    """Publish metric snapshots on every counter update."""
+
+    def __init__(self, event_bus: EventBus) -> None:
+        super().__init__(event_bus)
+
+    def snapshot(self) -> Dict[str, float]:
+        return {
+            "websocket_connections_total": websocket_connections_total._value.get(),  # type: ignore[attr-defined]
+            "websocket_reconnect_attempts_total": websocket_reconnect_attempts_total._value.get(),  # type: ignore[attr-defined]
+            "websocket_ping_failures_total": websocket_ping_failures_total._value.get(),  # type: ignore[attr-defined]
+        }
+
+    def _publish_snapshot(self) -> None:
+        self.publish_event("metrics_update", self.snapshot())
+
+    def record_connection(self) -> None:
+        """Increment connection counter and publish update."""
+        websocket_connections_total.inc()
+        self._publish_snapshot()
+
+    def record_reconnect_attempt(self) -> None:
+        """Increment reconnect counter and publish update."""
+        websocket_reconnect_attempts_total.inc()
+        self._publish_snapshot()
+
+    def record_ping_failure(self) -> None:
+        """Increment ping failure counter and publish update."""
+        websocket_ping_failures_total.inc()
+        self._publish_snapshot()
+
+    def publish_snapshot(self) -> None:
+        """Explicitly publish the current metric snapshot."""
+        self._publish_snapshot()
+
 
 _metrics_started = False
-
-
-def set_event_bus(bus: EventBusProtocol) -> None:
-    """Configure the ``EventBus`` used for publishing metric updates."""
-    global _event_bus
-    _event_bus = bus
-
-
-def snapshot() -> Dict[str, float]:
-    """Return a snapshot of current metric counters."""
-    return {
-        "websocket_connections_total": websocket_connections_total._value.get(),  # type: ignore[attr-defined]
-        "websocket_reconnect_attempts_total": websocket_reconnect_attempts_total._value.get(),  # type: ignore[attr-defined]
-        "websocket_ping_failures_total": websocket_ping_failures_total._value.get(),  # type: ignore[attr-defined]
-    }
-
-
-def _publish_snapshot() -> None:
-    if _event_bus:
-        try:
-            _event_bus.publish("metrics_update", snapshot())
-        except Exception:  # pragma: no cover - best effort
-            pass
 
 
 def start_metrics_server(port: int = 8003) -> None:
@@ -76,35 +85,11 @@ def start_metrics_server(port: int = 8003) -> None:
         start_http_server(port)
         _metrics_started = True
 
-def record_connection() -> None:
-    """Increment connection counter and publish update."""
-    websocket_connections_total.inc()
-    _publish_snapshot()
-
-def record_reconnect_attempt() -> None:
-    """Increment reconnect counter and publish update."""
-    websocket_reconnect_attempts_total.inc()
-    _publish_snapshot()
-
-def record_ping_failure() -> None:
-    """Increment ping failure counter and publish update."""
-    websocket_ping_failures_total.inc()
-    _publish_snapshot()
-
-
-def publish_snapshot() -> None:
-    """Explicitly publish the current metric snapshot."""
-    _publish_snapshot()
 
 __all__ = [
     "websocket_connections_total",
     "websocket_reconnect_attempts_total",
     "websocket_ping_failures_total",
-    "record_connection",
-    "record_reconnect_attempt",
-    "record_ping_failure",
-    "publish_snapshot",
-    "snapshot",
-    "set_event_bus",
+    "WebSocketMetrics",
     "start_metrics_server",
 ]


### PR DESCRIPTION
## Summary
- add thread-safe, immutable EventBus and EventPublisher mixin
- refactor websocket metrics provider to publish via shared EventBus
- rework websocket metrics to publish snapshots through EventBus

## Testing
- `PYTHONPATH=. pytest /tmp/test_new_metrics.py -q`
- `PYTHONPATH=. pytest /tmp/test_new_metrics_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3e75cad48320a7e85ff41df96a3c