### PR TITLE
Refactor start_api path handling

### DIFF
--- a/start_api.py
+++ b/start_api.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
-from __future__ import annotations
 
 import logging
-import os
 import sys
+from pathlib import Path
 
 from yosai_intel_dashboard.src.core.env_validation import validate_required_env
 
 logger = logging.getLogger(__name__)
 
 # Add project root to path
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Import Flask app directly from adapter
 from api.adapter import create_api_app


### PR DESCRIPTION
## Summary
- remove future annotations import and unused os
- use pathlib to set project root on sys.path

## Testing
- `python -m py_compile start_api.py`
- `pytest start_api.py` *(fails: NameError: name 'import_optional' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f45ed5ae48320bca60375dd5fb725