### PR TITLE
Use existing logo in manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ data/learned_mappings.json
 !package.json
 !package-lock.json
 !yosai_intel_dashboard/src/adapters/ui/tsconfig.json
+!public/manifest.json
 !dashboards/grafana/*.json
 !dashboards/performance/*.json
 !monitoring/grafana/*.json

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Yosai Intel Dashboard</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "short_name": "Yosai Dashboard",
+  "name": "Yosai Intel Dashboard",
+  "icons": [
+    {
+      "src": "../yosai_intel_dashboard/src/adapters/ui/assets/yosai_logo.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "../yosai_intel_dashboard/src/adapters/ui/assets/yosai_logo.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- add a web app manifest that pulls icon imagery from existing assets
- expose the new manifest to clients via index.html

## Testing
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*
- `npm run build` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68907beddc4083208832f0821e1ed232