### PR TITLE
Refactor callbacks to use shared EventBus

### DIFF
--- a/analytics/security_patterns/__init__.py
+++ b/analytics/security_patterns/__init__.py
@@ -22,29 +22,6 @@ from .pattern_detection import Threat, detect_critical_door_risks
 fallback_callbacks: TrulyUnifiedCallbacks | None = None
 
 
-class _SimpleCallbacks:
-    """Lightweight callback manager used when dependencies are missing."""
-
-    def __init__(self) -> None:
-        self._event_callbacks: Dict[SecurityEvent, List[Any]] = {
-            e: [] for e in SecurityEvent
-        }
-        self.history: List[tuple[SecurityEvent, Any]] = []
-
-    def register_event(self, event: SecurityEvent, func: Any) -> None:
-        self._event_callbacks.setdefault(event, []).append(func)
-
-    def trigger_event(self, event: SecurityEvent, data: Any | None = None) -> None:
-        for cb in self._event_callbacks.get(event, []):
-            cb(data)
-        self.history.append((event, data))
-
-    def clear_all_callbacks(self) -> None:
-        for lst in self._event_callbacks.values():
-            lst.clear()
-        self.history.clear()
-
-
 # ---------------------------------------------------------------------------
 # Public helpers
 
@@ -99,7 +76,7 @@ class SecurityPatternsAnalyzer:
         except Exception:  # pragma: no cover
             manager = fallback_callbacks
         if manager is None:
-            manager = _SimpleCallbacks()
+            manager = TrulyUnifiedCallbacks()
         if threats:
             manager.trigger_event(SecurityEvent.THREAT_DETECTED, {"threats": threats})
         manager.trigger_event(
@@ -184,7 +161,7 @@ def setup_isolated_security_testing() -> Any:
     try:  # pragma: no cover - may fail if heavy deps missing
         new_manager = TrulyUnifiedCallbacks()
     except Exception:  # pragma: no cover
-        new_manager = _SimpleCallbacks()
+        new_manager = TrulyUnifiedCallbacks()
     fallback_callbacks = new_manager
     try:  # pragma: no cover - import may fail if optional deps missing
         import security.events as se  # type: ignore

--- a/yosai_intel_dashboard/src/infrastructure/event_bus.py
+++ b/yosai_intel_dashboard/src/infrastructure/event_bus.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict, List, Tuple
+
+
+Callback = Callable[..., Any]
+
+
+class EventBus:
+    """Simple publish/subscribe event bus."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[Any, List[Tuple[int, Callback]]] = defaultdict(list)
+        self._metrics: Dict[Any, Dict[str, float]] = defaultdict(
+            lambda: {"calls": 0, "exceptions": 0, "total_time": 0.0}
+        )
+
+    # ------------------------------------------------------------------
+    def subscribe(self, event: Any, func: Callback, *, priority: int = 50) -> None:
+        """Subscribe *func* to *event* with optional *priority*."""
+
+        subs = self._subscribers[event]
+        subs.append((priority, func))
+        subs.sort(key=lambda x: x[0])
+
+    def unsubscribe(self, event: Any, func: Callback) -> None:
+        """Unsubscribe *func* from *event*."""
+
+        self._subscribers[event] = [
+            (p, f) for p, f in self._subscribers.get(event, []) if f != func
+        ]
+
+    # ------------------------------------------------------------------
+    def emit(self, event: Any, *args: Any, **kwargs: Any) -> List[Any]:
+        """Synchronously emit *event* to all subscribers."""
+
+        results: List[Any] = []
+        callbacks = list(self._subscribers.get(event, []))
+        for _, cb in callbacks:
+            start = time.perf_counter()
+            try:
+                if inspect.iscoroutinefunction(cb):
+                    result = asyncio.run(cb(*args, **kwargs))
+                else:
+                    result = cb(*args, **kwargs)
+                duration = time.perf_counter() - start
+                metric = self._metrics[event]
+                metric["calls"] += 1
+                metric["total_time"] += duration
+                results.append(result)
+            except Exception:
+                metric = self._metrics[event]
+                metric["calls"] += 1
+                metric["exceptions"] += 1
+                results.append(None)
+        return results
+
+    async def emit_async(self, event: Any, *args: Any, **kwargs: Any) -> List[Any]:
+        """Asynchronously emit *event* to all subscribers."""
+
+        results: List[Any] = []
+        for _, cb in self._subscribers.get(event, []):
+            start = time.perf_counter()
+            try:
+                if inspect.iscoroutinefunction(cb):
+                    result = await cb(*args, **kwargs)
+                else:
+                    result = cb(*args, **kwargs)
+                duration = time.perf_counter() - start
+                metric = self._metrics[event]
+                metric["calls"] += 1
+                metric["total_time"] += duration
+                results.append(result)
+            except Exception:
+                metric = self._metrics[event]
+                metric["calls"] += 1
+                metric["exceptions"] += 1
+                results.append(None)
+        return results
+
+    def get_callbacks(self, event: Any) -> List[Callback]:
+        """Return callbacks subscribed to *event*."""
+
+        return [cb for _, cb in self._subscribers.get(event, [])]
+
+    def get_metrics(self, event: Any) -> Dict[str, float]:
+        """Return metrics for *event*."""
+
+        return self._metrics[event]
+
+    def clear(self) -> None:
+        """Remove all subscriptions and metrics."""
+
+        self._subscribers.clear()
+        self._metrics.clear()
+
+
+class EventPublisher:
+    """Mixin providing convenient access to an :class:`EventBus`."""
+
+    def __init__(self, event_bus: EventBus | None = None) -> None:
+        self.event_bus = event_bus or EventBus()
+
+    def emit_event(self, event: Any, *args: Any, **kwargs: Any) -> List[Any]:
+        """Emit *event* on the configured :class:`EventBus`."""
+
+        return self.event_bus.emit(event, *args, **kwargs)


### PR DESCRIPTION
## Summary
- add reusable EventBus and EventPublisher mixin
- migrate TrulyUnifiedCallbacks and security analytics to EventBus
- update tests for event propagation

## Testing
- `pytest tests/test_callback_manager_events.py -q`
- `pytest tests/test_security_patterns.py::test_analyze_failed_access_returns_expected_keys -q`
- `pytest tests/test_security_patterns.py::test_detect_odd_time_zero_variance -q`
- `pytest tests/test_security_patterns.py::test_detection_functions_return_generators -q`
- `pytest tests/callbacks/test_security_callback_controller.py -q` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.analytics.analytics')*

------
https://chatgpt.com/codex/tasks/task_e_688fc059f7f48320bdf0ae36047435ca