### PR TITLE
Add bloom filter for blacklist lookups

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/WSG23/yosai-framework v0.0.0
 	github.com/WSG23/yosai_intel_dashboard_fresh/shared/errors v0.0.0
 	github.com/alicebob/miniredis/v2 v2.35.0
+	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/confluentinc/confluent-kafka-go v1.9.3-RC3
 	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/gorilla/websocket v1.5.0
@@ -36,6 +37,7 @@ require (
 require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -23,6 +23,10 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
+github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56jeWUzvzdls=
+github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -340,6 +344,8 @@ github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
+github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/gateway/middleware/auth_test.go
+++ b/gateway/middleware/auth_test.go
@@ -159,6 +159,22 @@ func TestAuthBlacklistedToken(t *testing.T) {
 	}
 }
 
+func TestTokenCacheBloomFilter(t *testing.T) {
+	srv, client := newRedis(t)
+	cache := NewTokenCache(client)
+	// Closing Redis should not affect a lookup for an ID that was never
+	// blacklisted because the bloom filter allows skipping the Redis call.
+	srv.Close()
+
+	ok, err := cache.IsBlacklisted(context.Background(), "unknown")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected not blacklisted")
+	}
+}
+
 func TestAuthTokenRefresh(t *testing.T) {
 	srv, client := newRedis(t)
 	priv, pub := genKeys(t)


### PR DESCRIPTION
## Summary
- incorporate an in-memory Bloom filter to skip Redis hits for non-blacklisted tokens
- wire Bloom filter into token cache in gateway middleware and shared cache package
- test Bloom filter usage and add dependency

## Testing
- `go test ./... -count=1`
- `pre-commit run --files gateway/middleware/auth.go gateway/cache/token_cache.go gateway/go.mod gateway/go.sum gateway/middleware/auth_test.go`


------
https://chatgpt.com/codex/tasks/task_e_688f47f39124832091177a16848742cf