### PR TITLE
refactor: centralize dependency wiring via BaseComponent

### DIFF
--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -27,11 +27,13 @@ class MetricsProvider(EventPublisher, LoggingMixin, SerializationMixin, BaseComp
         repo: MetricsRepository | None = None,
         interval: float = 1.0,
     ) -> None:
-        BaseComponent.__init__(self, component_id="metrics_provider")
-        EventPublisher.__init__(self, event_bus)
-
-        self.repo = repo or InMemoryMetricsRepository()
-        self.interval = interval
+        BaseComponent.__init__(
+            self,
+            component_id="metrics_provider",
+            event_bus=event_bus,
+            repo=repo or InMemoryMetricsRepository(),
+            interval=interval,
+        )
 
 
         self._stop = threading.Event()

--- a/tests/common/test_event_bus.py
+++ b/tests/common/test_event_bus.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.common.events import EventBus, EventPublisher
+from src.common.base import BaseComponent
 
 
 def test_publish_and_unsubscribe():
@@ -24,12 +25,11 @@ def test_event_publisher_mixin():
     bus = EventBus()
     received: dict[str, int] = {}
 
-    class Publisher(EventPublisher):
-        def __init__(self, eb: EventBus):
-            super().__init__(eb)
+    class Publisher(EventPublisher, BaseComponent):
+        pass
 
     bus.subscribe("evt", lambda payload: received.update(payload))
-    publisher = Publisher(bus)
+    publisher = Publisher(event_bus=bus)
     publisher.publish_event("evt", {"c": 3})
 
     assert received == {"c": 3}

--- a/tests/common/test_mixins.py
+++ b/tests/common/test_mixins.py
@@ -9,14 +9,11 @@ from src.common.mixins import LoggingMixin, SerializationMixin
 
 
 class DummyLoggingComponent(LoggingMixin, BaseComponent):
-    def __init__(self) -> None:
-        super().__init__()
+    pass
 
 
 class DummySerializationComponent(SerializationMixin, BaseComponent):
-    def __init__(self, value: int, component_id: str | None = None) -> None:
-        super().__init__(component_id)
-        self.value = value
+    pass
 
 
 def test_logging_mixin_logs(caplog):
@@ -27,7 +24,7 @@ def test_logging_mixin_logs(caplog):
 
 
 def test_serialization_mixin_roundtrip():
-    comp = DummySerializationComponent(5)
+    comp = DummySerializationComponent(value=5)
     data = comp.to_dict()
     assert data["value"] == 5
     new_comp = DummySerializationComponent.from_dict(data)


### PR DESCRIPTION
## Summary
- rely on BaseComponent for event publisher dependencies
- simplify MetricsProvider and repositories by using BaseComponent
- adjust tests for new initialization style

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/common/test_event_bus.py tests/websocket/test_metrics_provider.py tests/common/test_mixins.py tests/test_metrics_cache.py tests/api/test_metrics_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc056ff888320a9803de3f116f9ba