### PR TITLE
feat: configure alert manager

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/monitoring/alertmanager.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/alertmanager.yml
@@ -1,0 +1,12 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname']
+  receiver: default
+
+receivers:
+  - name: default
+    webhook_configs:
+      - url: http://notification-service/alert
+

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus.yml
@@ -7,6 +7,11 @@ rule_files:
 - /etc/prometheus/*_rules.yml
 - /etc/prometheus/*_rules.yaml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
 scrape_configs:
 - job_name: 'prometheus'
   static_configs:

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/system_threshold_rules.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/system_threshold_rules.yml
@@ -1,0 +1,28 @@
+groups:
+  - name: system_thresholds
+    rules:
+      - alert: HighCPUUsage
+        expr: sum(rate(container_cpu_usage_seconds_total[5m])) > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: CPU usage above 90%
+          description: High CPU usage detected across containers
+      - alert: HighMemoryUsage
+        expr: sum(container_memory_usage_bytes) / sum(container_spec_memory_limit_bytes) > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Memory usage above 90%
+          description: High memory consumption detected
+      - alert: HighErrorRate
+        expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Error rate above 5%
+          description: High HTTP error rate detected
+


### PR DESCRIPTION
## Summary
- wire prometheus to alertmanager
- add webhook alertmanager config
- add alert rules for CPU, memory, and error thresholds

## Testing
- `pre-commit run --files monitoring/prometheus.yml monitoring/prometheus/rules/system_threshold_rules.yml monitoring/alertmanager.yml`
- `pytest tests/monitoring/test_alerts.py tests/integration/test_alert_manager.py tests/integration/test_metrics_and_alerts.py tests/test_alert_dispatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_688f751e8b388320aa76b015ced95d84