### PR TITLE
Add security documentation and compliance tooling

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/security/architecture.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/architecture.md
@@ -1,0 +1,20 @@
+# Security Architecture
+
+This document describes the system components, trust boundaries, and data flows.
+
+## Components
+- **API Gateway**: entry point for external clients enforcing authentication and rate limiting.
+- **Service Layer**: microservices handling business logic.
+- **Data Stores**: relational and document databases storing application data.
+- **Analytics Pipeline**: processes events and generates intelligence.
+
+## Trust Boundaries
+- Boundary between external clients and the API Gateway.
+- Segmentation between internal services and data stores.
+- Separate analytics environment for processing sensitive data.
+
+## Data Flows
+- Clients interact with the API Gateway over HTTPS.
+- Services communicate via authenticated internal network channels.
+- Data from services flows to data stores with encryption at rest and in transit.
+- Analytics pipeline consumes sanitized data and outputs reports to authorized users.

--- a/yosai_intel_dashboard/src/infrastructure/security/compliance/GDPR_checklist.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/compliance/GDPR_checklist.md
@@ -1,0 +1,8 @@
+# GDPR Compliance Checklist
+
+- [ ] Identify and document personal data processing activities.
+- [ ] Obtain explicit consent for data collection and processing.
+- [ ] Provide mechanisms for data subject access and deletion requests.
+- [ ] Implement data minimization and retention policies.
+- [ ] Ensure data portability and breach notification procedures.
+- [ ] Conduct regular privacy impact assessments.

--- a/yosai_intel_dashboard/src/infrastructure/security/compliance/SOC2_checklist.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/compliance/SOC2_checklist.md
@@ -1,0 +1,9 @@
+# SOC 2 Compliance Checklist
+
+- [ ] Define security policies and procedures.
+- [ ] Implement access controls and authentication.
+- [ ] Monitor system activity and maintain audit logs.
+- [ ] Enforce change management processes.
+- [ ] Perform regular vulnerability assessments.
+- [ ] Train employees on security responsibilities.
+- [ ] Prepare incident response and disaster recovery plans.

--- a/yosai_intel_dashboard/src/infrastructure/security/compliance/collect_evidence.sh
+++ b/yosai_intel_dashboard/src/infrastructure/security/compliance/collect_evidence.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Collects audit evidence such as configs, logs, and system information.
+set -e
+OUTPUT_DIR=${1:-evidence}
+mkdir -p "$OUTPUT_DIR"
+
+echo "Collecting system information..."
+uname -a > "$OUTPUT_DIR/system_info.txt"
+
+echo "Collecting running processes..."
+ps aux > "$OUTPUT_DIR/process_list.txt"
+
+echo "Collecting application logs..."
+if [ -d logs ]; then
+  cp -r logs "$OUTPUT_DIR"/
+fi
+
+echo "Archiving evidence..."
+tar -czf "$OUTPUT_DIR.tgz" "$OUTPUT_DIR"
+
+echo "Evidence collected in $OUTPUT_DIR.tgz"

--- a/yosai_intel_dashboard/src/infrastructure/security/compliance/data_flow_diagrams.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/compliance/data_flow_diagrams.md
@@ -1,0 +1,11 @@
+# Data Flow Diagrams
+
+```mermaid
+graph TD
+    Client[Client] -->|HTTPS| APIGateway[API Gateway]
+    APIGateway --> Services[Internal Services]
+    Services --> DB[(Databases)]
+    Services --> Analytics[Analytics Pipeline]
+```
+
+These diagrams illustrate high-level data movement for compliance audits.

--- a/yosai_intel_dashboard/src/infrastructure/security/incident_response.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/incident_response.md
@@ -1,0 +1,24 @@
+# Incident Response Plan
+
+This document outlines the procedures for responding to security incidents.
+
+## Detection
+- Monitor logs and alerts for suspicious activity.
+- Use intrusion detection systems and anomaly detection.
+
+## Containment
+- Isolate affected systems to prevent spread.
+- Disable compromised accounts or services.
+
+## Eradication
+- Remove malicious artifacts and patch vulnerabilities.
+- Validate system integrity before restoring services.
+
+## Recovery
+- Restore systems from clean backups.
+- Monitor closely for signs of re‑infection.
+
+## Communication
+- Notify the security team immediately and escalate as needed.
+- Provide status updates to stakeholders throughout the incident lifecycle.
+- Document lessons learned and update runbooks.

--- a/yosai_intel_dashboard/src/infrastructure/security/training.md
+++ b/yosai_intel_dashboard/src/infrastructure/security/training.md
@@ -1,0 +1,23 @@
+# Developer Security Training
+
+This training program introduces secure coding practices and the OWASP Top 10.
+
+## OWASP Top 10 Overview
+1. Injection
+2. Broken Authentication
+3. Sensitive Data Exposure
+4. XML External Entities (XXE)
+5. Broken Access Control
+6. Security Misconfiguration
+7. Cross-Site Scripting (XSS)
+8. Insecure Deserialization
+9. Using Components with Known Vulnerabilities
+10. Insufficient Logging & Monitoring
+
+## Secure Coding Practices
+- Validate and sanitize all inputs.
+- Use parameterized queries and ORM protections.
+- Enforce least privilege and role-based access control.
+- Store secrets securely and rotate regularly.
+- Log security-relevant events and monitor for anomalies.
+- Review code for security issues before merging.


### PR DESCRIPTION
## Summary
- document incident response process
- outline security architecture and trust boundaries
- add developer security training on OWASP Top 10
- provide compliance resources (SOC2/GDPR checklists, data flow diagrams, evidence collection script)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688f8452c5048320a246413d6bf28524