### PR TITLE
test: stub scipy in analytics startup test

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py
@@ -1,13 +1,22 @@
 import importlib.util
 import pathlib
+import sys
+import types
 
 import pytest
 
 
 def load_app(jwt_secret: str):
+    if "scipy" not in sys.modules:
+        scipy_stub = types.ModuleType("scipy")
+        scipy_stub.stats = types.ModuleType("scipy.stats")
+        sys.modules["scipy"] = scipy_stub
+        sys.modules["scipy.stats"] = scipy_stub.stats
+
     module_path = pathlib.Path(__file__).parent / "test_endpoints_async.py"
     spec = importlib.util.spec_from_file_location("test_endpoints_async", module_path)
     module = importlib.util.module_from_spec(spec)
+    sys.modules["test_endpoints_async"] = module
     spec.loader.exec_module(module)
     return module.load_app(jwt_secret)
 


### PR DESCRIPTION
## Summary
- allow analytics startup test to run without requiring scipy by preloading a lightweight stub before importing helper module

## Testing
- `LIGHTWEIGHT_SERVICES=1 pytest yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f91be47488320bea92256e7f90558