### PR TITLE
Harden baseline metrics SQL and secret handling

### DIFF
--- a/tests/database/test_baseline_metrics_sql_injection.py
+++ b/tests/database/test_baseline_metrics_sql_injection.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import types
+
+from yosai_intel_dashboard.src.database.mock_database import MockDatabase
+
+
+def test_baseline_metrics_uses_parameters(monkeypatch):
+    mock_db = MockDatabase()
+    fake_conn = types.SimpleNamespace(create_database_connection=lambda: mock_db)
+    fake_sec = types.SimpleNamespace(
+        execute_secure_command=lambda c, s, p=None: c.execute_command(s, p),
+        execute_secure_sql=lambda c, s, p=None: c.execute_query(s, p),
+    )
+    fake_secure_query = types.SimpleNamespace(
+        SecureQueryBuilder=lambda **_: types.SimpleNamespace(
+            table=lambda x: x, build=lambda sql, params=None, logger=None: (sql, params)
+        )
+    )
+    monkeypatch.setitem(sys.modules, "database.connection", fake_conn)
+    monkeypatch.setitem(sys.modules, "security", types.ModuleType("security"))
+    monkeypatch.setitem(sys.modules, "security.secure_query_wrapper", fake_sec)
+    monkeypatch.setitem(
+        sys.modules, "infrastructure.database.secure_query", fake_secure_query
+    )
+    bm = importlib.import_module("yosai_intel_dashboard.src.database.baseline_metrics")
+    importlib.reload(bm)
+    db = bm.BaselineMetricsDB()
+    malicious = "1'; DROP TABLE users; --"
+    db.update_baseline("user", malicious, {"views": 1.0})
+    command, params = mock_db.commands[-1]
+    assert malicious not in command
+    assert params == ("user", malicious, "views", 1.0)
+
+    db.get_baseline("user", malicious)
+    query, qparams = mock_db.queries[-1]
+    assert malicious not in query
+    assert qparams == ("user", malicious)

--- a/tests/shared/test_request_signing.py
+++ b/tests/shared/test_request_signing.py
@@ -1,22 +1,39 @@
-from shared.request_signing import sign_request, verify_request, HEADER_SIGNATURE, HEADER_TIMESTAMP
+import os
+
+from shared.request_signing import (
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    sign_request,
+    verify_request,
+)
+
+
+def _set_secret(monkeypatch) -> str:
+    secret = os.urandom(16).hex()
+    monkeypatch.setenv("REQUEST_SIGNING_SECRET", secret)
+    return secret
 
 
 def test_sign_and_verify_roundtrip(monkeypatch):
-    secret = "s3cr3t"
+    secret = _set_secret(monkeypatch)
     method = "POST"
     path = "/test"
     body = b"payload"
 
-    headers = sign_request(secret, method, path, body)
+    headers = sign_request(os.environ["REQUEST_SIGNING_SECRET"], method, path, body)
     assert HEADER_SIGNATURE in headers and HEADER_TIMESTAMP in headers
-    assert verify_request(secret, method, path, body, headers)
+    # Ensure the secret is not leaked in headers
+    assert secret not in headers.values()
+    assert verify_request(os.environ["REQUEST_SIGNING_SECRET"], method, path, body, headers)
 
 
 def test_verify_rejects_modified_body(monkeypatch):
-    secret = "s3cr3t"
+    _set_secret(monkeypatch)
     method = "POST"
     path = "/test"
     body = b"payload"
 
-    headers = sign_request(secret, method, path, body)
-    assert not verify_request(secret, method, path, b"other", headers)
+    headers = sign_request(os.environ["REQUEST_SIGNING_SECRET"], method, path, body)
+    assert not verify_request(
+        os.environ["REQUEST_SIGNING_SECRET"], method, path, b"other", headers
+    )


### PR DESCRIPTION
## Summary
- refactor `BaselineMetricsDB` to build queries via `SecureQueryBuilder` and secure wrappers
- load request signing secret from environment and verify it never leaks in headers
- add tests covering SQL injection attempts and secret handling

## Testing
- `python scripts/detect_sql_strings.py 2>&1 | head -n 200`
- `pytest tests/database/test_baseline_metrics_sql_injection.py tests/shared/test_request_signing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689096fea4488320ae75ae2e22d65384