### PR TITLE
Use HyperLogLog sketches for unique counts

### DIFF
--- a/tests/test_approximate_unique_count.py
+++ b/tests/test_approximate_unique_count.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import redis
+
+# Load the module directly to avoid heavy package imports
+spec = importlib.util.spec_from_file_location(
+    "approximation",
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "services"
+    / "analytics"
+    / "approximation.py",
+)
+approx_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(approx_module)
+approximate_unique_count = approx_module.approximate_unique_count
+
+
+def test_approximate_unique_count_small():
+    series = pd.Series([1, 2, 2, 3, 4])
+    assert approximate_unique_count(series) == 4
+
+
+def test_approximate_unique_count_large():
+    # 50k unique values, each repeated twice
+    series = pd.Series(np.repeat(np.arange(50000), 2))
+    estimate = approximate_unique_count(series)
+    assert abs(estimate - 50000) / 50000 < 0.1

--- a/yosai_intel_dashboard/src/services/analytics/approximation.py
+++ b/yosai_intel_dashboard/src/services/analytics/approximation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+import math
+
+import pandas as pd
+
+
+def _leading_zero_count(x: int, bits: int) -> int:
+    if x == 0:
+        return bits
+    return bits - x.bit_length()
+
+
+def approximate_unique_count(series: pd.Series, precision: int = 14) -> int:
+    """Estimate unique values using a HyperLogLog sketch.
+
+    The algorithm uses a fixed number of registers determined by ``precision``
+    (``m = 2**precision``) and processes each element without storing the full
+    set of values, making it suitable for large datasets.
+    """
+
+    m = 1 << precision
+    registers = [0] * m
+    for value in series.dropna():
+        h = int(hashlib.sha1(str(value).encode("utf-8")).hexdigest(), 16)
+        idx = h & (m - 1)
+        w = h >> precision
+        rank = _leading_zero_count(w, 160 - precision) + 1
+        if rank > registers[idx]:
+            registers[idx] = rank
+    alpha = 0.7213 / (1 + 1.079 / m)
+    indicator = sum(2.0**-r for r in registers)
+    estimate = alpha * m * m / indicator
+    if estimate <= 2.5 * m:
+        v = registers.count(0)
+        if v > 0:
+            estimate = m * math.log(m / v)
+    return int(estimate)
+
+
+__all__ = ["approximate_unique_count"]

--- a/yosai_intel_dashboard/src/services/analytics/processor.py
+++ b/yosai_intel_dashboard/src/services/analytics/processor.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
+from .approximation import approximate_unique_count
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,9 +16,13 @@ class AnalyticsProcessor:
     def calculate_pattern_stats(self, df: pd.DataFrame) -> Tuple[int, int, int, int]:
         total_records = len(df)
         unique_users = (
-            int(df["person_id"].nunique()) if "person_id" in df.columns else 0
+            approximate_unique_count(df["person_id"])
+            if "person_id" in df.columns
+            else 0
         )
-        unique_devices = int(df["door_id"].nunique()) if "door_id" in df.columns else 0
+        unique_devices = (
+            approximate_unique_count(df["door_id"]) if "door_id" in df.columns else 0
+        )
         date_span = 0
         if "timestamp" in df.columns:
             ts = pd.to_datetime(df["timestamp"], errors="coerce")


### PR DESCRIPTION
## Summary
- add a HyperLogLog-based `approximate_unique_count` helper
- use the sketch-based estimator in analytics processor and generator
- cover estimator accuracy with unit tests

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/analytics/approximation.py yosai_intel_dashboard/src/services/analytics/processor.py yosai_intel_dashboard/src/services/analytics/generator.py tests/test_approximate_unique_count.py`
- `pytest tests/test_approximate_unique_count.py -q`
- `pytest tests/test_analytics_service.py -q` *(fails: SyntaxError: invalid syntax)*


------
https://chatgpt.com/codex/tasks/task_e_688f47f231508320bba92272e96bfce2