### PR TITLE
feat: add task launcher and wizard components

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/TaskLauncher.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/TaskLauncher.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Upload, LayoutDashboard, BarChart3, Filter } from 'lucide-react';
+
+interface TaskTemplate {
+  name: string;
+  href: string;
+  description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+const defaultTemplates: TaskTemplate[] = [
+  {
+    name: 'Upload Data',
+    href: '/upload',
+    description: 'Upload and process new data files',
+    icon: Upload,
+  },
+  {
+    name: 'Build Dashboard',
+    href: '/builder',
+    description: 'Create custom dashboard layouts',
+    icon: LayoutDashboard,
+  },
+  {
+    name: 'Run Analytics',
+    href: '/analytics',
+    description: 'Explore security analytics',
+    icon: BarChart3,
+  },
+  {
+    name: 'Query Data',
+    href: '/query-builder',
+    description: 'Construct complex data queries',
+    icon: Filter,
+  },
+];
+
+export interface TaskLauncherProps {
+  templates?: TaskTemplate[];
+  onSelect?: (template: TaskTemplate) => void;
+}
+
+const TaskLauncher: React.FC<TaskLauncherProps> = ({
+  templates = defaultTemplates,
+  onSelect,
+}) => {
+  return (
+    <div className="mb-6">
+      <h2 className="text-lg font-semibold mb-3">What would you like to do?</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        {templates.map((tpl) => {
+          const Icon = tpl.icon;
+          return (
+            <Link
+              key={tpl.name}
+              to={tpl.href}
+              onClick={() => onSelect?.(tpl)}
+              className="flex flex-col p-4 border rounded-md hover:bg-gray-50 transition-colors"
+            >
+              {Icon && <Icon className="h-6 w-6 mb-2 text-blue-600" />}
+              <span className="font-medium">{tpl.name}</span>
+              {tpl.description && (
+                <span className="text-sm text-gray-600">{tpl.description}</span>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TaskLauncher;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/Wizard.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/Wizard.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+
+export interface WizardStep {
+  title: string;
+  content: React.ReactNode;
+}
+
+export interface WizardProps {
+  steps: WizardStep[];
+  storageKey?: string;
+}
+
+const Wizard: React.FC<WizardProps> = ({ steps, storageKey }) => {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    const saved = Number(window.localStorage.getItem(storageKey));
+    if (!Number.isNaN(saved) && saved >= 0 && saved < steps.length) {
+      setCurrent(saved);
+    }
+  }, [storageKey, steps.length]);
+
+  const persist = (value: number) => {
+    if (storageKey) {
+      window.localStorage.setItem(storageKey, String(value));
+    }
+  };
+
+  const goTo = (index: number) => {
+    setCurrent(index);
+    persist(index);
+  };
+
+  const next = () => {
+    if (current < steps.length - 1) {
+      goTo(current + 1);
+    }
+  };
+
+  const prev = () => {
+    if (current > 0) {
+      goTo(current - 1);
+    }
+  };
+
+  const skip = () => {
+    next();
+  };
+
+  return (
+    <div className="wizard">
+      <div className="flex mb-4 space-x-2" role="tablist">
+        {steps.map((step, index) => (
+          <button
+            key={step.title}
+            type="button"
+            className={`px-3 py-1 rounded-md text-sm border ${
+              index === current
+                ? 'bg-blue-600 text-white'
+                : 'bg-white text-gray-600'
+            }`}
+            onClick={() => goTo(index)}
+            aria-selected={index === current}
+            role="tab"
+          >
+            {step.title}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4" role="tabpanel">
+        {steps[current]?.content}
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={prev}
+          disabled={current === 0}
+          className="px-3 py-1 border rounded-md disabled:opacity-50"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={skip}
+          disabled={current === steps.length - 1}
+          className="px-3 py-1 border rounded-md disabled:opacity-50"
+        >
+          Skip
+        </button>
+        <button
+          type="button"
+          onClick={next}
+          disabled={current === steps.length - 1}
+          className="px-3 py-1 border rounded-md disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Wizard;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
@@ -1,3 +1,5 @@
 export { default as ThresholdSlider } from './ThresholdSlider';
 export * from './lasso';
 export * from './useLassoSelection';
+export { default as TaskLauncher } from './TaskLauncher';
+export { default as Wizard } from './Wizard';

--- a/yosai_intel_dashboard/src/adapters/ui/pages/DashboardBuilder.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/DashboardBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { getPreferences } from '../services/preferences';
 import { saveTemplate, loadTemplate, ChartTemplate } from '../lib/dashboardTemplates';
+import { TaskLauncher, Wizard } from '../components/interaction';
 
 const chartTypes = ['Line', 'Bar', 'Pie'];
 
@@ -65,7 +66,7 @@ const DashboardBuilder: React.FC = () => {
     background: prefs.colorScheme === 'dark' ? '#1f2937' : '#f9fafb',
   };
 
-  return (
+  const designStep = (
     <div style={{ display: 'flex', height: '100%' }}>
       <div style={{ width: 200, padding: 10, borderRight: '1px solid #ccc' }}>
         <h3>Charts</h3>
@@ -112,6 +113,18 @@ const DashboardBuilder: React.FC = () => {
         ))}
       </div>
     </div>
+  );
+
+  const steps = [
+    { title: 'Design', content: designStep },
+    { title: 'Review', content: <div>Review your dashboard before saving.</div> },
+  ];
+
+  return (
+    <>
+      <TaskLauncher />
+      <Wizard steps={steps} storageKey="dashboard-builder-wizard" />
+    </>
   );
 };
 

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
@@ -2,13 +2,25 @@ import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { Upload as UploadComponent } from '../components/upload';
 import { UploadProvider } from '../state/uploadContext';
+import { TaskLauncher, Wizard } from '../components/interaction';
 
-const UploadPage: React.FC = () => (
-  <ErrorBoundary>
-    <UploadProvider>
-      <UploadComponent />
-    </UploadProvider>
-  </ErrorBoundary>
-);
+const UploadPage: React.FC = () => {
+  const steps = [
+    { title: 'Upload', content: <UploadComponent /> },
+    {
+      title: 'Review',
+      content: <div>Please review your upload before submitting.</div>,
+    },
+  ];
+
+  return (
+    <ErrorBoundary>
+      <TaskLauncher />
+      <UploadProvider>
+        <Wizard steps={steps} storageKey="upload-wizard-step" />
+      </UploadProvider>
+    </ErrorBoundary>
+  );
+};
 
 export default UploadPage;


### PR DESCRIPTION
## Summary
- add reusable TaskLauncher with common navigation templates
- create Wizard component for multi-step flows with progress persistence
- embed TaskLauncher and Wizard into Upload and DashboardBuilder pages

## Testing
- `npm test` *(fails: Cannot find module '.../yosai_intel_dashboard/src/adapters/ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688fbbdbfd208320848decf3e8a5de2e