### PR TITLE
Use generators for security pattern detection

### DIFF
--- a/analytics/security_patterns/pattern_detection.py
+++ b/analytics/security_patterns/pattern_detection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, Iterator
 
 import pandas as pd
 
@@ -14,18 +14,24 @@ class Threat:
     details: Dict[str, object]
 
 
-def detect_critical_door_risks(df: pd.DataFrame) -> List[Threat]:
-    """Detect repeated denied attempts on critical doors."""
+def detect_critical_door_risks(df: pd.DataFrame) -> Iterator[Threat]:
+    """Detect repeated denied attempts on critical doors.
+
+    Yields
+    ------
+    Threat
+        A detected critical door anomaly.
+    """
     if df.empty:
-        return []
+        return
     crit = df[
         (df.get("door_type") == "critical")
         & (df.get("access_result") == "Denied")
         & (df.get("clearance_level", 0) < df.get("required_clearance", 0))
     ]
     if crit.empty:
-        return []
-    return [Threat("critical_door_anomaly", {"events": crit.to_dict("records")})]
+        return
+    yield Threat("critical_door_anomaly", {"events": crit.to_dict("records")})
 
 
 __all__ = ["Threat", "detect_critical_door_risks"]


### PR DESCRIPTION
## Summary
- Refactor security pattern detectors to lazily yield threats
- Update security analyzer to consume generators
- Test that detection utilities return generators and still function

## Testing
- `pre-commit run --files analytics/security_patterns/pattern_detection.py analytics/security_patterns/odd_time_detection.py analytics/security_patterns/__init__.py tests/test_security_patterns.py`
- `pytest tests/test_security_patterns.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f47e707208320aaf4e86b33add7f2