### PR TITLE
Add security middleware and request signing

### DIFF
--- a/middleware/__init__.py
+++ b/middleware/__init__.py
@@ -1,0 +1,18 @@
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "TimingMiddleware",
+    "RateLimitMiddleware",
+    "SecurityHeadersMiddleware",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "TimingMiddleware":
+        return import_module("middleware.performance").TimingMiddleware
+    if name == "RateLimitMiddleware":
+        return import_module("middleware.rate_limit").RateLimitMiddleware
+    if name == "SecurityHeadersMiddleware":
+        return import_module("middleware.security_headers").SecurityHeadersMiddleware
+    raise AttributeError(name)

--- a/middleware/security_headers.py
+++ b/middleware/security_headers.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add common security headers to each response."""
+
+    def __init__(self, app, csp: str | None = None) -> None:
+        super().__init__(app)
+        self.csp = csp or "default-src 'self'"
+        self.hsts = "max-age=63072000; includeSubDomains; preload"
+        self.frame_options = "DENY"
+        self.content_type_options = "nosniff"
+        self.referrer_policy = "no-referrer"
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault("Content-Security-Policy", self.csp)
+        response.headers.setdefault("Strict-Transport-Security", self.hsts)
+        response.headers.setdefault("X-Frame-Options", self.frame_options)
+        response.headers.setdefault("X-Content-Type-Options", self.content_type_options)
+        response.headers.setdefault("Referrer-Policy", self.referrer_policy)
+        return response

--- a/nginx/dev_gateway.conf
+++ b/nginx/dev_gateway.conf
@@ -9,6 +9,14 @@ http {
 
     server {
         listen 80;
+        add_header Content-Security-Policy "default-src 'self'";
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+        add_header Referrer-Policy "no-referrer";
+        add_header Access-Control-Allow-Origin https://example.com;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+        add_header Access-Control-Allow-Headers "Authorization,Content-Type";
 
         location / {
             proxy_pass http://dashboard;

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -23,13 +23,17 @@ pid /var/run/nginx.pid;
         # Paths are provided via environment variables and expanded at runtime
         ssl_certificate ${SSL_CERT_PATH};
         ssl_certificate_key ${SSL_KEY_PATH};
-         ssl_protocols TLSv1.3;
+        ssl_protocols TLSv1.3;
 
-         # Security headers
-         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-         add_header X-Frame-Options DENY;
-         add_header X-Content-Type-Options nosniff;
-         add_header X-XSS-Protection "1; mode=block";
+        # Security headers
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header Content-Security-Policy "default-src 'self'" always;
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Access-Control-Allow-Origin https://example.com;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+        add_header Access-Control-Allow-Headers "Authorization,Content-Type";
 
          location /health {
              proxy_pass http://dashboard/health;

--- a/shared/http_client.py
+++ b/shared/http_client.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import hashlib
+
+import requests
+
+
+def create_pinned_session(fingerprint: str) -> requests.Session:
+    fp = fingerprint.lower().replace(":", "")
+    session = requests.Session()
+
+    def _check_cert(response, *args, **kwargs):
+        cert_bin = response.raw.connection.sock.getpeercert(binary_form=True)
+        actual = hashlib.sha256(cert_bin).hexdigest()
+        if actual.lower() != fp:
+            raise requests.exceptions.SSLError("certificate fingerprint mismatch")
+        return response
+
+    session.hooks.setdefault("response", []).append(_check_cert)
+    return session

--- a/shared/request_signing.py
+++ b/shared/request_signing.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Any, Dict
+
+HEADER_SIGNATURE = "X-Signature"
+HEADER_TIMESTAMP = "X-Signature-Timestamp"
+
+
+def _canonical_string(method: str, path: str, body: bytes, timestamp: str) -> bytes:
+    return b"\n".join([
+        method.upper().encode(),
+        path.encode(),
+        timestamp.encode(),
+        hashlib.sha256(body).hexdigest().encode(),
+    ])
+
+
+def sign_request(secret: str | bytes, method: str, path: str, body: bytes) -> Dict[str, str]:
+    """Return headers containing an HMAC signature for the request."""
+    if isinstance(secret, str):
+        secret_bytes = secret.encode()
+    else:
+        secret_bytes = secret
+    timestamp = str(int(time.time()))
+    msg = _canonical_string(method, path, body, timestamp)
+    sig = hmac.new(secret_bytes, msg, hashlib.sha256).digest()
+    b64 = base64.b64encode(sig).decode()
+    return {HEADER_SIGNATURE: b64, HEADER_TIMESTAMP: timestamp}
+
+
+def verify_request(secret: str | bytes, method: str, path: str, body: bytes, headers: Dict[str, str], max_skew: int = 300) -> bool:
+    """Verify HMAC signature from ``headers``.
+
+    ``max_skew`` specifies the maximum allowed clock skew in seconds.
+    """
+    signature = headers.get(HEADER_SIGNATURE)
+    timestamp = headers.get(HEADER_TIMESTAMP)
+    if not signature or not timestamp:
+        return False
+    if abs(int(time.time()) - int(timestamp)) > max_skew:
+        return False
+    expected = sign_request(secret, method, path, body)
+    return hmac.compare_digest(signature, expected[HEADER_SIGNATURE])

--- a/tests/middleware/test_security_headers.py
+++ b/tests/middleware/test_security_headers.py
@@ -1,0 +1,38 @@
+import types
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+from middleware.security_headers import SecurityHeadersMiddleware
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def create_app():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/")
+    def _root():
+        return {"ok": True}
+
+    return app
+
+
+async def test_security_headers_present():
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/")
+    assert resp.headers["Content-Security-Policy"] == "default-src 'self'"
+    assert resp.headers["Strict-Transport-Security"]
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["Referrer-Policy"] == "no-referrer"

--- a/tests/shared/test_certificate_pinning.py
+++ b/tests/shared/test_certificate_pinning.py
@@ -1,0 +1,49 @@
+import hashlib
+import importlib
+import sys
+import types
+
+import pytest
+
+# Ensure real requests package
+sys.modules.pop("requests", None)
+requests = importlib.import_module("requests")
+sys.modules["requests"] = requests
+
+from shared.http_client import create_pinned_session
+
+
+class DummySock:
+    def __init__(self, cert: bytes):
+        self._cert = cert
+
+    def getpeercert(self, binary_form=True):
+        return self._cert
+
+
+class DummyConn:
+    def __init__(self, sock):
+        self.sock = sock
+
+
+class DummyRaw:
+    def __init__(self, conn):
+        self.connection = conn
+
+
+def _call_hooks(session, raw):
+    resp = types.SimpleNamespace(raw=raw)
+    for hook in session.hooks["response"]:
+        hook(resp)
+
+
+def test_pinned_session_verifies_fingerprint():
+    cert = b"certdata"
+    fp = hashlib.sha256(cert).hexdigest()
+    raw = DummyRaw(DummyConn(DummySock(cert)))
+    session = create_pinned_session(fp)
+    _call_hooks(session, raw)
+
+    bad_session = create_pinned_session("00" * 32)
+    with pytest.raises(requests.exceptions.SSLError):
+        _call_hooks(bad_session, raw)

--- a/tests/shared/test_request_signing.py
+++ b/tests/shared/test_request_signing.py
@@ -1,0 +1,22 @@
+from shared.request_signing import sign_request, verify_request, HEADER_SIGNATURE, HEADER_TIMESTAMP
+
+
+def test_sign_and_verify_roundtrip(monkeypatch):
+    secret = "s3cr3t"
+    method = "POST"
+    path = "/test"
+    body = b"payload"
+
+    headers = sign_request(secret, method, path, body)
+    assert HEADER_SIGNATURE in headers and HEADER_TIMESTAMP in headers
+    assert verify_request(secret, method, path, body, headers)
+
+
+def test_verify_rejects_modified_body(monkeypatch):
+    secret = "s3cr3t"
+    method = "POST"
+    path = "/test"
+    body = b"payload"
+
+    headers = sign_request(secret, method, path, body)
+    assert not verify_request(secret, method, path, b"other", headers)

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -28,6 +28,7 @@ from api.monitoring_router import router as monitoring_router
 from api.routes.feature_flags import router as feature_flags_router
 from middleware.performance import TimingMiddleware
 from middleware.rate_limit import RateLimitMiddleware, RedisRateLimiter
+from middleware.security_headers import SecurityHeadersMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 from monitoring.request_metrics import (
     upload_file_bytes,
@@ -80,12 +81,13 @@ def create_api_app() -> "FastAPI":
     )
 
     settings = get_security_config()
+    service.app.add_middleware(SecurityHeadersMiddleware)
     service.app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type"],
     )
 
     # Initialize RBAC service

--- a/yosai_intel_dashboard/src/infrastructure/security/rasp_evaluation.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/rasp_evaluation.md
@@ -1,0 +1,13 @@
+# RASP / Application Firewall Evaluation
+
+The current codebase does not include a runtime application self-protection
+(RASP) or embedded web application firewall. Lightweight options such as
+[pyRASP](https://github.com) or wrapping the application with a WAF like
+[modsecurity] were evaluated.
+
+Given the deployment constraints, integrating a library that instruments
+Python bytecode dynamically (e.g. pyRASP) would introduce overhead and
+complexity. A pragmatic approach is to deploy Nginx with ModSecurity in front
+of the services to provide request filtering and anomaly detection while
+keeping the application layer lightweight. Further evaluation and benchmarking
+are recommended before full integration.


### PR DESCRIPTION
## Summary
- add middleware that sets CSP, HSTS, click-jacking, sniffing, referrer and CORS headers
- introduce HMAC request signing utilities and pinned certificate HTTP client
- update nginx configs and document RASP/WAF evaluation

## Testing
- `pytest tests/middleware/test_security_headers.py tests/shared/test_request_signing.py tests/shared/test_certificate_pinning.py`

------
https://chatgpt.com/codex/tasks/task_e_688f845035d083209202f76c41ccc981