### PR TITLE
Use deque-based rolling windows for metrics

### DIFF
--- a/yosai_intel_dashboard/src/mapping/metrics.py
+++ b/yosai_intel_dashboard/src/mapping/metrics.py
@@ -10,8 +10,8 @@ from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 def get_mapping_accuracy_summary() -> Dict[str, Any]:
     """Return aggregated statistics for mapping confidence scores."""
     monitor = get_performance_monitor()
-    values: List[float] = monitor.aggregated_metrics.get(
-        "column_mapping.confidence", []
+    values = list(
+        monitor.aggregated_metrics.get("column_mapping.confidence", [])
     )
     if not values:
         return {"count": 0}


### PR DESCRIPTION
## Summary
- use `deque(maxlen=1000)` to store aggregated performance metrics
- compute rolling averages with a sliding window deque
- adapt mapping metrics helper for new deque storage

## Testing
- `pytest tests/test_inference_drift_job.py tests/test_performance_monitor_model_drift.py tests/test_model_performance_monitor.py tests/monitoring/test_model_performance_monitor_drift.py tests/test_performance_profiler_integration.py` *(fails: ImportError: cannot import name 'get_monitoring_config'; NameError: name 'import_optional' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f47f398b08320a56c96217bbc1d5f