### PR TITLE
refactor: finalize import path migration

### DIFF
--- a/tools/diagnose_upload_config.py
+++ b/tools/diagnose_upload_config.py
@@ -11,13 +11,10 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
 from src.common.config import ConfigService
-try:  # allow tests to provide a lightweight stub
-    from config.dynamic_config import diagnose_upload_config, dynamic_config  # type: ignore
-except Exception:  # pragma: no cover - fallback to real implementation
-    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
-        diagnose_upload_config,
-        dynamic_config,
-    )
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+    diagnose_upload_config,
+    dynamic_config,
+)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/yosai_intel_dashboard/src/core/di/bootstrap.py
+++ b/yosai_intel_dashboard/src/core/di/bootstrap.py
@@ -1,13 +1,18 @@
 """Container bootstrap utilities."""
+
 from __future__ import annotations
 
 import logging
 
-from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
 from startup.registry_startup import register_optional_services
 from startup.service_registration import register_all_application_services
-from config.common_indexes import COMMON_INDEXES
 from yosai_intel_dashboard.src.database.index_optimizer import IndexOptimizer
+from yosai_intel_dashboard.src.infrastructure.config.common_indexes import (
+    COMMON_INDEXES,
+)
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
+    ServiceContainer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,5 +34,6 @@ def bootstrap_container() -> ServiceContainer:
         logger.warning("Failed to apply common index recommendations: %s", exc)
 
     return container
+
 
 __all__ = ["bootstrap_container"]

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -17,11 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional
 
 from database.query_optimizer import DatabaseQueryOptimizer
-from database.secure_exec import execute_batch, execute_command, execute_query
-from database.types import DBRows, DatabaseConnection
 from database.replicated_connection import ReplicatedDatabaseConnection
+from database.secure_exec import execute_batch, execute_command, execute_query
+from database.types import DatabaseConnection, DBRows
 from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
-
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints
     from .connection_pool import DatabaseConnectionPool
@@ -421,7 +420,7 @@ class ThreadSafeDatabaseManager(DatabaseManager):
 
 # Factory function
 def create_database_manager(config: DatabaseSettings) -> DatabaseManager:
-    """Create database manager from config.
+    """Create a database manager using the provided configuration.
 
     Deprecated: use :class:`DatabaseConnectionFactory` instead.
     """
@@ -479,7 +478,9 @@ class EnhancedPostgreSQLManager(DatabaseManager):
             shrink_interval=getattr(self.config, "shrink_interval", 0),
         )
 
-    def execute_query_with_retry(self, query: str, params: Optional[Dict] = None) -> DBRows:
+    def execute_query_with_retry(
+        self, query: str, params: Optional[Dict] = None
+    ) -> DBRows:
         encoded_query = UnicodeSQLProcessor.encode_query(query)
         optimized_query = self.optimizer.optimize_query(encoded_query)
 


### PR DESCRIPTION
## Summary
- replace remaining legacy config imports with new yosai_intel_dashboard paths
- clarify database manager factory docstring

## Testing
- `python -m scripts.verify_imports`
- `pre-commit run --files tools/diagnose_upload_config.py yosai_intel_dashboard/src/core/di/bootstrap.py yosai_intel_dashboard/src/infrastructure/config/database_manager.py`
- `pytest tests/test_upload_validator.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6890b843e4c48320b79c03384fc3ce4c