### PR TITLE
feat: add network-aware data saver settings

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/ResponsiveImage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ResponsiveImage.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { usePreferencesStore } from '../state';
+import { useNetworkStatus } from '../lib/network';
 
 interface Source {
   srcSet: string;
@@ -13,14 +15,28 @@ interface ResponsiveImageProps
 
 const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
   sources,
+  src,
   ...imgProps
-}) => (
-  <picture>
-    {sources.map((source, index) => (
-      <source key={index} {...source} />
-    ))}
-    <img {...imgProps} />
-  </picture>
-);
+}) => {
+  const { saveData } = usePreferencesStore();
+  const network = useNetworkStatus();
+  const slow =
+    ['slow-2g', '2g'].includes(network.effectiveType ?? '') || network.saveData;
+  const shouldReduce = saveData || slow;
+
+  if (shouldReduce) {
+    const lowSrc = src ?? sources[0]?.srcSet;
+    return <img {...imgProps} src={lowSrc} />;
+  }
+
+  return (
+    <picture>
+      {sources.map((source, index) => (
+        <source key={index} {...source} />
+      ))}
+      <img {...imgProps} src={src} />
+    </picture>
+  );
+};
 
 export default ResponsiveImage;

--- a/yosai_intel_dashboard/src/adapters/ui/components/analytics/ComparisonView.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/analytics/ComparisonView.tsx
@@ -8,6 +8,8 @@ import {
   CartesianGrid,
   ResponsiveContainer,
 } from 'recharts';
