### PR TITLE
feat: add context disclosure components

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/ClickExpand.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/ClickExpand.tsx
@@ -1,0 +1,24 @@
+import React, { useState, ReactNode } from 'react';
+import { useContextDisclosureShortcuts } from './Shortcuts';
+
+interface ClickExpandProps {
+  preview: ReactNode;
+  children: ReactNode;
+}
+
+const ClickExpand: React.FC<ClickExpandProps> = ({ preview, children }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  useContextDisclosureShortcuts(
+    () => setExpanded(true),
+    () => setExpanded(false)
+  );
+
+  return (
+    <div onClick={() => setExpanded(!expanded)}>
+      {expanded ? children : preview}
+    </div>
+  );
+};
+
+export default ClickExpand;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/HoverPreview.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/HoverPreview.tsx
@@ -1,0 +1,27 @@
+import React, { useState, ReactNode } from 'react';
+import { useContextDisclosureShortcuts } from './Shortcuts';
+
+interface HoverPreviewProps {
+  preview: ReactNode;
+  children: ReactNode;
+}
+
+const HoverPreview: React.FC<HoverPreviewProps> = ({ preview, children }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  useContextDisclosureShortcuts(
+    () => setExpanded(true),
+    () => setExpanded(false)
+  );
+
+  return (
+    <div
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+    >
+      {expanded ? children : preview}
+    </div>
+  );
+};
+
+export default HoverPreview;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/LongPressMenu.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/LongPressMenu.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useRef, ReactNode } from 'react';
+import { useContextDisclosureShortcuts } from './Shortcuts';
+
+interface LongPressMenuProps {
+  preview: ReactNode;
+  children: ReactNode;
+  delay?: number;
+}
+
+const LongPressMenu: React.FC<LongPressMenuProps> = ({ preview, children, delay = 500 }) => {
+  const [expanded, setExpanded] = useState(false);
+  const timerRef = useRef<number>();
+
+  useContextDisclosureShortcuts(
+    () => setExpanded(true),
+    () => setExpanded(false)
+  );
+
+  const startPress = () => {
+    timerRef.current = window.setTimeout(() => setExpanded(true), delay);
+  };
+
+  const cancelPress = () => {
+    window.clearTimeout(timerRef.current);
+    setExpanded(false);
+  };
+
+  return (
+    <div
+      onMouseDown={startPress}
+      onMouseUp={cancelPress}
+      onMouseLeave={cancelPress}
+      onTouchStart={startPress}
+      onTouchEnd={cancelPress}
+    >
+      {expanded ? children : preview}
+    </div>
+  );
+};
+
+export default LongPressMenu;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/Shortcuts.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/Shortcuts.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export const useContextDisclosureShortcuts = (
+  expand: () => void,
+  collapse: () => void
+) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'e') {
+        expand();
+      }
+      if (e.key === 'Escape') {
+        collapse();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [expand, collapse]);
+};

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/ClickExpand.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/ClickExpand.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import ClickExpand from '../ClickExpand';
+
+test('ClickExpand toggles on click and shortcuts', () => {
+  const { getByText } = render(
+    <ClickExpand preview={<div>preview</div>}>
+      <div>content</div>
+    </ClickExpand>
+  );
+
+  const container = getByText('preview');
+  fireEvent.click(container);
+  expect(getByText('content')).toBeInTheDocument();
+  fireEvent.click(getByText('content'));
+  expect(getByText('preview')).toBeInTheDocument();
+
+  fireEvent.keyDown(window, { key: 'e' });
+  expect(getByText('content')).toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(getByText('preview')).toBeInTheDocument();
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/HoverPreview.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/HoverPreview.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import HoverPreview from '../HoverPreview';
+
+test('HoverPreview toggles content on hover and shortcuts', () => {
+  const { getByText } = render(
+    <HoverPreview preview={<div>preview</div>}>
+      <div>content</div>
+    </HoverPreview>
+  );
+
+  const preview = getByText('preview');
+  fireEvent.mouseEnter(preview);
+  expect(getByText('content')).toBeInTheDocument();
+  fireEvent.mouseLeave(preview);
+  expect(getByText('preview')).toBeInTheDocument();
+
+  fireEvent.keyDown(window, { key: 'e' });
+  expect(getByText('content')).toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(getByText('preview')).toBeInTheDocument();
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/LongPressMenu.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/__tests__/LongPressMenu.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import LongPressMenu from '../LongPressMenu';
+
+jest.useFakeTimers();
+
+test('LongPressMenu reveals content after long press and hides on escape', () => {
+  const { getByText } = render(
+    <LongPressMenu preview={<div>preview</div>} delay={100}>
+      <div>menu</div>
+    </LongPressMenu>
+  );
+
+  const preview = getByText('preview');
+  fireEvent.mouseDown(preview);
+  jest.advanceTimersByTime(100);
+  expect(getByText('menu')).toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(getByText('preview')).toBeInTheDocument();
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/ContextDisclosure/index.ts
@@ -1,0 +1,4 @@
+export { default as HoverPreview } from './HoverPreview';
+export { default as ClickExpand } from './ClickExpand';
+export { default as LongPressMenu } from './LongPressMenu';
+export { useContextDisclosureShortcuts } from './Shortcuts';

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
@@ -1,3 +1,4 @@
 export { default as ThresholdSlider } from './ThresholdSlider';
 export * from './lasso';
 export * from './useLassoSelection';
+export * from './ContextDisclosure';

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import { useAnalyticsStore } from '../state/store';
 import { BarChart3, Filter, Download, AlertCircle } from 'lucide-react';
 import RiskDashboard from '../components/security/RiskDashboard';
 import { api } from '../api/client';
+import { HoverPreview, ClickExpand } from '../components/interaction/ContextDisclosure';
 import './Analytics.css';
 
 interface AnalyticsData {
@@ -126,14 +127,16 @@ const Analytics: React.FC = () => {
         </div>
       </div>
 
-      <RiskDashboard
-        score={riskData.score}
-        history={riskData.history}
-        factors={riskData.factors}
-      />
+      <HoverPreview preview={<div>Risk dashboard preview</div>}>
+        <RiskDashboard
+          score={riskData.score}
+          history={riskData.history}
+          factors={riskData.factors}
+        />
+      </HoverPreview>
 
       {analyticsData && (
-        <>
+        <ClickExpand preview={<div className="analytics-preview">Click to view analytics</div>}>
           <div className="stats-grid">
             <div className="stat-card">
               <h3>Total Records</h3>
@@ -146,7 +149,7 @@ const Analytics: React.FC = () => {
             <div className="stat-card">
               <h3>Date Range</h3>
               <p className="stat-value">
-                {new Date(analyticsData.date_range.start).toLocaleDateString()} - 
+                {new Date(analyticsData.date_range.start).toLocaleDateString()} -
                 {new Date(analyticsData.date_range.end).toLocaleDateString()}
               </p>
             </div>
@@ -163,7 +166,7 @@ const Analytics: React.FC = () => {
                       <span className="pattern-count">{pattern.count} occurrences</span>
                     </div>
                     <div className="pattern-bar">
-                      <div 
+                      <div
                         className="pattern-bar-fill"
                         style={{ width: `${pattern.percentage}%` }}
                       />
@@ -186,7 +189,7 @@ const Analytics: React.FC = () => {
               </div>
             </section>
           </div>
-        </>
+        </ClickExpand>
       )}
     </div>
   );

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { Upload as UploadComponent } from '../components/upload';
 import { UploadProvider } from '../state/uploadContext';
+import { LongPressMenu } from '../components/interaction/ContextDisclosure';
 
 const UploadPage: React.FC = () => (
   <ErrorBoundary>
     <UploadProvider>
-      <UploadComponent />
+      <LongPressMenu preview={<div>Hold to open upload</div>}>
+        <UploadComponent />
+      </LongPressMenu>
     </UploadProvider>
   </ErrorBoundary>
 );


### PR DESCRIPTION
## Summary
- add HoverPreview, ClickExpand, and LongPressMenu for progressive disclosure
- wrap analytics and upload pages with disclosure previews
- wire keyboard shortcuts and add tests

## Testing
- `npx react-scripts test --coverage --watchAll=false components/interaction/ContextDisclosure/__tests__` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npx jest components/interaction/ContextDisclosure/__tests__ --coverage` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbd8c49083209ab42756d6b425a9