### PR TITLE
refactor: make event bus history immutable

### DIFF
--- a/docs/development_principles.md
+++ b/docs/development_principles.md
@@ -1,14 +1,5 @@
 # Development Principles
 
-This project favors immutable data structures to reduce side effects and
-improve reasoning about state.
-
-- Use `dataclasses` with `frozen=True` or `attrs` frozen models instead of
-  mutable dictionaries and lists for structured data.
-- Prefer functional transformations such as `map`, `filter`, and
-  comprehensions over manual loops.
-- Validate immutability in tests by asserting that attempts to mutate frozen
-  objects raise `FrozenInstanceError`.
-
-These principles help maintain a predictable and maintainable codebase.
-
+- Prefer `dataclasses` or `attrs` frozen models over mutable dictionaries and lists for internal state.
+- Use functional tools like `map`, `filter`, and comprehensions when transforming collections.
+- Validate immutability in tests by attempting to mutate frozen objects and ensuring exceptions are raised.

--- a/src/common/events.py
+++ b/src/common/events.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 from collections import defaultdict
 from copy import deepcopy
+from dataclasses import dataclass
 from threading import RLock
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Mapping
+
+
+@dataclass(frozen=True)
+class Event:
+    """Immutable event record stored by :class:`EventBus`."""
+
+    type: str
+    data: Mapping[str, Any]
 
 
 class EventBus:
@@ -25,7 +34,7 @@ class EventBus:
         )
         self._lock = RLock()
         self._counter = 0
-        self._history: List[Dict[str, Any]] = []
+        self._history: List[Event] = []
 
     def subscribe(
         self, event_type: str, handler: Callable[[Mapping[str, Any]], None]
@@ -55,7 +64,7 @@ class EventBus:
         with self._lock:
             handlers = list(self._subscribers.get(event_type, {}).values())
         immutable_payload = MappingProxyType(deepcopy(dict(payload)))
-        self._history.append({"type": event_type, "data": dict(immutable_payload)})
+        self._history.append(Event(type=event_type, data=immutable_payload))
         for handler in handlers:
             handler(immutable_payload)
 
@@ -70,9 +79,14 @@ class EventBus:
         history = (
             self._history
             if event_type is None
-            else [e for e in self._history if e["type"] == event_type]
+            else list(filter(lambda e: e.type == event_type, self._history))
         )
-        return history[-limit:]
+        return list(
+            map(
+                lambda e: {"type": e.type, "data": {k: v for k, v in e.data.items()}},
+                history,
+            )
+        )[-limit:]
 
 
 class EventPublisher:
@@ -88,4 +102,4 @@ class EventPublisher:
         self._event_bus.emit(event_type, payload)
 
 
-__all__ = ["EventBus", "EventPublisher"]
+__all__ = ["Event", "EventBus", "EventPublisher"]

--- a/tests/common/test_event_bus.py
+++ b/tests/common/test_event_bus.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
+import pytest
+
 from src.common.events import EventBus, EventPublisher
 
 
@@ -33,3 +37,15 @@ def test_event_publisher_mixin():
     publisher.publish_event("evt", {"c": 3})
 
     assert received == {"c": 3}
+
+
+def test_event_history_immutable():
+    bus = EventBus()
+    bus.emit("evt", {"a": 1})
+    event = bus._history[0]
+
+    with pytest.raises(FrozenInstanceError):
+        event.type = "other"  # type: ignore[misc]
+
+    with pytest.raises(TypeError):
+        event.data["a"] = 2  # type: ignore[index]


### PR DESCRIPTION
## Summary
- replace mutable event history with frozen `Event` dataclass
- leverage `filter`/`map`/comprehensions for history retrieval
- add immutability test and development guideline

## Testing
- `pytest tests/common/test_event_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc066b724832092b3e319ba451d15