### PR TITLE
refactor: introduce metrics repository

### DIFF
--- a/docs/adr/0001-repository-pattern.md
+++ b/docs/adr/0001-repository-pattern.md
@@ -1,0 +1,15 @@
+# 1. Introduce Repository Pattern
+
+## Status
+Accepted
+
+## Context
+Metrics endpoints and WebSocket services previously accessed data directly through module-level structures. This tight coupling made unit testing difficult and obscured persistence boundaries.
+
+## Decision
+Define `MetricsRepository` protocol and `InMemoryMetricsRepository` implementation under `src/repository/`. Business services inject the repository interface instead of using hard-coded data.
+
+## Consequences
+* Data access can be swapped without changing service logic.
+* Unit tests use in-memory repositories for fast, isolated testing.
+* Future persistence layers (database, API) can implement the repository protocol.

--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -1,25 +1,34 @@
 from flask import Blueprint, jsonify
 
-metrics_bp = Blueprint('metrics', __name__, url_prefix='/v1/metrics')
+from src.repository import InMemoryMetricsRepository, MetricsRepository
 
-# Sample static data for demonstration purposes
-PERFORMANCE_METRICS = {'throughput': 100, 'latency_ms': 50}
-DRIFT_DATA = {'prediction_drift': 0.02, 'feature_drift': {'age': 0.01}}
-FEATURE_IMPORTANCES = {'age': 0.3, 'income': 0.2, 'score': 0.1}
+metrics_bp = Blueprint("metrics", __name__, url_prefix="/v1/metrics")
 
-@metrics_bp.get('/performance')
+_metrics_repo: MetricsRepository = InMemoryMetricsRepository()
+
+
+def set_metrics_repository(repo: MetricsRepository) -> None:
+    """Inject a metrics repository implementation."""
+    global _metrics_repo
+    _metrics_repo = repo
+
+
+@metrics_bp.get("/performance")
 def get_performance_metrics():
-    """Return sample performance metrics."""
-    return jsonify(PERFORMANCE_METRICS)
+    """Return performance metrics from the repository."""
+    return jsonify(_metrics_repo.get_performance_metrics())
 
-@metrics_bp.get('/drift')
+
+@metrics_bp.get("/drift")
 def get_drift_data():
-    """Return sample drift statistics."""
-    return jsonify(DRIFT_DATA)
+    """Return drift statistics from the repository."""
+    return jsonify(_metrics_repo.get_drift_data())
 
-@metrics_bp.get('/feature-importance')
+
+@metrics_bp.get("/feature-importance")
 def get_feature_importances():
-    """Return sample feature importances."""
-    return jsonify(FEATURE_IMPORTANCES)
+    """Return feature importances from the repository."""
+    return jsonify(_metrics_repo.get_feature_importances())
 
-__all__ = ['metrics_bp']
+
+__all__ = ["metrics_bp", "set_metrics_repository"]

--- a/src/repository/__init__.py
+++ b/src/repository/__init__.py
@@ -1,0 +1,5 @@
+"""Repository interfaces and implementations."""
+
+from .metrics import MetricsRepository, InMemoryMetricsRepository
+
+__all__ = ["MetricsRepository", "InMemoryMetricsRepository"]

