### PR TITLE
feat: improve accessibility for visualizations

### DIFF
--- a/graph_dashboard/src/components/GraphDashboard.tsx
+++ b/graph_dashboard/src/components/GraphDashboard.tsx
@@ -5,6 +5,7 @@ import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 import Heatmap from 'heatmap.js';
 import { request, gql } from 'graphql-request';
+import { AccessibleVisualization } from '../../../components/accessibility';
 
 type Node = { id: string; label: string; properties?: Record<string, string> };
 type Edge = { source: string; target: string; weight?: number };
@@ -61,26 +62,52 @@ export const GraphDashboard: React.FC = () => {
     a.click();
   };
 
-  const graphComponent = is3D ? (
+  const graphVisualization = is3D ? (
     <ForceGraph3D graphData={graph} />
   ) : (
     <ForceGraph2D graphData={graph} />
   );
 
+  const graphComponent = (
+    <AccessibleVisualization
+      title="Security Graph"
+      summary={`Graph with ${graph.nodes.length} nodes and ${graph.edges.length} edges.`}
+      tableData={{
+        headers: ['Node ID', 'Label'],
+        rows: graph.nodes.map((n) => [n.id, n.label]),
+      }}
+    >
+      {graphVisualization}
+    </AccessibleVisualization>
+  );
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 10 }}>
-        <button onClick={() => setIs3D(!is3D)}>{is3D ? '2D' : '3D'}</button>
+        <button
+          onClick={() => setIs3D(!is3D)}
+          aria-label="Toggle 3D view"
+        >
+          {is3D ? '2D' : '3D'}
+        </button>
         <input
           placeholder="Filter by label"
+          aria-label="Filter nodes by label"
           value={labelFilter}
           onChange={(e) => setLabelFilter(e.target.value)}
           style={{ marginLeft: 10 }}
         />
-        <button onClick={() => exportGraph('gephi')}>Export Gephi</button>
-        <button onClick={() => exportGraph('cytoscape')}>Export Cytoscape</button>
+        <button onClick={() => exportGraph('gephi')} aria-label="Export Gephi">
+          Export Gephi
+        </button>
+        <button
+          onClick={() => exportGraph('cytoscape')}
+          aria-label="Export Cytoscape"
+        >
+          Export Cytoscape
+        </button>
         <div style={{ width: 200, marginTop: 10 }}>
-          <Slider min={0} max={100} defaultValue={0} />
+          <Slider min={0} max={100} defaultValue={0} aria-label="Graph slider" />
         </div>
       </div>
       {graphComponent}

