### PR TITLE
Add social media integrations with classification

### DIFF
--- a/integrations/social/__init__.py
+++ b/integrations/social/__init__.py
@@ -1,0 +1,5 @@
+"""Social media integrations."""
+
+from .twitter import stream_twitter
+from .rss import ingest_rss
+from .reddit import scrape_reddit

--- a/integrations/social/reddit.py
+++ b/integrations/social/reddit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from intel_analysis_service.nlp import classify_sentiment, detect_threat
+from database import social_signals
+
+
+def scrape_reddit(
+    posts: Iterable[Dict[str, str]], location_filter: str
+) -> List[social_signals.SocialSignal]:
+    """Scrape Reddit posts filtered by location."""
+    alerts: List[social_signals.SocialSignal] = []
+    for post in posts:
+        if post.get("location") != location_filter:
+            continue
+        text = post.get("text", "")
+        sentiment = classify_sentiment(text)
+        threat = detect_threat(text)
+        alert = social_signals.SocialSignal(
+            source="reddit",
+            text=text,
+            location=post.get("location", ""),
+            sentiment=sentiment,
+            threat=threat,
+        )
+        social_signals.save_alert(alert)
+        alerts.append(alert)
+    return alerts

--- a/integrations/social/rss.py
+++ b/integrations/social/rss.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from intel_analysis_service.nlp import classify_sentiment, detect_threat
+from database import social_signals
+
+
+def ingest_rss(
+    items: Iterable[Dict[str, str]], location_filter: str
+) -> List[social_signals.SocialSignal]:
+    """Ingest RSS feed items filtered by location."""
+    alerts: List[social_signals.SocialSignal] = []
+    for item in items:
+        if item.get("location") != location_filter:
+            continue
+        text = item.get("text", "")
+        sentiment = classify_sentiment(text)
+        threat = detect_threat(text)
+        alert = social_signals.SocialSignal(
+            source="rss",
+            text=text,
+            location=item.get("location", ""),
+            sentiment=sentiment,
+            threat=threat,
+        )
+        social_signals.save_alert(alert)
+        alerts.append(alert)
+    return alerts

--- a/integrations/social/schema.py
+++ b/integrations/social/schema.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import List
+
+import strawberry
+
+from database import social_signals
+
+
+@strawberry.type
+class SocialSignalType:
+    source: str
+    text: str
+    location: str
+    sentiment: str
+    threat: bool
+
+
+@strawberry.type
+class Query:
+    @strawberry.field(name="socialSignals")
+    def resolve_social_signals(self) -> List[SocialSignalType]:
+        return social_signals.list_alerts()
+
+
+schema = strawberry.Schema(Query)

--- a/integrations/social/twitter.py
+++ b/integrations/social/twitter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from intel_analysis_service.nlp import classify_sentiment, detect_threat
+from database import social_signals
+
+
+def stream_twitter(
+    tweets: Iterable[Dict[str, str]], location_filter: str
+) -> List[social_signals.SocialSignal]:
+    """Process a stream of tweets filtered by location."""
+    alerts: List[social_signals.SocialSignal] = []
+    for tweet in tweets:
+        if tweet.get("location") != location_filter:
+            continue
+        text = tweet.get("text", "")
+        sentiment = classify_sentiment(text)
+        threat = detect_threat(text)
+        alert = social_signals.SocialSignal(
+            source="twitter",
+            text=text,
+            location=tweet.get("location", ""),
+            sentiment=sentiment,
+            threat=threat,
+        )
+        social_signals.save_alert(alert)
+        alerts.append(alert)
+    return alerts

