### PR TITLE
Optimize time-based lookups with binary search

### DIFF
--- a/yosai_intel_dashboard/src/core/error_handling.py
+++ b/yosai_intel_dashboard/src/core/error_handling.py
@@ -2,9 +2,12 @@
 """
 Comprehensive error handling system with Apple-style resilience patterns
 """
+from __future__ import annotations
+
 import functools
 import logging
 import time
+from bisect import bisect_left
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
@@ -176,7 +179,9 @@ class ErrorHandler(BaseModel):
     def get_error_summary(self, hours: int = 24) -> Dict[str, Any]:
         """Get error summary for the last N hours"""
         cutoff = datetime.now() - timedelta(hours=hours)
-        recent_errors = [e for e in self.error_history if e.timestamp >= cutoff]
+        timestamps = [e.timestamp for e in self.error_history]
+        idx = bisect_left(timestamps, cutoff)
+        recent_errors = self.error_history[idx:]
 
         return {
             "total_errors": len(recent_errors),

--- a/yosai_intel_dashboard/src/core/performance.py
+++ b/yosai_intel_dashboard/src/core/performance.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import functools
 import logging
-import math
 import threading
 import time
+from bisect import bisect_left
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -34,7 +34,6 @@ import yaml
 from prometheus_client import REGISTRY, Counter
 from prometheus_client.core import CollectorRegistry
 
-from monitoring.request_metrics import async_task_duration
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
     dynamic_config,
 )
@@ -45,10 +44,10 @@ except Exception:  # pragma: no cover - optional dependency
     QueryOptimizer = None  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
