### PR TITLE
feat: add chunk grouping and style tokens

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/ChunkGroup.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/ChunkGroup.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+interface ChunkGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+  limit?: number; // number of visible elements before collapsing
+}
+
+const ChunkGroup: React.FC<ChunkGroupProps> = ({
+  title,
+  children,
+  className = '',
+  limit = 7,
+  ...rest
+}) => {
+  const items = React.Children.toArray(children);
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = items.length > limit;
+  const visible = expanded ? items : items.slice(0, limit);
+
+  return (
+    <div className={className} {...rest}>
+      {title && <h3 className="mb-2 font-semibold">{title}</h3>}
+      {visible}
+      {hasMore && (
+        <button
+          type="button"
+          className="mt-2 text-sm text-blue-600 underline"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? 'Show Less' : 'Show More'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ChunkGroup;

--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/index.ts
@@ -1,1 +1,2 @@
 export { default as Navbar } from './Navbar';
+export { default as ChunkGroup } from './ChunkGroup';

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/styleTokens.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/styleTokens.ts
@@ -1,0 +1,12 @@
+export type Priority = 'low' | 'medium' | 'high' | 'critical';
+
+export const priorityLevels: Priority[] = ['low', 'medium', 'high', 'critical'];
+
+export const colorTokens: Record<Priority, string> = {
+  low: '#16a34a', // green-600
+  medium: '#facc15', // yellow-400
+  high: '#fb923c', // orange-400
+  critical: '#dc2626', // red-600
+};
+
+export const priorityColor = (priority: Priority): string => colorTokens[priority];

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { useAnalyticsStore } from '../state/store';
 import { BarChart3, Filter, Download, AlertCircle } from 'lucide-react';
+import { ChunkGroup } from '../components/layout';
 import RiskDashboard from '../components/security/RiskDashboard';
 import { api } from '../api/client';
 import './Analytics.css';
@@ -108,7 +109,7 @@ const Analytics: React.FC = () => {
     <div className="analytics-container">
       <div className="analytics-header">
         <h1>Security Analytics</h1>
-        <div className="header-actions">
+        <ChunkGroup className="header-actions">
           <select
             value={sourceType}
             onChange={(e) => setSourceType(e.target.value)}
@@ -123,7 +124,7 @@ const Analytics: React.FC = () => {
             <Download size={20} />
             Export CSV
           </button>
-        </div>
+        </ChunkGroup>
       </div>
 
       <RiskDashboard
@@ -155,7 +156,7 @@ const Analytics: React.FC = () => {
           <div className="analytics-sections">
             <section className="patterns-section">
               <h2>Top Security Patterns</h2>
-              <div className="patterns-list">
+              <ChunkGroup className="patterns-list" limit={9}>
                 {analyticsData.patterns.map((pattern, index) => (
                   <div key={index} className="pattern-item">
                     <div className="pattern-info">
@@ -163,7 +164,7 @@ const Analytics: React.FC = () => {
                       <span className="pattern-count">{pattern.count} occurrences</span>
                     </div>
                     <div className="pattern-bar">
-                      <div 
+                      <div
                         className="pattern-bar-fill"
                         style={{ width: `${pattern.percentage}%` }}
                       />
@@ -171,19 +172,19 @@ const Analytics: React.FC = () => {
                     </div>
                   </div>
                 ))}
-              </div>
+              </ChunkGroup>
             </section>
 
             <section className="devices-section">
               <h2>Device Distribution</h2>
-              <div className="device-grid">
+              <ChunkGroup className="device-grid" limit={9}>
                 {analyticsData.device_distribution.map((device, index) => (
                   <div key={index} className="device-card">
                     <span className="device-name">{device.device}</span>
                     <span className="device-count">{device.count}</span>
                   </div>
                 ))}
-              </div>
+              </ChunkGroup>
             </section>
           </div>
         </>

--- a/yosai_intel_dashboard/src/adapters/ui/pages/DashboardBuilder.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/DashboardBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { getPreferences } from '../services/preferences';
 import { saveTemplate, loadTemplate, ChartTemplate } from '../lib/dashboardTemplates';
+import { ChunkGroup } from '../components/layout';
 
 const chartTypes = ['Line', 'Bar', 'Pie'];
 
@@ -68,19 +69,21 @@ const DashboardBuilder: React.FC = () => {
   return (
     <div style={{ display: 'flex', height: '100%' }}>
       <div style={{ width: 200, padding: 10, borderRight: '1px solid #ccc' }}>
-        <h3>Charts</h3>
-        {chartTypes.map((type) => (
-          <div
-            key={type}
-            draggable
-            onDragStart={(e) => handleDragStart(e, type)}
-            style={{ marginBottom: 8, padding: 4, border: '1px solid #ddd', cursor: 'grab' }}
-          >
-            {type} Chart
-          </div>
-        ))}
-        <button onClick={saveCurrent} style={{ marginTop: 10, display: 'block' }}>Save Template</button>
-        <button onClick={loadCurrent} style={{ marginTop: 4, display: 'block' }}>Load Template</button>
+        <ChunkGroup>
+          <h3>Charts</h3>
+          {chartTypes.map((type) => (
+            <div
+              key={type}
+              draggable
+              onDragStart={(e) => handleDragStart(e, type)}
+              style={{ marginBottom: 8, padding: 4, border: '1px solid #ddd', cursor: 'grab' }}
+            >
+              {type} Chart
+            </div>
+          ))}
+          <button onClick={saveCurrent} style={{ marginTop: 10, display: 'block' }}>Save Template</button>
+          <button onClick={loadCurrent} style={{ marginTop: 4, display: 'block' }}>Load Template</button>
+        </ChunkGroup>
       </div>
       <div
         ref={workspaceRef}

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Download } from 'lucide-react';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { ChunkGroup } from '../components/layout';
 
 const Export: React.FC = () => {
   return (
-    <div className="page-container">
+    <ChunkGroup className="page-container">
       <h1>Export Data</h1>
       <p>Export functionality coming soon...</p>
-    </div>
+    </ChunkGroup>
   );
 };
 

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { LineChart as LineChartIcon } from 'lucide-react';
+import { ChunkGroup } from '../components/layout';
 import {
   LineChart,
   Line,
@@ -163,24 +164,26 @@ const Graphs: React.FC = () => {
 
   return (
     <div className="page-container">
-      <h1 className="mb-4 flex items-center space-x-2">
-        <LineChartIcon size={20} />
-        <span>Security Graphs</span>
-      </h1>
-      {availableCharts.length > 0 && (
-        <select
-          className="mb-4 border p-2 rounded"
-          value={selectedChart}
-          onChange={(e) => setSelectedChart(e.target.value)}
-          aria-label="Select chart type"
-        >
-          {availableCharts.map((chart) => (
-            <option key={chart.type} value={chart.type}>
-              {chart.name}
-            </option>
-          ))}
-        </select>
-      )}
+      <ChunkGroup>
+        <h1 className="mb-4 flex items-center space-x-2">
+          <LineChartIcon size={20} />
+          <span>Security Graphs</span>
+        </h1>
+        {availableCharts.length > 0 && (
+          <select
+            className="mb-4 border p-2 rounded"
+            value={selectedChart}
+            onChange={(e) => setSelectedChart(e.target.value)}
+            aria-label="Select chart type"
+          >
+            {availableCharts.map((chart) => (
+              <option key={chart.type} value={chart.type}>
+                {chart.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </ChunkGroup>
       <div role="presentation">{renderChart()}</div>
 
     </div>

--- a/yosai_intel_dashboard/src/adapters/ui/pages/QueryBuilder.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/QueryBuilder.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { ChunkGroup } from '../components/layout';
 
 interface Filter {
   id: number;
@@ -44,7 +45,7 @@ const QueryBuilder: React.FC = () => {
       <div className="grid grid-cols-2 gap-4">
         <div>
           <h2 className="font-semibold mb-2">Available Filters</h2>
-          <div className="space-y-2">
+          <ChunkGroup className="space-y-2" limit={9}>
             {availableFilters.map((f) => (
               <div
                 key={f.field}
@@ -55,11 +56,11 @@ const QueryBuilder: React.FC = () => {
                 {f.label}
               </div>
             ))}
-          </div>
+          </ChunkGroup>
         </div>
         <div>
           <h2 className="font-semibold mb-2">Build Query</h2>
-          <div
+          <ChunkGroup
             onDrop={onDrop}
             onDragOver={(e) => e.preventDefault()}
             className="min-h-[150px] border-2 border-dashed p-2 rounded"
@@ -86,7 +87,7 @@ const QueryBuilder: React.FC = () => {
             {filters.length === 0 && (
               <p className="text-gray-500 text-sm">Drag filters here</p>
             )}
-          </div>
+          </ChunkGroup>
         </div>
       </div>
 

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 
 import ErrorBoundary from '../components/ErrorBoundary';
 import {
@@ -22,6 +22,7 @@ import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { useRealTimeAnalytics } from '../hooks/useRealTimeAnalytics';
 import { AccessibleVisualization } from '../components/accessibility';
+import { ChunkGroup } from '../components/layout';
 
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'];
@@ -102,8 +103,8 @@ const RealTimeAnalyticsPage: React.FC = () => {
 
   return (
     <div className="p-3">
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center space-x-2">
+      <ChunkGroup className="flex items-center justify-between mb-3">
+        <ChunkGroup className="flex items-center space-x-2">
           <h2>Real-Time Analytics</h2>
           {!paused && <Badge className="bg-green-500 text-white">Live</Badge>}
           {paused && (
@@ -111,8 +112,8 @@ const RealTimeAnalyticsPage: React.FC = () => {
               Paused{pending ? ` (${pending})` : ''}
             </Badge>
           )}
-        </div>
-        <div className="space-x-2">
+        </ChunkGroup>
+        <ChunkGroup className="space-x-2">
           {!paused ? (
             <Button size="sm" onClick={() => setPaused(true)}>
               Pause
@@ -132,9 +133,9 @@ const RealTimeAnalyticsPage: React.FC = () => {
               </Button>
             </>
           )}
-        </div>
-      </div>
-      <div className="mb-4 space-y-1">
+        </ChunkGroup>
+      </ChunkGroup>
+      <ChunkGroup className="mb-4 space-y-1">
         <div>Total Events: {data.total_events ?? 0}</div>
         <div>
           Active Users:{' '}
@@ -144,7 +145,7 @@ const RealTimeAnalyticsPage: React.FC = () => {
           Active Doors:{' '}
           {data.active_doors ?? data.unique_doors ?? topDoors.length}
         </div>
-      </div>
+      </ChunkGroup>
 
       {topUsers.length > 0 && (
         <AccessibleVisualization

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
@@ -8,6 +8,7 @@ import { Activity, Users, AlertCircle } from 'lucide-react';
 import { useWebSocket } from '../hooks';
 import { useEventStream } from '../hooks/useEventStream';
 import useResponsiveChart from '../hooks/useResponsiveChart';
+import { ChunkGroup } from '../components/layout';
 
 interface AccessEvent {
   eventId: string;
@@ -141,7 +142,7 @@ export const RealTimeMonitoring: React.FC = () => {
 
   return (
     <div className="p-6 space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <ChunkGroup className="grid grid-cols-1 md:grid-cols-4 gap-4" limit={9}>
         <MetricCard
           title="Events/Second"
           value={metrics.eventsPerSecond.toFixed(1)}
@@ -165,12 +166,12 @@ export const RealTimeMonitoring: React.FC = () => {
           icon={AlertCircle}
           trend={metrics.anomaliesDetected > 0 ? 'alert' : 'good'}
         />
-      </div>
+      </ChunkGroup>
 
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
+          <ChunkGroup className="flex items-center justify-between">
+            <ChunkGroup className="flex items-center space-x-2">
               <CardTitle>Live Access Events</CardTitle>
               {!paused && <Badge className="bg-green-500 text-white">Live</Badge>}
               {paused && (
@@ -178,8 +179,8 @@ export const RealTimeMonitoring: React.FC = () => {
                   Paused{pending ? ` (${pending})` : ''}
                 </Badge>
               )}
-            </div>
-            <div className="space-x-2">
+            </ChunkGroup>
+            <ChunkGroup className="space-x-2">
               {!paused ? (
                 <Button size="sm" onClick={() => setPaused(true)}>
                   Pause
@@ -199,8 +200,8 @@ export const RealTimeMonitoring: React.FC = () => {
                   </Button>
                 </>
               )}
-            </div>
-          </div>
+            </ChunkGroup>
+          </ChunkGroup>
         </CardHeader>
         <CardContent ref={listRef} onTouchStart={() => setShowDetails(true)}>
           {listVisible && (

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { api } from '../api/client';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { ChunkGroup } from '../components/layout';
 
 interface UserSettings {
   theme: string;
@@ -48,43 +49,45 @@ const Settings: React.FC = () => {
     <div className="page-container">
       <h1 className="mb-4">Settings</h1>
       <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
-        <div>
-          <label htmlFor="theme" className="block font-semibold mb-1">
-            Theme
-          </label>
-          <select
-            id="theme"
-            name="theme"
-            value={settings.theme}
-            onChange={handleChange}
-            className="border rounded p-2 w-full"
+        <ChunkGroup>
+          <div>
+            <label htmlFor="theme" className="block font-semibold mb-1">
+              Theme
+            </label>
+            <select
+              id="theme"
+              name="theme"
+              value={settings.theme}
+              onChange={handleChange}
+              className="border rounded p-2 w-full"
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="itemsPerPage" className="block font-semibold mb-1">
+              Items Per Page
+            </label>
+            <input
+              type="number"
+              id="itemsPerPage"
+              name="itemsPerPage"
+              value={settings.itemsPerPage}
+              onChange={handleChange}
+              className="border rounded p-2 w-full"
+            />
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+            disabled={status === 'saving'}
           >
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="itemsPerPage" className="block font-semibold mb-1">
-            Items Per Page
-          </label>
-          <input
-            type="number"
-            id="itemsPerPage"
-            name="itemsPerPage"
-            value={settings.itemsPerPage}
-            onChange={handleChange}
-            className="border rounded p-2 w-full"
-          />
-        </div>
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-          disabled={status === 'saving'}
-        >
-          {status === 'saving' ? 'Saving...' : 'Save'}
-        </button>
-        {status === 'success' && <p className="text-green-600">Settings saved.</p>}
-        {status === 'error' && <p className="text-red-600">{error}</p>}
+            {status === 'saving' ? 'Saving...' : 'Save'}
+          </button>
+          {status === 'success' && <p className="text-green-600">Settings saved.</p>}
+          {status === 'error' && <p className="text-red-600">{error}</p>}
+        </ChunkGroup>
       </form>
     </div>
   );

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Upload.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { Upload as UploadComponent } from '../components/upload';
 import { UploadProvider } from '../state/uploadContext';
+import { ChunkGroup } from '../components/layout';
 
 const UploadPage: React.FC = () => (
   <ErrorBoundary>
     <UploadProvider>
-      <UploadComponent />
+      <ChunkGroup>
+        <UploadComponent />
+      </ChunkGroup>
     </UploadProvider>
   </ErrorBoundary>
 );


### PR DESCRIPTION
## Summary
- define priority levels and color tokens for shared styling
- add ChunkGroup layout component to group controls with optional expander
- apply ChunkGroup across pages to keep sections within 7±2 elements

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: Cannot find module './Call')*


------
https://chatgpt.com/codex/tasks/task_e_688fbbdcca308320a437227e013b8793