### PR TITLE
chore: drop `__future__.annotations` imports

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 import os

--- a/scripts/callback_graph.py
+++ b/scripts/callback_graph.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Generate a GraphViz diagram of registered Dash callbacks."""
 
-from __future__ import annotations
-
 import os
 
 from dash import Dash
@@ -10,7 +8,6 @@ from graphviz import Digraph
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.services.upload.callbacks import UploadCallbacks
-
 
 def load_callbacks() -> TrulyUnifiedCallbacks:
     """Create app, register callbacks and return coordinator."""

--- a/scripts/generate_dev_secrets.py
+++ b/scripts/generate_dev_secrets.py
@@ -3,12 +3,10 @@
 
 Writes the values to an env file rather than printing them to stdout.
 """
-from __future__ import annotations
 
 import argparse
 import logging
 import secrets
-
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate development secrets")


### PR DESCRIPTION
## Summary
- remove deprecated `from __future__ import annotations` from run script and helper utilities

## Testing
- `python -m py_compile run_api.py scripts/callback_graph.py scripts/generate_dev_secrets.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688f7ec1c22c8320b9de85b91b1a1f24