### PR TITLE
test: remove hardcoded secrets in tests

### DIFF
--- a/tests/test_rate_limit_tiers.py
+++ b/tests/test_rate_limit_tiers.py
@@ -1,3 +1,5 @@
+import os
+
 from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import DynamicConfigManager
 
 
@@ -17,10 +19,10 @@ security:
     path.write_text(yaml_text, encoding="utf-8")
     monkeypatch.setenv("YOSAI_CONFIG_FILE", str(path))
     required = {
-        "SECRET_KEY": "s",
-        "DB_PASSWORD": "pwd",
+        "SECRET_KEY": os.urandom(16).hex(),
+        "DB_PASSWORD": os.urandom(16).hex(),
         "AUTH0_CLIENT_ID": "cid",
-        "AUTH0_CLIENT_SECRET": "secret",
+        "AUTH0_CLIENT_SECRET": os.urandom(16).hex(),
         "AUTH0_DOMAIN": "dom",
         "AUTH0_AUDIENCE": "aud",
     }

--- a/tests/test_secrets_validator_references.py
+++ b/tests/test_secrets_validator_references.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from yosai_intel_dashboard.src.infrastructure.config.secrets_validator import (
@@ -30,8 +32,8 @@ def test_resolves_vault_reference(monkeypatch):
     src = MappingSource(
         {
             "SECRET_KEY": "vault:secret/path#token",
-            "DB_PASSWORD": "p" * 32,
-            "AUTH0_CLIENT_SECRET": "s" * 32,
+            "DB_PASSWORD": os.urandom(32).hex(),
+            "AUTH0_CLIENT_SECRET": os.urandom(32).hex(),
         }
     )
 
@@ -49,9 +51,9 @@ def test_resolves_aws_reference(monkeypatch):
 
     src = MappingSource(
         {
-            "SECRET_KEY": "k" * 32,
+            "SECRET_KEY": os.urandom(32).hex(),
             "DB_PASSWORD": "aws-secrets:db/pass",
-            "AUTH0_CLIENT_SECRET": "s" * 32,
+            "AUTH0_CLIENT_SECRET": os.urandom(32).hex(),
         }
     )
 


### PR DESCRIPTION
## Summary
- replace hardcoded test secrets with randomly generated values
- avoid static secret strings in security validator tests

## Testing
- `pytest tests/test_rate_limit_tiers.py tests/test_secrets_validator_references.py` *(fails: No module named 'botocore')*


------
https://chatgpt.com/codex/tasks/task_e_6890cd53583c832089dd6078fb50759d