### PR TITLE
Use asyncio.gather for concurrent pubsub cleanup

### DIFF
--- a/yosai_intel_dashboard/src/services/feature_flags/redis_store.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/redis_store.py
@@ -113,8 +113,10 @@ class RedisFeatureFlagStore:
                 with self._lock.write_lock():
                     self._flags[name] = flag
         finally:
-            await pubsub.unsubscribe(self.channel)
-            await pubsub.close()
+            await asyncio.gather(
+                pubsub.unsubscribe(self.channel),
+                pubsub.close(),
+            )
 
     def get_flag(self, name: str, default: bool = False) -> bool:
         with self._lock.read_lock():


### PR DESCRIPTION
## Summary
- Concurrently unsubscribe and close Redis pubsub connections using `asyncio.gather`

## Testing
- `pytest tests/test_feature_flag_fallback.py tests/test_feature_flag_audit_endpoint.py tests/test_feature_flag_audit.py tests/test_flag_evaluator.py -q` *(fails: NameError: name 'Any' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f47fb28308320800ab72676fe854b