### PR TITLE
refactor(ui): replace bootstrap with tailwind

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/App.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import '@fortawesome/fontawesome-free/css/all.min.css';
 import './styles/upload.css';
 import { Upload } from './components/upload';
+import { Shield } from 'lucide-react';
 
 function App() {
   return (
     <div className="App">
-      <nav className="navbar navbar-dark bg-dark mb-4">
-        <div className="container-fluid">
-          <span className="navbar-brand mb-0 h1">
-            <i className="fas fa-shield-alt me-2"></i>
+      <nav className="bg-gray-900 mb-4">
+        <div className="container mx-auto px-4">
+          <span className="flex items-center text-white text-xl font-semibold">
+            <Shield className="w-6 h-6 mr-2" />
             Yōsai Intel Dashboard
           </span>
         </div>
       </nav>
-      <div className="container-fluid">
+      <div className="container mx-auto px-4">
         <Upload />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove Bootstrap and Font Awesome imports
- rework navigation with Tailwind and lucide-react icon

## Testing
- `npm test` *(fails: Cannot find module 'yosai_intel_dashboard/src/adapters/ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688faa7ea1c083208bf0d6d489e18c3a