### PR TITLE
Add deprecation warnings for relocated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated `run_service_analysis` to use `analyze_data_with_service` and
   `create_analysis_results_display`.
+- Legacy API wrappers now emit `DeprecationWarning` and forward calls to
+  their relocated implementations.
 
 ### Fixed
 - Navigation bar icons failed to load when `app.get_asset_url` returned

--- a/docs/adr/0001-deprecate-legacy-apis.md
+++ b/docs/adr/0001-deprecate-legacy-apis.md
@@ -1,0 +1,20 @@
+# ADR 0001: Deprecate Legacy API Shims
+
+## Status
+Accepted
+
+## Context
+Several modules and helpers were relocated as part of ongoing refactors.
+Older entry points remained but gave no explicit indication that they would
+be removed.
+
+## Decision
+Legacy names now wrap the new implementations and emit
+`DeprecationWarning` when invoked. These shims maintain backward
+compatibility while guiding consumers toward the updated modules.
+
+## Consequences
+- Users receive runtime warnings directing them to the new APIs.
+- Shims can be safely removed in a future major release once consumers
+  have migrated.
+

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -6,6 +6,27 @@ remains as a compatibility layer but will be removed in a future release.
 `unicode_toolkit` provides hardened text utilities, DataFrame
 sanitization helpers and SQL encoding functions.
 
+## Renamed and Relocated APIs
+
+Several legacy entry points were moved in this release. Importing the old
+names now triggers a `DeprecationWarning` but continues to work via shims.
+Update your code to use the new locations:
+
+| Legacy API | Replacement |
+|------------|-------------|
+| `services.upload_endpoint.create_upload_blueprint` | `services.upload.upload_endpoint.create_upload_blueprint` |
+| `infrastructure.config.env_overrides.apply_env_overrides` | `EnvironmentProcessor().apply` |
+| `infrastructure.communication.RestClient` | `AsyncRestClient` |
+| `core.secret_manager.SecretManager` | `SecretsManager` |
+| `services.upload.processor.UploadProcessingService` | `UploadOrchestrator` |
+| `services.upload.processing.UploadProcessingService` | `services.upload.core.processor.UploadProcessingService` |
+| `services.upload.validators.ClientSideValidator` | `services.upload.validator.ClientSideValidator` |
+| `core.container.Container` | `ServiceContainer` |
+| `mapping.models.load_model` | `load_model_from_config` |
+| `infrastructure.security.UnicodeSecurityHandler` | `UnicodeSecurityProcessor` |
+
+These shims will be removed in a future major release.
+
 ## Quick Migration Reference
 
 ### Text Processing Migration

