### PR TITLE
feat: add interactive timeline utilities

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/Timeline.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Timeline.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Brush,
+  ResponsiveContainer,
+} from 'recharts';
+
+export interface TimelineDatum {
+  time: string | number;
+  value: number;
+}
+
+interface TimelineProps {
+  data: TimelineDatum[];
+  onRangeChange?: (range: { start: TimelineDatum; end: TimelineDatum }) => void;
+}
+
+const Timeline: React.FC<TimelineProps> = ({ data, onRangeChange }) => {
+  const [range, setRange] = useState<{ startIndex: number; endIndex: number }>(
+    {
+      startIndex: 0,
+      endIndex: data.length - 1,
+    },
+  );
+
+  const handleBrushChange = (r: any) => {
+    if (!r) return;
+    const { startIndex, endIndex } = r;
+    setRange({ startIndex, endIndex });
+    if (onRangeChange) {
+      const start = data[startIndex];
+      const end = data[endIndex];
+      if (start && end) {
+        onRangeChange({ start, end });
+      }
+    }
+  };
+
+  return (
+    <div style={{ width: '100%', height: 300, touchAction: 'none' }}>
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" />
+          <Brush
+            dataKey="time"
+            startIndex={range.startIndex}
+            endIndex={range.endIndex}
+            onChange={handleBrushChange}
+            travellerWidth={12}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default Timeline;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ThresholdSlider.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ThresholdSlider.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface ThresholdSliderProps {
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+const ThresholdSlider: React.FC<ThresholdSliderProps> = ({
+  value,
+  min = 0,
+  max = 100,
+  step = 1,
+  onChange,
+}) => (
+  <div className="flex flex-col space-y-2" style={{ touchAction: 'none' }}>
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      onTouchStart={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    />
+    <span className="text-center">{value}</span>
+  </div>
+);
+
+export default ThresholdSlider;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
@@ -1,0 +1,3 @@
+export { default as ThresholdSlider } from './ThresholdSlider';
+export * from './lasso';
+export * from './useLassoSelection';

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/lasso.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/lasso.ts
@@ -1,0 +1,23 @@
+export interface Point {
+  x: number;
+  y: number;
+  [key: string]: any;
+}
+
+export type Polygon = { x: number; y: number }[];
+
+export const isPointInPolygon = (point: Point, polygon: Polygon) => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x, yi = polygon[i].y;
+    const xj = polygon[j].x, yj = polygon[j].y;
+    const intersect =
+      yi > point.y !== yj > point.y &&
+      point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+};
+
+export const lassoSelect = (points: Point[], polygon: Polygon) =>
+  points.filter((p) => isPointInPolygon(p, polygon));

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/useLassoSelection.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/useLassoSelection.ts
@@ -1,0 +1,41 @@
+import { useState, useRef, useCallback } from 'react';
+import { Polygon } from './lasso';
+
+export const useLassoSelection = () => {
+  const [polygon, setPolygon] = useState<Polygon>([]);
+  const drawing = useRef(false);
+
+  const start = useCallback((x: number, y: number) => {
+    drawing.current = true;
+    setPolygon([{ x, y }]);
+  }, []);
+
+  const move = useCallback((x: number, y: number) => {
+    if (drawing.current) {
+      setPolygon((poly) => [...poly, { x, y }]);
+    }
+  }, []);
+
+  const end = useCallback(() => {
+    drawing.current = false;
+  }, []);
+
+  const reset = useCallback(() => setPolygon([]), []);
+
+  const handlers = {
+    onPointerDown: (e: React.PointerEvent) => start(e.clientX, e.clientY),
+    onPointerMove: (e: React.PointerEvent) => move(e.clientX, e.clientY),
+    onPointerUp: end,
+    onTouchStart: (e: React.TouchEvent) => {
+      const t = e.touches[0];
+      start(t.clientX, t.clientY);
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      const t = e.touches[0];
+      move(t.clientX, t.clientY);
+    },
+    onTouchEnd: end,
+  };
+
+  return { polygon, handlers, reset };
+};

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
@@ -10,6 +10,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
 } from 'recharts';
+import Timeline from '../components/Timeline';
 import { graphsAPI, AvailableChart } from '../api/graphs';
 
 const Graphs: React.FC = () => {
@@ -52,21 +53,13 @@ const Graphs: React.FC = () => {
     if (!chartData) return null;
 
     if (selectedChart === 'timeline' && chartData.hourly_distribution) {
-      const data = Object.entries(chartData.hourly_distribution).map(([hour, count]) => ({
-        hour,
-        count: Number(count),
-      }));
-      return (
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="hour" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="count" stroke="#8884d8" />
-          </LineChart>
-        </ResponsiveContainer>
+      const data = Object.entries(chartData.hourly_distribution).map(
+        ([hour, count]) => ({
+          time: hour,
+          value: Number(count),
+        }),
       );
+      return <Timeline data={data} />;
     }
 
     if (


### PR DESCRIPTION
## Summary
- add reusable timeline with draggable brush filter and touch handling
- implement threshold slider and lasso selection helpers
- wire timeline filter into graphs page

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npm run lint` *(fails: 1658 problems including prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fe5a9388320ba56c31d9fbf9bbf