### PR TITLE
Add missing indexes migration

### DIFF
--- a/migrations/004_add_missing_indexes.sql
+++ b/migrations/004_add_missing_indexes.sql
@@ -1,0 +1,5 @@
+-- Add indexes identified from query logs
+CREATE INDEX IF NOT EXISTS idx_access_events_timestamp ON access_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
+CREATE INDEX IF NOT EXISTS idx_incident_tickets_status ON incident_tickets(status);

--- a/migrations/versions/0004_add_missing_indexes.py
+++ b/migrations/versions/0004_add_missing_indexes.py
@@ -1,0 +1,25 @@
+"""Add indexes based on query log analysis"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa  # noqa:F401
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[1] / "004_add_missing_indexes.sql"
+    op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_incident_tickets_status")
+    op.execute("DROP INDEX IF EXISTS idx_anomaly_detections_type")
+    op.execute("DROP INDEX IF EXISTS idx_anomaly_detections_detected_at")
+    op.execute("DROP INDEX IF EXISTS idx_access_events_timestamp")


### PR DESCRIPTION
## Summary
- add SQL migration to create indexes on frequently queried columns
- add Alembic revision to apply and roll back the new indexes

## Testing
- `pytest migration_tests -q` *(fails: NameError: name 'import_optional' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f480bd3e48320934b26450942ad87