### PR TITLE
feat: add cross-cutting mixins

### DIFF
--- a/src/common/mixins.py
+++ b/src/common/mixins.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, Protocol, Type, TypeVar, runtime_checkable
 class Loggable(Protocol):
     """Protocol for objects capable of logging messages."""
 
-    def log(self, message: str) -> None:
-        """Log ``message`` to the configured logger."""
+    def log(self, message: str, level: int = logging.INFO) -> None:
+        """Log ``message`` at ``level`` to the configured logger."""
         ...
 
 
@@ -39,9 +39,9 @@ class LoggingMixin:
         """Return a module-level logger named for the concrete class."""
         return logging.getLogger(self.__class__.__name__)
 
-    def log(self, message: str) -> None:
-        """Log ``message`` with ``INFO`` severity."""
-        self.logger.info(message)
+    def log(self, message: str, level: int = logging.INFO) -> None:
+        """Log ``message`` using :func:`logging.Logger.log`."""
+        self.logger.log(level, message)
 
 
 class SerializationMixin:

--- a/tests/common/test_mixins.py
+++ b/tests/common/test_mixins.py
@@ -5,7 +5,12 @@ import logging
 import pytest
 
 from src.common.base import BaseComponent
-from src.common.mixins import LoggingMixin, SerializationMixin
+from src.common.mixins import (
+    Loggable,
+    LoggingMixin,
+    Serializable,
+    SerializationMixin,
+)
 
 
 class DummyLoggingComponent(LoggingMixin, BaseComponent):
@@ -21,13 +26,22 @@ class DummySerializationComponent(SerializationMixin, BaseComponent):
 
 def test_logging_mixin_logs(caplog):
     comp = DummyLoggingComponent()
+    assert isinstance(comp, Loggable)
     with caplog.at_level(logging.INFO):
         comp.log("hello world")
     assert "hello world" in caplog.text
 
 
+def test_logging_mixin_custom_level(caplog):
+    comp = DummyLoggingComponent()
+    with caplog.at_level(logging.DEBUG):
+        comp.log("debug msg", logging.DEBUG)
+    assert "debug msg" in caplog.text
+
+
 def test_serialization_mixin_roundtrip():
     comp = DummySerializationComponent(5)
+    assert isinstance(comp, Serializable)
     data = comp.to_dict()
     assert data["value"] == 5
     new_comp = DummySerializationComponent.from_dict(data)


### PR DESCRIPTION
## Summary
- support log levels in reusable logging mixin
- add logging/serialization mixins to `WebSocketDataProvider`
- test mixin protocols and custom log level

## Testing
- `pytest tests/common/test_mixins.py tests/common/test_base_component.py`

------
https://chatgpt.com/codex/tasks/task_e_688fc05fc7b08320859fc4d962bba79c