### PR TITLE
feat(graphql): cache analytics with DataLoader

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -5,8 +5,9 @@ This folder contains a lightweight GraphQL layer for the Yosai Intel Dashboard.
 `index.js` starts an Apollo Server instance backed by the existing REST API. It
 defines a basic schema for analytics data, resolves queries via `axios` calls to
 the REST endpoints and exposes a subscription example. `DataLoader` is used to
-batch requests when the same analytics data is requested multiple times during a
-single GraphQL operation. Query depth is limited to prevent expensive queries.
+batch and cache requests when the same analytics data is requested multiple
+times during a single GraphQL operation, ensuring each facility/time range pair
+is fetched only once. Query depth is limited to prevent expensive queries.
 
 Run the server locally with:
 


### PR DESCRIPTION
## Summary
- improve analytics GraphQL resolver with DataLoader caching
- document batching/caching in GraphQL README

## Testing
- `npm test` *(fails: Cannot find module 'yosai_intel_dashboard/src/adapters/ui/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688f7513520883209a077f7560af8977