### PR TITLE
Add key management utilities and tests

### DIFF
--- a/tests/security/test_key_management.py
+++ b/tests/security/test_key_management.py
@@ -1,0 +1,54 @@
+"""Tests for the key management utilities."""
+
+from pathlib import Path
+from unittest.mock import Mock
+import importlib.util
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "infrastructure"
+    / "security"
+    / "key_management.py"
+)
+spec = importlib.util.spec_from_file_location("key_management", MODULE_PATH)
+key_management = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(key_management)
+KeyManager = key_management.KeyManager
+hkdf = key_management.hkdf
+
+
+def test_hkdf_length_and_uniqueness():
+    base_key = b"root"
+    ctx_a = b"context-a"
+    ctx_b = b"context-b"
+
+    out_a = hkdf(base_key, context=ctx_a, length=42)
+    out_b = hkdf(base_key, context=ctx_b, length=42)
+
+    assert len(out_a) == 42
+    assert len(out_b) == 42
+    assert out_a != out_b
+
+
+def test_keymanager_rotate_invokes_writers():
+    writer1 = Mock()
+    writer2 = Mock()
+    km = KeyManager(b"old", writers=[writer1, writer2])
+
+    km.rotate(b"new")
+
+    writer1.assert_called_once_with(b"new")
+    writer2.assert_called_once_with(b"new")
+
+
+def test_keymanager_derive_is_deterministic():
+    km = KeyManager(b"master")
+    first = km.derive("purpose")
+    second = km.derive("purpose")
+
+    assert first == second
+

--- a/yosai_intel_dashboard/src/infrastructure/security/key_management.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/key_management.py
@@ -1,0 +1,69 @@
+"""Key derivation and rotation utilities.
+
+This module provides a small HKDF implementation and a :class:`KeyManager`
+that can rotate the root key and derive context specific keys.  The
+implementation is intentionally lightweight so it can be used in tests without
+external dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+import hashlib
+import hmac
+
+
+def hkdf(key_material: bytes, *, context: bytes, length: int = 32) -> bytes:
+    """Derive key material using a simplified HKDF construction.
+
+    The function uses HMAC-SHA256 as the underlying hash.  Only the ``info``
+    parameter (called ``context`` here) is exposed since that's all the
+    library currently needs.  ``length`` specifies the number of bytes to
+    return.
+
+    Args:
+        key_material: Initial key material.
+        context: Context specific information (``info`` in the HKDF spec).
+        length: Desired number of bytes to return. Defaults to ``32``.
+
+    Returns:
+        Derived key bytes of ``length`` size.
+    """
+
+    # Extract step with an empty salt.  This keeps the function deterministic
+    # which is useful for tests.
+    hash_len = hashlib.sha256().digest_size
+    prk = hmac.new(b"\x00" * hash_len, key_material, hashlib.sha256).digest()
+
+    # Expand step
+    t = b""
+    okm = b""
+    counter = 1
+    while len(okm) < length:
+        t = hmac.new(prk, t + context + bytes([counter]), hashlib.sha256).digest()
+        okm += t
+        counter += 1
+
+    return okm[:length]
+
+
+class KeyManager:
+    """Manage a root key and derive sub keys for different purposes."""
+
+    def __init__(self, root_key: bytes, writers: Iterable[Callable[[bytes], None]] | None = None):
+        self._root_key = root_key
+        self._writers = list(writers or [])
+
+    def derive(self, purpose: str, *, length: int = 32) -> bytes:
+        """Deterministically derive a key for the given ``purpose``."""
+
+        return hkdf(self._root_key, context=purpose.encode("utf-8"), length=length)
+
+    def rotate(self, new_root_key: bytes) -> None:
+        """Rotate the stored root key and persist it using the provided writers."""
+
+        self._root_key = new_root_key
+        for writer in self._writers:
+            writer(new_root_key)
+


### PR DESCRIPTION
## Summary
- add lightweight HKDF and KeyManager for key derivation and rotation
- add tests for hkdf uniqueness, key rotation, and deterministic derivation

## Testing
- `pytest tests/security/test_key_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f91bd14e8832089abe87e0f5a9bda