### PR TITLE
Add read-replica routing for database queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ DB_NAME=yosai_db
 DB_USER=yosai_user
 DB_GATEWAY_NAME=yosai_gateway_db
 DB_EVENTS_NAME=yosai_events_db
+# Optional JSON array of read replica URLs
+YOSAI_DATABASE_READ_REPLICAS=[]
 
 # Frontend configuration
 REACT_APP_API_BASE=/v1

--- a/tests/test_read_replica_routing.py
+++ b/tests/test_read_replica_routing.py
@@ -1,0 +1,40 @@
+from yosai_intel_dashboard.src.database.replicated_connection import (
+    ReplicatedDatabaseConnection,
+)
+
+
+class DummyConnection:
+    def __init__(self) -> None:
+        self.queries = []
+        self.commands = []
+
+    def execute_query(self, query, params=None):  # pragma: no cover - simple
+        self.queries.append(query)
+        return []
+
+    def execute_command(self, command, params=None):  # pragma: no cover - simple
+        self.commands.append(command)
+
+    def prepare_statement(self, name, query):  # pragma: no cover - simple
+        pass
+
+    def execute_prepared(self, name, params):  # pragma: no cover - simple
+        self.queries.append(name)
+        return []
+
+    def health_check(self):  # pragma: no cover - simple
+        return True
+
+
+def test_read_queries_use_replica():
+    primary = DummyConnection()
+    replica = DummyConnection()
+    conn = ReplicatedDatabaseConnection(primary, [replica])
+
+    conn.execute_query("SELECT 1")
+    conn.execute_command("UPDATE t SET x=1")
+
+    assert primary.commands == ["UPDATE t SET x=1"]
+    assert replica.queries == ["SELECT 1"]
+    assert not primary.queries
+    assert not replica.commands

--- a/yosai_intel_dashboard/src/database/replicated_connection.py
+++ b/yosai_intel_dashboard/src/database/replicated_connection.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Connection wrapper that routes read-only queries to replicas."""
+
+from itertools import cycle
+from typing import Iterable, Optional
+
+from .types import DBRows, DatabaseConnection
+
+
+class ReplicatedDatabaseConnection:
+    """Route reads to replica connections while writes go to primary."""
+
+    def __init__(
+        self,
+        primary: DatabaseConnection,
+        replicas: Iterable[DatabaseConnection],
+    ) -> None:
+        self._primary = primary
+        self._replicas = list(replicas)
+        self._cycle = cycle(self._replicas) if self._replicas else None
+
+    def _choose_replica(self) -> DatabaseConnection:
+        if self._cycle is None:
+            return self._primary
+        return next(self._cycle)
+
+    # -- read operations -------------------------------------------------
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> DBRows:
+        return self._choose_replica().execute_query(query, params)
+
+    def execute_prepared(self, name: str, params: tuple) -> DBRows:
+        return self._choose_replica().execute_prepared(name, params)
+
+    # -- write operations ------------------------------------------------
+    def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
+        self._primary.execute_command(command, params)
+
+    # -- shared operations -----------------------------------------------
+    def prepare_statement(self, name: str, query: str) -> None:
+        self._primary.prepare_statement(name, query)
+        for replica in self._replicas:
+            replica.prepare_statement(name, query)
+
+    def health_check(self) -> bool:
+        if not self._primary.health_check():
+            return False
+        return all(replica.health_check() for replica in self._replicas)
+
+    def close(self) -> None:
+        if hasattr(self._primary, "close"):
+            self._primary.close()
+        for replica in self._replicas:
+            if hasattr(replica, "close"):
+                replica.close()
+
+
+__all__ = ["ReplicatedDatabaseConnection"]

--- a/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/hierarchical_loader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import yaml
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .base_loader import BaseConfigLoader
 from .environment import get_environment
@@ -42,6 +42,7 @@ class DatabaseSettings(BaseModel):
     password: str = ""
     url: str = ""
     query_timeout_seconds: int = 600
+    read_replicas: list[str] = Field(default_factory=list)
 
 
 class SecuritySettings(BaseModel):

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -52,6 +52,7 @@ class DatabaseSettings(BaseModel):
     shrink_interval: int = 0
     use_intelligent_pool: bool = False
     query_timeout_seconds: int = 600
+    read_replicas: List[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def populate_url(cls, values: "DatabaseSettings") -> "DatabaseSettings":


### PR DESCRIPTION
## Summary
- support optional `read_replicas` setting in database config
- route read-only queries to replicas while writes go to primary
- document read replica URLs in `.env.example`

## Testing
- `pytest tests/test_read_replica_routing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4810f2bc8320852f5833be03ba73