### PR TITLE
Cache parsed DB connection strings

### DIFF
--- a/yosai_intel_dashboard/src/database/utils.py
+++ b/yosai_intel_dashboard/src/database/utils.py
@@ -6,11 +6,12 @@ connection URLs used throughout the project.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Optional
 from urllib.parse import urlparse
 
 
-@dataclass
+@dataclass(frozen=True)
 class ParsedConnection:
     """Normalized representation of a database connection string."""
 
@@ -52,6 +53,7 @@ class ParsedConnection:
         raise ValueError(f"Unsupported dialect: {dialect}")
 
 
+@lru_cache(maxsize=128)
 def parse_connection_string(url: str) -> ParsedConnection:
     """Parse and validate *url* returning a :class:`ParsedConnection`.
 


### PR DESCRIPTION
## Summary
- cache parsed database connection strings to avoid repeated url parsing

## Testing
- `pytest tests/database/test_connection_strings.py`

------
https://chatgpt.com/codex/tasks/task_e_688f48015d9483208f5a933e7d7a7267