### PR TITLE
Use Path to write requirements backup with encoding

### DIFF
--- a/scripts/setup_venv.py
+++ b/scripts/setup_venv.py
@@ -84,7 +84,7 @@ def backup_requirements():
     try:
         subprocess.run(
             [sys.executable, "-m", "pip", "freeze"],
-            stdout=open("requirements_backup.txt", "w"),
+            stdout=Path("requirements_backup.txt").open("w", encoding="utf-8"),
             check=True,
         )
         logger.info("✅ Requirements backed up to requirements_backup.txt")


### PR DESCRIPTION
## Summary
- use `Path.open` with UTF-8 encoding when backing up requirements

## Testing
- `pytest scripts/setup_venv.py -q`
- `python -m py_compile scripts/setup_venv.py`


------
https://chatgpt.com/codex/tasks/task_e_688f931843d48320b91745d40a0265bb