### PR TITLE
Add Any typing to upload utility

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py
+++ b/yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
@@ -13,7 +13,7 @@ def decode_and_validate_upload(
     contents: str,
     filename: str,
     validator: SecurityValidator | None = None,
-) -> Dict[str, any]:
+) -> Dict[str, Any]:
     """Decode base64 ``contents`` and validate upload metadata.
 
     Returns a dict with keys ``valid``, ``filename``, ``decoded`` (bytes or ``None``),


### PR DESCRIPTION
## Summary
- import Any in upload utility and update return type annotation

## Testing
- `pytest tests/test_upload_validator.py` *(fails: MemoryError)*

------
https://chatgpt.com/codex/tasks/task_e_688f931a11f883209c20bec7b17223cf