### PR TITLE
feat(ui): add bottom navigation with gesture hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ data/learned_mappings.json
 !package-lock.json
 !yosai_intel_dashboard/src/adapters/ui/tsconfig.json
 !public/manifest.json
+!yosai_intel_dashboard/src/adapters/ui/lib/
+!yosai_intel_dashboard/src/adapters/ui/lib/gestures.ts
+!yosai_intel_dashboard/src/adapters/ui/lib/gestures.ts
 !dashboards/grafana/*.json
 !dashboards/performance/*.json
 !monitoring/grafana/*.json

--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx
@@ -13,6 +13,7 @@ const MemoryRouter: React.FC<{ children: React.ReactNode }> = ({ children }) => 
 );
 
 test('shows brand text and toggles menu', () => {
+  (window as any).innerWidth = 500;
   render(
     <MemoryRouter>
       <Navbar />

--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.tsx
@@ -23,6 +23,7 @@ const Navbar: React.FC = () => {
   const navigate = useNavigate();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [activeTab, setActiveTab] = useState(location.pathname);
+  const [isMobile, setIsMobile] = useState(false);
 
   const navItems: NavItem[] = [
     { path: '/upload', label: 'Upload', icon: <Upload size={20} /> },
@@ -35,6 +36,17 @@ const Navbar: React.FC = () => {
   useEffect(() => {
     setActiveTab(location.pathname);
   }, [location]);
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobile) setIsMenuOpen(false);
+  }, [isMobile]);
 
   const handleNavClick = (path: string) => {
     setActiveTab(path);
@@ -50,15 +62,17 @@ const Navbar: React.FC = () => {
           <span className="brand-text">YOSAI Intelligence</span>
         </div>
 
-        <button 
-          className="mobile-menu-toggle"
-          onClick={() => setIsMenuOpen(!isMenuOpen)}
-          aria-label="Toggle menu"
-        >
-          {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
-        </button>
+        {isMobile && (
+          <button
+            className="mobile-menu-toggle"
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            aria-label="Toggle menu"
+          >
+            {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          </button>
+        )}
 
-        <div className={`navbar-menu ${isMenuOpen ? 'is-active' : ''}`}>
+        <div className={`navbar-menu ${isMobile && isMenuOpen ? 'is-active' : ''}`}>
           {navItems.map((item) => (
             <Link
               key={item.path}

--- a/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Upload, BarChart3, LineChart, Download, Settings, Plus } from 'lucide-react';
+import { useSwipe } from '../../lib/gestures';
+
+interface NavItem {
+  path: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  { path: '/upload', label: 'Upload', icon: <Upload size={24} /> },
+  { path: '/analytics', label: 'Analytics', icon: <BarChart3 size={24} /> },
+  { path: '/graphs', label: 'Graphs', icon: <LineChart size={24} /> },
+  { path: '/export', label: 'Export', icon: <Download size={24} /> },
+  { path: '/settings', label: 'Settings', icon: <Settings size={24} /> },
+];
+
+const BottomNav: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [activeIndex, setActiveIndex] = useState(
+    Math.max(0, navItems.findIndex((n) => n.path === location.pathname))
+  );
+
+  const swipeRef = useSwipe((dir) => {
+    if (dir === 'left') {
+      const next = (activeIndex + 1) % navItems.length;
+      setActiveIndex(next);
+      navigate(navItems[next].path);
+    }
+    if (dir === 'right') {
+      const prev = (activeIndex - 1 + navItems.length) % navItems.length;
+      setActiveIndex(prev);
+      navigate(navItems[prev].path);
+    }
+  });
+
+  return (
+    <nav
+      ref={swipeRef}
+      className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-md z-50"
+    >
+      <ul className="flex justify-around items-center py-2">
+        {navItems.map((item, idx) => (
+          <li key={item.path}>
+            <Link
+              to={item.path}
+              onClick={() => setActiveIndex(idx)}
+              className={`flex flex-col items-center justify-center w-11 h-11 rounded-full ${
+                activeIndex === idx ? 'text-blue-600' : 'text-gray-600'
+              }`}
+              aria-label={item.label}
+            >
+              {item.icon}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <button
+        className="absolute -top-6 left-1/2 -translate-x-1/2 w-14 h-14 bg-blue-600 text-white rounded-full flex items-center justify-center shadow-lg"
+        aria-label="Primary action"
+      >
+        <Plus size={28} />
+      </button>
+    </nav>
+  );
+};
+
+export default BottomNav;
+

--- a/yosai_intel_dashboard/src/adapters/ui/lib/gestures.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/lib/gestures.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react';
+import Hammer from 'hammerjs';
+
+type SwipeDir = 'left' | 'right' | 'up' | 'down';
+
+export const useSwipe = (onSwipe: (dir: SwipeDir) => void) => {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const hammer = new Hammer(ref.current);
+    hammer.get('swipe').set({ direction: Hammer.DIRECTION_ALL });
+    const handler = (ev: any) => {
+      switch (ev.direction) {
+        case Hammer.DIRECTION_LEFT:
+          onSwipe('left');
+          break;
+        case Hammer.DIRECTION_RIGHT:
+          onSwipe('right');
+          break;
+        case Hammer.DIRECTION_UP:
+          onSwipe('up');
+          break;
+        case Hammer.DIRECTION_DOWN:
+          onSwipe('down');
+          break;
+      }
+    };
+    hammer.on('swipe', handler);
+    return () => {
+      hammer.off('swipe', handler);
+      hammer.destroy();
+    };
+  }, [onSwipe]);
+
+  return ref;
+};
+
+export const usePinch = (onPinch: (scale: number) => void) => {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const hammer = new Hammer(ref.current);
+    hammer.get('pinch').set({ enable: true });
+    const handler = (ev: any) => onPinch(ev.scale);
+    hammer.on('pinch', handler);
+    return () => {
+      hammer.off('pinch', handler);
+      hammer.destroy();
+    };
+  }, [onPinch]);
+
+  return ref;
+};
+
+export const useLongPress = (onPress: () => void, time = 500) => {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const hammer = new Hammer(ref.current);
+    hammer.get('press').set({ time });
+    const handler = () => onPress();
+    hammer.on('press', handler);
+    return () => {
+      hammer.off('press', handler);
+      hammer.destroy();
+    };
+  }, [onPress, time]);
+
+  return ref;
+};
+


### PR DESCRIPTION
## Summary
- add Hammer.js hooks for swipe, pinch and long press gestures
- implement mobile bottom navigation with FAB and swipe navigation
- make top navbar responsive with hamburger menu on small screens

## Testing
- `npx react-scripts test --watchAll=false --runTestsByPath yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68908ce24b7483208c81509edb06ebe4