### PR TITLE
Implement graph ETL pipeline with Kafka streaming

### DIFF
--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/__init__.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/__init__.py
@@ -1,0 +1,16 @@
+"""Core modules for intel analysis service.
+
+Provides ETL pipeline, entity resolution, versioning, and streaming utilities.
+"""
+
+from .graph_entity_resolution import EntityResolver
+from .graph_etl_pipeline import GraphETLPipeline
+from .graph_versioning import GraphVersioner
+from .streaming import KafkaETLConsumer
+
+__all__ = [
+    "GraphETLPipeline",
+    "EntityResolver",
+    "GraphVersioner",
+    "KafkaETLConsumer",
+]

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_entity_resolution.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_entity_resolution.py
@@ -1,0 +1,33 @@
+"""Simple entity resolution for graph nodes.
+
+Nodes with the same ``name`` property are merged together. A confidence score is
+maintained and aliases for merged identifiers are recorded.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .graph_models import NodeMutation
+
+
+class EntityResolver:
+    """Resolve duplicate entities in a list of :class:`NodeMutation` objects."""
+
+    def resolve(self, nodes: List[NodeMutation]) -> List[NodeMutation]:
+        merged: Dict[str, NodeMutation] = {}
+        for node in nodes:
+            key = node.properties.get("name") or node.node_id
+            if key in merged:
+                existing = merged[key]
+                aliases = existing.properties.setdefault("aliases", [existing.node_id])
+                aliases.append(node.node_id)
+                existing.properties.update(node.properties)
+                existing.properties["confidence"] = min(
+                    1.0, existing.properties.get("confidence", 0.8) + 0.1
+                )
+            else:
+                props = dict(node.properties)
+                props["confidence"] = 0.8
+                merged[key] = NodeMutation(node.node_id, props, node.version)
+        return list(merged.values())

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_etl_pipeline.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_etl_pipeline.py
@@ -1,0 +1,58 @@
+"""ETL pipeline that converts access logs into graph mutations."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .graph_entity_resolution import EntityResolver
+from .graph_models import EdgeMutation, NodeMutation
+from .graph_versioning import GraphVersioner
+
+
+class GraphETLPipeline:
+    """Parse access logs and emit node/edge mutations with versioning."""
+
+    def __init__(
+        self,
+        resolver: EntityResolver | None = None,
+        versioner: GraphVersioner | None = None,
+    ) -> None:
+        self.resolver = resolver or EntityResolver()
+        self.versioner = versioner or GraphVersioner()
+
+    def parse_log_line(
+        self, line: str
+    ) -> tuple[List[NodeMutation], List[EdgeMutation]]:
+        """Parse a single access log line.
+
+        Expected format: ``timestamp,actor,target,action``.
+        """
+
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) != 4:
+            raise ValueError(
+                "log line must have 4 comma-separated values:"
+                " timestamp,actor,target,action"
+            )
+        timestamp, actor, target, action = parts
+        nodes = [
+            NodeMutation(actor, {"type": "actor", "name": actor}),
+            NodeMutation(target, {"type": "target", "name": target}),
+        ]
+        edge_props = {"action": action, "timestamp": timestamp}
+        edges = [EdgeMutation(actor, target, edge_props)]
+        return nodes, edges
+
+    def process_logs(self, logs: Iterable[str]):
+        """Process an iterable of raw log lines and return a snapshot."""
+
+        nodes: List[NodeMutation] = []
+        edges: List[EdgeMutation] = []
+        for line in logs:
+            n, e = self.parse_log_line(line)
+            nodes.extend(n)
+            edges.extend(e)
+        resolved_nodes = self.resolver.resolve(nodes)
+        versioned_nodes = self.versioner.version_nodes(resolved_nodes)
+        versioned_edges = self.versioner.version_edges(edges)
+        return self.versioner.snapshot(versioned_nodes, versioned_edges)

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_models.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_models.py
@@ -1,0 +1,25 @@
+"""Data models for graph mutations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NodeMutation:
+    """Represents a mutation to a graph node."""
+
+    node_id: str
+    properties: Dict[str, Any]
+    version: int = 0
+
+
+@dataclass
+class EdgeMutation:
+    """Represents a mutation to a graph edge."""
+
+    source: str
+    target: str
+    properties: Dict[str, Any]
+    version: int = 0

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_versioning.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_versioning.py
@@ -1,0 +1,39 @@
+"""Graph versioning helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from .graph_models import EdgeMutation, NodeMutation
+
+
+class GraphVersioner:
+    """Assign incremental versions to graph mutations and produce snapshots."""
+
+    def __init__(self) -> None:
+        self._node_version = 0
+        self._edge_version = 0
+
+    def version_nodes(self, nodes: List[NodeMutation]) -> List[NodeMutation]:
+        for node in nodes:
+            self._node_version += 1
+            node.version = self._node_version
+        return nodes
+
+    def version_edges(self, edges: List[EdgeMutation]) -> List[EdgeMutation]:
+        for edge in edges:
+            self._edge_version += 1
+            edge.version = self._edge_version
+        return edges
+
+    def snapshot(
+        self, nodes: List[NodeMutation], edges: List[EdgeMutation]
+    ) -> Dict[str, Any]:
+        """Return a serialisable snapshot of the current graph state."""
+
+        return {
+            "timestamp": datetime.utcnow().isoformat(),
+            "nodes": [node.__dict__ for node in nodes],
+            "edges": [edge.__dict__ for edge in edges],
+        }

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/streaming.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/streaming.py
@@ -1,0 +1,51 @@
+"""Kafka consumer integration for incremental graph updates."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+from .graph_etl_pipeline import GraphETLPipeline
+
+
+class KafkaETLConsumer:
+    """Consume access logs from Kafka and feed them into the ETL pipeline."""
+
+    def __init__(
+        self,
+        config: dict,
+        topics: Iterable[str],
+        pipeline: GraphETLPipeline,
+        consumer: Optional[object] = None,
+    ) -> None:
+        if consumer is None:
+            from confluent_kafka import Consumer  # type: ignore
+
+            consumer = Consumer(config)
+        consumer.subscribe(list(topics))
+        self.consumer = consumer
+        self.pipeline = pipeline
+
+    def run(
+        self,
+        handler: Callable[[dict], None],
+        timeout: float = 1.0,
+        max_messages: int | None = None,
+    ) -> None:
+        """Poll Kafka and process messages.
+
+        ``handler`` is called with the snapshot returned by the pipeline for each
+        message. ``max_messages`` can be used to limit the number of processed
+        messages (useful for testing).
+        """
+
+        processed = 0
+        while True:
+            if max_messages is not None and processed >= max_messages:
+                break
+            message = self.consumer.poll(timeout)
+            if message is None or getattr(message, "error", lambda: None)():
+                continue
+            log_line = message.value().decode("utf-8")
+            snapshot = self.pipeline.process_logs([log_line])
+            handler(snapshot)
+            processed += 1

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_entity_resolution.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_entity_resolution.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.graph_entity_resolution import EntityResolver  # noqa: E402
+from core.graph_models import NodeMutation  # noqa: E402
+
+
+def test_entity_resolution_merges_nodes():
+    resolver = EntityResolver()
+    nodes = [
+        NodeMutation("1", {"name": "alice"}),
+        NodeMutation("2", {"name": "alice"}),
+    ]
+    resolved = resolver.resolve(nodes)
+    assert len(resolved) == 1
+    node = resolved[0]
+    assert set(node.properties["aliases"]) == {"1", "2"}
+    assert node.properties["confidence"] > 0.8

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_graph_etl_pipeline.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_graph_etl_pipeline.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.graph_etl_pipeline import GraphETLPipeline  # noqa: E402
+
+
+def test_pipeline_generates_versioned_snapshot():
+    pipeline = GraphETLPipeline()
+    logs = ["2024-01-01T00:00:00Z,alice,bob,LOGIN"]
+    snapshot = pipeline.process_logs(logs)
+    assert snapshot["nodes"][0]["version"] == 1
+    assert snapshot["edges"][0]["version"] == 1

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_streaming.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_streaming.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.graph_etl_pipeline import GraphETLPipeline  # noqa: E402
+from core.streaming import KafkaETLConsumer  # noqa: E402
+
+
+class DummyMessage:
+    def __init__(self, value: bytes):
+        self._value = value
+
+    def error(self):
+        return None
+
+    def value(self):
+        return self._value
+
+
+class DummyConsumer:
+    def __init__(self, message: DummyMessage):
+        self._message = message
+        self.subscribed = False
+
+    def subscribe(self, topics):
+        self.subscribed = True
+
+    def poll(self, timeout):
+        msg, self._message = self._message, None
+        return msg
+
+
+def test_streaming_processes_message():
+    pipeline = GraphETLPipeline()
+    msg = DummyMessage(b"2024-01-01T00:00:00Z,alice,bob,LOGIN")
+    dummy_consumer = DummyConsumer(msg)
+    kafka_consumer = KafkaETLConsumer({}, ["logs"], pipeline, consumer=dummy_consumer)
+    snapshots = []
+    kafka_consumer.run(snapshots.append, max_messages=1)
+    assert snapshots and snapshots[0]["nodes"]


### PR DESCRIPTION
## Summary
- add ETL pipeline to turn access logs into versioned graph snapshots
- integrate Kafka consumer for incremental log processing
- provide entity resolution and graph versioning helpers

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/intel_analysis_service/core/__init__.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_models.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_entity_resolution.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_versioning.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_etl_pipeline.py yosai_intel_dashboard/src/services/intel_analysis_service/core/streaming.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_graph_etl_pipeline.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_entity_resolution.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_streaming.py` (fails: mypy errors outside changed files; bandit interrupted)
- `SKIP=mypy,bandit pre-commit run --files yosai_intel_dashboard/src/services/intel_analysis_service/core/__init__.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_models.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_entity_resolution.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_versioning.py yosai_intel_dashboard/src/services/intel_analysis_service/core/graph_etl_pipeline.py yosai_intel_dashboard/src/services/intel_analysis_service/core/streaming.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_graph_etl_pipeline.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_entity_resolution.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_streaming.py`
- `pytest yosai_intel_dashboard/src/services/intel_analysis_service/tests` (fails: No module named 'scipy')

------
https://chatgpt.com/codex/tasks/task_e_688f7e83fc708320a676e692c1b6ac21