### PR TITLE
refactor: remove future annotations

### DIFF
--- a/core/integrations/siem_connectors.py
+++ b/core/integrations/siem_connectors.py
@@ -1,7 +1,5 @@
 """Connectors for pushing events to common SIEM systems."""
 
-from __future__ import annotations
-
 from typing import Dict
 
 

--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -14,8 +14,6 @@ Example
 ...     shap.TreeExplainer(...)
 """
 
-from __future__ import annotations
-
 import importlib
 import logging
 import types

--- a/yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py
+++ b/yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import base64
 import os
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from yosai_intel_dashboard.src.core.exceptions import ValidationError
 
@@ -13,7 +11,7 @@ def decode_and_validate_upload(
     contents: str,
     filename: str,
     validator: SecurityValidator | None = None,
-) -> Dict[str, any]:
+) -> Dict[str, Any]:
     """Decode base64 ``contents`` and validate upload metadata.
 
     Returns a dict with keys ``valid``, ``filename``, ``decoded`` (bytes or ``None``),


### PR DESCRIPTION
## Summary
- remove postponed annotation evaluation from SIEM connector helper
- drop future annotations import from optional dependency loader
- strip future annotations from upload utils and use standard typing

## Testing
- `python -m py_compile core/integrations/siem_connectors.py optional_dependencies.py yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py`
- `PYTHONPATH=. pytest core/integrations/siem_connectors.py optional_dependencies.py yosai_intel_dashboard/src/infrastructure/validation/upload_utils.py -q` *(fails: ImportError: cannot import name 'DataLoader' from partially initialized module 'yosai_intel_dashboard.src.services.analytics.data.loader')*

------
https://chatgpt.com/codex/tasks/task_e_688f9318844c83208e81a2e218ed3894