### PR TITLE
feat(environment): add weather and event context

### DIFF
--- a/integrations/weather/etl.py
+++ b/integrations/weather/etl.py
@@ -1,72 +1,7 @@
-from __future__ import annotations
-
-"""ETL utilities for weather events."""
-
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Iterable, Protocol
-
-from database.protocols import ConnectionProtocol
-
-
-@dataclass
-class WeatherEvent:
-    """Normalized weather metrics for storage and analysis."""
-
-    timestamp: datetime
-    temperature: float
-    humidity: float
-    precipitation: float
-    wind: float
-    visibility: float
-    pressure: float
-    lightning: bool
-
-
-class WeatherClient(Protocol):
-    def fetch(self) -> dict:  # pragma: no cover - protocol definition
-        ...
-
-
-def normalize(raw: dict) -> WeatherEvent:
-    return WeatherEvent(
-        timestamp=raw["timestamp"],
-        temperature=float(raw.get("temperature", 0.0)),
-        humidity=float(raw.get("humidity", 0.0)),
-        precipitation=float(raw.get("precipitation", 0.0)),
-        wind=float(raw.get("wind", 0.0)),
-        visibility=float(raw.get("visibility", 0.0)),
-        pressure=float(raw.get("pressure", 0.0)),
-        lightning=bool(raw.get("lightning", False)),
-    )
-
-
-def run_weather_etl(db: ConnectionProtocol, clients: Iterable[WeatherClient]) -> list[WeatherEvent]:
-    """Fetch data from ``clients`` and persist to ``db``.
-
-    Returns the list of normalized :class:`WeatherEvent` objects that were
-    inserted.  The database interaction is intentionally simple: each event
-    results in a single ``INSERT`` command recorded on the connection.
-    """
-
-    events: list[WeatherEvent] = []
-    for client in clients:
-        event = normalize(client.fetch())
-        db.execute_command(
-            "INSERT INTO weather_events (timestamp, temperature, humidity, precipitation, wind, visibility, pressure, lightning) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
-            (
-                event.timestamp,
-                event.temperature,
-                event.humidity,
-                event.precipitation,
-                event.wind,
-                event.visibility,
-                event.pressure,
-                event.lightning,
-            ),
-        )
-        events.append(event)
-    return events
-
+from yosai_intel_dashboard.src.services.environment import (
+    WeatherEvent,
+    run_weather_etl,
+    normalize,
+)
 
 __all__ = ["WeatherEvent", "run_weather_etl", "normalize"]

--- a/intel_analysis_service/ml/feature_pipeline.py
+++ b/intel_analysis_service/ml/feature_pipeline.py
@@ -61,4 +61,14 @@ def build_context_features(
     )
 
     features = features.sort_values("timestamp").fillna(0)
+
+    if "events" in features:
+        features["event_density"] = (
+            features["events"].rolling(window=3, min_periods=1).sum()
+        )
+    if "social" in features:
+        features["social_sentiment"] = (
+            features["social"].rolling(window=3, min_periods=1).mean()
+        )
+
     return features

