### PR TITLE
Add security audit logger with SIEM streaming and CI scans

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,6 +53,12 @@ jobs:
           python-version: '3.11'
       - name: Run vulnerability scan
         run: python scripts/security_scan.py
+      - name: Run Bandit
+        run: bandit -r . -lll
+      - name: Run Safety
+        run: safety check --full-report --fail-on=high
+      - name: Scan JS dependencies
+        run: npm audit --audit-level=high
       - name: Scan for secrets
         run: python scripts/security_scan_secrets.py
       - name: Generate security report
@@ -115,6 +121,17 @@ jobs:
           name: snyk-results
           path: snyk-results.json
 
+  owasp-zap:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: OWASP ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.10.0
+        with:
+          target: 'http://localhost:8000'
+          fail_action: true
+
   secret-scan:
     needs: build-test
     runs-on: ubuntu-latest
@@ -135,7 +152,7 @@ jobs:
           path: secret-scan-report.json
 
   release:
-    needs: [trivy-scan, snyk-scan, security-scan]
+    needs: [trivy-scan, snyk-scan, security-scan, owasp-zap]
 
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/deployment/pentest-config.yaml
+++ b/deployment/pentest-config.yaml
@@ -1,0 +1,7 @@
+# Configuration overrides to support post-deployment penetration testing
+logging:
+  level: debug
+  enable_http_headers: true
+security:
+  rate_limit_per_minute: 1000  # relaxed for testing
+  allow_test_accounts: true

--- a/docs/pentest-guide.md
+++ b/docs/pentest-guide.md
@@ -1,0 +1,40 @@
+# Post-Deployment Penetration Testing Guide
+
+This guide outlines how to perform security testing against a deployed instance
+of the Yosai Intel Dashboard.
+
+## Configuration
+
+Use the provided configuration overrides in
+`deployment/pentest-config.yaml` to relax rate limits and enable verbose
+logging. Apply the configuration during deployment:
+
+```bash
+helm upgrade --install dashboard helm/chart -f deployment/pentest-config.yaml
+```
+
+## Recommended Tools
+
+1. **OWASP ZAP** – Automated scanning for common vulnerabilities.
+2. **Nmap** – Network mapping and service enumeration.
+3. **SQLMap** – Detect SQL injection flaws.
+4. **custom scripts** – Probe business logic and authorization paths.
+
+## Running Tests
+
+1. Ensure the environment is deployed with pentest configuration.
+2. Execute OWASP ZAP against the public endpoint:
+
+   ```bash
+   zap-baseline.py -t https://<host>/ -a -r zap-report.html
+   ```
+
+3. Run `npm audit` and `safety` against running services for dependency
+   issues.
+4. Report findings in a security ticket and rotate any credentials used
+   during the test.
+
+## Cleanup
+
+After testing, revert to the standard configuration to restore default
+security posture.

--- a/tests/security/test_audit_logger.py
+++ b/tests/security/test_audit_logger.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+# Stub heavy dependencies before importing the audit logger
+dummy_module = types.ModuleType("monitoring.anomaly_detector")
+
+
+class _StubAnomalyDetector:
+    def score(self, user_id, source_ip):
+        return 0.0, False
+
+
+dummy_module.AnomalyDetector = _StubAnomalyDetector
+sys.modules.setdefault("monitoring.anomaly_detector", dummy_module)
+
+siem_module = types.ModuleType("core.integrations.siem_connectors")
+
+
+def _noop_send(event, system):
+    pass
+
+
+siem_module.send_to_siem = _noop_send
+sys.modules.setdefault("core.integrations.siem_connectors", siem_module)
+
+module_path = (
+    Path(__file__).resolve().parents[2]
+    / "yosai_intel_dashboard/src/infrastructure/security/audit_logger.py"
+)
+spec = importlib.util.spec_from_file_location("audit_logger", module_path)
+audit_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader  # type: ignore[truthy-function]
+sys.modules["audit_logger"] = audit_module
+spec.loader.exec_module(audit_module)
+SecurityAuditLogger = audit_module.SecurityAuditLogger
+
+
+def test_security_audit_logger_appends_and_alerts(tmp_path, monkeypatch):
+    # capture SIEM events
+    events = []
+
+    def mock_send(event, system):
+        events.append((event, system))
+
+    monkeypatch.setattr(audit_module, "send_to_siem", mock_send)
+
+    notifications = []
+
+    class DummyAlertManager:
+        def _notify(self, message):
+            notifications.append(message)
+
+    class DummyDetector:
+        def score(self, user_id, source_ip):
+            return 0.0, True  # always anomaly
+
+    log_file = tmp_path / "audit.log"
+    logger = SecurityAuditLogger(
+        log_path=log_file,
+        alert_manager=DummyAlertManager(),
+        anomaly_detector=DummyDetector(),
+    )
+
+    logger.log_auth_event(
+        user_id="u1", action="login", success=False, source_ip="1.1.1.1"
+    )
+    logger.log_permission_event(
+        user_id="u1", permission="admin", granted=False, resource="/secure"
+    )
+
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 2
+    record = json.loads(lines[0])
+    assert record["type"] == "auth"
+    assert events[0][0]["type"] == "auth"
+    assert notifications, "Expected alert notification for anomaly"

