### PR TITLE
Add traffic integrations and arrival estimator

### DIFF
--- a/integrations/traffic/__init__.py
+++ b/integrations/traffic/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .google import parse_google_traffic
+from .here import parse_here_traffic
+from .transit import parse_transit_feed
+
+__all__ = [
+    "parse_google_traffic",
+    "parse_here_traffic",
+    "parse_transit_feed",
+]

--- a/integrations/traffic/google.py
+++ b/integrations/traffic/google.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from database import transport_events
+
+
+def parse_google_traffic(payload: Dict) -> List[transport_events.TrafficEvent]:
+    """Parse Google traffic API payload and persist events.
+
+    Args:
+        payload: Parsed JSON from Google traffic API.
+
+    Returns:
+        List of ``TrafficEvent`` objects stored in the database.
+    """
+    events: List[transport_events.TrafficEvent] = []
+    for item in payload.get("congestion", []):
+        event = transport_events.TrafficEvent(
+            event_type="congestion",
+            location=item["location"],
+            delay_minutes=item.get("delay_minutes", 0),
+            source="google",
+        )
+        transport_events.add_event(event)
+        events.append(event)
+    for item in payload.get("incidents", []):
+        event = transport_events.TrafficEvent(
+            event_type="incident",
+            location=item["location"],
+            delay_minutes=item.get("delay_minutes", 0),
+            source="google",
+        )
+        transport_events.add_event(event)
+        events.append(event)
+    return events

--- a/integrations/traffic/here.py
+++ b/integrations/traffic/here.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from database import transport_events
+
+
+def parse_here_traffic(payload: Dict) -> List[transport_events.TrafficEvent]:
+    """Parse HERE traffic API payload and persist events."""
+    events: List[transport_events.TrafficEvent] = []
+    for item in payload.get("incidents", []):
+        event = transport_events.TrafficEvent(
+            event_type="incident",
+            location=item["location"],
+            delay_minutes=item.get("delay_minutes", 0),
+            source="here",
+        )
+        transport_events.add_event(event)
+        events.append(event)
+    for item in payload.get("congestion", []):
+        event = transport_events.TrafficEvent(
+            event_type="congestion",
+            location=item["location"],
+            delay_minutes=item.get("delay_minutes", 0),
+            source="here",
+        )
+        transport_events.add_event(event)
+        events.append(event)
+    return events

--- a/integrations/traffic/transit.py
+++ b/integrations/traffic/transit.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from database import transport_events
+
+
+def parse_transit_feed(payload: Dict) -> List[transport_events.TrafficEvent]:
+    """Parse public transit feed and persist schedule events."""
+    events: List[transport_events.TrafficEvent] = []
+    for item in payload.get("schedules", []):
+        event = transport_events.TrafficEvent(
+            event_type="schedule",
+            location=item["stop"],
+            delay_minutes=item.get("delay_minutes", 0),
+            source="transit",
+        )
+        transport_events.add_event(event)
+        events.append(event)
+    return events

--- a/services/arrival_estimator.py
+++ b/services/arrival_estimator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from database import transport_events
+
+
+class ArrivalEstimator:
+    """Estimate arrival times using transport event data."""
+
+    def __init__(self, base_speed_kmph: float = 40.0) -> None:
+        self.base_speed = base_speed_kmph
+
+    def estimate(
+        self,
+        distance_km: float,
+        location: str,
+        start_time: datetime | None = None,
+    ) -> datetime:
+        """Estimate arrival time for a trip.
+
+        Args:
+            distance_km: Distance to travel.
+            location: Location identifier used to look up transport events.
+            start_time: Starting time of the trip. Defaults to ``datetime.utcnow``.
+        """
+        if start_time is None:
+            start_time = datetime.utcnow()
+        travel_minutes = (distance_km / self.base_speed) * 60
+        delay_minutes = transport_events.total_delay(location)
+        return start_time + timedelta(minutes=travel_minutes + delay_minutes)

--- a/tests/integrations/test_traffic.py
+++ b/tests/integrations/test_traffic.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from integrations.traffic import (
+    parse_google_traffic,
+    parse_here_traffic,
+    parse_transit_feed,
+)
+from database import transport_events
+from services.arrival_estimator import ArrivalEstimator
+
+
+def test_feed_parsing() -> None:
+    transport_events.clear_events()
+    google_data = {
+        "congestion": [{"location": "Main St", "delay_minutes": 5}],
+        "incidents": [{"location": "Main St", "delay_minutes": 3}],
+    }
+    here_data = {
+        "incidents": [{"location": "Main St", "delay_minutes": 2}],
+    }
+    transit_data = {
+        "schedules": [{"stop": "Main St", "delay_minutes": 1}],
+    }
+
+    parse_google_traffic(google_data)
+    parse_here_traffic(here_data)
+    parse_transit_feed(transit_data)
+
+    events = transport_events.get_events()
+    assert len(events) == 4
+    assert transport_events.total_delay("Main St") == 11
+
+
+def test_prediction_accuracy() -> None:
+    transport_events.clear_events()
+    parse_google_traffic({"congestion": [{"location": "Route", "delay_minutes": 4}]})
+
+    estimator = ArrivalEstimator(base_speed_kmph=60)
+    start = datetime(2024, 1, 1, 8, 0, 0)
+    arrival = estimator.estimate(distance_km=30, location="Route", start_time=start)
+
+    assert arrival == start + timedelta(minutes=34)

--- a/yosai_intel_dashboard/src/database/transport_events.py
+++ b/yosai_intel_dashboard/src/database/transport_events.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class TrafficEvent:
+    """Represents a traffic-related event affecting travel time."""
+
+    event_type: str
+    location: str
+    delay_minutes: int
+    source: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+_events: List[TrafficEvent] = []
+
+
+def add_event(event: TrafficEvent) -> None:
+    """Persist a transport event."""
+    _events.append(event)
+
+
+def get_events(location: Optional[str] = None) -> List[TrafficEvent]:
+    """Return stored events, optionally filtered by location."""
+    events = _events
+    if location is not None:
+        events = [e for e in events if e.location == location]
+    return list(events)
+
+
+def total_delay(location: str) -> int:
+    """Aggregate delay in minutes for a given location."""
+    return sum(e.delay_minutes for e in get_events(location))
+
+
+def clear_events() -> None:
+    """Clear all stored events (used in tests)."""
+    _events.clear()
+
+
+__all__ = [
+    "TrafficEvent",
+    "add_event",
+    "get_events",
+    "total_delay",
+    "clear_events",
+]


### PR DESCRIPTION
## Summary
- add traffic feed adapters for Google, HERE, and public transit
- persist transport events and use them for arrival estimation
- cover feed parsing and arrival predictions with tests

## Testing
- `pytest tests/integrations/test_traffic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9fca30948320a5f5ef8f58d09197