### PR TITLE
feat: integrate neo4j graph workflows

### DIFF
--- a/unit_tests/test_neo4j_integration.py
+++ b/unit_tests/test_neo4j_integration.py
@@ -1,0 +1,49 @@
+"""End-to-end tests for Neo4j powered graph workflows."""
+
+import pathlib
+import sys
+
+# Add the services source tree to the module search path
+sys.path.append(
+    str(pathlib.Path(__file__).resolve().parents[1] / "yosai_intel_dashboard" / "src" / "services")
+)
+
+from graph.neo4j_client import Neo4jClient
+from intel_analysis_service.core.ml.graph_classification import GraphClassifier
+from intel_analysis_service.core.ml.embeddings import GCN
+
+
+def _build_normal_graph(client: Neo4jClient):
+    client.add_node("user1", label="Person")
+    client.add_node("device1", label="Device")
+    client.add_edge("user1", "device1", "ACCESSED")
+    return client.get_graph()
+
+
+def _build_anomalous_graph(client: Neo4jClient):
+    client.add_node("user1", label="Person")
+    client.add_node("device1", label="Device")
+    client.add_node("device2", label="Device")
+    client.add_edge("user1", "device1", "ACCESSED")
+    client.add_edge("user1", "device2", "ACCESSED")
+    return client.get_graph()
+
+
+def test_neo4j_relationship_alerts() -> None:
+    client = Neo4jClient()
+    g_normal = _build_normal_graph(client)
+    client.graph.clear()
+    g_anom = _build_anomalous_graph(client)
+
+    classifier = GraphClassifier(embedder=GCN(dimensions=4), neo4j_client=client)
+    classifier.fit([g_normal, g_anom], [0, 1])
+
+    # Ingest new events and classify directly from Neo4j
+    client.graph.clear()
+    _ = _build_anomalous_graph(client)
+    prediction = classifier.predict_from_neo4j()[0]
+    assert prediction == 1
+
+    # Embeddings should have been written back to Neo4j
+    embeddings = client.read_node_embeddings()
+    assert "user1" in embeddings

--- a/yosai_intel_dashboard/src/services/graph/neo4j_client.py
+++ b/yosai_intel_dashboard/src/services/graph/neo4j_client.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Simple Neo4j client used for tests and lightweight integrations.
+
+The client wraps the official Neo4j Python driver when available.  When no
+connection details are supplied it falls back to an in-memory ``networkx``
+representation which mimics a tiny subset of Neo4j functionality.  This
+makes it suitable for unit tests where running a full database would be
+impractical.
+"""
+
+from typing import Any, Iterable, Mapping, Dict
+
+import networkx as nx
+
+try:  # pragma: no cover - optional dependency
+    from neo4j import GraphDatabase  # type: ignore
+except Exception:  # pragma: no cover - handled dynamically
+    GraphDatabase = None  # type: ignore
+
+
+class Neo4jClient:
+    """Utility for interacting with Neo4j or an in-memory substitute."""
+
+    def __init__(self, uri: str | None = None, user: str | None = None, password: str | None = None) -> None:
+        self.driver = None
+        if uri and GraphDatabase is not None:  # pragma: no cover - requires neo4j server
+            self.driver = GraphDatabase.driver(uri, auth=(user or "", password or ""))
+        self.graph = nx.MultiDiGraph()
+
+    # ------------------------------------------------------------------
+    # Driver management
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            self.driver.close()
+
+    def run_cypher(self, query: str, parameters: Mapping[str, Any] | None = None):
+        """Execute a Cypher query if a real driver is configured."""
+        if self.driver is None:
+            raise RuntimeError("Neo4j driver not initialised")
+        with self.driver.session() as session:  # pragma: no cover - requires neo4j server
+            return session.run(query, parameters or {})
+
+    # ------------------------------------------------------------------
+    # In-memory helpers used in tests
+    # ------------------------------------------------------------------
+    def add_node(self, node_id: str, **properties: Any) -> None:
+        """Create or update a node in the backing store."""
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            cypher = "MERGE (n {id: $id}) SET n += $props"
+            self.run_cypher(cypher, {"id": node_id, "props": properties})
+        else:
+            self.graph.add_node(node_id, **properties)
+
+    def add_edge(self, source: str, target: str, rel_type: str, **properties: Any) -> None:
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            cypher = (
+                f"MATCH (a {{id:$source}}),(b {{id:$target}}) "
+                f"MERGE (a)-[r:{rel_type}]->(b) SET r += $props"
+            )
+            self.run_cypher(cypher, {"source": source, "target": target, "props": properties})
+        else:
+            self.graph.add_edge(source, target, key=rel_type, type=rel_type, **properties)
+
+    def get_graph(self) -> nx.MultiDiGraph:
+        """Return the entire graph as a :class:`networkx.MultiDiGraph`."""
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            g = nx.MultiDiGraph()
+            nodes = self.run_cypher("MATCH (n) RETURN n.id as id, n as data")
+            for record in nodes:
+                props = {k: v for k, v in record["data"].items() if k != "id"}
+                g.add_node(record["id"], **props)
+            edges = self.run_cypher(
+                "MATCH (a)-[r]->(b) RETURN a.id as source, b.id as target, type(r) as type, r as data"
+            )
+            for record in edges:
+                props = {k: v for k, v in record["data"].items()}
+                g.add_edge(record["source"], record["target"], key=record["type"], type=record["type"], **props)
+            return g
+        return self.graph.copy()
+
+    def write_node_embeddings(self, embeddings: Mapping[str, Iterable[float]]) -> None:
+        """Persist node embeddings as the ``embedding`` property."""
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            for node_id, emb in embeddings.items():
+                self.run_cypher(
+                    "MATCH (n {id:$id}) SET n.embedding = $emb",
+                    {"id": node_id, "emb": list(map(float, emb))},
+                )
+        else:
+            for node_id, emb in embeddings.items():
+                if node_id in self.graph:
+                    self.graph.nodes[node_id]["embedding"] = list(map(float, emb))
+
+    def read_node_embeddings(self) -> Dict[str, list[float]]:
+        """Return embeddings stored on nodes, if present."""
+        if self.driver is not None:  # pragma: no cover - requires neo4j server
+            result = self.run_cypher(
+                "MATCH (n) WHERE exists(n.embedding) RETURN n.id as id, n.embedding as emb"
+            )
+            return {record["id"]: record["emb"] for record in result}
+        return {
+            str(node): data["embedding"]
+            for node, data in self.graph.nodes(data=True)
+            if "embedding" in data
+        }

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/ml/__init__.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/ml/__init__.py
@@ -1,6 +1,6 @@
 """Graph machine learning utilities."""
 
-from .embeddings import GraphSAGE, Node2Vec
+from .embeddings import GraphSAGE, Node2Vec, GCN
 from .attention_models import GraphAttentionNetwork
 from .link_prediction import LinkPredictor
 from .graph_classification import GraphClassifier
@@ -15,6 +15,7 @@ from .api import (
 __all__ = [
     "Node2Vec",
     "GraphSAGE",
+    "GCN",
     "GraphAttentionNetwork",
     "LinkPredictor",
     "GraphClassifier",

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/ml/graph_classification.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/ml/graph_classification.py
@@ -8,29 +8,65 @@ import numpy as np
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score
 
-from .embeddings import Node2Vec, GraphSAGE
+from .embeddings import Node2Vec, GraphSAGE, GCN
+from graph.neo4j_client import Neo4jClient
 
 
 class GraphClassifier:
-    """Classify graphs based on learned embeddings."""
+    """Classify graphs based on learned embeddings.
 