--- a/src/repository/metrics.py
+++ b/src/repository/metrics.py
@@ -1,0 +1,53 @@
+"""Metric repository abstractions and in-memory implementation."""
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+
+class MetricsRepository(Protocol):
+    """Persistence operations for metric data."""
+
+    def get_performance_metrics(self) -> Dict[str, Any]: ...
+    def get_drift_data(self) -> Dict[str, Any]: ...
+    def get_feature_importances(self) -> Dict[str, Any]: ...
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a combined metric snapshot."""
+        return {
+            "performance": self.get_performance_metrics(),
+            "drift": self.get_drift_data(),
+            "feature_importance": self.get_feature_importances(),
+        }
+
+
+class InMemoryMetricsRepository:
+    """Simple in-memory storage for metric data."""
+
+    def __init__(
+        self,
+        performance: Dict[str, Any] | None = None,
+        drift: Dict[str, Any] | None = None,
+        feature_importances: Dict[str, Any] | None = None,
+    ) -> None:
+        self._performance = performance or {"throughput": 100, "latency_ms": 50}
+        self._drift = drift or {"prediction_drift": 0.02, "feature_drift": {"age": 0.01}}
+        self._feature_importances = feature_importances or {"age": 0.3, "income": 0.2, "score": 0.1}
+
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        return self._performance
+
+    def get_drift_data(self) -> Dict[str, Any]:
+        return self._drift
+
+    def get_feature_importances(self) -> Dict[str, Any]:
+        return self._feature_importances
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "performance": self.get_performance_metrics(),
+            "drift": self.get_drift_data(),
+            "feature_importance": self.get_feature_importances(),
+        }
+
+
+__all__ = ["MetricsRepository", "InMemoryMetricsRepository"]

--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -4,25 +4,19 @@ from __future__ import annotations
 import threading
 from typing import Any, Dict, Protocol
 
+from src.repository import MetricsRepository
+
 
 class EventBusProtocol(Protocol):
     def publish(self, event_type: str, data: Dict[str, Any]) -> None: ...
 
 
-def generate_sample_metrics() -> Dict[str, Any]:
-    """Return static metric payload for demonstration."""
-    return {
-        'performance': {'throughput': 100, 'latency_ms': 50},
-        'drift': {'prediction_drift': 0.02},
-        'feature_importance': {'age': 0.3}
-    }
-
-
 class MetricsProvider:
     """Publish metrics updates to an event bus periodically."""
 
-    def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+    def __init__(self, event_bus: EventBusProtocol, repo: MetricsRepository, interval: float = 1.0) -> None:
         self.event_bus = event_bus
+        self.repo = repo
         self.interval = interval
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -30,8 +24,8 @@ class MetricsProvider:
 
     def _run(self) -> None:
         while not self._stop.is_set():
-            payload = generate_sample_metrics()
-            self.event_bus.publish('metrics_update', payload)
+            payload = self.repo.snapshot()
+            self.event_bus.publish("metrics_update", payload)
             self._stop.wait(self.interval)
 
     def stop(self) -> None:
@@ -39,4 +33,4 @@ class MetricsProvider:
         self._thread.join(timeout=1)
 
 
-__all__ = ['MetricsProvider', 'generate_sample_metrics']
+__all__ = ["MetricsProvider"]

--- a/tests/api/test_metrics_endpoints.py
+++ b/tests/api/test_metrics_endpoints.py
@@ -1,33 +1,38 @@
 from flask import Flask
 
-from src.api.metrics import metrics_bp, PERFORMANCE_METRICS, DRIFT_DATA, FEATURE_IMPORTANCES
+from src.api.metrics import metrics_bp, set_metrics_repository
+from src.repository import InMemoryMetricsRepository
 
 
-def create_app():
+def create_app(repo: InMemoryMetricsRepository) -> Flask:
     app = Flask(__name__)
+    set_metrics_repository(repo)
     app.register_blueprint(metrics_bp)
     return app
 
 
-def test_performance_endpoint():
-    app = create_app()
+def test_performance_endpoint() -> None:
+    repo = InMemoryMetricsRepository(performance={"t": 1})
+    app = create_app(repo)
     client = app.test_client()
-    resp = client.get('/v1/metrics/performance')
+    resp = client.get("/v1/metrics/performance")
     assert resp.status_code == 200
-    assert resp.get_json() == PERFORMANCE_METRICS
+    assert resp.get_json() == {"t": 1}
 
 
-def test_drift_endpoint():
-    app = create_app()
+def test_drift_endpoint() -> None:
+    repo = InMemoryMetricsRepository(drift={"prediction_drift": 0.3})
+    app = create_app(repo)
     client = app.test_client()
-    resp = client.get('/v1/metrics/drift')
+    resp = client.get("/v1/metrics/drift")
     assert resp.status_code == 200
-    assert resp.get_json() == DRIFT_DATA
+    assert resp.get_json() == {"prediction_drift": 0.3}
 
 
-def test_feature_importance_endpoint():
-    app = create_app()
+def test_feature_importance_endpoint() -> None:
+    repo = InMemoryMetricsRepository(feature_importances={"a": 0.1})
+    app = create_app(repo)
     client = app.test_client()
-    resp = client.get('/v1/metrics/feature-importance')
+    resp = client.get("/v1/metrics/feature-importance")
     assert resp.status_code == 200
-    assert resp.get_json() == FEATURE_IMPORTANCES
+    assert resp.get_json() == {"a": 0.1}


### PR DESCRIPTION
## Summary
- add MetricsRepository protocol with in-memory implementation
- inject repository into metrics API and WebSocket provider
- document repository usage in ADR

## Testing
- `pytest tests/api/test_metrics_endpoints.py tests/websocket/test_metrics_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f3e771b0483209c81a07548282f85