### PR TITLE
Improve SQL security and secret management

### DIFF
--- a/tests/security/test_jwt_secret_env.py
+++ b/tests/security/test_jwt_secret_env.py
@@ -1,0 +1,39 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+SRC_PATH = pathlib.Path(__file__).resolve().parents[2] / "yosai_intel_dashboard" / "src" / "services" / "security" / "jwt_service.py"
+
+
+def load_jwt_service(secret_path: str = "vault/path"):
+    spec = importlib.util.spec_from_file_location("jwt_service", SRC_PATH)
+    module = importlib.util.module_from_spec(spec)
+    secrets_mod = types.ModuleType("yosai_intel_dashboard.src.services.common.secrets")
+    called = {}
+
+    def fake_get_secret(key: str) -> str:
+        called["key"] = key
+        return "top"
+
+    secrets_mod.get_secret = fake_get_secret
+    secrets_mod.invalidate_secret = lambda key=None: None
+    sys.modules["yosai_intel_dashboard.src.services.common.secrets"] = secrets_mod
+    spec.loader.exec_module(module)
+    return module, called
+
+
+def test_read_jwt_secret_uses_env(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_PATH", "vault/custom")
+    module, called = load_jwt_service()
+    assert module._read_jwt_secret() == "top"
+    assert called["key"] == "vault/custom"
+
+
+def test_read_jwt_secret_requires_env(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET_PATH", raising=False)
+    module, _ = load_jwt_service()
+    with pytest.raises(RuntimeError):
+        module._read_jwt_secret()

--- a/tests/security/test_secure_query_builder.py
+++ b/tests/security/test_secure_query_builder.py
@@ -1,0 +1,21 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+SRC_PATH = pathlib.Path(__file__).resolve().parents[2] / "yosai_intel_dashboard" / "src"
+SECURE_QUERY_FILE = SRC_PATH / "infrastructure" / "database" / "secure_query.py"
+spec = importlib.util.spec_from_file_location(
+    "infrastructure.database.secure_query", SECURE_QUERY_FILE
+)
+secure_query = importlib.util.module_from_spec(spec)
+sys.modules["infrastructure.database.secure_query"] = secure_query
+spec.loader.exec_module(secure_query)
+SecureQueryBuilder = secure_query.SecureQueryBuilder
+
+
+def test_secure_query_builder_blocks_table_injection():
+    builder = SecureQueryBuilder(allowed_tables={"consent_log"})
+    with pytest.raises(ValueError):
+        builder.table("consent_log; DROP TABLE users;--")

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -122,12 +122,15 @@ register_health_check(app, "database", _db_check)
 register_health_check(app, "message_broker", _broker_check)
 register_health_check(app, "external_api", _external_api_check)
 
-_SECRET_PATH = "secret/data/jwt#secret"
+JWT_SECRET_PATH_ENV = "JWT_SECRET_PATH"
 
 
 def _jwt_secret() -> str:
     """Return the current JWT secret."""
-    return get_secret(_SECRET_PATH)
+    secret_path = os.getenv(JWT_SECRET_PATH_ENV)
+    if not secret_path:
+        raise RuntimeError("JWT_SECRET_PATH not configured")
+    return get_secret(secret_path)
 
 
 def verify_token(authorization: str = Header("")) -> dict:


### PR DESCRIPTION
## Summary
- Harden compliance DB validation with parameterized queries
- Load JWT secret path from environment variables to avoid hardcoded secrets
- Add security tests for query builder and JWT secret handling

## Testing
- `bandit -r . -f json -o /tmp/bandit.json`
- `pytest tests/security/test_secure_query_builder.py tests/security/test_jwt_secret_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68909d5b499c832081a797faa8aabb88