### PR TITLE
feat(security): add OAuth PKCE, RBAC, MFA and argon2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ pandas==2.1.4
 numpy==1.26.4
 Authlib==1.6.1
 python-jose==3.5.0
+argon2-cffi==23.1.0
+pyotp==2.9.0
 cssutils==2.8.0
 scipy==1.11.3
 scikit-learn==1.7.1

--- a/yosai_intel_dashboard/src/security/__init__.py
+++ b/yosai_intel_dashboard/src/security/__init__.py
@@ -1,0 +1,17 @@
+"""Security utilities including RBAC models and decorators."""
+
+from .roles import (
+    ROLES,
+    Role,
+    get_permissions_for_roles,
+    require_permission,
+    require_roles,
+)
+
+__all__ = [
+    "Role",
+    "ROLES",
+    "get_permissions_for_roles",
+    "require_permission",
+    "require_roles",
+]

--- a/yosai_intel_dashboard/src/security/roles.py
+++ b/yosai_intel_dashboard/src/security/roles.py
@@ -1,0 +1,67 @@
+"""Role based access control models and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import wraps
+from typing import Callable, Dict, List, Set
+
+from flask import abort, session
+
+
+@dataclass(frozen=True)
+class Role:
+    name: str
+    permissions: Set[str]
+
+
+ROLES: Dict[str, Role] = {
+    "admin": Role("admin", {"admin:read", "admin:write"}),
+    "user": Role("user", {"dashboard:view"}),
+}
+
+
+def get_permissions_for_roles(role_names: List[str]) -> Set[str]:
+    perms: Set[str] = set()
+    for name in role_names:
+        role = ROLES.get(name)
+        if role:
+            perms |= role.permissions
+    return perms
+
+
+def require_roles(*required: str) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            roles = set(session.get("roles", []))
+            if not roles.intersection(required):
+                abort(403)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_permission(permission: str) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            perms = set(session.get("permissions", []))
+            if permission not in perms:
+                abort(403)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = [
+    "Role",
+    "ROLES",
+    "get_permissions_for_roles",
+    "require_roles",
+    "require_permission",
+]


### PR DESCRIPTION
## Summary
- implement OAuth2/OIDC login using PKCE and issue short-lived JWTs with refresh support
- add RBAC roles with permission decorators and TOTP-based MFA for admin flows
- migrate password hashing to Argon2 and ensure session cookies are secure

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/auth.py yosai_intel_dashboard/src/security/__init__.py yosai_intel_dashboard/src/security/roles.py yosai_intel_dashboard/src/core/security.py requirements.txt tests/integration/test_auth_flow.py`
- `pytest tests/integration/test_auth_flow.py tests/integration/test_auth_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_688f844f1f00832097c7bfa29545d0c3