### PR TITLE
Reduce list comprehension memory in unicode sanitization

### DIFF
--- a/tests/test_sanitize_unicode_output.py
+++ b/tests/test_sanitize_unicode_output.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+
+import pandas as pd
+
+
+def _import_optional(name, fallback=None):
+    return fallback
+
+
+builtins.import_optional = _import_optional
+
+core_config_stub = types.ModuleType("yosai_intel_dashboard.src.core.config")
+core_config_stub.get_max_display_rows = lambda config=None: 100
+sys.modules.setdefault("yosai_intel_dashboard.src.core.config", core_config_stub)
+
+from yosai_intel_dashboard.src.file_processing.utils import (  # noqa: E402
+    sanitize_dataframe_unicode,
+)
+
+
+def test_sanitize_dataframe_unicode_stream_equivalence():
+    df = pd.DataFrame({"text": ["bad\ud83d\ude00", "ok"]})
+    expected = pd.DataFrame({"text": ["bad😀", "ok"]})
+
+    direct = sanitize_dataframe_unicode(df, chunk_size=1, stream=False)
+    streamed = pd.concat(
+        list(sanitize_dataframe_unicode(df, chunk_size=1, stream=True))
+    )
+
+    pd.testing.assert_frame_equal(direct, expected)
+    pd.testing.assert_frame_equal(streamed, expected)

--- a/yosai_intel_dashboard/src/file_processing/utils.py
+++ b/yosai_intel_dashboard/src/file_processing/utils.py
@@ -8,15 +8,19 @@ from typing import Any, Dict, Iterable
 import chardet
 import pandas as pd
 
-from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
-from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from yosai_intel_dashboard.src.core.config import get_max_display_rows
-from yosai_intel_dashboard.src.core.performance_file_processor import PerformanceFileProcessor
+from yosai_intel_dashboard.src.core.performance_file_processor import (
+    PerformanceFileProcessor,
+)
 from yosai_intel_dashboard.src.core.unicode import (
     UnicodeProcessor,
     safe_format_number,
     safe_unicode_decode,
     sanitize_for_utf8,
+)
+from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+    dynamic_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -59,10 +63,7 @@ def sanitize_dataframe_unicode(
         for start in range(0, len(df), chunk_size):
             chunk = df.iloc[start : start + chunk_size].copy()
             for col in obj_cols:
-                chunk[col] = [
-                    UnicodeProcessor.clean_text(x) if isinstance(x, str) else x
-                    for x in chunk[col].astype(str)
-                ]
+                chunk[col] = chunk[col].astype(str).map(UnicodeProcessor.clean_text)
             yield chunk
 
     if stream:


### PR DESCRIPTION
## Summary
- refactor unicode sanitization to map over columns instead of building large temporary lists
- add regression test to ensure stream and non-stream outputs match

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/file_processing/utils.py tests/test_sanitize_unicode_output.py` (skipped: bandit, mypy)
- `pytest tests/test_sanitize_unicode_output.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f47e527548320951cf021db549207