### PR TITLE
Resolve remote secret references

### DIFF
--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
 import pytest
 
-from yosai_intel_dashboard.src.infrastructure.config.secrets_validator import DockerSecretSource, SecretsValidator
+from yosai_intel_dashboard.src.infrastructure.config.secrets_validator import (
+    DockerSecretSource,
+    SecretsValidator,
+)
 
 
 def test_docker_secret_source(tmp_path):
     # placeholder value used for test secrets
     (tmp_path / "SECRET_KEY").write_text("placeholdersecret" * 2)
     src = DockerSecretSource(tmp_path)
-    assert src.get_secret("SECRET_KEY").startswith("dockersecret")
+    assert src.get_secret("SECRET_KEY") == "placeholdersecret" * 2
     assert src.get_secret("MISSING") is None
 
 

--- a/tests/test_secrets_validator_references.py
+++ b/tests/test_secrets_validator_references.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from yosai_intel_dashboard.src.infrastructure.config.secrets_validator import (
+    SecretSource,
+    SecretsValidator,
+)
+from yosai_intel_dashboard.src.infrastructure.config.secure_config_manager import (
+    SecureConfigManager,
+)
+
+
+class MappingSource(SecretSource):
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get_secret(self, key: str):
+        return self.mapping.get(key)
+
+
+def test_resolves_vault_reference(monkeypatch):
+    def fake_read_vault(self, path, field):
+        assert path == "secret/path"
+        assert field == "token"
+        return "v" * 32
+
+    monkeypatch.setattr(SecureConfigManager, "_read_vault_secret", fake_read_vault)
+
+    src = MappingSource(
+        {
+            "SECRET_KEY": "vault:secret/path#token",
+            "DB_PASSWORD": "p" * 32,
+            "AUTH0_CLIENT_SECRET": "s" * 32,
+        }
+    )
+
+    validator = SecretsValidator(environment="production")
+    secrets = validator.validate_production_secrets(src)
+    assert secrets["SECRET_KEY"] == "v" * 32
+
+
+def test_resolves_aws_reference(monkeypatch):
+    def fake_read_aws(self, name):
+        assert name == "db/pass"
+        return "a" * 32
+
+    monkeypatch.setattr(SecureConfigManager, "_read_aws_secret", fake_read_aws)
+
+    src = MappingSource(
+        {
+            "SECRET_KEY": "k" * 32,
+            "DB_PASSWORD": "aws-secrets:db/pass",
+            "AUTH0_CLIENT_SECRET": "s" * 32,
+        }
+    )
+
+    validator = SecretsValidator(environment="production")
+    secrets = validator.validate_production_secrets(src)
+    assert secrets["DB_PASSWORD"] == "a" * 32

--- a/yosai_intel_dashboard/src/infrastructure/config/secrets_validator.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/secrets_validator.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .secure_config_manager import SecureConfigManager
+
 logger = logging.getLogger(__name__)
 
 
@@ -147,8 +149,21 @@ class SecretsValidator:
         source = source or EnvSecretSource()
         missing: List[str] = []
         secrets: Dict[str, str] = {}
+        manager: SecureConfigManager | None = None
         for key in self.REQUIRED_PRODUCTION_SECRETS:
             value = source.get_secret(key)
+            if isinstance(value, str) and (
+                value.startswith("vault:") or value.startswith("aws-secrets:")
+            ):
+                if manager is None:
+                    manager = SecureConfigManager.__new__(SecureConfigManager)
+                    manager.client = None  # type: ignore[attr-defined]
+                    manager.aws_client = None  # type: ignore[attr-defined]
+                    manager.fernet = None  # type: ignore[attr-defined]
+                try:
+                    value = manager._resolve_secret_values(value)  # type: ignore[assignment]
+                except Exception:
+                    value = None
             if not value or len(value) < 32 or value.startswith("test-"):
                 missing.append(key)
             else:


### PR DESCRIPTION
## Summary
- resolve `vault:` and `aws-secrets:` secret references in `validate_production_secrets`
- test resolving Vault and AWS Secrets Manager references
- fix Docker secret source test to match actual file content

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/secrets_validator.py tests/test_docker_secrets.py tests/test_secrets_validator_references.py`
- `pytest tests/test_docker_secrets.py tests/test_secrets_validator_references.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f91baa9e88320b86d751799b81bdc