--- a/yosai_intel_dashboard/src/infrastructure/security/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/__init__.py
@@ -7,6 +7,7 @@ All deprecated individual validators have been removed and consolidated.
 from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
 from .attack_detection import AttackDetection
+from .audit_logger import AuditEvent, SecurityAuditLogger
 from .secrets_validator import SecretsValidator, register_health_endpoint
 from .secure_query_wrapper import (
     execute_secure_command,
@@ -55,4 +56,6 @@ __all__ = [
     "register_health_endpoint",
     "execute_secure_sql",
     "execute_secure_command",
+    "SecurityAuditLogger",
+    "AuditEvent",
 ]

--- a/yosai_intel_dashboard/src/infrastructure/security/audit_logger.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/audit_logger.py
@@ -1,0 +1,121 @@
+"""Append-only audit logger for security events with SIEM streaming."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.integrations.siem_connectors import send_to_siem
+from monitoring.alerts import AlertManager
+from monitoring.anomaly_detector import AnomalyDetector
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    """Represents a security event captured by the audit logger."""
+
+    type: str
+    timestamp: str
+    details: Dict[str, Any]
+
+
+class SecurityAuditLogger:
+    """Append-only logger that streams events to SIEM and triggers alerts."""
+
+    def __init__(
+        self,
+        log_path: str | Path = "security_audit.log",
+        *,
+        siem_system: str = "elk",
+        alert_manager: Optional[AlertManager] = None,
+        anomaly_detector: Optional[AnomalyDetector] = None,
+    ) -> None:
+        self.log_path = Path(log_path)
+        self.siem_system = siem_system
+        self.alert_manager = alert_manager or AlertManager()
+        self.anomaly_detector = anomaly_detector or AnomalyDetector()
+
+    # ------------------------------------------------------------------
+    def _write_event(self, event: AuditEvent) -> None:
+        """Append *event* to log file and forward to SIEM/monitoring."""
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(asdict(event)) + "\n")
+
+        send_to_siem(asdict(event), self.siem_system)
+
+        user_id = event.details.get("user_id")
+        source_ip = event.details.get("source_ip")
+        _, is_anomaly = self.anomaly_detector.score(user_id, source_ip)
+        if is_anomaly:
+            # Real-time alert on anomalous event
+            message = f"Anomalous security event detected: {event.details}"
+            self.alert_manager._notify(message)  # pragma: no cover - alert side effect
+
+    # ------------------------------------------------------------------
+    def _create_event(self, event_type: str, details: Dict[str, Any]) -> AuditEvent:
+        return AuditEvent(
+            type=event_type,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            details=details,
+        )
+
+    # ------------------------------------------------------------------
+    def log_auth_event(
+        self,
+        *,
+        user_id: str,
+        action: str,
+        success: bool,
+        source_ip: Optional[str] = None,
+    ) -> None:
+        """Log authentication events such as logins."""
+        details = {
+            "user_id": user_id,
+            "action": action,
+            "success": success,
+            "source_ip": source_ip,
+        }
+        self._write_event(self._create_event("auth", details))
+
+    # ------------------------------------------------------------------
+    def log_permission_event(
+        self,
+        *,
+        user_id: str,
+        permission: str,
+        granted: bool,
+        resource: Optional[str] = None,
+    ) -> None:
+        """Log permission checks and changes."""
+        details = {
+            "user_id": user_id,
+            "permission": permission,
+            "granted": granted,
+            "resource": resource,
+        }
+        self._write_event(self._create_event("permission", details))
+
+    # ------------------------------------------------------------------
+    def log_data_access(
+        self,
+        *,
+        user_id: str,
+        resource: str,
+        action: str,
+        source_ip: Optional[str] = None,
+    ) -> None:
+        """Log data access events."""
+        details = {
+            "user_id": user_id,
+            "resource": resource,
+            "action": action,
+            "source_ip": source_ip,
+        }
+        self._write_event(self._create_event("data_access", details))
+
+
+__all__ = ["SecurityAuditLogger", "AuditEvent"]


### PR DESCRIPTION
## Summary
- implement append-only security audit logger that streams events to SIEM and alerts on anomalies
- extend CI pipeline with Bandit, Safety, npm audit, and OWASP ZAP
- add pentest configuration and guide for post-deployment testing

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/security/audit_logger.py yosai_intel_dashboard/src/infrastructure/security/__init__.py tests/security/test_audit_logger.py .github/workflows/pipeline.yml deployment/pentest-config.yaml docs/pentest-guide.md` *(fails: mypy - Incompatible types in assignment)*
- `pytest tests/security/test_audit_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_688f8451715883208d644a81987b9955