### PR TITLE
Harden SQL query building

### DIFF
--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -86,9 +86,7 @@ def get_last_timestamp(cur: DictCursor) -> datetime:
 def update_timestamp(cur: DictCursor, ts: datetime) -> None:
     builder = SecureQueryBuilder(allowed_tables={CHECKPOINT_TABLE})
     table = builder.table(CHECKPOINT_TABLE)
-    sql, params = builder.build(
-        f"UPDATE {table} SET last_ts = %s", (ts,), logger=LOG
-    )
+    sql, params = builder.build(f"UPDATE {table} SET last_ts = %s", (ts,), logger=LOG)
     execute_command(cur, sql, params)
 
 
@@ -121,8 +119,8 @@ def insert_rows(cur: DictCursor, rows: list[dict[str, Any]]) -> None:
         f"INSERT INTO {table} ({cols}) VALUES ({placeholders})"
         " ON CONFLICT (event_id) DO NOTHING"
     )
-    builder.build(query, logger=LOG)
-    execute_values(cur, query, values)
+    sql, _ = builder.build(query, logger=LOG)
+    execute_values(cur, sql, values)
 
 
 def replicate_once(src, tgt) -> None:


### PR DESCRIPTION
## Summary
- ensure secure SQL statement construction in replication script
- return sanitized SQL for timescale analytics queries

## Testing
- `pre-commit run --files scripts/replicate_to_timescale.py yosai_intel_dashboard/src/services/analytics/timescale_queries.py`
- `pytest tests/analytics/test_timescale_queries.py` *(fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.analytics.analytics')*


------
https://chatgpt.com/codex/tasks/task_e_6890ccec4bb08320bd70a1ffb143b57c