--- a/yosai_intel_dashboard/src/adapters/ui/components/accessibility/AccessibleVisualization.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/accessibility/AccessibleVisualization.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './highContrast.css';
+import { useVoiceNavigation } from './useVoiceNavigation';
+import { useHighContrast } from './useHighContrast';
+
+interface TableData {
+  headers: string[];
+  rows: (string | number)[][];
+}
+
+interface AccessibleVisualizationProps {
+  title: string;
+  summary: string;
+  tableData: TableData;
+  children: React.ReactNode;
+}
+
+export const AccessibleVisualization: React.FC<AccessibleVisualizationProps> = ({
+  title,
+  summary,
+  tableData,
+  children,
+}) => {
+  const [showTable, setShowTable] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useHighContrast();
+  useEffect(() => {
+    if ('speechSynthesis' in window) {
+      const utter = new SpeechSynthesisUtterance(summary);
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utter);
+    }
+  }, [summary]);
+
+  const toggleView = () => setShowTable((v) => !v);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleView();
+    }
+  };
+
+  useVoiceNavigation({
+    'show table': () => setShowTable(true),
+    'show chart': () => setShowTable(false),
+  });
+
+  return (
+    <div ref={containerRef} role="region" aria-label={title} className="accessible-viz">
+      <div className="sr-only" aria-live="polite">
+        {summary}
+      </div>
+      <button
+        onClick={toggleView}
+        onKeyDown={handleKeyDown}
+        aria-pressed={showTable}
+        aria-label={showTable ? 'Show chart view' : 'Show table view'}
+      >
+        {showTable ? 'Show Chart' : 'Show Table'}
+      </button>
+      {showTable ? (
+        <table role="table" className="a11y-table">
+          <thead>
+            <tr>
+              {tableData.headers.map((h) => (
+                <th key={h} scope="col">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {tableData.rows.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <div role="img" aria-label={`${title} visualization`} tabIndex={0}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccessibleVisualization;

--- a/yosai_intel_dashboard/src/adapters/ui/components/accessibility/highContrast.css
+++ b/yosai_intel_dashboard/src/adapters/ui/components/accessibility/highContrast.css
@@ -1,0 +1,20 @@
+.high-contrast {
+  background-color: #000;
+  color: #fff;
+}
+
+.high-contrast button {
+  background-color: #fff;
+  color: #000;
+}
+
+.a11y-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.a11y-table th,
+.a11y-table td {
+  border: 1px solid #666;
+  padding: 4px 8px;
+}

--- a/yosai_intel_dashboard/src/adapters/ui/components/accessibility/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/accessibility/index.ts
@@ -1,0 +1,3 @@
+export { AccessibleVisualization } from './AccessibleVisualization';
+export { useVoiceNavigation } from './useVoiceNavigation';
+export { useHighContrast } from './useHighContrast';

--- a/yosai_intel_dashboard/src/adapters/ui/components/accessibility/useHighContrast.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/accessibility/useHighContrast.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+export const useHighContrast = () => {
+  useEffect(() => {
+    if (window.matchMedia && window.matchMedia('(prefers-contrast: more)').matches) {
+      document.body.classList.add('high-contrast');
+    }
+  }, []);
+};
+
+export default useHighContrast;

--- a/yosai_intel_dashboard/src/adapters/ui/components/accessibility/useVoiceNavigation.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/accessibility/useVoiceNavigation.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+type CommandMap = Record<string, () => void>;
+
+export const useVoiceNavigation = (commands: CommandMap) => {
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) return;
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+
+    recognition.onresult = (event: any) => {
+      const transcript = event.results[event.results.length - 1][0].transcript
+        .trim()
+        .toLowerCase();
+      Object.entries(commands).forEach(([phrase, handler]) => {
+        if (transcript.includes(phrase)) {
+          handler();
+        }
+      });
+    };
+
+    recognition.start();
+    return () => recognition.stop();
+  }, [commands]);
+};
+
+export default useVoiceNavigation;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { graphsAPI, AvailableChart } from '../api/graphs';
+import { AccessibleVisualization } from '../components/accessibility';
 
 const Graphs: React.FC = () => {
   const [availableCharts, setAvailableCharts] = useState<AvailableChart[]>([]);
@@ -57,15 +58,24 @@ const Graphs: React.FC = () => {
         count: Number(count),
       }));
       return (
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="hour" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="count" stroke="#8884d8" />
-          </LineChart>
-        </ResponsiveContainer>
+        <AccessibleVisualization
+          title="Hourly Distribution"
+          summary={`Hourly distribution with ${data.length} data points.`}
+          tableData={{
+            headers: ['Hour', 'Count'],
+            rows: data.map((d) => [d.hour, d.count]),
+          }}
+        >
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="hour" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="count" stroke="#8884d8" />
+            </LineChart>
+          </ResponsiveContainer>
+        </AccessibleVisualization>
       );
     }
 
@@ -80,15 +90,24 @@ const Graphs: React.FC = () => {
         }),
       );
       return (
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="hour" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="count" stroke="#82ca9d" />
-          </LineChart>
-        </ResponsiveContainer>
+        <AccessibleVisualization
+          title="Temporal Patterns"
+          summary={`Temporal patterns with ${data.length} data points.`}
+          tableData={{
+            headers: ['Hour', 'Count'],
+            rows: data.map((d) => [d.hour, d.count]),
+          }}
+        >
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="hour" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="count" stroke="#82ca9d" />
+            </LineChart>
+          </ResponsiveContainer>
+        </AccessibleVisualization>
       );
     }
 
