### PR TITLE
refactor: centralize navigation items

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.tsx
@@ -1,22 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { 
-  Upload, 
-  BarChart3, 
-  LineChart, 
-  Download, 
-  Settings,
-  Menu,
-  X,
-  Shield
-} from 'lucide-react';
+import { Menu, X, Shield } from 'lucide-react';
+import { navItems } from '../navigation/navItems';
 import './Navbar.css';
-
-interface NavItem {
-  path: string;
-  label: string;
-  icon: React.ReactNode;
-}
 
 const Navbar: React.FC = () => {
   const location = useLocation();
@@ -24,14 +10,6 @@ const Navbar: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [activeTab, setActiveTab] = useState(location.pathname);
   const [isMobile, setIsMobile] = useState(false);
-
-  const navItems: NavItem[] = [
-    { path: '/upload', label: 'Upload', icon: <Upload size={20} /> },
-    { path: '/analytics', label: 'Analytics', icon: <BarChart3 size={20} /> },
-    { path: '/graphs', label: 'Graphs', icon: <LineChart size={20} /> },
-    { path: '/export', label: 'Export', icon: <Download size={20} /> },
-    { path: '/settings', label: 'Settings', icon: <Settings size={20} /> }
-  ];
 
   useEffect(() => {
     setActiveTab(location.pathname);
@@ -80,7 +58,7 @@ const Navbar: React.FC = () => {
               className={`navbar-item ${activeTab === item.path ? 'is-active' : ''}`}
               onClick={() => handleNavClick(item.path)}
             >
-              {item.icon}
+              <item.icon size={20} />
               <span className="navbar-label">{item.label}</span>
             </Link>
           ))}

--- a/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
@@ -1,21 +1,8 @@
 import React, { useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { Upload, BarChart3, LineChart, Download, Settings, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useSwipe } from '../../lib/gestures';
-
-interface NavItem {
-  path: string;
-  label: string;
-  icon: React.ReactNode;
-}
-
-const navItems: NavItem[] = [
-  { path: '/upload', label: 'Upload', icon: <Upload size={24} /> },
-  { path: '/analytics', label: 'Analytics', icon: <BarChart3 size={24} /> },
-  { path: '/graphs', label: 'Graphs', icon: <LineChart size={24} /> },
-  { path: '/export', label: 'Export', icon: <Download size={24} /> },
-  { path: '/settings', label: 'Settings', icon: <Settings size={24} /> },
-];
+import { navItems } from './navItems';
 
 const BottomNav: React.FC = () => {
   const location = useLocation();
@@ -53,7 +40,7 @@ const BottomNav: React.FC = () => {
               }`}
               aria-label={item.label}
             >
-              {item.icon}
+              <item.icon size={24} />
             </Link>
           </li>
         ))}

--- a/yosai_intel_dashboard/src/adapters/ui/components/navigation/navItems.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/navigation/navItems.ts
@@ -1,0 +1,17 @@
+import type { ComponentType } from 'react';
+import { Upload, BarChart3, LineChart, Download, Settings } from 'lucide-react';
+
+export interface NavItem {
+  path: string;
+  label: string;
+  icon: ComponentType<{ size?: number }>;
+}
+
+export const navItems: NavItem[] = [
+  { path: '/upload', label: 'Upload', icon: Upload },
+  { path: '/analytics', label: 'Analytics', icon: BarChart3 },
+  { path: '/graphs', label: 'Graphs', icon: LineChart },
+  { path: '/export', label: 'Export', icon: Download },
+  { path: '/settings', label: 'Settings', icon: Settings },
+];
+


### PR DESCRIPTION
## Summary
- add a shared navItems config for repeated navigation entries
- update Navbar and BottomNav to source their routes from the shared list

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/components/navigation/navItems.ts yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.tsx yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx`
- `npm test` *(fails: Cannot find module '/workspace/yosai_intel_dashboard_fresh/yosai_intel_dashboard/src/adapters/ui/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689091d801148320b90cc7c98863be4e