### PR TITLE
refactor: centralize config helpers

### DIFF
--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+import importlib.util
+from pathlib import Path
+
+# Dynamically import the new helpers module
+helpers_path = (
+    Path(__file__).resolve().parents[1]
+    / "yosai_intel_dashboard"
+    / "src"
+    / "core"
+    / "utils"
+    / "config_helpers.py"
+)
+_spec = importlib.util.spec_from_file_location("config_helpers", helpers_path)
+config_helpers = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(config_helpers)  # type: ignore
+
+
+class Dummy:
+    def __init__(self):
+        self.performance = SimpleNamespace(ai_confidence_threshold=0.9)
+        self.upload = SimpleNamespace(max_file_size_mb=42)
+        self.uploads = SimpleNamespace(DEFAULT_CHUNK_SIZE=256)
+        self.security = SimpleNamespace(max_upload_mb=21)
+        self.max_upload_size_mb = 84
+        self.upload_chunk_size = 512
+        self.ai_confidence_threshold = 0.91
+
+
+def test_get_ai_confidence_threshold_from_nested():
+    cfg = Dummy()
+    assert config_helpers.get_ai_confidence_threshold(cfg) == 0.9
+
+
+def test_get_ai_confidence_threshold_alt_attrs():
+    cfg = SimpleNamespace(ai_threshold=0.88)
+    assert config_helpers.get_ai_confidence_threshold(cfg) == 0.88
+    cfg = {"ai_confidence_threshold": 0.77}
+    assert config_helpers.get_ai_confidence_threshold(cfg) == 0.77
+
+
+def test_get_ai_confidence_threshold_default():
+    assert config_helpers.get_ai_confidence_threshold(None) == 0.8
+
+
+def test_get_max_upload_size_mb_attrs():
+    cfg = Dummy()
+    assert config_helpers.get_max_upload_size_mb(cfg) == 84
+
+
+def test_get_max_upload_size_mb_alt_attrs():
+    cfg = SimpleNamespace(max_size_mb=33)
+    assert config_helpers.get_max_upload_size_mb(cfg) == 33
+    cfg = SimpleNamespace(security=SimpleNamespace(max_upload_mb=77))
+    assert config_helpers.get_max_upload_size_mb(cfg) == 77
+    cfg = {"max_upload_size_mb": 55}
+    assert config_helpers.get_max_upload_size_mb(cfg) == 55
+
+
+def test_get_max_upload_size_mb_default():
+    assert config_helpers.get_max_upload_size_mb(None) == 100
+
+
+def test_get_upload_chunk_size_attrs():
+    cfg = Dummy()
+    assert config_helpers.get_upload_chunk_size(cfg) == 512
+
+
+def test_get_upload_chunk_size_alt_attrs():
+    cfg = SimpleNamespace(chunk_size=1024)
+    assert config_helpers.get_upload_chunk_size(cfg) == 1024
+    cfg = SimpleNamespace(uploads=SimpleNamespace(DEFAULT_CHUNK_SIZE=256))
+    assert config_helpers.get_upload_chunk_size(cfg) == 256
+    cfg = {"upload_chunk_size": 128}
+    assert config_helpers.get_upload_chunk_size(cfg) == 128
+
+
+def test_get_upload_chunk_size_default():
+    assert config_helpers.get_upload_chunk_size(None) == 50000
+
+
+def test_configuration_service_integration():
+    from yosai_intel_dashboard.src.services.configuration_service import (
+        DynamicConfigurationService,
+    )
+    from src.common.config import ConfigService
+
+    cfg = ConfigService(
+        {
+            "ai_confidence_threshold": 0.66,
+            "max_upload_size_mb": 123,
+            "upload_chunk_size": 987,
+        }
+    )
+    service = DynamicConfigurationService(cfg=cfg)
+    assert service.ai_confidence_threshold == 0.66
+    assert service.max_upload_size_mb == 123
+    assert service.upload_chunk_size == 987