@@ -106,6 +125,7 @@ const Graphs: React.FC = () => {
           className="mb-4 border p-2 rounded"
           value={selectedChart}
           onChange={(e) => setSelectedChart(e.target.value)}
+          aria-label="Select chart type"
         >
           {availableCharts.map((chart) => (
             <option key={chart.type} value={chart.type}>
@@ -114,7 +134,7 @@ const Graphs: React.FC = () => {
           ))}
         </select>
       )}
-      <div>{renderChart()}</div>
+      <div role="presentation">{renderChart()}</div>
     </div>
   );
 };

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -13,6 +13,7 @@ import {
   Cell,
 } from 'recharts';
 import { useRealTimeAnalytics } from '../hooks/useRealTimeAnalytics';
+import { AccessibleVisualization } from '../components/accessibility';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'];
 
@@ -48,46 +49,73 @@ const RealTimeAnalyticsPage: React.FC = () => {
       </div>
 
       {topUsers.length > 0 && (
-        <div className="mb-4" style={{ width: '100%', height: 300 }}>
-          <ResponsiveContainer>
-            <BarChart data={topUsers.slice(0, 10)}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="user_id" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="count" fill="#8884d8" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+        <AccessibleVisualization
+          title="Top Users"
+          summary={`Top users chart with ${topUsers.length} entries.`}
+          tableData={{
+            headers: ['User ID', 'Count'],
+            rows: topUsers.slice(0, 10).map((u) => [u.user_id, u.count]),
+          }}
+        >
+          <div className="mb-4" style={{ width: '100%', height: 300 }}>
+            <ResponsiveContainer>
+              <BarChart data={topUsers.slice(0, 10)}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="user_id" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="count" fill="#8884d8" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </AccessibleVisualization>
       )}
 
       {topDoors.length > 0 && (
-        <div className="mb-4" style={{ width: '100%', height: 300 }}>
-          <ResponsiveContainer>
-            <BarChart data={topDoors.slice(0, 10)}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="door_id" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="count" fill="#82ca9d" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+        <AccessibleVisualization
+          title="Top Doors"
+          summary={`Top doors chart with ${topDoors.length} entries.`}
+          tableData={{
+            headers: ['Door ID', 'Count'],
+            rows: topDoors.slice(0, 10).map((d) => [d.door_id, d.count]),
+          }}
+        >
+          <div className="mb-4" style={{ width: '100%', height: 300 }}>
+            <ResponsiveContainer>
+              <BarChart data={topDoors.slice(0, 10)}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="door_id" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="count" fill="#82ca9d" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </AccessibleVisualization>
       )}
 
       {patterns.length > 0 && (
-        <div className="mb-4" style={{ width: '100%', height: 300 }}>
-          <ResponsiveContainer>
-            <PieChart>
-              <Pie data={patterns} dataKey="count" nameKey="pattern" label>
-                {patterns.map((_, i) => (
-                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
+        <AccessibleVisualization
+          title="Access Patterns"
+          summary={`Access patterns chart with ${patterns.length} entries.`}
+          tableData={{
+            headers: ['Pattern', 'Count'],
+            rows: patterns.map((p) => [p.pattern, p.count]),
+          }}
+        >
+          <div className="mb-4" style={{ width: '100%', height: 300 }}>
+            <ResponsiveContainer>
+              <PieChart>
+                <Pie data={patterns} dataKey="count" nameKey="pattern" label>
+                  {patterns.map((_, i) => (
+                    <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </AccessibleVisualization>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add accessibility components with ARIA roles, high-contrast theme and voice navigation
- render charts with accessible summaries and data table toggles
- integrate accessible wrappers into graph dashboard and analytics pages

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fea6ef8832091d1b02dd721174e