+import { usePreferencesStore } from '../../state';
+import { useNetworkStatus } from '../../lib/network';
 
 export interface SeriesPoint {
   x: string;
@@ -32,6 +34,10 @@ const ComparisonView: React.FC<ComparisonViewProps> = ({
   labels = ['Series A', 'Series B'],
 }) => {
   const [mode, setMode] = useState<'overlay' | 'side-by-side'>('overlay');
+  const { saveData } = usePreferencesStore();
+  const network = useNetworkStatus();
+  const dataSaver =
+    saveData || network.saveData || ['slow-2g', '2g'].includes(network.effectiveType ?? '');
 
   const merged = useMemo(() => {
     const map: Record<string, { a?: number; b?: number }> = {};
@@ -77,32 +83,56 @@ const ComparisonView: React.FC<ComparisonViewProps> = ({
       {mode === 'overlay' ? (
         <ResponsiveContainer width="100%" height={300}>
           <LineChart data={merged}>
-            <CartesianGrid strokeDasharray="3 3" />
+            {!dataSaver && <CartesianGrid strokeDasharray="3 3" />}
             <XAxis dataKey="x" />
             <YAxis />
             <Tooltip />
-            <Line type="monotone" dataKey="a" stroke="#8884d8" name={labels[0]} />
-            <Line type="monotone" dataKey="b" stroke="#82ca9d" name={labels[1]} />
+            <Line
+              type="monotone"
+              dataKey="a"
+              stroke="#8884d8"
+              name={labels[0]}
+              dot={!dataSaver}
+            />
+            <Line
+              type="monotone"
+              dataKey="b"
+              stroke="#82ca9d"
+              name={labels[1]}
+              dot={!dataSaver}
+            />
           </LineChart>
         </ResponsiveContainer>
       ) : (
         <div className="flex space-x-4" style={{ height: 300 }}>
           <ResponsiveContainer width="50%" height="100%">
-            <LineChart data={seriesA}>
-              <CartesianGrid strokeDasharray="3 3" />
+            <LineChart data={dataSaver ? seriesA.filter((_, i) => i % 2 === 0) : seriesA}>
+              {!dataSaver && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis dataKey="x" />
               <YAxis />
               <Tooltip />
-              <Line type="monotone" dataKey="value" stroke="#8884d8" name={labels[0]} />
+              <Line
+                type="monotone"
+                dataKey="value"
+                stroke="#8884d8"
+                name={labels[0]}
+                dot={!dataSaver}
+              />
             </LineChart>
           </ResponsiveContainer>
           <ResponsiveContainer width="50%" height="100%">
-            <LineChart data={seriesB}>
-              <CartesianGrid strokeDasharray="3 3" />
+            <LineChart data={dataSaver ? seriesB.filter((_, i) => i % 2 === 0) : seriesB}>
+              {!dataSaver && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis dataKey="x" />
               <YAxis />
               <Tooltip />
-              <Line type="monotone" dataKey="value" stroke="#82ca9d" name={labels[1]} />
+              <Line
+                type="monotone"
+                dataKey="value"
+                stroke="#82ca9d"
+                name={labels[1]}
+                dot={!dataSaver}
+              />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/yosai_intel_dashboard/src/adapters/ui/components/security/RiskDashboard.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/security/RiskDashboard.tsx
@@ -13,7 +13,8 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
-import useDataSaver from '../../hooks/useDataSaver';
+import { usePreferencesStore } from '../../state';
+import { useNetworkStatus } from '../../lib/network';
 
 interface RiskFactor {
   name: string;
@@ -34,7 +35,10 @@ const RiskDashboard: React.FC<RiskDashboardProps> = ({
 }) => {
   const [displayScore, setDisplayScore] = useState(score);
   const [expanded, setExpanded] = useState(false);
-  const dataSaver = useDataSaver();
+  const { saveData } = usePreferencesStore();
+  const network = useNetworkStatus();
+  const dataSaver =
+    saveData || network.saveData || ['slow-2g', '2g'].includes(network.effectiveType ?? '');
 
   useEffect(() => {
     let start = displayScore;

--- a/yosai_intel_dashboard/src/adapters/ui/lib/network.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/lib/network.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+export interface NetworkStatus {
+  online: boolean;
+  saveData: boolean;
+  effectiveType?: string;
+}
+
+/**
+ * Reads the current network information from the browser.
+ */
+export function readNetworkStatus(): NetworkStatus {
+  const nav: any = typeof navigator !== 'undefined' ? navigator : {};
+  const connection = nav.connection || nav.mozConnection || nav.webkitConnection;
+  return {
+    online: nav.onLine ?? true,
+    saveData: Boolean(connection?.saveData),
+    effectiveType: connection?.effectiveType,
+  };
+}
+
+/**
+ * React hook that subscribes to changes in network status.
+ */
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>(readNetworkStatus());
+
+  useEffect(() => {
+    const update = () => setStatus(readNetworkStatus());
+    const nav: any = typeof navigator !== 'undefined' ? navigator : {};
+    const connection = nav.connection || nav.mozConnection || nav.webkitConnection;
+
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    connection?.addEventListener?.('change', update);
+
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+      connection?.removeEventListener?.('change', update);
+    };
+  }, []);
+
+  return status;
+}

--- a/yosai_intel_dashboard/src/adapters/ui/state/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/state/index.ts
@@ -2,5 +2,6 @@ export * from './store';
 export * from './sessionSlice';
 export * from './analyticsSlice';
 export * from './uiSlice';
+export * from './preferences';
 
 export * from './ZustandProvider';

--- a/yosai_intel_dashboard/src/adapters/ui/state/preferences/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/state/preferences/index.ts
@@ -1,0 +1,1 @@
+export * from './slice';

--- a/yosai_intel_dashboard/src/adapters/ui/state/preferences/slice.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/state/preferences/slice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from 'zustand';
+
+export interface PreferencesSlice {
+  saveData: boolean;
+  setSaveData: (value: boolean) => void;
+}
+
+export const createPreferencesSlice: StateCreator<PreferencesSlice, [], [], PreferencesSlice> = (set) => ({
+  saveData: false,
+  setSaveData: (value: boolean) => set({ saveData: value }),
+});

--- a/yosai_intel_dashboard/src/adapters/ui/state/store.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/state/store.ts
@@ -5,6 +5,10 @@ import { createAnalyticsSlice, AnalyticsSlice } from './analyticsSlice';
 import { createUploadSlice, UploadSlice } from './uploadSlice';
 import { createSelectionSlice, SelectionSlice } from './selectionSlice';
 import { createUiSlice, UiSlice } from './uiSlice';
+import {
+  createPreferencesSlice,
+  PreferencesSlice,
+} from './preferences';
 
 
 export type BoundState =
@@ -12,7 +16,8 @@ export type BoundState =
   AnalyticsSlice &
   UploadSlice &
   SelectionSlice &
-  UiSlice;
+  UiSlice &
+  PreferencesSlice;
 
 
 export const boundStore = createStore<BoundState>()((...a) => ({
@@ -21,6 +26,7 @@ export const boundStore = createStore<BoundState>()((...a) => ({
   ...createUploadSlice(...a),
   ...createSelectionSlice(...a),
   ...createUiSlice(...a),
+  ...createPreferencesSlice(...a),
 
 }));
 
@@ -56,4 +62,10 @@ export const useUiStore = () =>
     tableDensity: state.tableDensity,
     setTableDensity: state.setTableDensity,
 
+  }));
+
+export const usePreferencesStore = () =>
+  useBoundStore((state) => ({
+    saveData: state.saveData,
+    setSaveData: state.setSaveData,
   }));


### PR DESCRIPTION
## Summary
- add network helper and `useNetworkStatus` hook
- add preferences slice with `saveData` toggle
- reduce image quality and chart detail when data saver or slow network

## Testing
- `npm test` *(fails: Cannot find module '.../ui/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68908ce42ef483208fbf7793dc56c9f8