### PR TITLE
Warm caches at startup using usage statistics

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 
 from api.adapter import create_api_app
+from yosai_intel_dashboard.src.core.cache_warmer import IntelligentCacheWarmer
 from yosai_intel_dashboard.src.core.di.bootstrap import bootstrap_container
 from yosai_intel_dashboard.src.core.env_validation import validate_required_env
 from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
@@ -14,17 +17,20 @@ if __name__ == "__main__":
     container = bootstrap_container()
 
     cache_cfg = get_cache_config()
+    cache_manager = container.get("cache_manager")
+
+    def _load(key: str) -> None:
+        return None
+
+    # Warm cache based on stored usage statistics
+    usage_path = getattr(cache_cfg, "usage_stats_path", os.getenv("CACHE_USAGE_FILE"))
+    if usage_path and hasattr(cache_manager, "get"):
+        warmer = IntelligentCacheWarmer(cache_manager, _load)
+        asyncio.run(warmer.warm_from_file(usage_path))
+
     warm_keys = getattr(cache_cfg, "warm_keys", [])
-    if warm_keys:
-        cache_manager = container.get("cache_manager")
-        if hasattr(cache_manager, "warm"):
-
-            def _load(key: str) -> None:
-                return None
-
-            import asyncio
-
-            asyncio.run(cache_manager.warm(warm_keys, _load))
+    if warm_keys and hasattr(cache_manager, "warm"):
+        asyncio.run(cache_manager.warm(warm_keys, _load))
 
     app = create_api_app()
     app.state.container = container

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import pytest
 
 from yosai_intel_dashboard.src.core.cache_warmer import IntelligentCacheWarmer, UsagePatternAnalyzer
 from yosai_intel_dashboard.src.core.hierarchical_cache_manager import HierarchicalCacheManager
+
+
+@pytest.fixture
+def async_runner():
+    return asyncio.run
 
 
 def _loader(key: str) -> str:
@@ -21,12 +27,29 @@ def test_predicted_keys_cached(async_runner):
 
     async_runner(warmer.warm())
 
-    assert cache.get("a") == "value-a"
-    assert cache.get("b") == "value-b"
+    assert async_runner(cache.get("a")) == "value-a"
+    assert async_runner(cache.get("b")) == "value-b"
 
 
 def test_warm_populates_keys(async_runner):
     cache = HierarchicalCacheManager()
     async_runner(cache.warm(["x", "y"], _loader))
-    assert cache.get("x") == "value-x"
-    assert cache.get("y") == "value-y"
+    assert async_runner(cache.get("x")) == "value-x"
+    assert async_runner(cache.get("y")) == "value-y"
+
+
+def test_warm_from_file(async_runner, tmp_path):
+    cache = HierarchicalCacheManager()
+    warmer = IntelligentCacheWarmer(cache, _loader)
+    warmer.record_usage("a")
+    warmer.record_usage("b")
+    warmer.record_usage("a")
+    stats = tmp_path / "stats.json"
+    warmer.save_stats(stats)
+
+    new_cache = HierarchicalCacheManager()
+    new_warmer = IntelligentCacheWarmer(new_cache, _loader)
+    async_runner(new_warmer.warm_from_file(stats))
+
+    assert async_runner(new_cache.get("a")) == "value-a"
+    assert async_runner(new_cache.get("b")) == "value-b"

--- a/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
+++ b/yosai_intel_dashboard/src/core/hierarchical_cache_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Simple hierarchical cache with three levels and basic metrics."""
 
 import asyncio
+import inspect
 import logging
 import os
 import time
@@ -134,8 +135,8 @@ class HierarchicalCacheManager(BaseModel):
                 value = await loader(key)
             else:
                 value = await asyncio.to_thread(loader, key)
-            self.set(key, value, level=1)
-            self.set(key, value, level=2)
+            await self.set(key, value, level=1)
+            await self.set(key, value, level=2)
 
         await asyncio.gather(*(_populate(k) for k in keys))
 


### PR DESCRIPTION
## Summary
- allow usage statistics to be saved and loaded for predictive cache warming
- warm caches on startup using stored usage data
- ensure hierarchical cache warming awaits async cache operations

## Testing
- `pytest tests/test_cache_warmer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f480697d88320a3dedd4730e53a37