### PR TITLE
Add performance benchmarks with thresholds

### DIFF
--- a/tests/performance/test_compliance_benchmarks.py
+++ b/tests/performance/test_compliance_benchmarks.py
@@ -7,6 +7,9 @@ import pandas as pd
 import pytest
 
 
+SCHEDULED_DELETIONS_THRESHOLD_SECONDS = 0.1
+
+
 def original_process(df: pd.DataFrame) -> int:
     processed = 0
     for _, row in df.iterrows():
@@ -55,3 +58,7 @@ def test_process_scheduled_deletions_benchmark():
 
     assert baseline == optimized
     assert optimized_duration <= original_duration
+    assert optimized_duration <= SCHEDULED_DELETIONS_THRESHOLD_SECONDS, (
+        f"Optimized processing took {optimized_duration:.4f}s, "
+        f"expected <= {SCHEDULED_DELETIONS_THRESHOLD_SECONDS}s"
+    )

--- a/tests/performance/test_event_processing.py
+++ b/tests/performance/test_event_processing.py
@@ -3,6 +3,8 @@ import time
 import uuid
 from datetime import datetime
 
+import pytest
+
 
 class PerformanceTestRunner:
     """Simple event processing performance benchmark."""
@@ -30,6 +32,21 @@ class PerformanceTestRunner:
         total = end - start
         print(f"Processed {self.num_events} events in {total:.2f} seconds")
         return total
+
+
+EVENT_PROCESSING_THRESHOLD_SECONDS = 0.2
+
+
+@pytest.mark.performance
+def test_event_processing_benchmark_threshold() -> None:
+    runner = PerformanceTestRunner(num_events=10000)
+    total = runner.run()
+    assert (
+        total <= EVENT_PROCESSING_THRESHOLD_SECONDS
+    ), (
+        f"Processing {runner.num_events} events took {total:.2f}s, "
+        f"exceeding threshold {EVENT_PROCESSING_THRESHOLD_SECONDS}s"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add threshold-based test for event-processing benchmark
- enforce max duration for scheduled deletion processing benchmark

## Testing
- `pytest tests/performance/test_compliance_benchmarks.py tests/performance/test_event_processing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7518a7188320b87bda89fc4ab227