### PR TITLE
Mitigate security issues and remove hardcoded secrets

### DIFF
--- a/tests/file_processing/test_chunk_cache.py
+++ b/tests/file_processing/test_chunk_cache.py
@@ -99,11 +99,12 @@ def test_cache_rejects_pickle(tmp_path, monkeypatch):
 
     evil_file = tmp_path / "evil_triggered"
 
+    def _touch(path: Path) -> None:
+        path.write_text("")
+
     class Exploit:
         def __reduce__(self):
-            import builtins
-
-            return (builtins.exec, (f"open('{evil_file}', 'w').close()",))
+            return (_touch, (evil_file,))
 
     cache_file.write_bytes(pickle.dumps(Exploit()))
 

--- a/tests/integration/test_rbac_endpoints.py
+++ b/tests/integration/test_rbac_endpoints.py
@@ -4,6 +4,7 @@ from enum import Enum
 from types import ModuleType, SimpleNamespace
 
 import pytest
+import os
 from flask import Flask
 
 
@@ -129,7 +130,7 @@ def _create_app(monkeypatch, rbac_service):
     )
 
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = os.urandom(16).hex()
     app.config["RBAC_SERVICE"] = rbac_service
     app.register_blueprint(module.compliance_bp)
     return app, login_mod

--- a/tests/integration/test_timescale.py
+++ b/tests/integration/test_timescale.py
@@ -84,7 +84,7 @@ def test_timescale_policies(tmp_path):
             "SELECT job_id FROM timescaledb_information.jobs WHERE hypertable_name='access_events' AND proc_name='policy_compression'"
         )
         job = cur.fetchone()[0]
-        cur.execute(f"SELECT run_job({job})")
+        cur.execute("SELECT run_job(%s)", (job,))
         conn.commit()
 
         cur.execute(
@@ -96,7 +96,7 @@ def test_timescale_policies(tmp_path):
             "SELECT job_id FROM timescaledb_information.jobs WHERE hypertable_name='access_events' AND proc_name='policy_retention'"
         )
         job = cur.fetchone()[0]
-        cur.execute(f"SELECT run_job({job})")
+        cur.execute("SELECT run_job(%s)", (job,))
         conn.commit()
         cur.execute("SELECT COUNT(*) FROM access_events")
         assert cur.fetchone()[0] == 0

--- a/tests/test_csrf_enforcement.py
+++ b/tests/test_csrf_enforcement.py
@@ -2,10 +2,11 @@ import asyncio
 from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
+import os
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 import pytest
 
-serializer = URLSafeTimedSerializer("secret")
+serializer = URLSafeTimedSerializer(os.urandom(16).hex())
 app = FastAPI()
 
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import os
 
 import pytest
 from flask import Flask, session
@@ -14,6 +15,8 @@ spec.loader.exec_module(rbac)
 require_role = rbac.require_role
 require_permission = rbac.require_permission
 
+SECRET_KEY = os.urandom(16).hex()
+
 
 class DummyService:
     async def has_role(self, user_id: str, role: str) -> bool:
@@ -25,7 +28,7 @@ class DummyService:
 
 def test_require_role_async_allows():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -39,7 +42,7 @@ def test_require_role_async_allows():
 
 def test_require_role_async_forbidden():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -53,7 +56,7 @@ def test_require_role_async_forbidden():
 
 def test_require_permission_sync_allows():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -67,7 +70,7 @@ def test_require_permission_sync_allows():
 
 def test_require_permission_sync_forbidden():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -81,7 +84,7 @@ def test_require_permission_sync_forbidden():
 
 def test_require_role_sync_allows():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -95,7 +98,7 @@ def test_require_role_sync_allows():
 
 def test_require_role_sync_forbidden():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -109,7 +112,7 @@ def test_require_role_sync_forbidden():
 
 def test_require_permission_async_allows():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -123,7 +126,7 @@ def test_require_permission_async_allows():
 
 def test_require_permission_async_forbidden():
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -137,7 +140,7 @@ def test_require_permission_async_forbidden():
 
 def test_biometric_block_role(monkeypatch):
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"
@@ -152,7 +155,7 @@ def test_biometric_block_role(monkeypatch):
 
 def test_biometric_block_permission(monkeypatch):
     app = Flask(__name__)
-    app.secret_key = "test"
+    app.secret_key = SECRET_KEY
     app.config["RBAC_SERVICE"] = DummyService()
     with app.test_request_context():
         session["user_id"] = "u1"


### PR DESCRIPTION
## Summary
- replace `exec`-based pickle exploit with harmless helper
- randomize secret material in tests and avoid hardcoded keys
- parameterize SQL statements and quote prepared statement names

## Testing
- `pytest tests/test_csrf_enforcement.py`
- `pytest tests/integration/test_auth_flow.py tests/test_rbac.py tests/integration/test_rbac_endpoints.py tests/file_processing/test_chunk_cache.py tests/integration/test_timescale.py::test_timescale_policies -q` *(failed: ModuleNotFoundError: No module named 'requests.adapters'; 'requests' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_6890b548e54083209d422e2d2de2b6c9