### PR TITLE
feat: add CDN asset support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ REACT_APP_WS_URL=localhost:5001
 PERMISSION_SERVICE_URL=http://rbac-service:8081
 SERVICE_REGISTRY_URL=http://service-registry:8500
 
+# Asset CDN
+ASSET_CDN_URL=
+CDN_DISTRIBUTION_ID=
+
 # Cache configuration
 # Comma separated list of keys to pre-warm at startup
 CACHE_WARM_KEYS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial changelog with standard sections.
 - Database migration `0003` adds `ml_models` table for the model registry.
+- Configurable CDN asset URLs with deployment-time cache invalidation.
 
 ### Changed
 - Updated `run_service_analysis` to use `analyze_data_with_service` and

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,3 +13,9 @@ fi
 
 echo "Deploying image tag $(git rev-parse --short HEAD)"
 # Placeholder for real deployment commands
+
+if [[ -n "${CDN_DISTRIBUTION_ID:-}" ]]; then
+  echo "Invalidating CDN distribution $CDN_DISTRIBUTION_ID"
+  aws cloudfront create-invalidation --distribution-id "$CDN_DISTRIBUTION_ID" --paths "/*"
+fi
+

--- a/yosai_intel_dashboard/src/core/app_factory/__init__.py
+++ b/yosai_intel_dashboard/src/core/app_factory/__init__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Fresh, minimal app factory."""
 
+import os
+
 import dash
 import dash_bootstrap_components as dbc
 from dash import dcc, html
@@ -17,9 +19,13 @@ from yosai_intel_dashboard.src.infrastructure.error_handling.handlers import (
 def create_app(mode=None, **kwargs):
     """Create a working Dash app with logo, navigation, and routing - HTTPS ready."""
 
+    assets_external = os.environ.get("ASSET_CDN_URL")
+
     app = dash.Dash(
         __name__,
         external_stylesheets=[dbc.themes.BOOTSTRAP],
+        assets_url_path="/assets",
+        assets_external_path=assets_external or None,
     )
 
     register_error_handlers(app.server)

--- a/yosai_intel_dashboard/src/utils/assets_debug.py
+++ b/yosai_intel_dashboard/src/utils/assets_debug.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Debug utilities for Dash asset serving with safe imports."""
 
+from __future__ import annotations
+
 try:
-    from dash import html  # type: ignore
+    from dash import get_asset_url, html  # type: ignore
 
     DASH_AVAILABLE = True
 except ImportError:
@@ -12,7 +14,7 @@ except ImportError:
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable
 
 from yosai_intel_dashboard.src.core.unicode import safe_encode_text
 
@@ -83,8 +85,13 @@ def navbar_icon(filename: str, alt: str, fallback_text: str, *, warn: bool = Tru
     """
     path = NAVBAR_ICON_DIR / filename
     if path.is_file():
+        src = (
+            get_asset_url(f"navbar_icons/{filename}")
+            if DASH_AVAILABLE
+            else f"/assets/navbar_icons/{filename}"
+        )
         return html.Img(
-            src=f"/assets/navbar_icons/{filename}",
+            src=src,
             className="nav-icon nav-icon--image",
             alt=alt,
         )

--- a/yosai_intel_dashboard/src/utils/safe_components.py
+++ b/yosai_intel_dashboard/src/utils/safe_components.py
@@ -4,8 +4,10 @@ Emergency Safe Components
 Provides safe fallback components that are guaranteed to be JSON serializable
 """
 
+from __future__ import annotations
+
 import dash_bootstrap_components as dbc
-from dash import dcc, html
+from dash import get_asset_url, html
 
 from .assets_debug import navbar_icon
 
@@ -18,7 +20,7 @@ def safe_navbar():
                 [
                     html.A(
                         html.Img(
-                            src="/assets/yosai_logo_name_black.png",
+                            src=get_asset_url("yosai_logo_name_black.png"),
                             height="46px",
                             className="navbar__logo",
                             alt="logo",


### PR DESCRIPTION
## Summary
- allow configuring Dash assets to load from a CDN
- add CDN invalidation to deployment script
- document CDN variables and usage

## Testing
- `pytest tests/utils/test_assets_debug.py tests/utils/test_asset_serving.py`
- `pre-commit run --files .env.example deploy.sh CHANGELOG.md yosai_intel_dashboard/src/core/app_factory/__init__.py yosai_intel_dashboard/src/utils/assets_debug.py yosai_intel_dashboard/src/utils/safe_components.py` *(fails: mypy reports numerous existing errors)*
- `SKIP=mypy,bandit,import-style-check pre-commit run --files .env.example deploy.sh CHANGELOG.md yosai_intel_dashboard/src/core/app_factory/__init__.py yosai_intel_dashboard/src/utils/assets_debug.py yosai_intel_dashboard/src/utils/safe_components.py`

------
https://chatgpt.com/codex/tasks/task_e_688f4805bbb0832082fc80690b615eaa