### PR TITLE
feat: rotate secrets via secret manager

### DIFF
--- a/k8s/config/api-secrets.yaml
+++ b/k8s/config/api-secrets.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: yosai-dev
 type: Opaque
 stringData:
-  AUTH0_CLIENT_ID: ""
-  AUTH0_CLIENT_SECRET: ""
+  SECRET_KEY: vault:secret/data/api#secret_key
+  DB_PASSWORD: vault:secret/data/db#password
+  AUTH0_CLIENT_ID: vault:secret/data/auth0#client_id
+  AUTH0_CLIENT_SECRET: vault:secret/data/auth0#client_secret

--- a/scripts/rotate_secrets.py
+++ b/scripts/rotate_secrets.py
@@ -1,21 +1,43 @@
 #!/usr/bin/env python3
 """Rotate Kubernetes secrets for staging environments.
 
-This script generates new SECRET_KEY and database password values,
-updates ``k8s/config/api-secrets.yaml`` with those values and applies
-the manifest with ``kubectl`` if the cluster is reachable.
+This script generates new secret values, writes them to the configured
+secret backend and updates ``k8s/config/api-secrets.yaml`` with
+references to those locations.
 """
 from __future__ import annotations
 
 import logging
+import os
 import secrets
 import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml
 
+from optional_dependencies import import_optional
+
+hvac = import_optional("hvac")
+boto3 = import_optional("boto3")
+
 SECRETS_FILE = Path("k8s/config/api-secrets.yaml")
+
+# Mapping of secret names to backend locations
+SECRET_SPECS = {
+    "SECRET_KEY": {
+        "vault": ("secret/data/api", "secret_key"),
+        "aws": "prod/app_secret",
+    },
+    "DB_PASSWORD": {
+        "vault": ("secret/data/db", "password"),
+        "aws": "prod/db_password",
+    },
+    "TIMESCALE_DB_PASSWORD": {
+        "vault": ("secret/data/timescale", "password"),
+        "aws": "prod/timescale_db_password",
+    },
+}
 
 
 def generate_token(length: int = 32) -> str:
@@ -23,19 +45,75 @@ def generate_token(length: int = 32) -> str:
     return secrets.token_urlsafe(length)
 
 
+def _get_vault_client() -> Optional[Any]:
+    if not hvac:
+        return None
+    addr = os.getenv("VAULT_ADDR")
+    token = os.getenv("VAULT_TOKEN")
+    if not (addr and token):
+        return None
+    try:
+        return hvac.Client(url=addr, token=token)
+    except Exception:  # pragma: no cover - network/setup issues
+        logging.exception("failed to initialise Vault client")
+        return None
+
+
+def _get_aws_client() -> Optional[Any]:
+    if not boto3:
+        return None
+    region = os.getenv("AWS_REGION")
+    if not region:
+        return None
+    try:
+        return boto3.client("secretsmanager", region_name=region)
+    except Exception:  # pragma: no cover - network/setup issues
+        logging.exception("failed to initialise AWS client")
+        return None
+
+
+def _write_vault_secret(client: Any, path: str, field: str, value: str) -> str:
+    client.secrets.kv.v2.create_or_update_secret(path=path, secret={field: value})
+    return f"vault:{path}#{field}"
+
+
+def _write_aws_secret(client: Any, name: str, value: str) -> str:
+    try:
+        client.put_secret_value(SecretId=name, SecretString=value)
+    except getattr(client, "exceptions", object()).__dict__.get(
+        "ResourceNotFoundException", Exception
+    ):
+        client.create_secret(Name=name, SecretString=value)
+    return f"aws-secrets:{name}"
+
+
 def update_secrets(file_path: Path = SECRETS_FILE) -> Dict[str, str]:
-    """Update the secrets file with new credentials."""
+    """Generate secrets, store them in the backend and update references."""
     data: Dict[str, Any] = yaml.safe_load(file_path.read_text())
     string_data = data.setdefault("stringData", {})
