### PR TITLE
Use Path.open with utf-8 in update_docs

### DIFF
--- a/update_docs.py
+++ b/update_docs.py
@@ -40,7 +40,7 @@ for file_path in doc_files:
 
     print(f"Updating {file_path}...")
 
-    with open(file_path, "r") as f:
+    with Path(file_path).open("r", encoding="utf-8") as f:
         content = f.read()
 
     original_content = content
@@ -58,7 +58,7 @@ for file_path in doc_files:
             )
             content = note + content
 
-    with open(file_path, "w") as f:
+    with Path(file_path).open("w", encoding="utf-8") as f:
         f.write(content)
 
     print(f"  ✓ Updated {file_path}")


### PR DESCRIPTION
## Summary
- ensure update_docs.py reads and writes files via Path.open with UTF-8 encoding

## Testing
- `python -m py_compile update_docs.py`
- `pytest -k update_docs -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688f7ec3f9508320bc8d28540c3f6108