### PR TITLE
tune gc thresholds

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -340,6 +340,12 @@ Resource optimizers use the environment variables `MAX_MEMORY`,
 `core/plugins/config/staging.yaml`). When the process exceeds these thresholds,
 warnings are logged and background tasks may be throttled.
 
+Garbage collection is tuned globally via `sitecustomize.py`, which sets
+`gc.set_threshold(1000, 10, 10)` to reduce the frequency of collections in
+long-running services. Short-lived helper scripts can opt out entirely by
+setting `SHORT_LIVED_PROCESS=1`; after calling `gc.collect()` the collector is
+disabled to avoid unnecessary overhead.
+
 ### Async File Processor
 
 `services.data_processing.async_file_processor.AsyncFileProcessor` loads large

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,6 +1,8 @@
+import gc
 import importlib
 import importlib.machinery
 import importlib.util
+import os
 import pathlib
 import sys
 
@@ -8,6 +10,17 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Tune garbage collection behaviour.  The higher thresholds reduce the
+# frequency of collections for long-running services while keeping memory
+# usage bounded.
+gc.set_threshold(1000, 10, 10)
+
+# Allow short-lived helper processes to skip the collector entirely once
+# they have released resources.  Opt in via ``SHORT_LIVED_PROCESS=1``.
+if os.getenv("SHORT_LIVED_PROCESS") == "1":
+    gc.collect()
+    gc.disable()
 
 # Provide lightweight service stubs for environments without full dependencies
 if "services" not in sys.modules:


### PR DESCRIPTION
## Summary
- reduce collection frequency by bumping GC thresholds
- optionally disable GC in short-lived helper scripts via `SHORT_LIVED_PROCESS`
- document GC tuning and environment variable in performance monitoring guide

## Testing
- `black sitecustomize.py --check`
- `isort sitecustomize.py --check -v`
- `flake8 sitecustomize.py`
- `mypy --strict sitecustomize.py` *(fails: "Argument 1 to 'module_from_spec' has incompatible type 'ModuleSpec | None'")*
- `pytest` *(fails: FileNotFoundError and missing dependencies, 240 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f7507e16c8320ac68589ce9ec9ccf