### PR TITLE
Integrate behavioral biometrics into RBAC checks

### DIFF
--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -133,3 +133,33 @@ def test_require_permission_async_forbidden():
             return "ok"
 
         assert asyncio.run(endpoint()) == ("Forbidden", 403)
+
+
+def test_biometric_block_role(monkeypatch):
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.config["RBAC_SERVICE"] = DummyService()
+    with app.test_request_context():
+        session["user_id"] = "u1"
+        monkeypatch.setattr(rbac, "_verify_behavioral_biometrics", lambda req: False)
+
+        @require_role("admin")
+        def endpoint():
+            return "ok"
+
+        assert endpoint() == ("Forbidden", 403)
+
+
+def test_biometric_block_permission(monkeypatch):
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.config["RBAC_SERVICE"] = DummyService()
+    with app.test_request_context():
+        session["user_id"] = "u1"
+        monkeypatch.setattr(rbac, "_verify_behavioral_biometrics", lambda req: False)
+
+        @require_permission("read")
+        def endpoint():
+            return "ok"
+
+        assert endpoint() == ("Forbidden", 403)


### PR DESCRIPTION
## Summary
- add helper to load behavioral biometrics verification lazily
- enforce biometric verification in `require_role` and `require_permission`
- test RBAC decorators block requests when biometrics fail

## Testing
- `pytest tests/test_rbac.py` *(fails: MemoryError)*

------
https://chatgpt.com/codex/tasks/task_e_68909d609c248320a4f52a17feff3cdc