--- a/yosai_intel_dashboard/src/core/container.py
+++ b/yosai_intel_dashboard/src/core/container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+import warnings
 
 from .protocols import (
     AnalyticsServiceProtocol,
@@ -46,4 +47,15 @@ def get_unicode_processor() -> UnicodeProcessorProtocol:
 
 
 # Backwards compatibility -------------------------------------------------
-Container = ServiceContainer
+
+
+class Container(ServiceContainer):
+    """Deprecated alias for :class:`ServiceContainer`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "Container is deprecated; use ServiceContainer",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/yosai_intel_dashboard/src/core/secret_manager.py
+++ b/yosai_intel_dashboard/src/core/secret_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -93,7 +94,16 @@ def validate_secrets(manager: Optional[SecretsManager] = None) -> dict[str, Any]
     return summary
 
 
-# Backwards compatibility alias
-SecretManager = SecretsManager
+class SecretManager(SecretsManager):
+    """Deprecated alias for :class:`SecretsManager`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "SecretManager is deprecated; use SecretsManager",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
 
 __all__ = ["SecretMetadata", "SecretsManager", "SecretManager", "validate_secrets"]

--- a/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
+++ b/yosai_intel_dashboard/src/infrastructure/communication/rest_client.py
@@ -7,6 +7,7 @@ import os
 import ssl
 from dataclasses import dataclass
 from typing import Any, MutableMapping
+import warnings
 
 import aiohttp
 from tracing import propagate_context
@@ -175,5 +176,14 @@ __all__ = [
     "RestClient",
 ]
 
-# Backwards compatibility
-RestClient = AsyncRestClient
+
+class RestClient(AsyncRestClient):
+    """Deprecated synchronous-style client alias for :class:`AsyncRestClient`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "RestClient is deprecated; use AsyncRestClient",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/yosai_intel_dashboard/src/infrastructure/config/env_overrides.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/env_overrides.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 from typing import Any
+import warnings
 
 from .environment_processor import EnvironmentProcessor
 
 
 def apply_env_overrides(config: Any) -> None:
-    """Apply environment variable overrides using :class:`EnvironmentProcessor`."""
+    """Apply environment variable overrides using :class:`EnvironmentProcessor`.
 
+    Deprecated: use :class:`EnvironmentProcessor` directly.
+    """
+
+    warnings.warn(
+        "apply_env_overrides is deprecated; use EnvironmentProcessor().apply",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     processor = EnvironmentProcessor()
     processor.apply(config)
 

--- a/yosai_intel_dashboard/src/infrastructure/security/unicode_security_handler.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/unicode_security_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Security-focused Unicode handling utilities."""
 
 from typing import Any
+import warnings
 
 import pandas as pd
 
@@ -11,6 +12,13 @@ from yosai_intel_dashboard.src.core.unicode import sanitize_dataframe, sanitize_
 
 class UnicodeSecurityHandler:
     """Backward compatibility wrapper for :class:`UnicodeSecurityProcessor`."""
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "UnicodeSecurityHandler is deprecated; use UnicodeSecurityProcessor",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @staticmethod
     def sanitize_unicode_input(text: Any) -> str:

--- a/yosai_intel_dashboard/src/mapping/models/__init__.py
+++ b/yosai_intel_dashboard/src/mapping/models/__init__.py
@@ -7,6 +7,7 @@ from typing import Dict, Type
 from .base import MappingModel
 from .heuristic import HeuristicMappingModel
 from .rule_based import ColumnRules, RuleBasedModel, load_rules
+import warnings
 
 
 class MLMappingModel(HeuristicMappingModel):
@@ -35,7 +36,13 @@ def load_model_from_config(path: str) -> MappingModel:
 
 
 # Backwards compatibility
-load_model = load_model_from_config
+def load_model(*args, **kwargs) -> MappingModel:
+    warnings.warn(
+        "load_model is deprecated; use load_model_from_config",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return load_model_from_config(*args, **kwargs)
 
 __all__ = [
     "ColumnRules",

--- a/yosai_intel_dashboard/src/services/upload/processing.py
+++ b/yosai_intel_dashboard/src/services/upload/processing.py
@@ -1,5 +1,24 @@
-"""Backward compatibility wrapper for UploadProcessingService."""
+"""Backward compatibility wrapper for ``UploadProcessingService``."""
 
-from .core.processor import UploadProcessingService
+from __future__ import annotations
+
+import warnings
+
+from .core.processor import UploadProcessingService as _UploadProcessingService
+
+
+class UploadProcessingService(_UploadProcessingService):
+    """Deprecated alias for :class:`core.processor.UploadProcessingService`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "services.upload.processing.UploadProcessingService is deprecated; "
+            "use services.upload.core.processor.UploadProcessingService",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
 
 __all__ = ["UploadProcessingService"]
+

--- a/yosai_intel_dashboard/src/services/upload/processor.py
+++ b/yosai_intel_dashboard/src/services/upload/processor.py
@@ -1,7 +1,25 @@
-"""Backward compatibility wrapper for UploadOrchestrator."""
+"""Backward compatibility wrapper for ``UploadOrchestrator``."""
 
-from .orchestrator import UploadOrchestrator
+from __future__ import annotations
 
-UploadProcessingService = UploadOrchestrator
+import warnings
+
+from .orchestrator import UploadOrchestrator as _UploadOrchestrator
+
+
+class UploadProcessingService(_UploadOrchestrator):
+    """Deprecated alias for :class:`UploadOrchestrator`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "UploadProcessingService is deprecated; use UploadOrchestrator",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+UploadOrchestrator = _UploadOrchestrator
 
 __all__ = ["UploadProcessingService", "UploadOrchestrator"]
+

--- a/yosai_intel_dashboard/src/services/upload/validators.py
+++ b/yosai_intel_dashboard/src/services/upload/validators.py
@@ -1,5 +1,24 @@
-"""Backward compatibility wrapper for ClientSideValidator."""
+"""Backward compatibility wrapper for ``ClientSideValidator``."""
 
-from .validator import ClientSideValidator
+from __future__ import annotations
+
+import warnings
+
+from .validator import ClientSideValidator as _ClientSideValidator
+
+
+class ClientSideValidator(_ClientSideValidator):
+    """Deprecated alias for :class:`validator.ClientSideValidator`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[override]
+        warnings.warn(
+            "services.upload.validators.ClientSideValidator is deprecated; "
+            "use services.upload.validator.ClientSideValidator",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
 
 __all__ = ["ClientSideValidator"]
+

--- a/yosai_intel_dashboard/src/services/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload_endpoint.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import warnings
+
 # Explicitly import only the public symbols from the upload endpoint module.
 from .upload.upload_endpoint import (
     StatusSchema,
     UploadRequestSchema,
     UploadResponseSchema,
-    create_upload_blueprint,
+    create_upload_blueprint as _create_upload_blueprint,
 )
 
 # Re-export the imported symbols to maintain the public API of this module.
@@ -17,3 +19,15 @@ __all__ = [
     "StatusSchema",
     "create_upload_blueprint",
 ]
+
+
+def create_upload_blueprint(*args, **kwargs):
+    """Deprecated wrapper for :func:`upload.upload_endpoint.create_upload_blueprint`."""
+
+    warnings.warn(
+        "services.upload_endpoint.create_upload_blueprint is deprecated; "
+        "use services.upload.upload_endpoint.create_upload_blueprint",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _create_upload_blueprint(*args, **kwargs)


### PR DESCRIPTION
## Summary
- warn when calling legacy helpers like `apply_env_overrides`, `RestClient`, and `SecretManager`
- document API relocation in migration guide and ADR
- note deprecation shim behavior in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp'; 241 errors)*
- `python -m py_compile yosai_intel_dashboard/src/core/container.py yosai_intel_dashboard/src/core/secret_manager.py yosai_intel_dashboard/src/infrastructure/communication/rest_client.py yosai_intel_dashboard/src/infrastructure/config/env_overrides.py yosai_intel_dashboard/src/infrastructure/security/unicode_security_handler.py yosai_intel_dashboard/src/mapping/models/__init__.py yosai_intel_dashboard/src/services/upload/processing.py yosai_intel_dashboard/src/services/upload/processor.py yosai_intel_dashboard/src/services/upload/validators.py yosai_intel_dashboard/src/services/upload_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_688f3e7b57ec8320975608b9c6e49ac5