### PR TITLE
Use generators for large comprehensions

### DIFF
--- a/scripts/migrate_kafka_schemas.py
+++ b/scripts/migrate_kafka_schemas.py
@@ -126,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-    subjects = [s for subs in SCHEMA_MAP.values() for s in subs]
+    subjects = (s for subs in SCHEMA_MAP.values() for s in subs)
     fetch_current_versions(args.schema_registry, subjects)
 
     for path_str, subs in SCHEMA_MAP.items():

--- a/scripts/migrate_to_timescale.py
+++ b/scripts/migrate_to_timescale.py
@@ -281,9 +281,9 @@ def insert_rows(cur: cursor, table: str, rows: List[dict[str, Any]]) -> None:
     if not rows:
         return
     columns = rows[0].keys()
-    values = [tuple(row[col] for col in columns) for row in rows]
+    values = (tuple(row[col] for col in columns) for row in rows)
     cols = ",".join(columns)
-    placeholders = ",".join(["%s"] * len(columns))
+    placeholders = ",".join("%s" for _ in columns)
     query = f"INSERT INTO {table} ({cols}) VALUES ({placeholders})"
     execute_batch(cur, query, values)
 
@@ -394,8 +394,7 @@ def run_verification(target_conn: connection) -> None:
             "SELECT table_name FROM information_schema.tables "
             "WHERE table_schema='public'",
         )
-        tables = [r[0] for r in cur.fetchall()]
-        LOG.info("Tables: %s", ", ".join(tables))
+        LOG.info("Tables: %s", ", ".join(r[0] for r in cur.fetchall()))
         execute_query(
             cur, "SELECT * FROM timescaledb_information.compressed_hypertables"
         )

--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -13,10 +13,9 @@ from prometheus_client import Gauge, start_http_server
 from psycopg2.extras import DictCursor, execute_values
 
 from database.secure_exec import execute_command, execute_query
+from yosai_intel_dashboard.src.services.common.secrets import get_secret
 
 LOG = logging.getLogger(__name__)
-
-from yosai_intel_dashboard.src.services.common.secrets import get_secret
 
 
 def _resolve_dsn(value: str | None, field: str) -> str:
@@ -92,9 +91,9 @@ def fetch_new_rows(cur: DictCursor, last_ts: datetime) -> list[dict[str, Any]]:
 def insert_rows(cur: DictCursor, rows: list[dict[str, Any]]) -> None:
     if not rows:
         return
-    values = [tuple(row[f] for f in FIELDS) for row in rows]
+    values = (tuple(row[f] for f in FIELDS) for row in rows)
     cols = ",".join(FIELDS)
-    placeholders = ",".join(["%s"] * len(FIELDS))
+    placeholders = ",".join("%s" for _ in FIELDS)
     query = (
         f"INSERT INTO access_events ({cols}) VALUES ({placeholders})"
         " ON CONFLICT (event_id) DO NOTHING"


### PR DESCRIPTION
## Summary
- replace list comprehensions with generator expressions in Timescale migration and replication scripts
- switch Kafka schema migration subject list to a generator expression

## Testing
- `pre-commit run --files scripts/migrate_kafka_schemas.py scripts/migrate_to_timescale.py scripts/replicate_to_timescale.py` *(fails: mypy reported 896 errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688f481457548320ba0665e59bb0dd96