### PR TITLE
Add user-friendly guide and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 An AI-powered modular security intelligence dashboard for physical access control monitoring.
 
+## Quick Start for End Users
+
+1. Open the dashboard in your browser and sign in with your credentials.
+2. Use the navigation menu to access analytics, real-time monitoring, uploads, and settings.
+3. For tips on working with alerts and customizing your view, see the [User Guide](docs/user_guide.md).
+
 ## Migration Status
 
 The clean architecture migration is **COMPLETE**. All source code now resides under `yosai_intel_dashboard/src/` and requires **Python 3.11+**. The compatibility layer exposing top-level packages has been removed; import modules directly from the canonical package, e.g. `from yosai_intel_dashboard.src.core import ...`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,27 @@
+# Yōsai Intel Dashboard User Guide
+
+This guide helps non-technical users navigate the Yōsai Intel Dashboard.
+
+## Getting Started
+
+1. **Access the Dashboard**: Open the dashboard URL provided by your administrator.
+2. **Sign In**: Enter your username and password. Use the "Forgot password" link if you need to reset your credentials.
+
+## Navigating the Dashboard
+
+- **Analytics**: View charts and metrics that summarize system activity.
+- **Real-Time Monitoring**: Watch live event streams and status updates.
+- **Uploads**: Import data files using the guided upload flow.
+- **Settings**: Update your profile and notification preferences.
+
+## Working with Alerts
+
+Alerts appear at the top of the dashboard when important events occur. Click an alert to see details or dismiss it once reviewed.
+
+## Customizing Your View
+
+Use the dashboard builder to rearrange panels or add new widgets. Your layout is saved automatically for future visits.
+
+## Need Help?
+
+Contact your system administrator or consult the in-app help menu for additional support.


### PR DESCRIPTION
## Summary
- Introduce a Quick Start section in README to orient non-technical users and link to end-user documentation
- Add a new User Guide with plain-language instructions for navigation, alerts, and customization

## Testing
- `pre-commit run --files README.md docs/user_guide.md`


------
https://chatgpt.com/codex/tasks/task_e_6890bf14cf4c8320ab1f023e2a92729a