-    updates = {
-        "SECRET_KEY": generate_token(),
-        "DB_PASSWORD": generate_token(),
-    }
-    if "TIMESCALE_DB_PASSWORD" in string_data:
-        updates["TIMESCALE_DB_PASSWORD"] = generate_token()
-    string_data.update(updates)
+
+    vault_client = _get_vault_client()
+    aws_client = _get_aws_client()
+    backend = "vault" if vault_client else "aws" if aws_client else None
+    if backend is None:
+        raise RuntimeError("No secret backend configured")
+
+    references: Dict[str, str] = {}
+    for key, spec in SECRET_SPECS.items():
+        if key == "TIMESCALE_DB_PASSWORD" and key not in string_data:
+            continue
+        value = generate_token()
+        if backend == "vault":
+            path, field = spec["vault"]
+            ref = _write_vault_secret(vault_client, path, field, value)
+        else:
+            name = spec["aws"]
+            ref = _write_aws_secret(aws_client, name, value)
+        string_data[key] = ref
+        references[key] = ref
+
     file_path.write_text(yaml.safe_dump(data))
-    return updates
+    return references
 
 
 def cluster_reachable() -> bool:
@@ -75,10 +153,14 @@ def restart_deployment(
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
-    updates = update_secrets()
+    try:
+        updates = update_secrets()
+    except RuntimeError as exc:  # pragma: no cover - configuration issue
+        logging.error("%s", exc)
+        return
     logging.info("Secrets rotated and written to %s", SECRETS_FILE)
-    for key in updates:
-        logging.info("rotated %s", key)
+    for key, ref in updates.items():
+        logging.info("rotated %s -> %s", key, ref)
     apply_config()
     restart_deployment()
 

--- a/tests/scripts/test_rotate_secrets.py
+++ b/tests/scripts/test_rotate_secrets.py
@@ -1,0 +1,67 @@
+"""Tests for scripts.rotate_secrets."""
+
+from __future__ import annotations
+
+import types
+
+import yaml
+
+from scripts import rotate_secrets
+
+
+class DummyVault:
+    def __init__(self) -> None:
+        self.stored = {}
+        self.secrets = types.SimpleNamespace(kv=types.SimpleNamespace(v2=self))
+
+    def create_or_update_secret(self, path: str, secret: dict) -> None:  # type: ignore[override]
+        self.stored[path] = secret
+
+
+class DummyAWS:
+    class exceptions:  # pragma: no cover - simple namespace
+        class ResourceNotFoundException(Exception):
+            pass
+
+    def __init__(self) -> None:
+        self.values = {}
+
+    def put_secret_value(self, SecretId: str, SecretString: str) -> None:
+        self.values[SecretId] = SecretString
+
+    def create_secret(
+        self, Name: str, SecretString: str
+    ) -> None:  # pragma: no cover - not used
+        self.values[Name] = SecretString
+
+
+def test_update_secrets_vault(monkeypatch, tmp_path):
+    path = tmp_path / "secrets.yaml"
+    path.write_text("stringData: {}\n", encoding="utf-8")
+
+    client = DummyVault()
+    monkeypatch.setattr(rotate_secrets, "_get_vault_client", lambda: client)
+    monkeypatch.setattr(rotate_secrets, "_get_aws_client", lambda: None)
+
+    refs = rotate_secrets.update_secrets(file_path=path)
+
+    data = yaml.safe_load(path.read_text())
+    assert data["stringData"]["SECRET_KEY"].startswith("vault:")
+    assert client.stored  # ensure something was written
+    assert all(r.startswith("vault:") for r in refs.values())
+
+
+def test_update_secrets_aws(monkeypatch, tmp_path):
+    path = tmp_path / "secrets.yaml"
+    path.write_text("stringData: {}\n", encoding="utf-8")
+
+    client = DummyAWS()
+    monkeypatch.setattr(rotate_secrets, "_get_vault_client", lambda: None)
+    monkeypatch.setattr(rotate_secrets, "_get_aws_client", lambda: client)
+
+    refs = rotate_secrets.update_secrets(file_path=path)
+
+    data = yaml.safe_load(path.read_text())
+    assert data["stringData"]["SECRET_KEY"].startswith("aws-secrets:")
+    assert client.values  # ensure something was written
+    assert all(r.startswith("aws-secrets:") for r in refs.values())


### PR DESCRIPTION
## Summary
- rotate Kubernetes secrets by writing new values to Vault or AWS Secrets Manager
- reference secret manager entries in `k8s/config/api-secrets.yaml`
- add tests covering Vault and AWS flows

## Testing
- `pre-commit run --files scripts/rotate_secrets.py k8s/config/api-secrets.yaml tests/scripts/test_rotate_secrets.py`
- `pytest tests/scripts/test_rotate_secrets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f91b66b3083209b1318f671383b5e