### PR TITLE
feat: add zipkin tracing exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,9 +680,12 @@ Example Prometheus expressions:
 
 ### Tracing Setup
 
-All services use OpenTelemetry with Jaeger for distributed tracing. Set the
-`JAEGER_ENDPOINT` environment variable to the collector endpoint
-(`http://localhost:14268/api/traces` by default) before starting a service.
+All services use OpenTelemetry and can export traces to Jaeger or Zipkin.
+Select the backend by setting `TRACING_EXPORTER` to `jaeger` or `zipkin`
+(`jaeger` is the default). Configure the collector endpoint via
+`JAEGER_ENDPOINT` or `ZIPKIN_ENDPOINT` environment variables
+(`http://localhost:14268/api/traces` and `http://localhost:9411/api/v2/spans`
+by default).
 
 ```python
 from tracing import init_tracing
@@ -701,7 +704,10 @@ This ensures traces from Python and Go components are reported consistently.
 
 Set the following variables to configure tracing and metrics endpoints:
 
-- `JAEGER_ENDPOINT` – URL of the Jaeger collector (defaults to `http://localhost:14268/api/traces`).
+- `TRACING_EXPORTER` – `jaeger` or `zipkin` (defaults to `jaeger`).
+- `JAEGER_ENDPOINT` / `ZIPKIN_ENDPOINT` – URL of the respective collector
+  (defaults to `http://localhost:14268/api/traces` and
+  `http://localhost:9411/api/v2/spans`).
 - `REPLICATION_METRICS_PORT` – Port used by `scripts/replicate_to_timescale.py` to expose Prometheus metrics (defaults to `8004`).
 - All services expose Prometheus metrics at the `/metrics` endpoint. No additional configuration is required.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,15 +42,16 @@ With these variables set, a log line looks similar to the following:
 
 ## Viewing Traces
 
