### PR TITLE
Migrate time-series tables to TimescaleDB

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -95,3 +95,29 @@ CREATE TABLE IF NOT EXISTS emergency_lockdowns (
     active BOOLEAN DEFAULT FALSE,
     activated_at TIMESTAMPTZ
 );
+
+-- Anomaly detections stored as a hypertable for efficient retention and compression
+CREATE TABLE IF NOT EXISTS anomaly_detections (
+    anomaly_id UUID PRIMARY KEY,
+    event_id UUID REFERENCES access_events(event_id),
+    anomaly_type VARCHAR(50) NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    confidence_score FLOAT NOT NULL,
+    description TEXT,
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ai_model_version VARCHAR(50),
+    additional_context JSONB,
+    is_verified BOOLEAN,
+    verified_by VARCHAR(50),
+    verified_at TIMESTAMPTZ
+);
+SELECT create_hypertable('anomaly_detections', 'detected_at', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
+ALTER TABLE anomaly_detections
+  SET (
+       timescaledb.compress,
+       timescaledb.compress_orderby = 'detected_at DESC'
+  );
+SELECT add_compression_policy('anomaly_detections', INTERVAL '30 days');
+SELECT add_retention_policy('anomaly_detections', INTERVAL '180 days');

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -42,6 +42,11 @@ def _ensure_timescale(connection) -> None:
     connection.execute(
         text("SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE)")
     )
+    connection.execute(
+        text(
+            "SELECT create_hypertable('anomaly_detections', 'detected_at', if_not_exists => TRUE)"
+        )
+    )
 
 
 def run_migrations_offline() -> None:

--- a/migrations/timescale/001_create_hypertables.sql
+++ b/migrations/timescale/001_create_hypertables.sql
@@ -18,3 +18,22 @@ CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
 CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
 CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
 CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
+
+-- Anomaly detections hypertable
+CREATE TABLE IF NOT EXISTS anomaly_detections (
+    anomaly_id UUID PRIMARY KEY,
+    event_id UUID REFERENCES access_events(event_id),
+    anomaly_type VARCHAR(50) NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    confidence_score FLOAT NOT NULL,
+    description TEXT,
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ai_model_version VARCHAR(50),
+    additional_context JSONB,
+    is_verified BOOLEAN,
+    verified_by VARCHAR(50),
+    verified_at TIMESTAMPTZ
+);
+SELECT create_hypertable('anomaly_detections', 'detected_at', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);

--- a/migrations/timescale/003_setup_compression.sql
+++ b/migrations/timescale/003_setup_compression.sql
@@ -6,3 +6,11 @@ ALTER TABLE access_events
   );
 
 SELECT add_compression_policy('access_events', INTERVAL '30 days');
+
+ALTER TABLE anomaly_detections
+  SET (
+       timescaledb.compress,
+       timescaledb.compress_orderby = 'detected_at DESC'
+  );
+
+SELECT add_compression_policy('anomaly_detections', INTERVAL '30 days');

--- a/migrations/timescale/004_retention_policies.sql
+++ b/migrations/timescale/004_retention_policies.sql
@@ -1,1 +1,2 @@
 SELECT add_retention_policy('access_events', INTERVAL '365 days');
+SELECT add_retention_policy('anomaly_detections', INTERVAL '180 days');


### PR DESCRIPTION
## Summary
- migrate anomaly detection events into a TimescaleDB hypertable
- apply compression and retention policies for access and anomaly events
- extend migration script and setup SQL for TimescaleDB features

## Testing
- `pytest tests/analytics/test_timescale_queries.py -q` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.analytics.analytics')*

------
https://chatgpt.com/codex/tasks/task_e_688f4812e8ec83208c663931d6729757