### PR TITLE
refactor: standardize callbacks to unified decorator

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
@@ -7,15 +7,19 @@ from dash import html
 from dash._callback_context import callback_context
 from dash.dependencies import Input, Output
 
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.interfaces.service_protocols import get_device_learning_service
+from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
+    get_device_learning_service,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
 
 
 def register_callbacks(app, container) -> None:
     """Register device learning callbacks."""
     callbacks = TrulyUnifiedCallbacks(app)
 
-    @callbacks.register_handler(
+    @callbacks.callback(
         Output("device-learning-status", "children"),
         [
             Input("file-upload-store", "data"),

--- a/yosai_intel_dashboard/src/adapters/ui/pages/upload/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/upload/callbacks.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.services.upload.controllers.upload_controller import UnifiedUploadController
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
+from yosai_intel_dashboard.src.services.upload.controllers.upload_controller import (
+    UnifiedUploadController,
+)
 
 
 def register_callbacks(app, container) -> None:
@@ -14,7 +18,7 @@ def register_callbacks(app, container) -> None:
     callbacks = TrulyUnifiedCallbacks(app)
     controller = UnifiedUploadController()
 
-    @callbacks.register_handler(
+    @callbacks.callback(
         [Output("to-column-map-btn", "disabled"), Output("uploaded-df-store", "data")],
         [Input("drag-drop-upload", "contents"), Input("drag-drop-upload", "filename")],
         callback_id="file_upload_handle",


### PR DESCRIPTION
## Summary
- align upload page with unified callback decorator
- align device learning page with unified callback decorator

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/pages/upload/callbacks.py yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py` *(fails: Found 924 errors in 179 files (checked 2 source files), bandit failed)*
- `pytest tests/test_new_page_callbacks.py` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6890bf3cc4b08320aabb7a9e3a452226