### PR TITLE
refactor: add callback manager autoregistration

### DIFF
--- a/scripts/callback_graph.py
+++ b/scripts/callback_graph.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 from dash import Dash
 from graphviz import Digraph
 
+import yosai_intel_dashboard.src.services.upload.callbacks  # noqa: F401
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
     TrulyUnifiedCallbacks,
 )
-from yosai_intel_dashboard.src.services.upload.callbacks import UploadCallbacks
+
 
 def load_callbacks() -> TrulyUnifiedCallbacks:
     """Create app, register callbacks and return coordinator."""
     app = Dash(__name__)
     coord = TrulyUnifiedCallbacks(app)
-    coord.register_all_callbacks(UploadCallbacks)
+    coord.register_all_callbacks()
     return coord
 
 

--- a/tests/test_callback_manager_autoregister.py
+++ b/tests/test_callback_manager_autoregister.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dash import Dash
+
+from yosai_intel_dashboard.src.infrastructure.callbacks.callback_registry import (
+    ComponentCallbackManager,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
+
+
+class DemoManager(ComponentCallbackManager):
+    registry_name = "demo"
+
+    def __init__(self, registry):
+        super().__init__(registry)
+
+    def register_all(self):
+        return {}
+
+
+def test_component_callback_manager_auto_registration():
+    app_manual = Dash(__name__)
+    coord_manual = TrulyUnifiedCallbacks(app_manual, security_validator=object())
+    coord_manual.register_all_callbacks(DemoManager)
+
+    app_auto = Dash(__name__)
+    coord_auto = TrulyUnifiedCallbacks(app_auto, security_validator=object())
+    coord_auto.register_all_callbacks()
+
+    assert "demo" in ComponentCallbackManager.REGISTRY
+    assert coord_manual._namespaces == coord_auto._namespaces
+    assert coord_manual.registered_callbacks == coord_auto.registered_callbacks

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Type
 
 from dash import Dash
 from dash.dependencies import Input, Output, State
+
+from src.common.meta import AutoRegister
 
 if TYPE_CHECKING:  # pragma: no cover
     from .unified_callbacks import CallbackHandler
 else:  # pragma: no cover - fallback to generic callable at runtime
     CallbackHandler = Callable[..., Any]
+
 
 class CallbackRegistry:
     """Minimal registry tracking registered callbacks."""
@@ -57,12 +60,16 @@ class CallbackRegistry:
         return decorator
 
 
-class ComponentCallbackManager:
+class ComponentCallbackManager(metaclass=AutoRegister):
     """Base class for components that register callbacks."""
+
+    REGISTRY: Dict[str, Type["ComponentCallbackManager"]] = {}
 
     def __init__(self, registry: CallbackRegistry) -> None:
         self.registry = registry
         self.component_name = self.__class__.__name__.replace("CallbackManager", "")
 
-    def register_all(self) -> Dict[str, CallbackHandler]:  # pragma: no cover - interface
+    def register_all(
+        self,
+    ) -> Dict[str, CallbackHandler]:  # pragma: no cover - interface
         raise NotImplementedError

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -596,7 +596,15 @@ class TrulyUnifiedCallbacks:
     def register_all_callbacks(
         self, *manager_classes: type["ComponentCallbackManager"]
     ) -> None:
-        """Instantiate and register callbacks from provided managers."""
+        """Instantiate and register callbacks from provided managers.
+
+        If no ``manager_classes`` are provided, all classes registered on
+        :class:`ComponentCallbackManager` via the :class:`~src.common.meta.AutoRegister`
+        metaclass are used.
+        """
+
+        if not manager_classes:
+            manager_classes = tuple(ComponentCallbackManager.REGISTRY.values())
 
         class _Registry(CallbackRegistry):
             def __init__(self, coord: "TrulyUnifiedCallbacks") -> None:

--- a/yosai_intel_dashboard/src/services/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/services/upload/callbacks.py
@@ -17,6 +17,8 @@ from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import
 class UploadCallbacks(ComponentCallbackManager):
     """Register upload related callbacks using :class:`TrulyUnifiedCallbacks`."""
 
+    registry_name = "upload"
+
     def register_all(self) -> Dict[str, CallbackHandler]:
         callbacks: TrulyUnifiedCallbacks = self.registry.callbacks
         callbacks.register_upload_callbacks()


### PR DESCRIPTION
## Summary
- extend AutoRegister metaclass to callback managers
- default `TrulyUnifiedCallbacks.register_all_callbacks` to registered managers
- cover callback manager registration with regression test

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/callbacks/callback_registry.py yosai_intel_dashboard/src/services/upload/callbacks.py yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py scripts/callback_graph.py tests/test_callback_manager_autoregister.py`
- `PYTHONPATH=. pytest standalone_tests/test_auto_register.py standalone_tests/test_callback_manager_autoregister.py -q --confcutdir=standalone_tests`


------
https://chatgpt.com/codex/tasks/task_e_688fc05d8e2c8320a493c621f87b5a4d