### PR TITLE
Add export service and visualization sharing

### DIFF
--- a/services/export/__init__.py
+++ b/services/export/__init__.py
@@ -1,0 +1,5 @@
+"""Lightweight export service package for tests."""
+
+from .service import ExportService
+
+__all__ = ["ExportService"]

--- a/services/export/service.py
+++ b/services/export/service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import base64
+import io
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+# External libraries used only for demonstration; they are optional at runtime.
+import matplotlib.pyplot as plt  # type: ignore[import]
+
+
+@dataclass
+class ExportedView:
+    """Simple container for exported visualization data."""
+
+    content: bytes | str
+    format: str
+    annotations: List[str] = field(default_factory=list)
+    version: int = 1
+
+
+class ExportService:
+    """Service capable of exporting matplotlib figures to multiple formats.
+
+    The service keeps exported views in memory so tests can access the stored
+    content via a generated shareable link.  It also supports collaborative
+    annotations which bump the view version on each update.
+    """
+
+    def __init__(self) -> None:
+        self._views: Dict[str, ExportedView] = {}
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+    def _save_image(self, fig: plt.Figure, fmt: str) -> bytes:
+        buf = io.BytesIO()
+        fig.savefig(buf, format=fmt)
+        buf.seek(0)
+        return buf.read()
+
+    def _save_html(self, fig: plt.Figure) -> str:
+        image = self._save_image(fig, "png")
+        b64 = base64.b64encode(image).decode("ascii")
+        return f"<html><body><img src='data:image/png;base64,{b64}'/></body></html>"
+
+    def export(self, fig: plt.Figure, fmt: str) -> bytes | str:
+        fmt = fmt.lower()
+        if fmt in {"svg", "png", "jpeg", "jpg", "pdf"}:
+            return self._save_image(fig, fmt)
+        if fmt == "html":
+            return self._save_html(fig)
+        raise ValueError(f"unsupported format: {fmt}")
+
+    # ------------------------------------------------------------------
+    # Shareable links and annotations
+    # ------------------------------------------------------------------
+    def create_shareable(self, fig: plt.Figure, fmt: str) -> tuple[str, str, str]:
+        """Export ``fig`` and return (id, link, embed code)."""
+
+        content = self.export(fig, fmt)
+        view_id = str(uuid.uuid4())
+        self._views[view_id] = ExportedView(content=content, format=fmt)
+        link = f"/export/{view_id}"
+        embed = f"<iframe src='{link}'></iframe>"
+        return view_id, link, embed
+
+    def add_annotation(self, view_id: str, note: str) -> ExportedView:
+        view = self._views[view_id]
+        view.annotations.append(note)
+        view.version += 1
+        return view
+
+    def get_view(self, view_id: str) -> ExportedView:
+        return self._views[view_id]

--- a/src/infrastructure/monitoring/visualization.py
+++ b/src/infrastructure/monitoring/visualization.py
@@ -1,35 +1,75 @@
 """Simple plotting utilities for monitoring visualizations."""
+
 from __future__ import annotations
 
-from typing import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
 
 import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+
+from services.export import ExportService
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+_EXPORTER = ExportService()
 
 
-def drift_chart(values: Sequence[float]):
+@dataclass
+class Visualization:
+    """Visualization metadata with collaboration helpers."""
+
+    figure: plt.Figure
+    shareable_link: str
+    embed_code: str
+    view_id: str
+    annotations: List[str] = field(default_factory=list)
+    version: int = 1
+
+    def annotate(self, note: str) -> None:
+        """Attach an annotation and bump the version."""
+
+        view = _EXPORTER.add_annotation(self.view_id, note)
+        self.annotations = view.annotations
+        self.version = view.version
+
+
+def _build_visualization(fig: plt.Figure, fmt: str) -> Visualization:
+    view_id, link, embed = _EXPORTER.create_shareable(fig, fmt)
+    view = _EXPORTER.get_view(view_id)
+    return Visualization(fig, link, embed, view_id, view.annotations, view.version)
+
+
+def drift_chart(values: Sequence[float], fmt: str = "html") -> Visualization:
     """Generate a line chart representing drift over time."""
+
     fig, ax = plt.subplots()
     ax.plot(list(values))
-    ax.set_title('Drift')
-    return fig
+    ax.set_title("Drift")
+    return _build_visualization(fig, fmt)
 
 
-def heatmap(matrix: Sequence[Sequence[float]]):
+def heatmap(matrix: Sequence[Sequence[float]], fmt: str = "html") -> Visualization:
     """Generate a heatmap from a 2D matrix."""
+
     fig, ax = plt.subplots()
-    ax.imshow(matrix, aspect='auto')
-    ax.set_title('Heatmap')
-    return fig
+    ax.imshow(matrix, aspect="auto")
+    ax.set_title("Heatmap")
+    return _build_visualization(fig, fmt)
 
 
-def distribution_plot(values: Iterable[float]):
+def distribution_plot(values: Iterable[float], fmt: str = "html") -> Visualization:
     """Generate a histogram to visualize a distribution."""
+
     fig, ax = plt.subplots()
     ax.hist(list(values), bins=10)
-    ax.set_title('Distribution')
-    return fig
+    ax.set_title("Distribution")
+    return _build_visualization(fig, fmt)
 
 
-__all__ = ['drift_chart', 'heatmap', 'distribution_plot']
+__all__ = [
+    "Visualization",
+    "drift_chart",
+    "heatmap",
+    "distribution_plot",
+]

--- a/tests/services/test_export_visualization.py
+++ b/tests/services/test_export_visualization.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from src.infrastructure.monitoring.visualization import drift_chart
+
+
+def test_drift_chart_provides_shareable_link_and_annotations():
+    viz = drift_chart([1, 2, 3])
+    assert viz.shareable_link.startswith("/export/")
+    assert "<iframe" in viz.embed_code
+
+    before = viz.version
+    viz.annotate("note")
+    assert viz.version == before + 1
+    assert viz.annotations[-1] == "note"


### PR DESCRIPTION
## Summary
- implement lightweight export service supporting SVG, PNG/JPEG, PDF and HTML exports with shareable links and annotations
- enhance monitoring visualizations to return shareable objects and allow collaborative annotations
- add unit test for export and annotation flow

## Testing
- `pre-commit run --files services/export/__init__.py services/export/service.py src/infrastructure/monitoring/visualization.py tests/services/test_export_visualization.py` *(fails: mypy reports existing type errors)*
- `pytest tests/services/test_export_visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8ff02de48320bb7684ecaac5f514