### PR TITLE
Use memory mapping for large file ingestion

### DIFF
--- a/yosai_intel_dashboard/src/core/performance_file_processor.py
+++ b/yosai_intel_dashboard/src/core/performance_file_processor.py
@@ -23,7 +23,9 @@ class PerformanceFileProcessor:
     def __init__(
         self, chunk_size: int = DEFAULT_CHUNK_SIZE, *, max_memory_mb: int | None = None
     ) -> None:
-        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+            dynamic_config,
+        )
 
         self.chunk_size = chunk_size
         self.logger = logging.getLogger(__name__)
@@ -64,7 +66,12 @@ class PerformanceFileProcessor:
         if isinstance(file_path, (str, Path)):
             handle = Path(file_path)
 
-        reader = pd.read_csv(handle, chunksize=self.chunk_size, encoding=encoding)
+        reader = pd.read_csv(
+            handle,
+            chunksize=self.chunk_size,
+            encoding=encoding,
+            memory_map=True,
+        )
 
         def generator() -> Iterable[pd.DataFrame]:
             rows = 0


### PR DESCRIPTION
## Summary
- enable pandas memory mapping when reading CSV files
- use mmap for JSON ingestion and ensure cleanup
- memory-map chunked CSV processing in performance file processor

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/utils/pandas_readers.py yosai_intel_dashboard/src/core/performance_file_processor.py` *(failed: mypy errors)*
- `pytest tests/test_file_processor.py tests/services/test_async_file_processor_nodisk.py` *(failed: NameError: import_optional undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688f47eae700832080703ef4ace3deb2