--- a/yosai_intel_dashboard/src/services/environment/__init__.py
+++ b/yosai_intel_dashboard/src/services/environment/__init__.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Environmental data utilities.
+
+This module centralises ETL routines for weather data along with connectors
+for additional contextual signals such as social media and local event feeds.
+The exposed helpers make it easy to merge these heterogeneous sources and to
+correlate them with access logs for downstream analytics.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable, Iterable, List, Protocol, Sequence, Tuple
+
+import pandas as pd
+
+from yosai_intel_dashboard.src.database.protocols import ConnectionProtocol
+
+
+# ---------------------------------------------------------------------------
+# Weather ETL
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WeatherEvent:
+    """Normalized weather metrics for storage and analysis."""
+
+    timestamp: datetime
+    temperature: float
+    humidity: float
+    precipitation: float
+    wind: float
+    visibility: float
+    pressure: float
+    lightning: bool
+
+
+class WeatherClient(Protocol):
+    """Protocol for weather data providers."""
+
+    def fetch(self) -> dict:
+        ...
+
+
+def normalize(raw: dict) -> WeatherEvent:
+    """Normalize a raw weather payload into :class:`WeatherEvent`."""
+
+    return WeatherEvent(
+        timestamp=raw["timestamp"],
+        temperature=float(raw.get("temperature", 0.0)),
+        humidity=float(raw.get("humidity", 0.0)),
+        precipitation=float(raw.get("precipitation", 0.0)),
+        wind=float(raw.get("wind", 0.0)),
+        visibility=float(raw.get("visibility", 0.0)),
+        pressure=float(raw.get("pressure", 0.0)),
+        lightning=bool(raw.get("lightning", False)),
+    )
+
+
+def run_weather_etl(
+    db: ConnectionProtocol, clients: Iterable[WeatherClient]
+) -> list[WeatherEvent]:
+    """Fetch data from ``clients`` and persist to ``db``.
+
+    Returns the list of normalized :class:`WeatherEvent` objects that were
+    inserted.  The database interaction is intentionally simple: each event
+    results in a single ``INSERT`` command recorded on the connection.
+    """
+
+    events: list[WeatherEvent] = []
+    for client in clients:
+        event = normalize(client.fetch())
+        db.execute_command(
+            "INSERT INTO weather_events (timestamp, temperature, humidity, precipitation, wind, visibility, pressure, lightning)"
+            " VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
+            (
+                event.timestamp,
+                event.temperature,
+                event.humidity,
+                event.precipitation,
+                event.wind,
+                event.visibility,
+                event.pressure,
+                event.lightning,
+            ),
+        )
+        events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Event feed connectors
+# ---------------------------------------------------------------------------
+
+
+class EventConnector(Protocol):
+    """Protocol representing a generic event feed."""
+
+    def fetch(self) -> Sequence[dict]:
+        ...
+
+
+class SocialMediaConnector:
+    """Connector for social media feeds.
+
+    Parameters
+    ----------
+    fetch_fn:
+        Callable returning an iterable of event dictionaries.  Each event must
+        contain at least a ``timestamp`` field and may include additional
+        metadata such as ``sentiment``.
+    """
+
+    def __init__(self, fetch_fn: Callable[[], Sequence[dict]]):
+        self._fetch = fetch_fn
+
+    def fetch(self) -> Sequence[dict]:  # pragma: no cover - thin wrapper
+        return self._fetch()
+
+
+class LocalEventConnector:
+    """Connector for local event feeds."""
+
+    def __init__(self, fetch_fn: Callable[[], Sequence[dict]]):
+        self._fetch = fetch_fn
+
+    def fetch(self) -> Sequence[dict]:  # pragma: no cover - thin wrapper
+        return self._fetch()
+
+
+def merge_environmental_data(
+    weather_events: Iterable[WeatherEvent],
+    event_records: Iterable[dict],
+) -> pd.DataFrame:
+    """Merge weather data with additional event records."""
+
+    w_df = pd.DataFrame([e.__dict__ for e in weather_events])
+    e_df = pd.DataFrame(list(event_records))
+    if not e_df.empty:
+        e_df = e_df.groupby("timestamp").sum(numeric_only=True).reset_index()
+    return (
+        pd.merge(w_df, e_df, on="timestamp", how="outer")
+        .sort_values("timestamp")
+        .fillna(0)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Correlation utilities
+# ---------------------------------------------------------------------------
+
+AccessRecord = Tuple[str, str]
+TimedAccessRecord = Tuple[datetime, str, str]
+
+
+def correlate_access_with_weather(
+    access_records: Iterable[TimedAccessRecord],
+    weather_events: Iterable[WeatherEvent],
+    window: timedelta,
+    spike_threshold: int,
+) -> List[datetime]:
+    """Flag weather events that coincide with access spikes."""
+
+    times = sorted(ts for ts, _u, _r in access_records)
+    flagged: List[datetime] = []
+    for event in weather_events:
+        start = event.timestamp - window
+        end = event.timestamp + window
+        count = 0
+        for t in times:
+            if t < start:
+                continue
+            if t > end:
+                break
+            count += 1
+        if count >= spike_threshold:
+            flagged.append(event.timestamp)
+    return flagged
+
+
+__all__ = [
+    "WeatherEvent",
+    "WeatherClient",
+    "run_weather_etl",
+    "normalize",
+    "SocialMediaConnector",
+    "LocalEventConnector",
+    "merge_environmental_data",
+    "correlate_access_with_weather",
+    "AccessRecord",
+    "TimedAccessRecord",
+]

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/behavioral_cliques.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/behavioral_cliques.py
@@ -9,17 +9,9 @@ can highlight unusual behaviour worthy of further investigation.
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Set, Tuple
-
-try:  # pragma: no cover - optional dependency
-    from integrations.weather.etl import WeatherEvent
-except Exception:  # pragma: no cover - fallback when integration missing
-    WeatherEvent = Any  # type: ignore
+from typing import Dict, Iterable, Set, Tuple
 
 AccessRecord = Tuple[str, str]
-# Access record with timestamp for correlation against weather events
-TimedAccessRecord = Tuple[datetime, str, str]
 
 
 def cluster_users_by_coaccess(records: Iterable[AccessRecord]) -> Dict[frozenset[str], Set[str]]:
@@ -56,43 +48,9 @@ def detect_behavioral_deviations(
     return {user: res for user, res in deviations.items()}
 
 
-def correlate_access_with_weather(
-    access_records: Iterable[TimedAccessRecord],
-    weather_events: Iterable[WeatherEvent],
-    window: timedelta,
-    spike_threshold: int,
-) -> List[datetime]:
-    """Flag weather events that coincide with access spikes.
-
-    The function joins ``access_records`` with ``weather_events`` within the
-    provided time ``window``.  For each weather event, if the number of access
-    records in the surrounding window meets or exceeds ``spike_threshold`` the
-    event timestamp is returned.  Callers can use this to highlight anomalous
-    activity such as login spikes during storms.
-    """
-
-    times = sorted(ts for ts, _u, _r in access_records)
-    flagged: List[datetime] = []
-    for event in weather_events:
-        start = event.timestamp - window
-        end = event.timestamp + window
-        count = 0
-        for t in times:
-            if t < start:
-                continue
-            if t > end:
-                break
-            count += 1
-        if count >= spike_threshold:
-            flagged.append(event.timestamp)
-    return flagged
-
-
 __all__ = [
     "cluster_users_by_coaccess",
     "detect_behavioral_deviations",
-    "correlate_access_with_weather",
     "AccessRecord",
-    "TimedAccessRecord",
 ]
 


### PR DESCRIPTION
## Summary
- add environment service with weather ETL, event connectors, and correlation helpers
- generate contextual features for event density and social sentiment
- enable anomaly detector to account for environmental context

## Testing
- `pytest tests/integrations/test_weather.py tests/ml/test_context_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68909708f75883209081de5ee66be685