### PR TITLE
feat: lazily initialize upload data store

### DIFF
--- a/tests/stubs/utils/upload_store.py
+++ b/tests/stubs/utils/upload_store.py
@@ -1,3 +1,10 @@
+from __future__ import annotations
+
 from tests.fakes import FakeUploadStore
 
-uploaded_data_store = FakeUploadStore()
+_fake_store = FakeUploadStore()
+uploaded_data_store = _fake_store
+
+
+def get_uploaded_data_store() -> FakeUploadStore:
+    return _fake_store

--- a/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Protocol, runtime_checkable
 
+import pandas as pd
+
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
+    ServiceContainer,
+)
 from yosai_intel_dashboard.src.mapping.core.interfaces import (
     ProcessorInterface,
     StorageInterface,
 )
 from yosai_intel_dashboard.src.mapping.core.models import MappingData
-
-import pandas as pd
-
-from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 
 
 @runtime_checkable
@@ -117,7 +118,9 @@ def get_door_mapping_service(
     c = _get_container(container)
     if c and c.has("door_mapping_service"):
         return c.get("door_mapping_service")
-    from yosai_intel_dashboard.src.services.door_mapping_service import door_mapping_service
+    from yosai_intel_dashboard.src.services.door_mapping_service import (
+        door_mapping_service,
+    )
 
     return door_mapping_service
 
@@ -129,7 +132,9 @@ def get_device_learning_service(
     c = _get_container(container)
     if c and c.has("device_learning_service"):
         return c.get("device_learning_service")
-    from yosai_intel_dashboard.src.services.device_learning_service import create_device_learning_service
+    from yosai_intel_dashboard.src.services.device_learning_service import (
+        create_device_learning_service,
+    )
 
     return create_device_learning_service()
 
@@ -141,10 +146,12 @@ def get_upload_data_service(
     c = _get_container(container)
     if c and c.has("upload_data_service"):
         return c.get("upload_data_service")
-    from yosai_intel_dashboard.src.services.upload_data_service import UploadDataService as UploadDataSvc
-    from yosai_intel_dashboard.src.utils.upload_store import uploaded_data_store
+    from yosai_intel_dashboard.src.services.upload_data_service import (
+        UploadDataService as UploadDataSvc,
+    )
+    from yosai_intel_dashboard.src.utils.upload_store import get_uploaded_data_store
 
-    return UploadDataSvc(uploaded_data_store)
+    return UploadDataSvc(get_uploaded_data_store())
 
 
 def get_mapping_service(
@@ -283,6 +290,8 @@ def get_database_analytics_retriever(
     c = _get_container(container)
     if c and c.has("database_analytics_retriever"):
         return c.get("database_analytics_retriever")
-    from yosai_intel_dashboard.src.services.database_retriever import DatabaseAnalyticsRetriever
+    from yosai_intel_dashboard.src.services.database_retriever import (
+        DatabaseAnalyticsRetriever,
+    )
 
     return DatabaseAnalyticsRetriever(helper)

--- a/yosai_intel_dashboard/src/services/upload/upload_data_service.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_data_service.py
@@ -1,5 +1,7 @@
 """Service helpers for accessing uploaded data from the store."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, List
 
@@ -11,12 +13,17 @@ except ImportError:  # pragma: no cover - for Python <3.12
 
 import pandas as pd
 
-from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
-    get_upload_data_service,
     UploadDataServiceProtocol,
+    get_upload_data_service,
 )
-from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore, uploaded_data_store
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
+    ServiceContainer,
+)
+from yosai_intel_dashboard.src.utils.upload_store import (
+    UploadedDataStore,
+    get_uploaded_data_store,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +31,9 @@ logger = logging.getLogger(__name__)
 class UploadDataService(UploadDataServiceProtocol):
     """Concrete service providing access to uploaded data via a store."""
 
-    def __init__(self, store: UploadedDataStore = uploaded_data_store) -> None:
+    def __init__(self, store: UploadedDataStore | None = None) -> None:
         """Initialize the service with the given ``UploadedDataStore``."""
-        self.store = store
+        self.store = store or get_uploaded_data_store()
 
     @override
     def get_uploaded_data(self) -> Dict[str, pd.DataFrame]:


### PR DESCRIPTION
## Summary
- delay cache manager creation in upload store until first use
- lazily initialize global UploadedDataStore via accessor
- update upload services and stubs to use new accessor

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/utils/upload_store.py yosai_intel_dashboard/src/core/interfaces/service_protocols.py yosai_intel_dashboard/src/services/upload/upload_data_service.py tests/stubs/utils/upload_store.py` *(fails: flake8 undefined names, mypy errors)*
- `SKIP=flake8,mypy,bandit pre-commit run --files yosai_intel_dashboard/src/utils/upload_store.py yosai_intel_dashboard/src/core/interfaces/service_protocols.py yosai_intel_dashboard/src/services/upload/upload_data_service.py tests/stubs/utils/upload_store.py`
- `pytest tests/test_upload_data_service.py tests/test_upload_store_threading.py` *(fails: cannot import 'FileProcessorProtocol'; NameError: import_optional not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f48173b0c83208fbb5098e4183519