### PR TITLE
feat: add CQRS-style user services

### DIFF
--- a/tests/services/test_user_cqrs.py
+++ b/tests/services/test_user_cqrs.py
@@ -1,0 +1,19 @@
+from yosai_intel_dashboard.src.services.user import (
+    UserCommand,
+    UserCommandService,
+    UserQuery,
+    UserQueryService,
+)
+
+
+def test_user_command_and_query_services() -> None:
+    store: dict[str, str] = {}
+    command_service = UserCommandService(store)
+    query_service = UserQueryService(store)
+
+    command = UserCommand(user_id="u1", name="Alice")
+    command_service.create_user(command)
+
+    query = UserQuery(user_id="u1")
+    result = query_service.get_user(query)
+    assert result == "Alice"

--- a/yosai_intel_dashboard/src/services/user/__init__.py
+++ b/yosai_intel_dashboard/src/services/user/__init__.py
@@ -1,0 +1,12 @@
+"""CQRS style user services."""
+
+from .command_service import UserCommandService
+from .models import UserCommand, UserQuery
+from .query_service import UserQueryService
+
+__all__ = [
+    "UserCommand",
+    "UserQuery",
+    "UserCommandService",
+    "UserQueryService",
+]

--- a/yosai_intel_dashboard/src/services/user/command_service.py
+++ b/yosai_intel_dashboard/src/services/user/command_service.py
@@ -1,0 +1,29 @@
+"""Service for handling user write operations."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .models import UserCommand
+
+
+class UserCommandService:
+    """Service dedicated to command operations on users."""
+
+    def __init__(self, store: Dict[str, str] | None = None) -> None:
+        """Initialize the service with an optional ``store``.
+
+        Args:
+            store: Mutable mapping used to persist user data. If ``None`` a new
+                dictionary is created.
+        """
+
+        self.store: Dict[str, str] = store if store is not None else {}
+
+    def create_user(self, command: UserCommand) -> None:
+        """Create or update a user using ``command``."""
+
+        self.store[command.user_id] = command.name
+
+
+__all__ = ["UserCommandService"]

--- a/yosai_intel_dashboard/src/services/user/models.py
+++ b/yosai_intel_dashboard/src/services/user/models.py
@@ -1,0 +1,26 @@
+"""Data models for user command and query operations."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UserCommand(BaseModel):
+    """Model representing a write operation on a user.
+
+    Attributes:
+        user_id: Unique identifier of the user to create or modify.
+        name: Human readable name associated with the user.
+    """
+
+    user_id: str
+    name: str
+
+
+class UserQuery(BaseModel):
+    """Model representing a read operation for a user."""
+
+    user_id: str
+
+
+__all__ = ["UserCommand", "UserQuery"]

--- a/yosai_intel_dashboard/src/services/user/query_service.py
+++ b/yosai_intel_dashboard/src/services/user/query_service.py
@@ -1,0 +1,29 @@
+"""Service for handling user read operations."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .models import UserQuery
+
+
+class UserQueryService:
+    """Service dedicated to querying user information."""
+
+    def __init__(self, store: Dict[str, str] | None = None) -> None:
+        """Initialize the service with an optional ``store``.
+
+        Args:
+            store: Mutable mapping used to retrieve user data. If ``None`` a new
+                dictionary is created.
+        """
+
+        self.store: Dict[str, str] = store if store is not None else {}
+
+    def get_user(self, query: UserQuery) -> Optional[str]:
+        """Return the user name for ``query.user_id`` if present."""
+
+        return self.store.get(query.user_id)
+
+
+__all__ = ["UserQueryService"]


### PR DESCRIPTION
## Summary
- add user command and query models to illustrate write vs read separation
- implement corresponding services dedicated to command and query operations
- cover basic CQRS flow with unit test

## Testing
- `pytest tests/services/test_user_cqrs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f751081dc8320bae0082d8ffe150d