### PR TITLE
Add weather integrations and analytics correlation

### DIFF
--- a/integrations/weather/__init__.py
+++ b/integrations/weather/__init__.py
@@ -1,0 +1,16 @@
+"""Weather data integrations.
+
+This package provides clients for external weather APIs and utilities to
+normalize weather metrics for use by the analytics stack.
+"""
+
+from .clients import OpenWeatherMapClient, NOAAClient, LocalSensorClient
+from .etl import WeatherEvent, run_weather_etl
+
+__all__ = [
+    "OpenWeatherMapClient",
+    "NOAAClient",
+    "LocalSensorClient",
+    "WeatherEvent",
+    "run_weather_etl",
+]

--- a/integrations/weather/clients.py
+++ b/integrations/weather/clients.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Weather API clients.
+
+The clients defined in this module provide minimal wrappers around the
+OpenWeatherMap and NOAA public APIs.  They are intentionally lightweight so
+that unit tests can easily stub out network access by injecting a custom
+``http_get`` callable.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional, Protocol
+import json
+from urllib import request
+
+
+class HttpGet(Protocol):
+    """Callable signature for performing HTTP GET requests."""
+
+    def __call__(self, url: str) -> bytes:  # pragma: no cover - protocol
+        ...
+
+
+def _default_http_get(url: str) -> bytes:
+    with request.urlopen(url) as resp:  # pragma: no cover - network
+        return resp.read()
+
+
+@dataclass
+class OpenWeatherMapClient:
+    """Client for the OpenWeatherMap current weather endpoint."""
+
+    api_key: str
+    lat: float
+    lon: float
+    http_get: HttpGet = _default_http_get
+
+    def fetch(self) -> dict:
+        url = (
+            "https://api.openweathermap.org/data/2.5/weather"
+            f"?lat={self.lat}&lon={self.lon}&appid={self.api_key}&units=metric"
+        )
+        payload = json.loads(self.http_get(url).decode("utf-8"))
+        return {
+            "timestamp": datetime.fromtimestamp(payload["dt"], tz=timezone.utc),
+            "temperature": payload["main"]["temp"],
+            "humidity": payload["main"]["humidity"],
+            "precipitation": payload.get("rain", {}).get("1h", 0.0),
+            "wind": payload.get("wind", {}).get("speed", 0.0),
+            "visibility": payload.get("visibility", 0.0),
+            "pressure": payload["main"].get("pressure", 0.0),
+            "lightning": any(w.get("id", 0) // 100 == 2 for w in payload.get("weather", [])),
+        }
+
+
+@dataclass
+class NOAAClient:
+    """Client for the NOAA latest observation endpoint."""
+
+    station: str
+    http_get: HttpGet = _default_http_get
+
+    def fetch(self) -> dict:
+        url = f"https://api.weather.gov/stations/{self.station}/observations/latest"
+        payload = json.loads(self.http_get(url).decode("utf-8"))
+        props = payload["properties"]
+        return {
+            "timestamp": datetime.fromisoformat(
+                props["timestamp"].replace("Z", "+00:00")
+            ),
+            "temperature": props.get("temperature", {}).get("value"),
+            "humidity": props.get("relativeHumidity", {}).get("value"),
+            "precipitation": props.get("precipitationLastHour", {}).get("value", 0.0),
+            "wind": props.get("windSpeed", {}).get("value"),
+            "visibility": props.get("visibility", {}).get("value"),
+            "pressure": props.get("barometricPressure", {}).get("value"),
+            "lightning": False,  # NOAA endpoint does not report lightning directly
+        }
+
+
+class LocalSensorClient:
+    """Simple client that reads metrics from a local sensor callback."""
+
+    def __init__(self, reader: Callable[[], dict]) -> None:
+        self._reader = reader
+
+    def fetch(self) -> dict:
+        data = self._reader()
+        data.setdefault("timestamp", datetime.now(timezone.utc))
+        return data
+
+
+__all__ = ["OpenWeatherMapClient", "NOAAClient", "LocalSensorClient"]

--- a/integrations/weather/etl.py
+++ b/integrations/weather/etl.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""ETL utilities for weather events."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Protocol
+
+from database.protocols import ConnectionProtocol
+
+
+@dataclass
+class WeatherEvent:
+    """Normalized weather metrics for storage and analysis."""
+
+    timestamp: datetime
+    temperature: float
+    humidity: float
+    precipitation: float
+    wind: float
+    visibility: float
+    pressure: float
+    lightning: bool
+
+
+class WeatherClient(Protocol):
+    def fetch(self) -> dict:  # pragma: no cover - protocol definition
+        ...
+
+
+def normalize(raw: dict) -> WeatherEvent:
+    return WeatherEvent(
+        timestamp=raw["timestamp"],
+        temperature=float(raw.get("temperature", 0.0)),
+        humidity=float(raw.get("humidity", 0.0)),
+        precipitation=float(raw.get("precipitation", 0.0)),
+        wind=float(raw.get("wind", 0.0)),
+        visibility=float(raw.get("visibility", 0.0)),
+        pressure=float(raw.get("pressure", 0.0)),
+        lightning=bool(raw.get("lightning", False)),
+    )
+
+
+def run_weather_etl(db: ConnectionProtocol, clients: Iterable[WeatherClient]) -> list[WeatherEvent]:
+    """Fetch data from ``clients`` and persist to ``db``.
+
+    Returns the list of normalized :class:`WeatherEvent` objects that were
+    inserted.  The database interaction is intentionally simple: each event
+    results in a single ``INSERT`` command recorded on the connection.
+    """
+
+    events: list[WeatherEvent] = []
+    for client in clients:
+        event = normalize(client.fetch())
+        db.execute_command(
+            "INSERT INTO weather_events (timestamp, temperature, humidity, precipitation, wind, visibility, pressure, lightning) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
+            (
+                event.timestamp,
+                event.temperature,
+                event.humidity,
+                event.precipitation,
+                event.wind,
+                event.visibility,
+                event.pressure,
+                event.lightning,
+            ),
+        )
+        events.append(event)
+    return events
+
+
+__all__ = ["WeatherEvent", "run_weather_etl", "normalize"]

--- a/tests/integrations/test_weather.py
+++ b/tests/integrations/test_weather.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from database.mock_database import MockDatabase
+from integrations.weather.clients import (
+    LocalSensorClient,
+    NOAAClient,
+    OpenWeatherMapClient,
+)
+from integrations.weather.etl import WeatherEvent, run_weather_etl
+from yosai_intel_dashboard.src.services.intel_analysis_service.core.behavioral_cliques import (
+    correlate_access_with_weather,
+)
+
+
+def test_openweathermap_client_parses_metrics():
+    sample = {
+        "dt": 0,
+        "main": {"temp": 20, "humidity": 80, "pressure": 1000},
+        "wind": {"speed": 5},
+        "visibility": 10000,
+        "weather": [{"id": 200}],
+        "rain": {"1h": 1.5},
+    }
+
+    def fake_get(url: str) -> bytes:
+        return json.dumps(sample).encode("utf-8")
+
+    client = OpenWeatherMapClient("k", 0.0, 0.0, http_get=fake_get)
+    data = client.fetch()
+    assert data["temperature"] == 20
+    assert data["lightning"] is True
+    assert data["precipitation"] == 1.5
+
+
+def test_noaa_client_parses_metrics():
+    sample = {
+        "properties": {
+            "timestamp": "2023-01-01T00:00:00+00:00",
+            "temperature": {"value": 10},
+            "relativeHumidity": {"value": 50},
+            "precipitationLastHour": {"value": 0.2},
+            "windSpeed": {"value": 3},
+            "visibility": {"value": 5000},
+            "barometricPressure": {"value": 90000},
+        }
+    }
+
+    def fake_get(url: str) -> bytes:
+        return json.dumps(sample).encode("utf-8")
+
+    client = NOAAClient("STATION", http_get=fake_get)
+    data = client.fetch()
+    assert data["humidity"] == 50
+    assert data["wind"] == 3
+
+
+def test_local_sensor_client_returns_data():
+    payload = {
+        "timestamp": datetime.now(timezone.utc),
+        "temperature": 5,
+    }
+    client = LocalSensorClient(lambda: payload)
+    data = client.fetch()
+    assert data["temperature"] == 5
+
+
+def test_weather_etl_inserts_into_database():
+    db = MockDatabase()
+    now = datetime.now(timezone.utc)
+    client = LocalSensorClient(
+        lambda: {
+            "timestamp": now,
+            "temperature": 1,
+            "humidity": 2,
+            "precipitation": 3,
+            "wind": 4,
+            "visibility": 5,
+            "pressure": 6,
+            "lightning": True,
+        }
+    )
+    events = run_weather_etl(db, [client])
+    assert len(events) == 1
+    assert db.commands  # insertion recorded
+
+
+def test_correlate_access_with_weather_flags_spikes():
+    t = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    weather = [
+        WeatherEvent(
+            timestamp=t,
+            temperature=0,
+            humidity=0,
+            precipitation=10,
+            wind=0,
+            visibility=0,
+            pressure=0,
+            lightning=False,
+        )
+    ]
+    access_records = [
+        (t - timedelta(minutes=1), "u", "r"),
+        (t - timedelta(minutes=2), "u", "r"),
+        (t - timedelta(minutes=3), "u", "r"),
+        (t - timedelta(minutes=4), "u", "r"),
+        (t - timedelta(minutes=5), "u", "r"),
+        (t - timedelta(minutes=6), "u", "r"),
+    ]
+    flagged = correlate_access_with_weather(
+        access_records, weather, window=timedelta(minutes=5), spike_threshold=5
+    )
+    assert flagged == [t]


### PR DESCRIPTION
## Summary
- add OpenWeatherMap, NOAA, and local sensor clients
- normalize weather metrics and load into `weather_events`
- correlate access spikes with nearby weather events
- cover adapters, ETL, and correlation logic with tests

## Testing
- `pytest tests/integrations/test_weather.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f9fca05ac8320b98d7112bbd7e4d6