### PR TITLE
feat: expand secret scan and enforce high severity

### DIFF
--- a/scripts/security_scan_secrets.py
+++ b/scripts/security_scan_secrets.py
@@ -13,6 +13,9 @@ DEFAULT_PATTERNS = [
     re.compile(p, re.IGNORECASE)
     for p in ["dev", "development", "test", "secret", "change[-_]?me"]
 ]
+CREDENTIAL_NAME_PATTERN = re.compile(
+    r"(PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL)", re.IGNORECASE
+)
 
 
 def entropy(value: str) -> float:
@@ -24,19 +27,39 @@ def entropy(value: str) -> float:
 
 
 def main() -> None:
-    secret = os.getenv("SECRET_KEY", "")
-    errors = []
-    if not secret or any(p.search(secret) for p in DEFAULT_PATTERNS) or entropy(secret) < 3.5:
-        errors.append("Secret may be weak or missing")
-    severity = "HIGH" if errors else "LOW"
+    target_vars = {"SECRET_KEY", "DB_PASSWORD", "AUTH0_CLIENT_SECRET"}
+    for name in os.environ:
+        if CREDENTIAL_NAME_PATTERN.search(name):
+            target_vars.add(name)
+
+    results = []
+    for name in sorted(target_vars):
+        value = os.getenv(name, "")
+        issues: list[str] = []
+        if not value:
+            issues.append("Value is missing")
+        else:
+            if any(p.search(value) for p in DEFAULT_PATTERNS):
+                issues.append("Contains common weak pattern")
+            if entropy(value) < 3.5:
+                issues.append("Low entropy")
+        severity = "HIGH" if issues else "LOW"
+        results.append({"variable": name, "severity": severity, "issues": issues})
+
+    overall_severity = "HIGH" if any(r["severity"] == "HIGH" for r in results) else "LOW"
     data = {
         "name": "Secrets scan",
-        "severity": severity,
-        "findings": errors,
-        "remediation": "Rotate weak or missing secrets." if errors else "No action required",
+        "overall_severity": overall_severity,
+        "results": results,
+        "remediation": (
+            "Rotate weak or missing secrets." if overall_severity == "HIGH" else "No action required"
+        ),
     }
     with open("security_secrets_scan.json", "w", encoding="utf-8") as fh:
-        json.dump(data, fh)
+        json.dump(data, fh, indent=2)
+
+    if overall_severity == "HIGH":
+        raise SystemExit("High severity secrets detected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- broaden secret scan to include DB_PASSWORD, AUTH0_CLIENT_SECRET, and any env var matching common credential patterns
- output structured per-variable findings and fail CI on high-severity results

## Testing
- `python -m py_compile scripts/security_scan_secrets.py`
- `pytest tests/test_security_comprehensive.py` *(fails: MemoryError)*

------
https://chatgpt.com/codex/tasks/task_e_688f91bc523c8320ae65144668b32758