### PR TITLE
feat: enhance routing and visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "postcss-import": "^16.1.1",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "webpack-bundle-analyzer": "^4.10.2"
   },
   "scripts": {
     "start": "cd yosai_intel_dashboard/src/adapters/ui && react-scripts start",

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -1,0 +1,21 @@
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+module.exports = {
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
+  plugins: [
+    new BundleAnalyzerPlugin({
+      analyzerMode: process.env.ANALYZE ? 'server' : 'disabled',
+      openAnalyzer: false,
+    }),
+  ],
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+};

--- a/yosai_intel_dashboard/src/adapters/ui/components/visualization/BaseVisualization.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/visualization/BaseVisualization.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import useVisualizationPerformance from '../../hooks/useVisualizationPerformance';
+import './skeleton.css';
 
 export interface BaseVisualizationProps {
   width?: number;
   height?: number;
   rowHeight?: number;
   dataLength?: number;
+  loading?: boolean;
   onSetup?: (gl: WebGLRenderingContext) => void;
   onRender: (gl: WebGLRenderingContext, frame: number) => void;
   children?: React.ReactNode;
@@ -22,6 +24,7 @@ const BaseVisualization: React.FC<BaseVisualizationProps> = ({
   height = 150,
   rowHeight = 20,
   dataLength = 0,
+  loading = false,
   onSetup,
   onRender,
   children
@@ -67,6 +70,10 @@ const BaseVisualization: React.FC<BaseVisualizationProps> = ({
   const startIndex = Math.floor(scrollTop / rowHeight);
   const endIndex = Math.min(dataLength, startIndex + visibleCount);
   const offsetY = startIndex * rowHeight;
+
+  if (loading) {
+    return <div className="skeleton" style={{ width, height }} />;
+  }
 
   return (
     <div

--- a/yosai_intel_dashboard/src/adapters/ui/components/visualization/skeleton.css
+++ b/yosai_intel_dashboard/src/adapters/ui/components/visualization/skeleton.css
@@ -1,0 +1,14 @@
+.skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/yosai_intel_dashboard/src/adapters/ui/index.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/index.tsx
@@ -1,57 +1,70 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
-const RealTimeAnalyticsPage = React.lazy(() => import('./pages/RealTimeAnalyticsPage'));
-const Upload = React.lazy(() => import('./pages/Upload'));
-const Analytics = React.lazy(() => import('./pages/Analytics'));
-const Graphs = React.lazy(() => import('./pages/Graphs'));
-const Export = React.lazy(() => import('./pages/Export'));
-const Settings = React.lazy(() => import('./pages/Settings'));
-const DashboardBuilder = React.lazy(() => import('./pages/DashboardBuilder'));
+const SuspenseList = (React as any).SuspenseList;
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './queryClient';
 import { ZustandProvider } from './state';
 import { SelectionProvider } from './core/interaction/SelectionContext';
 
+const RealTimeAnalyticsPage = React.lazy(() => import('./pages/RealTimeAnalyticsPage')) as any;
+RealTimeAnalyticsPage.preload = () => import('./pages/RealTimeAnalyticsPage');
+
+const Upload = React.lazy(() => import('./pages/Upload')) as any;
+Upload.preload = () => import('./pages/Upload');
+
+const Analytics = React.lazy(() => import('./pages/Analytics')) as any;
+Analytics.preload = () => import('./pages/Analytics');
+
+const Graphs = React.lazy(() => import('./pages/Graphs')) as any;
+Graphs.preload = () => import('./pages/Graphs');
+
+const Export = React.lazy(() => import('./pages/Export')) as any;
+Export.preload = () => import('./pages/Export');
+
+const Settings = React.lazy(() => import('./pages/Settings')) as any;
+Settings.preload = () => import('./pages/Settings');
+
+const DashboardBuilder = React.lazy(() => import('./pages/DashboardBuilder')) as any;
+DashboardBuilder.preload = () => import('./pages/DashboardBuilder');
+
 import "./index.css";
+
 const rootEl = document.getElementById('root');
 if (rootEl) {
   const root = ReactDOM.createRoot(rootEl as HTMLElement);
   root.render(
     <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <Suspense fallback={<div>Loading...</div>}>
-
-            <Routes>
-              <Route path="/" element={<Navigate to="/upload" replace />} />
-              <Route path="/upload" element={<Upload />} />
-              <Route path="/analytics" element={<Analytics />} />
-              <Route path="/graphs" element={<Graphs />} />
-              <Route path="/export" element={<Export />} />
-              <Route path="/settings" element={<Settings />} />
-              <Route path="/builder" element={<DashboardBuilder />} />
-            </Routes>
-          </Suspense>
-        </BrowserRouter>
-      </QueryClientProvider>
-
-
-              <Routes>
-                <Route path="/" element={<Navigate to="/upload" replace />} />
-                <Route path="/upload" element={<Upload />} />
-                <Route path="/analytics" element={<Analytics />} />
-                <Route path="/graphs" element={<Graphs />} />
-                <Route path="/export" element={<Export />} />
-                <Route path="/settings" element={<Settings />} />
-              </Routes>
-            </Suspense>
+      <SelectionProvider>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <SuspenseList revealOrder="forwards" tail="collapsed">
+              <Suspense fallback={<div>Loading...</div>}>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/upload" replace />} />
+                  <Route path="/upload" element={<Upload />} />
+                  <Route path="/analytics" element={<Analytics />} />
+                  <Route path="/graphs" element={<Graphs />} />
+                  <Route path="/export" element={<Export />} />
+                  <Route path="/settings" element={<Settings />} />
+                  <Route path="/builder" element={<DashboardBuilder />} />
+                </Routes>
+              </Suspense>
+            </SuspenseList>
           </BrowserRouter>
         </QueryClientProvider>
       </SelectionProvider>
-
     </React.StrictMode>
   );
+
+  const pages = [Upload, Analytics, Graphs, Export, Settings, DashboardBuilder];
+  if ('requestIdleCallback' in window) {
+    (window as any).requestIdleCallback(() =>
+      pages.forEach((p) => p.preload?.())
+    );
+  } else {
+    setTimeout(() => pages.forEach((p) => p.preload?.()), 2000);
+  }
 }
 
 const rtEl = document.getElementById('real-time-root');


### PR DESCRIPTION
## Summary
- streamline router setup and add predictive preloading via SuspenseList
- add skeleton loader for visualizations and bundle analyzer config

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npm run lint` *(fails: 1882 problems, 1868 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbdfcf2c83208ae91b5ca1270344