### PR TITLE
Configure TimescaleDB chunk interval for event data

### DIFF
--- a/docs/timescale_integration.md
+++ b/docs/timescale_integration.md
@@ -2,10 +2,12 @@
 
 The dashboard can store access events in TimescaleDB for efficient time-series
 analytics. Hypertables are created automatically when the `TimescaleDBManager`
-initialises. Events are compressed after thirty days and removed after one
-year using retention policies. The policy durations can be overridden with the
-environment variables `TIMESCALE_COMPRESSION_DAYS` and
-`TIMESCALE_RETENTION_DAYS`.
+initialises. By default the hypertables are partitioned into daily chunks, but
+the interval can be adjusted (e.g. to `1 month`) using the
+`TIMESCALE_CHUNK_INTERVAL` environment variable. Events are compressed after
+thirty days and removed after one year using retention policies. The policy
+durations can be overridden with the environment variables
+`TIMESCALE_COMPRESSION_DAYS` and `TIMESCALE_RETENTION_DAYS`.
 
 
 ## Data Retention

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS access_events (
     metadata JSONB
 );
 
-SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE);
+SELECT create_hypertable('access_events', 'time', chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
 ALTER TABLE access_events
   SET (
        timescaledb.compress,

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -39,8 +39,11 @@ def _get_url(section: str) -> str:
 def _ensure_timescale(connection) -> None:
     """Create TimescaleDB extension and hypertable if missing."""
     connection.execute(text("CREATE EXTENSION IF NOT EXISTS timescaledb"))
+    chunk = os.getenv("TIMESCALE_CHUNK_INTERVAL", "1 day")
     connection.execute(
-        text("SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE)")
+        text(
+            "SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE, chunk_time_interval => INTERVAL :chunk)"
+        ).bindparams(chunk=chunk)
     )
 
 

--- a/migrations/timescale/001_create_hypertables.sql
+++ b/migrations/timescale/001_create_hypertables.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS access_events (
     response_time_ms INTEGER,
     metadata JSONB
 );
-SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE);
+SELECT create_hypertable('access_events', 'time', chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
 
 -- Indexes for common query patterns
 CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);

--- a/scripts/init_timescaledb.sql
+++ b/scripts/init_timescaledb.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS access_events (
     response_time_ms INTEGER,
     metadata JSONB
 );
-SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE);
+SELECT create_hypertable('access_events', 'time', chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
 ALTER TABLE access_events
   SET (timescaledb.compress,
        timescaledb.compress_orderby = 'time DESC',

--- a/scripts/migrate_to_timescale.py
+++ b/scripts/migrate_to_timescale.py
@@ -161,15 +161,17 @@ def setup_timescale(conn: connection) -> None:
             )
             """,
         )
+        chunk_interval = os.getenv("TIMESCALE_CHUNK_INTERVAL", "1 day")
         cur.execute(
             """
             SELECT create_hypertable(
                 'access_events',
                 'time',
-                chunk_time_interval => INTERVAL '1 day',
+                chunk_time_interval => %s::interval,
                 if_not_exists => TRUE
             )
-            """
+            """,
+            (chunk_interval,),
         )
 
         # indexes for common query patterns

--- a/tests/migration/test_init_timescale_sql.py
+++ b/tests/migration/test_init_timescale_sql.py
@@ -10,6 +10,7 @@ def _read_sql() -> str:
 def test_hypertable_and_index_creation() -> None:
     sql = _read_sql()
     assert "create_hypertable('access_events'" in sql
+    assert "chunk_time_interval" in sql
     # primary key index ensures index creation
     assert "primary key" in sql
 

--- a/yosai_intel_dashboard/src/services/timescale/manager.py
+++ b/yosai_intel_dashboard/src/services/timescale/manager.py
@@ -78,6 +78,7 @@ class TimescaleDBManager:
     # ------------------------------------------------------------------
     async def _setup(self, conn: asyncpg.Connection) -> None:
         await conn.execute("CREATE EXTENSION IF NOT EXISTS timescaledb")
+        chunk_interval = os.getenv("TIMESCALE_CHUNK_INTERVAL", "1 day")
         await conn.execute(
             """
             CREATE TABLE IF NOT EXISTS access_events (
@@ -94,7 +95,8 @@ class TimescaleDBManager:
             """,
         )
         await conn.execute(
-            "SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE)"
+            "SELECT create_hypertable('access_events', 'time', if_not_exists => TRUE, chunk_time_interval => $1::interval)",
+            chunk_interval,
         )
         await conn.execute(
             """
@@ -144,7 +146,8 @@ class TimescaleDBManager:
             """,
         )
         await conn.execute(
-            "SELECT create_hypertable('model_monitoring_events', 'time', if_not_exists => TRUE)"
+            "SELECT create_hypertable('model_monitoring_events', 'time', if_not_exists => TRUE, chunk_time_interval => $1::interval)",
+            chunk_interval,
         )
         await conn.execute(
             "SELECT add_compression_policy('model_monitoring_events', INTERVAL $1 || ' days', if_not_exists => TRUE)",


### PR DESCRIPTION
## Summary
- support configurable chunk interval for TimescaleDB hypertables
- apply chunk interval to migrations and SQL setup scripts
- document `TIMESCALE_CHUNK_INTERVAL` usage and test SQL for partitioning

## Testing
- `pytest -q` *(fails: missing dependencies)*
- `pytest tests/migration/test_init_timescale_sql.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f480c7ff883209e68f319e4aa4e16