### PR TITLE
refactor: enforce immutable compliance config

### DIFF
--- a/docs/development_principles.md
+++ b/docs/development_principles.md
@@ -1,0 +1,14 @@
+# Development Principles
+
+This project favors immutable data structures to reduce side effects and
+improve reasoning about state.
+
+- Use `dataclasses` with `frozen=True` or `attrs` frozen models instead of
+  mutable dictionaries and lists for structured data.
+- Prefer functional transformations such as `map`, `filter`, and
+  comprehensions over manual loops.
+- Validate immutability in tests by asserting that attempts to mutate frozen
+  objects raise `FrozenInstanceError`.
+
+These principles help maintain a predictable and maintainable codebase.
+

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -277,7 +277,7 @@ CREATE TABLE IF NOT EXISTS compliance_audit_log (
 ```python
 from plugins.compliance_plugin.config import ComplianceConfig
 
-config = ComplianceConfig({"audit_retention_days": 365})
+config = ComplianceConfig.from_dict({"audit_retention_days": 365})
 ```
 
 # =============================================================================

--- a/tests/test_compliance_config.py
+++ b/tests/test_compliance_config.py
@@ -1,0 +1,18 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from yosai_intel_dashboard.src.adapters.api.plugins.compliance_plugin.config import (
+    ComplianceConfig,
+)
+
+
+def test_compliance_config_is_immutable():
+    config = ComplianceConfig.from_dict({"audit_retention_days": 10})
+    with pytest.raises(FrozenInstanceError):
+        config.audit_retention_days = 5
+
+
+def test_compliance_config_ignores_invalid_keys():
+    config = ComplianceConfig.from_dict({"nonexistent": 123})
+    assert not hasattr(config, "nonexistent")

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/config.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/config.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Dict
 
 
-@dataclass
+@dataclass(frozen=True)
 class ComplianceConfig:
     """Configuration for compliance plugin"""
 
@@ -57,15 +57,18 @@ class ComplianceConfig:
     csv_auto_classification: bool = True
     csv_consent_checking: bool = True
 
-    def __init__(self, config_dict: Dict[str, Any]):
-        """Initialize from configuration dictionary"""
-        for key, value in config_dict.items():
-            if hasattr(self, key):
-                setattr(self, key, value)
+    @classmethod
+    def from_dict(cls, config_dict: Dict[str, Any]) -> "ComplianceConfig":
+        """Create a configuration object from a dictionary."""
+        valid_fields = {f.name for f in fields(cls)}
+        filtered = filter(lambda item: item[0] in valid_fields, config_dict.items())
+        return cls(**dict(filtered))
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary"""
         return {
-            field.name: getattr(self, field.name)
-            for field in self.__dataclass_fields__.values()
+            name: value
+            for name, value in map(
+                lambda f: (f.name, getattr(self, f.name)), fields(self)
+            )
         }

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/plugin.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/plugin.py
@@ -6,11 +6,11 @@ Main Compliance Plugin Class - Extracted from __init__.py
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from yosai_intel_dashboard.src.core.plugins.base import BasePlugin
 from plugins.common_callbacks import csv_pre_process_callback
+
+from yosai_intel_dashboard.src.core.plugins.base import BasePlugin
 
 from .api import ComplianceAPI
 from .config import ComplianceConfig
@@ -46,13 +46,13 @@ class CompliancePlugin(BasePlugin):
         self.is_initialized = False
         self.is_database_ready = False
 
-    def initialize(self, container: Container, config: Dict[str, Any]) -> bool:
+    def initialize(self, container: Any, config: Dict[str, Any]) -> bool:
         """Initialize the compliance plugin"""
         try:
             logger.info("Initializing Compliance Plugin v%s", self.version)
 
             # 1. Load plugin configuration
-            self.config = ComplianceConfig(config.get("compliance", {}))
+            self.config = ComplianceConfig.from_dict(config.get("compliance", {}))
 
             if not self.config.enabled:
                 logger.info("Compliance plugin is disabled in configuration")
@@ -293,7 +293,7 @@ class CompliancePlugin(BasePlugin):
 
         return {"deleted_records": deleted_count if "deleted_count" in locals() else 0}
 
-    def _register_services_with_container(self, container: Container) -> None:
+    def _register_services_with_container(self, container: Any) -> None:
         """Register compliance services with the DI container"""
         if not self.services:
             return


### PR DESCRIPTION
## Summary
- refactor compliance configuration to a frozen dataclass using functional transformations
- use the new `from_dict` constructor and update integration docs
- add immutability tests and document development principles

## Testing
- `pytest tests/test_compliance_config.py`
- `pre-commit run --files docs/integration-guide.md yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/config.py yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/plugin.py docs/development_principles.md tests/test_compliance_config.py` *(fails: mypy reports multiple errors across repository)*


------
https://chatgpt.com/codex/tasks/task_e_688f3e80f7f08320a0eb5b3301130179