--- a/tests/integrations/test_social.py
+++ b/tests/integrations/test_social.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# make intel_analysis_service package available
+sys.path.append(
+    str(pathlib.Path(__file__).resolve().parents[2] / "yosai_intel_dashboard" / "src" / "services")
+)
+
+from database import social_signals
+from integrations.social import reddit, rss, schema, twitter
+
+
+def setup_function() -> None:
+    social_signals.clear_alerts()
+
+
+def test_twitter_stream_classification() -> None:
+    tweets = [
+        {"text": "good day", "location": "SF"},
+        {"text": "bad attack", "location": "SF"},
+        {"text": "great", "location": "LA"},
+    ]
+    alerts = twitter.stream_twitter(tweets, "SF")
+    assert len(alerts) == 2
+    assert alerts[0].sentiment == "positive"
+    assert alerts[1].sentiment == "negative" and alerts[1].threat is True
+    stored = social_signals.list_alerts()
+    assert len(stored) == 2 and all(a.location == "SF" for a in stored)
+
+
+def test_rss_and_reddit_ingestion() -> None:
+    rss_items = [{"text": "bad weather", "location": "NY"}]
+    reddit_posts = [{"text": "love this", "location": "NY"}]
+    rss_alerts = rss.ingest_rss(rss_items, "NY")
+    reddit_alerts = reddit.scrape_reddit(reddit_posts, "NY")
+    assert rss_alerts[0].sentiment == "negative"
+    assert reddit_alerts[0].sentiment == "positive"
+    assert len(social_signals.list_alerts()) == 2
+
+
+def test_graphql_resolver_exposes_alerts() -> None:
+    twitter.stream_twitter([{"text": "attack now", "location": "TX"}], "TX")
+    query = "{ socialSignals { source text location sentiment threat } }"
+    result = schema.schema.execute_sync(query)
+    assert not result.errors
+    data = result.data["socialSignals"]
+    assert len(data) == 1 and data[0]["threat"] is True

--- a/yosai_intel_dashboard/src/database/social_signals.py
+++ b/yosai_intel_dashboard/src/database/social_signals.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import List
+
+
+@dataclass
+class SocialSignal:
+    source: str
+    text: str
+    location: str
+    sentiment: str
+    threat: bool
+
+
+_alerts: List[SocialSignal] = []
+_lock = Lock()
+
+
+def save_alert(alert: SocialSignal) -> None:
+    """Persist ``alert`` to the in-memory store."""
+    with _lock:
+        _alerts.append(alert)
+
+
+def list_alerts() -> List[SocialSignal]:
+    """Return a copy of all stored alerts."""
+    with _lock:
+        return list(_alerts)
+
+
+def clear_alerts() -> None:
+    """Remove all stored alerts. Useful for tests."""
+    with _lock:
+        _alerts.clear()

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/nlp/__init__.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/nlp/__init__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Literal, Set
+
+# Simple NLP utilities for sentiment and threat classification
+
+_POSITIVE_WORDS: Set[str] = {"good", "great", "love", "happy"}
+_NEGATIVE_WORDS: Set[str] = {"bad", "terrible", "hate", "angry"}
+_THREAT_WORDS: Set[str] = {"attack", "bomb", "threat", "kill"}
+
+
+def _tokenize(text: str) -> Set[str]:
+    """Tokenize ``text`` into a set of lowercase words."""
+    return {t.lower().strip('.,!?') for t in text.split()}
+
+
+def classify_sentiment(text: str) -> Literal["positive", "negative", "neutral"]:
+    """Classify sentiment of ``text`` using a small keyword list."""
+    tokens = _tokenize(text)
+    if tokens & _POSITIVE_WORDS:
+        return "positive"
+    if tokens & _NEGATIVE_WORDS:
+        return "negative"
+    return "neutral"
+
+
+def detect_threat(text: str) -> bool:
+    """Return ``True`` if ``text`` contains threat-related terms."""
+    tokens = _tokenize(text)
+    return bool(tokens & _THREAT_WORDS)


### PR DESCRIPTION
## Summary
- Add Twitter, RSS, and Reddit scrapers with location filtering
- Implement simple sentiment and threat detection utilities
- Persist social alerts and expose them through a GraphQL resolver
- Cover new parsing and classification logic with tests

## Testing
- `pytest tests/integrations/test_social.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9fcb95648320b43a7e272f35d3f6