--- a/yosai_intel_dashboard/src/core/utils/__init__.py
+++ b/yosai_intel_dashboard/src/core/utils/__init__.py
@@ -1,0 +1,11 @@
+from .config_helpers import (
+    get_ai_confidence_threshold,
+    get_max_upload_size_mb,
+    get_upload_chunk_size,
+)
+
+__all__ = [
+    "get_ai_confidence_threshold",
+    "get_max_upload_size_mb",
+    "get_upload_chunk_size",
+]

--- a/yosai_intel_dashboard/src/core/utils/config_helpers.py
+++ b/yosai_intel_dashboard/src/core/utils/config_helpers.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Utility helpers for resolving configuration values.
+
+These functions provide a single place to retrieve common configuration
+settings.  They accept any object or mapping that exposes the relevant
+attributes and fall back to defaults from :class:`ConfigService` when a value
+is not provided.
+"""
+
+from typing import Any, Mapping
+
+from src.common.config import ConfigService
+
+
+_default_cfg = ConfigService()
+
+
+def _mapping_or_attr(cfg: Any, attr: str, default: Any) -> Any:
+    """Return *attr* from *cfg* supporting mappings and attributes."""
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return cfg.get(attr, default)
+    return getattr(cfg, attr, default)
+
+
+def get_ai_confidence_threshold(cfg: Any | None = None) -> float:
+    """Return the AI confidence threshold from *cfg* or defaults."""
+    default = _default_cfg.ai_confidence_threshold
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return float(cfg.get("ai_confidence_threshold", default))
+    if hasattr(cfg, "performance") and hasattr(
+        cfg.performance, "ai_confidence_threshold"
+    ):
+        return float(cfg.performance.ai_confidence_threshold)
+    if hasattr(cfg, "ai_confidence_threshold"):
+        return float(cfg.ai_confidence_threshold)
+    if hasattr(cfg, "ai_threshold"):
+        return float(cfg.ai_threshold)
+    return default
+
+
+def get_max_upload_size_mb(cfg: Any | None = None) -> int:
+    """Return the maximum upload size in megabytes from *cfg* or defaults."""
+    default = _default_cfg.max_upload_size_mb
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return int(cfg.get("max_upload_size_mb", default))
+    if hasattr(cfg, "max_upload_size_mb"):
+        return int(cfg.max_upload_size_mb)
+    if hasattr(cfg, "max_size_mb"):
+        return int(cfg.max_size_mb)
+    if hasattr(cfg, "security") and hasattr(cfg.security, "max_upload_mb"):
+        return int(cfg.security.max_upload_mb)
+    if hasattr(cfg, "upload") and hasattr(cfg.upload, "max_file_size_mb"):
+        return int(cfg.upload.max_file_size_mb)
+    return default
+
+
+def get_upload_chunk_size(cfg: Any | None = None) -> int:
+    """Return the upload chunk size from *cfg* or defaults."""
+    default = _default_cfg.upload_chunk_size
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return int(cfg.get("upload_chunk_size", default))
+    if hasattr(cfg, "upload_chunk_size"):
+        return int(cfg.upload_chunk_size)
+    if hasattr(cfg, "chunk_size"):
+        return int(cfg.chunk_size)
+    if hasattr(cfg, "uploads") and hasattr(cfg.uploads, "DEFAULT_CHUNK_SIZE"):
+        return int(cfg.uploads.DEFAULT_CHUNK_SIZE)
+    return default
+
+
+__all__ = [
+    "get_ai_confidence_threshold",
+    "get_max_upload_size_mb",
+    "get_upload_chunk_size",
+]

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -18,6 +18,7 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
+from yosai_intel_dashboard.src.core.utils import get_max_upload_size_mb
 
 logger = logging.getLogger(__name__)
 
@@ -329,7 +330,7 @@ class DynamicConfigManager(BaseConfigLoader):
         return self.security.pbkdf2_iterations
 
     def get_max_upload_size(self) -> int:
-        return self.security.max_upload_mb
+        return get_max_upload_size_mb(self)
 
     def get_db_pool_size(self) -> int:
         return self.performance.db_pool_size
@@ -345,11 +346,11 @@ class DynamicConfigManager(BaseConfigLoader):
 
     def get_max_upload_size_bytes(self) -> int:
         """Get maximum upload size in bytes."""
-        return self.upload.max_file_size_bytes
+        return get_max_upload_size_mb(self) * 1024 * 1024
 
     def validate_large_file_support(self) -> bool:
         """Check if configuration supports 50MB+ files."""
-        return self.upload.max_file_size_mb >= 50
+        return get_max_upload_size_mb(self) >= 50
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)

--- a/yosai_intel_dashboard/src/services/common/config_utils.py
+++ b/yosai_intel_dashboard/src/services/common/config_utils.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 """Shared configuration helpers for validation classes."""
 
-from typing import Any, Mapping
+from typing import Any
+
+from yosai_intel_dashboard.src.core.utils import (
+    get_ai_confidence_threshold,
+    get_max_upload_size_mb,
+    get_upload_chunk_size,
+)
 
 
 def create_config_methods(cls: Any) -> Any:
@@ -13,14 +19,9 @@ def create_config_methods(cls: Any) -> Any:
 def common_init(self: Any, config: Any | None = None) -> None:
     """Initialize configuration defaults."""
     self.config = config or {}
-    if isinstance(self.config, Mapping):
-        self.max_size_mb = self.config.get("max_upload_size_mb", 100)
-        self.ai_threshold = self.config.get("ai_confidence_threshold", 0.8)
-        self.chunk_size = self.config.get("upload_chunk_size", 1048576)
-    else:
-        self.max_size_mb = getattr(self.config, "max_upload_size_mb", 100)
-        self.ai_threshold = getattr(self.config, "ai_confidence_threshold", 0.8)
-        self.chunk_size = getattr(self.config, "upload_chunk_size", 1048576)
+    self.max_size_mb = get_max_upload_size_mb(self.config)
+    self.ai_threshold = get_ai_confidence_threshold(self.config)
+    self.chunk_size = get_upload_chunk_size(self.config)
 
 
 __all__ = ["create_config_methods", "common_init"]

--- a/yosai_intel_dashboard/src/services/configuration_service.py
+++ b/yosai_intel_dashboard/src/services/configuration_service.py
@@ -10,6 +10,11 @@ from typing import Any, Dict
 from yosai_intel_dashboard.src.core.interfaces.protocols import (
     ConfigurationServiceProtocol,
 )
+from yosai_intel_dashboard.src.core.utils import (
+    get_ai_confidence_threshold,
+    get_max_upload_size_mb,
+    get_upload_chunk_size,
+)
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
     DynamicConfigManager,
     dynamic_config,
@@ -31,17 +36,17 @@ class DynamicConfigurationService(ConfigurationServiceProtocol):
     # Simple pass-through wrappers
     @property
     def max_upload_size_mb(self) -> int:
-        return self._cfg.max_upload_size_mb
+        return get_max_upload_size_mb(self._cfg)
 
     def get_max_upload_size_bytes(self) -> int:
-        return self._cfg.max_upload_size_mb * 1024 * 1024
+        return get_max_upload_size_mb(self._cfg) * 1024 * 1024
 
     def validate_large_file_support(self) -> bool:
-        return self._cfg.max_upload_size_mb >= 50
+        return get_max_upload_size_mb(self._cfg) >= 50
 
     @property
     def upload_chunk_size(self) -> int:
-        return self._cfg.upload_chunk_size
+        return get_upload_chunk_size(self._cfg)
 
     def get_max_parallel_uploads(self) -> int:
         return self._manager.get_max_parallel_uploads()
@@ -50,8 +55,8 @@ class DynamicConfigurationService(ConfigurationServiceProtocol):
         return self._manager.get_validator_rules()
 
     @property
-    def ai_confidence_threshold(self) -> int:
-        return self._cfg.ai_confidence_threshold
+    def ai_confidence_threshold(self) -> float:
+        return get_ai_confidence_threshold(self._cfg)
 
     def get_db_pool_size(self) -> int:
         return self._manager.get_db_pool_size()


### PR DESCRIPTION
## Summary
- add shared config helper functions for common settings
- use new helpers in dynamic and service configs
- cover helpers with regression tests

## Testing
- `pytest --noconftest tests/test_config_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689096ffc6508320bb81064bb522639d