### PR TITLE
feat: add contextual tips and learning suggestions

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/overlay/Hint.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/overlay/Hint.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Info } from 'lucide-react';
+import Tooltip from './Tooltip';
+import { logTipInteraction } from '../../services/analytics/usage';
+
+interface HintProps {
+  id: string;
+  message: string;
+}
+
+const Hint: React.FC<HintProps> = ({ id, message }) => {
+  const handleClick = () => {
+    logTipInteraction({ id, action: 'click' });
+  };
+
+  const handleView = () => {
+    logTipInteraction({ id, action: 'view' });
+  };
+
+  return (
+    <Tooltip text={message} onOpen={handleView}>
+      <button
+        onClick={handleClick}
+        className="text-blue-600 hover:text-blue-800 focus:outline-none"
+        aria-label="Hint"
+      >
+        <Info size={16} />
+      </button>
+    </Tooltip>
+  );
+};
+
+export default Hint;
+export { Hint };

--- a/yosai_intel_dashboard/src/adapters/ui/components/overlay/Tooltip.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/overlay/Tooltip.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+  onOpen?: () => void;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ text, children, onOpen }) => {
+  const [visible, setVisible] = useState(false);
+
+  const show = () => {
+    if (!visible) {
+      onOpen?.();
+    }
+    setVisible(true);
+  };
+
+  const hide = () => setVisible(false);
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+    >
+      {children}
+      {visible && (
+        <div className="absolute z-10 p-2 text-sm text-white bg-gray-800 rounded shadow-md whitespace-nowrap">
+          {text}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;
+export { Tooltip };

--- a/yosai_intel_dashboard/src/adapters/ui/pages/LearnMore.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/LearnMore.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { getLearningSuggestions } from '../services/analytics/usage';
+import Hint from '../components/overlay/Hint';
+
+const LearnMore: React.FC = () => {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchSuggestions = async () => {
+      const data = await getLearningSuggestions();
+      setSuggestions(data);
+    };
+    fetchSuggestions();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Learn More</h1>
+      {suggestions.length === 0 ? (
+        <p>No suggestions available.</p>
+      ) : (
+        <ul className="pl-5 space-y-2 list-disc">
+          {suggestions.map((s, idx) => (
+            <li key={idx} className="flex items-center space-x-2">
+              <span>{s}</span>
+              <Hint id={`suggestion-${idx}`} message="Why this suggestion?" />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default LearnMore;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/index.ts
@@ -6,3 +6,4 @@ export { default as Settings } from './Settings';
 export { default as RealTimeAnalyticsPage } from './RealTimeAnalyticsPage';
 export { default as RealTimeMonitoring } from './RealTimeMonitoring';
 export { default as DashboardBuilder } from './DashboardBuilder';
+export { default as LearnMore } from './LearnMore';

--- a/yosai_intel_dashboard/src/adapters/ui/services/analytics/usage.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/services/analytics/usage.ts
@@ -1,0 +1,34 @@
+interface TipInteraction {
+  id: string;
+  action: 'view' | 'click';
+  context?: string;
+}
+
+export const logTipInteraction = async (
+  interaction: TipInteraction
+): Promise<void> => {
+  try {
+    await fetch('/api/analytics/tip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...interaction, timestamp: Date.now() }),
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to log tip interaction', err);
+  }
+};
+
+export const getLearningSuggestions = async (): Promise<string[]> => {
+  try {
+    const res = await fetch('/api/analytics/suggestions');
+    if (!res.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return await res.json();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to fetch learning suggestions', err);
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary
- add Tooltip and Hint overlay components for contextual guidance
- log tip interactions and fetch learning suggestions via analytics service
- provide Learn More page to surface personalized suggestions

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npm run lint` *(fails: 1870 problems detected)*


------
https://chatgpt.com/codex/tasks/task_e_688fbbe190888320b19c3d126e19cdfb