-    def __init__(self, embedder: Node2Vec | GraphSAGE | None = None) -> None:
+    The classifier can optionally integrate with :class:`Neo4jClient` allowing
+    graphs to be read from and embeddings written back to a Neo4j database.
+    """
+
+    def __init__(
+        self,
+        embedder: Node2Vec | GraphSAGE | GCN | None = None,
+        neo4j_client: Neo4jClient | None = None,
+    ) -> None:
         self.embedder = embedder or Node2Vec()
         self.model = LogisticRegression()
+        self.neo4j_client = neo4j_client
+
+    # ------------------------------------------------------------------
+    # Data access helpers
+    # ------------------------------------------------------------------
+    def load_graph_from_neo4j(self) -> nx.Graph:
+        if self.neo4j_client is None:
+            raise ValueError("Neo4j client not configured")
+        return self.neo4j_client.get_graph()
 
     def _graph_embedding(self, graph: nx.Graph) -> np.ndarray:
+        """Return an embedding for ``graph`` and persist it if possible."""
         self.embedder.fit(graph)
         embeddings = self.embedder.get_embeddings()
+        if self.neo4j_client is not None:
+            self.neo4j_client.write_node_embeddings(embeddings)
+            embeddings = {
+                k: np.asarray(v, dtype=float)
+                for k, v in self.neo4j_client.read_node_embeddings().items()
+            }
         return np.mean(list(embeddings.values()), axis=0)
 
+    # ------------------------------------------------------------------
+    # Model API
+    # ------------------------------------------------------------------
     def fit(self, graphs: Sequence[nx.Graph], labels: Sequence[int]) -> "GraphClassifier":
         X = [self._graph_embedding(g) for g in graphs]
         self.model.fit(X, labels)
         return self
 
+    def fit_from_neo4j(self, labels: Sequence[int]) -> "GraphClassifier":
+        graph = self.load_graph_from_neo4j()
+        return self.fit([graph], labels)
+
     def predict(self, graphs: Sequence[nx.Graph]) -> List[int]:
         X = [self._graph_embedding(g) for g in graphs]
         return list(self.model.predict(X))
+
+    def predict_from_neo4j(self) -> List[int]:
+        graph = self.load_graph_from_neo4j()
+        return self.predict([graph])
 
     def evaluate(self, graphs: Sequence[nx.Graph], labels: Sequence[int]) -> float:
         preds = self.predict(graphs)


### PR DESCRIPTION
## Summary
- add lightweight Neo4j client with in-memory fallback
- extend GraphClassifier to train/predict using Neo4j graphs
- provide simple GCN embedder and neo4j integration test

## Testing
- `pytest unit_tests/test_neo4j_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68909705f7108320825515daeccfbd53