### PR TITLE
Use Path.open with UTF-8 for mapping file

### DIFF
--- a/tools/cli_mapping_tester.py
+++ b/tools/cli_mapping_tester.py
@@ -132,7 +132,7 @@ async def test_mapping_service(
                 # Test applying existing mappings
                 mappings_file = Path("data/learned_mappings.json")
                 if mappings_file.exists():
-                    with open(mappings_file) as f:
+                    with mappings_file.open(encoding="utf-8") as f:
                         mappings_data = json.load(f)
 
                     result["mapping_application"] = {


### PR DESCRIPTION
## Summary
- use `Path.open` with explicit UTF-8 encoding when reading `learned_mappings.json`

## Testing
- `python -m py_compile tools/cli_mapping_tester.py`
- `pytest tests/test_warning_filters.py -q` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.analytics.analytics')*

------
https://chatgpt.com/codex/tasks/task_e_688f45eb509c8320aeb3a6e7041a5e86