### PR TITLE
Add logging and serialization mixins

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,12 @@
+"""Common utilities and shared abstractions."""
+
+from .base import BaseComponent
+from .mixins import LoggingMixin, SerializationMixin, Loggable, Serializable
+
+__all__ = [
+    "BaseComponent",
+    "LoggingMixin",
+    "SerializationMixin",
+    "Loggable",
+    "Serializable",
+]

--- a/src/common/base.py
+++ b/src/common/base.py
@@ -1,0 +1,12 @@
+"""Base building block for application components."""
+from __future__ import annotations
+
+
+class BaseComponent:
+    """Provide a lightweight base implementation for components."""
+
+    def __init__(self, component_id: str | None = None) -> None:
+        self.component_id = component_id or self.__class__.__name__
+
+
+__all__ = ["BaseComponent"]

--- a/src/common/mixins.py
+++ b/src/common/mixins.py
@@ -1,0 +1,65 @@
+"""Cross-cutting mixins for logging and serialization concerns."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Protocol, Type, TypeVar, runtime_checkable
+
+
+@runtime_checkable
+class Loggable(Protocol):
+    """Protocol for objects capable of logging messages."""
+
+    def log(self, message: str) -> None:
+        """Log ``message`` to the configured logger."""
+        ...
+
+
+T = TypeVar("T", bound="Serializable")
+
+
+@runtime_checkable
+class Serializable(Protocol):
+    """Protocol for objects supporting basic serialization."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the object into a dictionary representation."""
+        ...
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+        """Recreate the object from a dictionary representation."""
+        ...
+
+
+class LoggingMixin:
+    """Provide a convenience ``log`` method using ``logging``."""
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return a module-level logger named for the concrete class."""
+        return logging.getLogger(self.__class__.__name__)
+
+    def log(self, message: str) -> None:
+        """Log ``message`` with ``INFO`` severity."""
+        self.logger.info(message)
+
+
+class SerializationMixin:
+    """Implement ``to_dict``/``from_dict`` helpers using ``__dict__``."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a shallow copy of ``__dict__``."""
+        return dict(self.__dict__)
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+        """Instantiate ``cls`` using ``data`` as keyword arguments."""
+        return cls(**data)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "Loggable",
+    "Serializable",
+    "LoggingMixin",
+    "SerializationMixin",
+]

--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import threading
 from typing import Any, Dict, Protocol
 
+from src.common.base import BaseComponent
+from src.common.mixins import LoggingMixin, SerializationMixin
+
 
 class EventBusProtocol(Protocol):
     def publish(self, event_type: str, data: Dict[str, Any]) -> None: ...
@@ -18,25 +21,32 @@ def generate_sample_metrics() -> Dict[str, Any]:
     }
 
 
-class MetricsProvider:
+class MetricsProvider(LoggingMixin, SerializationMixin, BaseComponent):
     """Publish metrics updates to an event bus periodically."""
 
     def __init__(self, event_bus: EventBusProtocol, interval: float = 1.0) -> None:
+        super().__init__(component_id="metrics_provider")
         self.event_bus = event_bus
         self.interval = interval
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
+        self.log("MetricsProvider started")
 
     def _run(self) -> None:
         while not self._stop.is_set():
             payload = generate_sample_metrics()
             self.event_bus.publish('metrics_update', payload)
+            self.log("Published metrics update")
             self._stop.wait(self.interval)
 
     def stop(self) -> None:
         self._stop.set()
         self._thread.join(timeout=1)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return serializable state for ``SerializationMixin``."""
+        return {"interval": self.interval}
 
 
 __all__ = ['MetricsProvider', 'generate_sample_metrics']

--- a/tests/common/test_mixins.py
+++ b/tests/common/test_mixins.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.common.base import BaseComponent
+from src.common.mixins import LoggingMixin, SerializationMixin
+
+
+class DummyLoggingComponent(LoggingMixin, BaseComponent):
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class DummySerializationComponent(SerializationMixin, BaseComponent):
+    def __init__(self, value: int, component_id: str | None = None) -> None:
+        super().__init__(component_id)
+        self.value = value
+
+
+def test_logging_mixin_logs(caplog):
+    comp = DummyLoggingComponent()
+    with caplog.at_level(logging.INFO):
+        comp.log("hello world")
+    assert "hello world" in caplog.text
+
+
+def test_serialization_mixin_roundtrip():
+    comp = DummySerializationComponent(5)
+    data = comp.to_dict()
+    assert data["value"] == 5
+    new_comp = DummySerializationComponent.from_dict(data)
+    assert isinstance(new_comp, DummySerializationComponent)
+    assert new_comp.value == 5


### PR DESCRIPTION
## Summary
- add reusable logging and serialization mixins with typed Protocols
- integrate mixins and BaseComponent into MetricsProvider
- test mixin logging and serialization behavior in isolation

## Testing
- `pytest tests/common/test_mixins.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp', ImportError: cannot import name 'create_config_manager' from 'config', ...)*

------
https://chatgpt.com/codex/tasks/task_e_688f3e7a205083208097e09214281ffc