-1. Launch the Jaeger all-in-one image (already included in
+1. Launch the Jaeger all-in-one image or a Zipkin server (both included in
    `docker-compose.dev.yml`):
    ```bash
-   docker-compose -f docker-compose.dev.yml up jaeger
+   docker-compose -f docker-compose.dev.yml up jaeger # or zipkin
    ```
-2. Open the Jaeger UI at [http://localhost:16686](http://localhost:16686) and
-   select the desired service from the dropdown.
-3. Spans from all services will appear when the `JAEGER_ENDPOINT` environment
-   variable points to the collector (defaults to
-   `http://localhost:14268/api/traces`).
+2. Open the Jaeger UI at [http://localhost:16686](http://localhost:16686) or the
+   Zipkin UI at [http://localhost:9411](http://localhost:9411) and select the
+   desired service.
+3. Spans from all services will appear when `TRACING_EXPORTER` is set to
+   `jaeger` or `zipkin` and the matching `JAEGER_ENDPOINT` or `ZIPKIN_ENDPOINT`
+   points to the collector (defaults to the standard localhost ports).
 
 This setup lets you correlate logs with traces to debug issues across services.

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -204,10 +204,12 @@ Adjust the `elasticsearch` output section if you have a different destination.
 
 ### Distributed Tracing
 
-All services export OpenTelemetry traces to Jaeger. Set the `JAEGER_ENDPOINT`
-environment variable to the collector URL (`http://localhost:14268/api/traces`
-by default). Invoke `init_tracing("analytics-microservice")` during startup of
-the analytics microservice so spans are reported correctly.
+All services export OpenTelemetry traces to Jaeger or Zipkin. Choose the backend
+with the `TRACING_EXPORTER` environment variable (`jaeger` by default) and set
+`JAEGER_ENDPOINT` or `ZIPKIN_ENDPOINT` to the collector URL (defaults are
+`http://localhost:14268/api/traces` and `http://localhost:9411/api/v2/spans`).
+Invoke `init_tracing("analytics-microservice")` during startup so spans are
+reported correctly.
 
 See [Observability Guide](observability.md) for instructions on viewing logs and traces.
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.22.0
-	github.com/rabbitmq/amqp091-go v1.5.0
+	github.com/rabbitmq/amqp091-go v1.8.1
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/riferrei/srclient v0.7.3
 	github.com/sirupsen/logrus v1.9.3
@@ -27,6 +27,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
+	go.opentelemetry.io/otel/exporters/zipkin v1.17.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	golang.org/x/time v0.8.0
@@ -66,6 +67,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/openzipkin/zipkin-go v0.4.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -263,6 +263,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nrwiersma/avro-benchmarks v0.0.0-20210913175520-21aec48c8f76/go.mod h1:iKyFMidsk/sVYONJRE372sJuX/QTRPacU7imPqqsu7g=
+github.com/openzipkin/zipkin-go v0.4.2 h1:zjqfqHjUpPmB3c1GlCvvgsM1G4LkvqQbBDueDOCg/jA=
+github.com/openzipkin/zipkin-go v0.4.2/go.mod h1:ZeVkFjuuBiSy13y8vpSDCjMi9GoI3hPpCJSBx/EYFhY=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -300,8 +302,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
-github.com/rabbitmq/amqp091-go v1.5.0 h1:VouyHPBu1CrKyJVfteGknGOGCzmOz0zcv/tONLkb7rg=
-github.com/rabbitmq/amqp091-go v1.5.0/go.mod h1:JsV0ofX5f1nwOGafb8L5rBItt9GyhfQfcJj+oyz0dGg=
+github.com/rabbitmq/amqp091-go v1.8.1 h1:RejT1SBUim5doqcL6s7iN6SBmsQqyTgXb1xMlH0h1hA=
+github.com/rabbitmq/amqp091-go v1.8.1/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
 github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
 github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/riferrei/srclient v0.7.3 h1:JRR6jgfINWUcYZhBRHEg/NAFv7giVmjkoouRbWbakgw=
@@ -341,6 +343,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -353,7 +356,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -362,6 +364,8 @@ go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=
 go.opentelemetry.io/otel v1.37.0/go.mod h1:ehE/umFRLnuLa/vSccNq9oS1ErUlkkK71gMcN34UG8I=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0 h1:D7UpUy2Xc2wsi1Ras6V40q806WM07rqoCWzXu7Sqy+4=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0/go.mod h1:nPCqOnEH9rNLKqH/+rrUjiMzHJdV1BlpKcTwRTyKkKI=
+go.opentelemetry.io/otel/exporters/zipkin v1.17.0 h1:oi5+xMN3pflqWSd4EX6FiO+Cn3KbFBBzeQmD5LMIf0c=
+go.opentelemetry.io/otel/exporters/zipkin v1.17.0/go.mod h1:pNir+S6/f0HFGfbXhobXLTFu60KtAzw8aGSUpt9A6VU=
 go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/WgbsdpcPoZE=
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/sdk v1.37.0 h1:ItB0QUqnjesGRvNcmAcU0LyvkVyGJ2xftD29bWdDvKI=
@@ -369,7 +373,7 @@ go.opentelemetry.io/otel/sdk v1.37.0/go.mod h1:VredYzxUvuo2q3WRcDnKDjbdvmO0sCzOv
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
@@ -388,9 +392,7 @@ golang.org/x/exp v0.0.0-20250718183923-645b1fa84792/go.mod h1:A+z0yzpGtvnG90cToK
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -468,7 +470,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/gateway/internal/tracing/tracing.go
+++ b/gateway/internal/tracing/tracing.go
@@ -3,21 +3,26 @@ package tracing
 import (
         "context"
         "os"
+        "strings"
 
         "go.opentelemetry.io/otel"
         "go.opentelemetry.io/otel/exporters/jaeger"
+        zipkin "go.opentelemetry.io/otel/exporters/zipkin"
         "go.opentelemetry.io/otel/propagation"
         "go.opentelemetry.io/otel/trace"
         sdkresource "go.opentelemetry.io/otel/sdk/resource"
         sdktrace "go.opentelemetry.io/otel/sdk/trace"
         semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/sirupsen/logrus"
+        "github.com/sirupsen/logrus"
 )
 
 const (
+        ExporterEnv           = "TRACING_EXPORTER"
         JaegerEndpointEnv     = "JAEGER_ENDPOINT"
+        ZipkinEndpointEnv     = "ZIPKIN_ENDPOINT"
         DefaultJaegerEndpoint = "http://localhost:14268/api/traces"
+        DefaultZipkinEndpoint = "http://localhost:9411/api/v2/spans"
         ServiceVersionEnv     = "SERVICE_VERSION"
         EnvironmentEnv        = "APP_ENV"
 )
@@ -51,13 +56,31 @@ func (f *traceFormatter) Format(entry *logrus.Entry) ([]byte, error) {
         return f.JSONFormatter.Format(entry)
 }
 
-// InitTracing configures OpenTelemetry with a Jaeger exporter and returns
+// InitTracing configures OpenTelemetry with a Jaeger or Zipkin exporter and returns
 // a shutdown function to flush spans.
 func InitTracing(name string) (func(context.Context) error, error) {
         serviceName = name
-        endpoint := os.Getenv(JaegerEndpointEnv)
-        if endpoint == "" {
-                endpoint = DefaultJaegerEndpoint
+        exporter := strings.ToLower(os.Getenv(ExporterEnv))
+        var (
+                endpoint string
+                err error
+                exp sdktrace.SpanExporter
+        )
+        if exporter == "zipkin" {
+                endpoint = os.Getenv(ZipkinEndpointEnv)
+                if endpoint == "" {
+                        endpoint = DefaultZipkinEndpoint
+                }
+                exp, err = zipkin.New(endpoint)
+        } else {
+                endpoint = os.Getenv(JaegerEndpointEnv)
+                if endpoint == "" {
+                        endpoint = DefaultJaegerEndpoint
+                }
+                exp, err = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
+        }
+        if err != nil {
+                return nil, err
         }
         serviceVersion = os.Getenv(ServiceVersionEnv)
         if serviceVersion == "" {
@@ -67,17 +90,13 @@ func InitTracing(name string) (func(context.Context) error, error) {
         if serviceEnvironment == "" {
                 serviceEnvironment = "development"
         }
-        exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
-        if err != nil {
-                return nil, err
-        }
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exp),
-		sdktrace.WithResource(sdkresource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
-		)),
-	)
+        tp := sdktrace.NewTracerProvider(
+                sdktrace.WithBatcher(exp),
+                sdktrace.WithResource(sdkresource.NewWithAttributes(
+                        semconv.SchemaURL,
+                        semconv.ServiceName(serviceName),
+                )),
+        )
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -236,6 +236,12 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
+opentelemetry-exporter-zipkin==1.21.0
+    # via -r requirements.txt
+opentelemetry-exporter-zipkin-json==1.21.0
+    # via opentelemetry-exporter-zipkin
+opentelemetry-exporter-zipkin-proto-http==1.21.0
+    # via opentelemetry-exporter-zipkin
 opentelemetry-sdk==1.35.0
     # via
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ fastapi==0.116.1
 opentelemetry-api==1.35.0
 opentelemetry-sdk==1.35.0
 opentelemetry-exporter-jaeger==1.21.0
+opentelemetry-exporter-zipkin==1.21.0
 pika==1.3.2
 boto3==1.34.103
 

--- a/tracing/__init__.py
+++ b/tracing/__init__.py
@@ -6,17 +6,31 @@ import structlog
 from opentelemetry import context as ot_context
 from opentelemetry import propagate, trace
 from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.zipkin.json import ZipkinExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import get_current_span
 
-from .config import DEFAULT_JAEGER_ENDPOINT, JAEGER_ENDPOINT_ENV
+from .config import (
+    DEFAULT_JAEGER_ENDPOINT,
+    DEFAULT_TRACING_EXPORTER,
+    DEFAULT_ZIPKIN_ENDPOINT,
+    JAEGER_ENDPOINT_ENV,
+    TRACING_EXPORTER_ENV,
+    ZIPKIN_ENDPOINT_ENV,
+)
 
 
 def init_tracing(service_name: str) -> None:
-    endpoint = os.getenv(JAEGER_ENDPOINT_ENV, DEFAULT_JAEGER_ENDPOINT)
-    exporter = JaegerExporter(collector_endpoint=endpoint)
+    exporter_type = os.getenv(TRACING_EXPORTER_ENV, DEFAULT_TRACING_EXPORTER).lower()
+    if exporter_type == "zipkin":
+        endpoint = os.getenv(ZIPKIN_ENDPOINT_ENV, DEFAULT_ZIPKIN_ENDPOINT)
+        exporter = ZipkinExporter(endpoint=endpoint)
+    else:
+        endpoint = os.getenv(JAEGER_ENDPOINT_ENV, DEFAULT_JAEGER_ENDPOINT)
+        exporter = JaegerExporter(collector_endpoint=endpoint)
+
     provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)

--- a/tracing/config.py
+++ b/tracing/config.py
@@ -1,2 +1,10 @@
+"""Configuration constants for tracing backends."""
+
+TRACING_EXPORTER_ENV = "TRACING_EXPORTER"
+DEFAULT_TRACING_EXPORTER = "jaeger"
+
 JAEGER_ENDPOINT_ENV = "JAEGER_ENDPOINT"
 DEFAULT_JAEGER_ENDPOINT = "http://localhost:14268/api/traces"
+
+ZIPKIN_ENDPOINT_ENV = "ZIPKIN_ENDPOINT"
+DEFAULT_ZIPKIN_ENDPOINT = "http://localhost:9411/api/v2/spans"

--- a/yosai_framework/config.py
+++ b/yosai_framework/config.py
@@ -17,6 +17,7 @@ class ServiceConfig:
     log_level: str = "INFO"
     metrics_addr: str = ""
     tracing_endpoint: str = ""
+    tracing_exporter: str = "jaeger"
     enable_profiling: bool = False
 
 
@@ -40,6 +41,7 @@ def load_config(path: str) -> ServiceConfig:
             log_level=cfg.log_level,
             metrics_addr=cfg.metrics_addr,
             tracing_endpoint=cfg.tracing_endpoint,
+            tracing_exporter=cfg.tracing_exporter,
         )
     )
     if errors:

--- a/yosai_intel_dashboard/src/infrastructure/config/service.schema.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/service.schema.yaml
@@ -9,6 +9,9 @@ properties:
     type: string
   tracing_endpoint:
     type: string
+  tracing_exporter:
+    type: string
+    default: jaeger
   enable_profiling:
     type: boolean
     default: false

--- a/yosai_intel_dashboard/src/infrastructure/config/validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/validator.py
@@ -10,6 +10,7 @@ class YosaiConfig:
     log_level: str = "INFO"
     metrics_addr: str = ""
     tracing_endpoint: str = ""
+    tracing_exporter: str = "jaeger"
 
 
 class ConfigValidator:
@@ -40,6 +41,9 @@ class ConfigValidator:
             ("http://", "https://")
         ):
             errors.append("tracing_endpoint must start with http:// or https://")
+
+        if cfg.tracing_exporter.lower() not in {"jaeger", "zipkin"}:
+            errors.append("tracing_exporter must be 'jaeger' or 'zipkin'")
 
         if cfg.metrics_addr and cfg.metrics_addr == cfg.tracing_endpoint:
             errors.append("metrics_addr and tracing_endpoint must differ")


### PR DESCRIPTION
## Summary
- allow choosing Jaeger or Zipkin tracing exporter via `TRACING_EXPORTER`
- enable Zipkin support for BaseService and gateway tracing
- document tracing exporter options and endpoints

## Testing
- `python - <<'PY'
import sys, requests, structlog, pytest
import tests.config
sys.modules['requests'] = requests
sys.modules['structlog'] = structlog
sys.exit(pytest.main(['tests/test_yosai_framework_service.py']))
PY`
- `cd gateway && go test ./internal/tracing >/tmp/go-test.log && tail -n 20 /tmp/go-test.log`

------
https://chatgpt.com/codex/tasks/task_e_688f751446b0832092cc28c7c8658cb6