### PR TITLE
feat: add TTL query cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ flask-babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
 Flask-Caching==2.0.2
+cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
 pandas==2.1.4

--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -1,16 +1,32 @@
 from flask import Blueprint, jsonify
 
-from src.repository import InMemoryMetricsRepository, MetricsRepository
+from src.repository import (
+    CachedMetricsRepository,
+    InMemoryMetricsRepository,
+    MetricsRepository,
+)
 
 metrics_bp = Blueprint("metrics", __name__, url_prefix="/v1/metrics")
 
-_metrics_repo: MetricsRepository = InMemoryMetricsRepository()
+_metrics_repo: MetricsRepository = CachedMetricsRepository(InMemoryMetricsRepository())
 
 
-def set_metrics_repository(repo: MetricsRepository) -> None:
-    """Inject a metrics repository implementation."""
+def set_metrics_repository(
+    repo: MetricsRepository, *, use_cache: bool = True, ttl: int = 60
+) -> None:
+    """Inject a metrics repository implementation.
+
+    Parameters
+    ----------
+    repo:
+        The underlying metrics repository.
+    use_cache:
+        If ``True`` (default), wrap ``repo`` in :class:`CachedMetricsRepository`.
+    ttl:
+        Cache expiration in seconds when ``use_cache`` is enabled.
+    """
     global _metrics_repo
-    _metrics_repo = repo
+    _metrics_repo = CachedMetricsRepository(repo, ttl=ttl) if use_cache else repo
 
 
 @metrics_bp.get("/performance")

--- a/src/repository/__init__.py
+++ b/src/repository/__init__.py
@@ -1,5 +1,5 @@
 """Repository interfaces and implementations."""
 
-from .metrics import MetricsRepository, InMemoryMetricsRepository
+from .metrics import MetricsRepository, InMemoryMetricsRepository, CachedMetricsRepository
 
-__all__ = ["MetricsRepository", "InMemoryMetricsRepository"]
+__all__ = ["MetricsRepository", "InMemoryMetricsRepository", "CachedMetricsRepository"]

--- a/tests/test_metrics_cache.py
+++ b/tests/test_metrics_cache.py
@@ -1,0 +1,33 @@
+import time
+
+from src.repository import CachedMetricsRepository, MetricsRepository
+
+
+class DummyRepo(MetricsRepository):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_performance_metrics(self):  # type: ignore[override]
+        self.calls += 1
+        return {"calls": self.calls}
+
+    def get_drift_data(self):  # type: ignore[override]
+        return {}
+
+    def get_feature_importances(self):  # type: ignore[override]
+        return {}
+
+
+def test_cache_returns_cached_value_and_expires():
+    repo = DummyRepo()
+    cached = CachedMetricsRepository(repo, ttl=0.01)
+
+    first = cached.get_performance_metrics()
+    second = cached.get_performance_metrics()
+    assert first == second
+    assert repo.calls == 1
+
+    time.sleep(0.02)
+    third = cached.get_performance_metrics()
+    assert third != first
+    assert repo.calls == 2


### PR DESCRIPTION
## Summary
- wrap metrics repository in a thread-safe TTL cache to avoid redundant heavy queries
- support cached metrics repositories in API and expose TTL configuration
- add cachetools dependency and tests for cache expiration

## Testing
- `pytest tests/api/test_metrics_endpoints.py tests/test_metrics_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4805a3588320b95cf2c7bf5cca0f