### PR TITLE
feat: add hot-path redis clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,13 @@ memory and CPU optimizers keep resource usage within the thresholds described in
 Large uploads are streamed through the `AsyncFileProcessor` to avoid blocking
 the event loop.
 
+### Hot-path Redis Clients
+
+Separate Redis databases can be used for frequently accessed data. Set
+`SESSION_REDIS_URL` for session tokens and `METRICS_REDIS_URL` for recent
+metrics. When only `REDIS_URL` is provided, database `0` stores sessions and
+database `1` stores metrics by default.
+
 ### Cache Warming
 
 Use `IntelligentCacheWarmer` with a `HierarchicalCacheManager` to prefill

--- a/tests/infrastructure/test_redis_clients.py
+++ b/tests/infrastructure/test_redis_clients.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def test_clients_use_distinct_dbs(monkeypatch):
+    monkeypatch.setenv("SESSION_REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("METRICS_REDIS_URL", "redis://localhost:6379/1")
+
+    class DummyRedis:
+        def __init__(self, db: int) -> None:
+            self.connection_pool = types.SimpleNamespace(connection_kwargs={"db": db})
+
+        @classmethod
+        def from_url(cls, url: str) -> "DummyRedis":
+            db = int(url.rsplit("/", 1)[-1])
+            return cls(db)
+
+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=DummyRedis))
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard/src/infrastructure/cache/redis_client.py"
+    )
+    spec = importlib.util.spec_from_file_location("redis_client", path)
+    assert spec and spec.loader
+    rc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rc)  # type: ignore[union-attr]
+    session = rc.get_session_client()
+    metrics = rc.get_metrics_client()
+    assert session.connection_pool.connection_kwargs["db"] == 0
+    assert metrics.connection_pool.connection_kwargs["db"] == 1
+    assert rc.redis_client is session

--- a/yosai_intel_dashboard/src/infrastructure/cache/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/cache/__init__.py
@@ -1,14 +1,19 @@
 """Caching implementations for Yosai Intel Dashboard."""
+
 from .cache_manager import (
     CacheConfig,
     InMemoryCacheManager,
     RedisCacheManager,
     cache_with_lock,
 )
+from .redis_client import get_metrics_client, get_session_client, redis_client
 
 __all__ = [
     "CacheConfig",
     "InMemoryCacheManager",
     "RedisCacheManager",
     "cache_with_lock",
+    "get_session_client",
+    "get_metrics_client",
+    "redis_client",
 ]

--- a/yosai_intel_dashboard/src/infrastructure/cache/redis_client.py
+++ b/yosai_intel_dashboard/src/infrastructure/cache/redis_client.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Helpers for Redis clients used on hot-path data."""
+
+import os
+from typing import Optional
+
+import redis
+
+_session_client: Optional[redis.Redis] = None
+_metrics_client: Optional[redis.Redis] = None
+
+
+def _create_client(url: str) -> redis.Redis:
+    """Create a Redis client from a URL."""
+    return redis.Redis.from_url(url)
+
+
+def get_session_client() -> redis.Redis:
+    """Return Redis client for session token storage.
+
+    The URL is read from ``SESSION_REDIS_URL`` with a fallback to ``REDIS_URL``
+    and finally ``redis://localhost:6379/0``.
+    """
+
+    global _session_client
+    if _session_client is None:
+        url = os.getenv("SESSION_REDIS_URL") or os.getenv(
+            "REDIS_URL", "redis://localhost:6379/0"
+        )
+        _session_client = _create_client(url)
+    return _session_client
+
+
+def get_metrics_client() -> redis.Redis:
+    """Return Redis client for recent metrics caching.
+
+    The URL is read from ``METRICS_REDIS_URL`` with a fallback to ``REDIS_URL``
+    and finally ``redis://localhost:6379/1`` (separate DB from session data).
+    """
+
+    global _metrics_client
+    if _metrics_client is None:
+        url = os.getenv("METRICS_REDIS_URL") or os.getenv(
+            "REDIS_URL", "redis://localhost:6379/1"
+        )
+        _metrics_client = _create_client(url)
+    return _metrics_client
+
+
+# Backwards compatibility for modules expecting ``redis_client``.
+# This points to the session client since it's the primary hot path.
+redis_client = get_session_client()
+
+__all__ = [
+    "get_session_client",
+    "get_metrics_client",
+    "redis_client",
+]


### PR DESCRIPTION
## Summary
- add helpers to configure Redis clients for sessions and metrics
- expose hot-path redis clients and document their usage
- test distinct Redis DB configuration for session and metrics clients

## Testing
- `pytest tests/infrastructure/test_redis_clients.py`
- `pytest tests/security/test_security_metrics.py tests/upload/test_file_validator_component.py` *(fails: ImportError: cannot import name '_get_auditor'; NameError: authorize_resource is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f48015568832094efd05530865bbb