### PR TITLE
Add theme color and iOS meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.json" />
     <title>Yosai Intel Dashboard</title>
   </head>


### PR DESCRIPTION
## Summary
- add theme color and Apple web app meta tags to public index.html

## Testing
- `pre-commit run --files public/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68908ce0699c8320ba94c6290c48e417