-    from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (
+    from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (  # noqa: F401, E501
         ModelMetrics,
     )
-    from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import (
+    from yosai_intel_dashboard.src.core.monitoring.user_experience_metrics import (  # noqa: F401, E501
         AlertDispatcher,
     )
 
@@ -214,6 +213,13 @@ class PerformanceMonitor:
             if self.budgets:
                 _check_budget(name.split(".")[0], value, self.budgets, self.dispatcher)
 
+    def get_metrics_since(self, cutoff: datetime) -> List[PerformanceMetric]:
+        """Return metrics with timestamp >= ``cutoff`` using binary search."""
+        metrics_list = list(self.metrics)
+        timestamps = [m.timestamp for m in metrics_list]
+        idx = bisect_left(timestamps, cutoff)
+        return metrics_list[idx:]
+
     def start_timer(self, name: str) -> None:
         """Start a named timer"""
         self.active_timers[name] = time.time()
@@ -298,7 +304,7 @@ class PerformanceMonitor:
     def get_metrics_summary(self, hours: int = 24) -> Dict[str, Any]:
         """Get performance metrics summary"""
         cutoff = datetime.now() - timedelta(hours=hours)
-        recent_metrics = [m for m in self.metrics if m.timestamp >= cutoff]
+        recent_metrics = self.get_metrics_since(cutoff)
 
         if not recent_metrics:
             return {"total_metrics": 0}
@@ -332,10 +338,9 @@ class PerformanceMonitor:
         cutoff = datetime.now() - timedelta(hours=hours)
 
         slow_ops = []
-        for metric in self.metrics:
+        for metric in self.get_metrics_since(cutoff):
             if (
-                metric.timestamp >= cutoff
-                and metric.metric_type == MetricType.EXECUTION_TIME
+                metric.metric_type == MetricType.EXECUTION_TIME
                 and metric.value > threshold
             ):
                 slow_ops.append(
@@ -353,11 +358,8 @@ class PerformanceMonitor:
         """Return how often deprecated functions were called in the last ``hours``."""
         cutoff = datetime.now() - timedelta(hours=hours)
         counts: Dict[str, int] = defaultdict(int)
-        for metric in self.metrics:
-            if (
-                metric.timestamp >= cutoff
-                and metric.metric_type == MetricType.DEPRECATED_USAGE
-            ):
+        for metric in self.get_metrics_since(cutoff):
+            if metric.metric_type == MetricType.DEPRECATED_USAGE:
                 counts[metric.name] += 1
         return dict(counts)
 
@@ -396,7 +398,7 @@ class PerformanceMonitor:
         drift_threshold: float = 0.05,
         fields: Iterable[str] = ("accuracy", "precision", "recall"),
     ) -> bool:
-        """Return ``True`` if ``metrics`` deviate from ``baseline`` by more than ``drift_threshold``.
+        """Return True if metrics deviate from baseline beyond ``drift_threshold``.
 
         Parameters
         ----------
@@ -879,20 +881,20 @@ def get_performance_dashboard() -> Dict[str, Any]:
 
 def export_performance_report(hours: int = 24) -> pd.DataFrame:
     """Export performance data as DataFrame for analysis"""
-    metrics = []
+    metrics: List[Dict[str, Any]] = []
     cutoff = datetime.now() - timedelta(hours=hours)
+    monitor = get_performance_monitor()
 
-    for metric in get_performance_monitor().metrics:
-        if metric.timestamp >= cutoff:
-            metrics.append(
-                {
-                    "timestamp": metric.timestamp,
-                    "name": metric.name,
-                    "type": metric.metric_type.value,
-                    "value": metric.value,
-                    "duration": metric.duration,
-                    **metric.metadata,
-                }
-            )
+    for metric in monitor.get_metrics_since(cutoff):
+        metrics.append(
+            {
+                "timestamp": metric.timestamp,
+                "name": metric.name,
+                "type": metric.metric_type.value,
+                "value": metric.value,
+                "duration": metric.duration,
+                **metric.metadata,
+            }
+        )
 
     return pd.DataFrame(metrics)

--- a/yosai_intel_dashboard/src/core/security.py
+++ b/yosai_intel_dashboard/src/core/security.py
@@ -9,6 +9,7 @@ import hashlib
 import logging
 import secrets
 import time
+from bisect import bisect_left
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
@@ -19,10 +20,15 @@ from typing import Any, Dict, List, Optional
 # :class:`~validation.security_validator.SecurityValidator` for sanitization tasks.
 from validation.security_validator import SecurityValidator
 from yosai_intel_dashboard.src.core.base_model import BaseModel
+from yosai_intel_dashboard.src.core.domain.entities.access_events import (
+    AccessEventModel,
+)
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
     dynamic_config,
 )
-main
+from yosai_intel_dashboard.src.infrastructure.monitoring.anomaly_detector import (
+    AnomalyDetector,
+)
 
 
 class SecurityLevel(Enum):
@@ -215,7 +221,9 @@ class SecurityAuditor(BaseModel):
     def get_security_summary(self, hours: int = 24) -> Dict[str, Any]:
         """Get security events summary"""
         cutoff = datetime.now() - timedelta(hours=hours)
-        recent_events = [e for e in self.events if e.timestamp >= cutoff]
+        timestamps = [e.timestamp for e in self.events]
+        idx = bisect_left(timestamps, cutoff)
+        recent_events = self.events[idx:]
 
         if not recent_events:
             return {"total_events": 0}
@@ -305,6 +313,13 @@ except Exception:  # pragma: no cover
             return {"valid": True, "sanitized": value}
 
     security_validator = _FallbackValidator()
+
+
+def validate_user_input(value: str, field: str) -> str:
+    """Validate and sanitize user input."""
+    result = security_validator.validate_input(value, field)
+    return result.get("sanitized", value)
+
 
 rate_limiter = RateLimiter()
 security_auditor = SecurityAuditor()
@@ -399,8 +414,7 @@ def initialize_validation_callbacks() -> None:
     """Set up request validation callbacks on import."""
     try:
         from security.validation_middleware import ValidationMiddleware
-        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
-
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (  # noqa: E501
             TrulyUnifiedCallbacks,
         )
     except Exception:


### PR DESCRIPTION
## Summary
- add helper to slice metrics deque via `bisect_left`
- replace linear scans in performance, error-handling, and security summaries
- expose `validate_user_input` for external callers

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/performance.py yosai_intel_dashboard/src/core/error_handling.py yosai_intel_dashboard/src/core/security.py`
- `pytest tests/di/test_performance_monitor.py::test_container_records_resolution_time -q`


------
https://chatgpt.com/codex/tasks/task_e_688f47f070b08320bec93ca96c900739