### PR TITLE
Add deprecation warnings and migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   `create_analysis_results_display`.
 - Legacy API wrappers now emit `DeprecationWarning` and forward calls to
   their relocated implementations.
+- Added deprecation warnings for `publish`, `register_all_services`,
+  `sanitize_data_frame`, and `safe_unicode_encode` to guide migration.
 
 ### Fixed
 - Navigation bar icons failed to load when `app.get_asset_url` returned

--- a/docs/adr/0006-deprecation-shims.md
+++ b/docs/adr/0006-deprecation-shims.md
@@ -1,0 +1,16 @@
+# ADR 0006: Deprecation Shims for Renamed APIs
+
+## Context
+Several public APIs were relocated or renamed as part of ongoing
+refactoring. External integrations still rely on the legacy entry
+points.
+
+## Decision
+Maintain thin compatibility shims at the old import locations. Each
+shim forwards calls to the new implementation and issues a
+`DeprecationWarning` to alert downstream users.
+
+## Consequences
+- Enables incremental migration for integrators.
+- Requires maintaining additional wrapper code until the next major
+  release when the shims can be removed.

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -41,6 +41,11 @@ Update your code to use the new locations:
 | `core.container.Container` | `ServiceContainer` |
 | `mapping.models.load_model` | `load_model_from_config` |
 | `infrastructure.security.UnicodeSecurityHandler` | `UnicodeSecurityProcessor` |
+| `startup.service_registration.register_all_services` | `startup.service_registration.register_all_application_services` |
+| `infrastructure.config.complete_service_registration.register_all_services` | `register_all_application_services` |
+| `core.protocols.EventBus.publish` | `emit` |
+| `core.unicode.sanitize_data_frame` | `sanitize_dataframe` |
+| `core.unicode.safe_unicode_encode` | `safe_encode` |
 
 These shims will be removed in a future major release.
 

--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -12,6 +12,7 @@ from yosai_intel_dashboard.src.core.interfaces.protocols import (
 )
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from yosai_intel_dashboard.src.services.metadata_enhancement_engine import register_metadata_services
+import warnings
 
 
 def register_all_application_services(container: ServiceContainer) -> None:
@@ -31,6 +32,11 @@ def register_all_application_services(container: ServiceContainer) -> None:
 
 def register_all_services(container: ServiceContainer) -> None:
     """Backward compatible alias for register_all_application_services."""
+    warnings.warn(
+        "register_all_services is deprecated; use register_all_application_services",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     register_all_application_services(container)
 
 

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     runtime_checkable,
 )
+import warnings
 
 import pandas as pd
 
@@ -348,6 +349,11 @@ class EventBusProtocol(Protocol):
         self, event_type: str, data: Dict[str, Any], source: str | None = None
     ) -> None:
         """Backward compatible alias for :meth:`emit`."""
+        warnings.warn(
+            "publish is deprecated; use emit",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.emit(event_type, data, source)
 
     @abstractmethod

--- a/yosai_intel_dashboard/src/core/unicode.py
+++ b/yosai_intel_dashboard/src/core/unicode.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Iterable, Optional, Union
+import warnings
 
 import pandas as pd  # type: ignore[import]
 
@@ -397,6 +398,11 @@ def utf8_safe_decode(data: bytes) -> str:
 def sanitize_data_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Deprecated alias for :func:`sanitize_dataframe`."""
 
+    warnings.warn(
+        "sanitize_data_frame is deprecated; use sanitize_dataframe",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return sanitize_dataframe(df)
 
 
@@ -409,6 +415,11 @@ def handle_surrogate_characters(text: str) -> str:
 def safe_unicode_encode(value: Any) -> str:
     """Deprecated wrapper around :func:`safe_encode`."""
 
+    warnings.warn(
+        "safe_unicode_encode is deprecated; use safe_encode",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return safe_encode(value)
 
 

--- a/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/complete_service_registration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from startup import service_registration
+import warnings
 
 
 def register_all_application_services(container: ServiceContainer) -> None:
@@ -14,8 +15,12 @@ def register_all_application_services(container: ServiceContainer) -> None:
 
 def register_all_services(container: ServiceContainer) -> None:
     """Backward compatible alias for register_all_application_services."""
-
-    service_registration.register_all_services(container)
+    warnings.warn(
+        "register_all_services is deprecated; use register_all_application_services",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    service_registration.register_all_application_services(container)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add DeprecationWarning shims for legacy helpers like `sanitize_data_frame`, `safe_unicode_encode`, `publish`, and `register_all_services`
- document renamed APIs in migration guide and changelog
- record ADR covering the decision to maintain deprecation shims

## Testing
- `pytest` *(fails: ModuleNotFoundError and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fc061c178832086690a3148045ed8