### PR TITLE
feat: add progressive section component

### DIFF
--- a/cypress/e2e/progressive-section.cy.ts
+++ b/cypress/e2e/progressive-section.cy.ts
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+
+describe('ProgressiveSection accessibility', () => {
+  it('hides content from screen readers until expanded', () => {
+    cy.visit('/analytics');
+    cy.get('#drilldown-metrics')
+      .should('have.attr', 'aria-hidden', 'true')
+      .and('not.be.visible');
+    cy.contains('button', 'Drill-down Metrics').click();
+    cy.get('#drilldown-metrics')
+      .should('have.attr', 'aria-hidden', 'false')
+      .and('be.visible');
+  });
+});

--- a/docs/ui_guidelines.md
+++ b/docs/ui_guidelines.md
@@ -1,0 +1,13 @@
+# UI Guidelines
+
+## Progressive Reveal
+
+Use the `ProgressiveSection` component to hide complex metrics or settings until users request them. This pattern keeps interfaces focused while maintaining accessibility.
+
+```tsx
+<ProgressiveSection title="Advanced Settings">
+  {/* advanced controls here */}
+</ProgressiveSection>
+```
+
+Content wrapped in `ProgressiveSection` is hidden from screen readers and keyboard navigation until expanded, reducing noise for assistive technology users.

--- a/docs/visualization-style-guide.md
+++ b/docs/visualization-style-guide.md
@@ -2,6 +2,10 @@
 
 This guide standardizes how visual elements appear across the dashboard. Each section shows the preferred styling and a minimal code sample using the built-in helpers.
 
+## Progressive Reveal
+
+When presenting dense or advanced metrics, wrap supplementary charts or controls in a `ProgressiveSection`. This keeps initial views approachable while allowing interested users to drill down for more detail.
+
 ## Drift Chart
 
 Use line charts to display model drift or other time‑series metrics.

--- a/yosai_intel_dashboard/src/adapters/ui/components/ProgressiveSection.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ProgressiveSection.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useId } from 'react';
+
+interface ProgressiveSectionProps {
+  title: string;
+  children: React.ReactNode;
+  /** Whether the section starts expanded */
+  initiallyExpanded?: boolean;
+  /** Optional id for the content element */
+  id?: string;
+  className?: string;
+}
+
+/**
+ * A reusable section that progressively reveals details on demand.
+ * Content is hidden from assistive technologies until expanded.
+ */
+const ProgressiveSection: React.FC<ProgressiveSectionProps> = ({
+  title,
+  children,
+  initiallyExpanded = false,
+  id,
+  className = '',
+}) => {
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+  const generatedId = useId();
+  const contentId = id || generatedId;
+
+  return (
+    <section className={className}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={() => setExpanded((e) => !e)}
+        className="progressive-section-toggle"
+      >
+        {title}
+      </button>
+      <div
+        id={contentId}
+        hidden={!expanded}
+        aria-hidden={!expanded}
+        className="progressive-section-content"
+      >
+        {children}
+      </div>
+    </section>
+  );
+};
+
+export default ProgressiveSection;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
@@ -3,6 +3,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import { useAnalyticsStore } from '../state/store';
 import { BarChart3, Filter, Download, AlertCircle } from 'lucide-react';
 import { ChunkGroup } from '../components/layout';
+import ProgressiveSection from '../components/ProgressiveSection';
 const RiskDashboard = React.lazy(
   () => import('../components/security/RiskDashboard'),
 );
@@ -176,7 +177,11 @@ const Analytics: React.FC = () => {
             </div>
           </div>
 
-          <div className="analytics-sections">
+          <ProgressiveSection
+            title="Drill-down Metrics"
+            id="drilldown-metrics"
+            className="analytics-sections"
+          >
             <section className="patterns-section">
               <h2>Top Security Patterns</h2>
               <ChunkGroup className="patterns-list" limit={9}>
@@ -213,7 +218,7 @@ const Analytics: React.FC = () => {
                 ))}
               </ChunkGroup>
             </section>
-          </div>
+          </ProgressiveSection>
         </ClickExpand>
       )}
     </div>

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { LineChart as LineChartIcon } from 'lucide-react';
 import { ChunkGroup } from '../components/layout';
+import ProgressiveSection from '../components/ProgressiveSection';
 import {
   LineChart,
   Line,
@@ -183,6 +184,20 @@ const Graphs: React.FC = () => {
             ))}
           </select>
         )}
+        <ProgressiveSection
+          title="Advanced Settings"
+          id="graph-advanced-settings"
+          className="mt-2"
+        >
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={showDetails}
+              onChange={(e) => setShowDetails(e.target.checked)}
+            />
+            <span>Show chart details</span>
+          </label>
+        </ProgressiveSection>
       </ChunkGroup>
       <div role="presentation">{renderChart()}</div>
 


### PR DESCRIPTION
## Summary
- add reusable ProgressiveSection component for on-demand details
- apply ProgressiveSection in Analytics and Graphs pages
- document progressive reveal pattern and add accessibility test

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: unable to resolve dependency tree)*
- `npx cypress run --spec cypress/e2e/progressive-section.cy.ts` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6890970b37e48320be5f5aac346f6032