### PR TITLE
Add usage analytics and ROI utilities

### DIFF
--- a/analytics/metrics/roi.ts
+++ b/analytics/metrics/roi.ts
@@ -1,0 +1,34 @@
+export const calculateROI = (revenue: number, cost: number): number => {
+  return cost === 0 ? 0 : (revenue - cost) / cost;
+};
+
+export interface ABTestOutcome {
+  variant: string;
+  conversions: number;
+  participants: number;
+  revenuePerConversion: number;
+  costPerParticipant: number;
+}
+
+export interface ROIResult {
+  variant: string;
+  roi: number;
+}
+
+export const linkABTestOutcomes = (outcomes: ABTestOutcome[]): ROIResult[] => {
+  return outcomes.map(outcome => {
+    const revenue = outcome.conversions * outcome.revenuePerConversion;
+    const cost = outcome.participants * outcome.costPerParticipant;
+    return {
+      variant: outcome.variant,
+      roi: calculateROI(revenue, cost),
+    };
+  });
+};
+
+const roi = {
+  calculateROI,
+  linkABTestOutcomes,
+};
+
+export default roi;

--- a/docs/analytics_dashboard.md
+++ b/docs/analytics_dashboard.md
@@ -1,0 +1,5 @@
+# Analytics Dashboard Methodology
+
+The usage dashboard aggregates in-application events to highlight feature adoption, error frequency, and user proficiency. UI components record activity through `services/analytics/usage.ts`, which maintains counters for adoption and errors while tracking proficiency levels per user. Updates are broadcast on the `usage_update` event channel, allowing `pages/UsageDashboard.tsx` to render live metrics.
+
+This approach provides a lightweight view of engagement without external dependencies. Metrics can be reset or extended with additional event types as new analytics requirements arise.

--- a/docs/roi_metrics.md
+++ b/docs/roi_metrics.md
@@ -1,0 +1,9 @@
+# ROI Metrics Methodology
+
+Return on investment (ROI) for A/B experiments is derived by pairing each test outcome with cost and revenue assumptions. The helper in `analytics/metrics/roi.ts` maps raw A/B results to ROI values using the formula:
+
+```
+ROI = (revenue - cost) / cost
+```
+
+where revenue is computed from conversions and expected revenue per conversion, and cost derives from participants and their cost per acquisition. The utility returns ROI for each variant, enabling rapid comparison of experimental outcomes.

--- a/services/analytics/usage.ts
+++ b/services/analytics/usage.ts
@@ -1,0 +1,49 @@
+import { eventBus, Listener } from '../../yosai_intel_dashboard/src/adapters/ui/eventBus';
+
+export interface UsageSnapshot {
+  adoption: Record<string, number>;
+  errors: Record<string, number>;
+  proficiency: Record<string, number>;
+}
+
+const adoptionCounts: Record<string, number> = {};
+const errorCounts: Record<string, number> = {};
+const proficiencyLevels: Record<string, number> = {};
+
+export const snapshot = (): UsageSnapshot => ({
+  adoption: { ...adoptionCounts },
+  errors: { ...errorCounts },
+  proficiency: { ...proficiencyLevels },
+});
+
+const publish = () => {
+  eventBus.emit('usage_update', snapshot());
+};
+
+export const recordAdoption = (feature: string): void => {
+  adoptionCounts[feature] = (adoptionCounts[feature] || 0) + 1;
+  publish();
+};
+
+export const recordError = (feature: string): void => {
+  errorCounts[feature] = (errorCounts[feature] || 0) + 1;
+  publish();
+};
+
+export const recordProficiency = (userId: string, level: number): void => {
+  proficiencyLevels[userId] = level;
+  publish();
+};
+
+export const onUsageUpdate = (listener: Listener<UsageSnapshot>): (() => void) =>
+  eventBus.on('usage_update', listener);
+
+const usageMetrics = {
+  recordAdoption,
+  recordError,
+  recordProficiency,
+  snapshot,
+  onUsageUpdate,
+};
+
+export default usageMetrics;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/UsageDashboard.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/UsageDashboard.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
+import {
+  snapshot as getSnapshot,
+  onUsageUpdate,
+  UsageSnapshot,
+} from '../services/analytics/usage';
+
+const UsageDashboard: React.FC = () => {
+  const [stats, setStats] = useState<UsageSnapshot>(getSnapshot());
+
+  useEffect(() => {
+    const unsub = onUsageUpdate(setStats);
+    setStats(getSnapshot());
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  return (
+    <ErrorBoundary>
+      <div className="usage-dashboard">
+        <h1>Usage Dashboard</h1>
+
+        <section>
+          <h2>Adoption</h2>
+          <ul>
+            {Object.entries(stats.adoption).map(([feature, count]) => (
+              <li key={feature}>{feature}: {count}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2>Errors</h2>
+          <ul>
+            {Object.entries(stats.errors).map(([feature, count]) => (
+              <li key={feature}>{feature}: {count}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2>Proficiency Levels</h2>
+          <ul>
+            {Object.entries(stats.proficiency).map(([user, level]) => (
+              <li key={user}>{user}: {level}</li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default UsageDashboard;


### PR DESCRIPTION
## Summary
- collect UI events and proficiency metrics
- display usage analytics in dashboard
- link A/B test outcomes to ROI calculations

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbe50a988320a1dd73fef451a5b3