### PR TITLE
chore: add SQL safety scan to CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,6 +23,29 @@ jobs:
         run: |
           ./scripts/run_tests_and_smoke.sh
 
+  sql-scan:
+    needs: build-test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Check for unsafe SQL strings
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.py')
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Scanning changed files:"
+            echo "$CHANGED_FILES"
+            PYTHONPATH=. python scripts/sql_migration_report.py $CHANGED_FILES
+            PYTHONPATH=. python scripts/detect_sql_strings.py $CHANGED_FILES
+          else
+            echo "No Python files changed."
+          fi
+
   profile-critical:
     needs: build-test
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,19 @@ with factory.get_connection() as conn:
 Direct calls like `execute_query(factory.get_connection(), ...)` are flagged by
 a custom linter that runs via `make lint` and `pytest`.
 
+### SQL Query Safety
+
+New SQL queries must use parameterized statements. Before committing, scan
+modified Python files for unsafe string interpolation:
+
+```bash
+PYTHONPATH=. python scripts/sql_migration_report.py <changed files>
+PYTHONPATH=. python scripts/detect_sql_strings.py <changed files>
+```
+
+The CI pipeline runs the same scripts on pull requests and will fail if they
+detect concatenated or interpolated SQL strings.
+
 See [docs/test_architecture.md](docs/test_architecture.md) and
 [docs/testing_with_protocols.md](docs/testing_with_protocols.md) for details on
 the testing protocols, container builder and available test doubles.

--- a/scripts/detect_sql_strings.py
+++ b/scripts/detect_sql_strings.py
@@ -83,16 +83,18 @@ def main() -> int:
                 for lineno, kind in matches:
                     report.append((path, lineno, kind))
 
+    exit_code = 0
     if report:
         for path, lineno, kind in report:
             print(f"{path}:{lineno}: {kind} SQL construction")
+        exit_code = 1
     else:
         print("No SQL interpolation patterns found.")
 
     if args.rewrite:
         print("--rewrite not implemented; manual review needed.")
 
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run sql_migration_report.py and detect_sql_strings.py on PRs
- exit when SQL strings detected
- document running SQL safety checks before commit

## Testing
- `python scripts/sql_migration_report.py >/tmp/sql_migration_report.log || true`
- `python scripts/detect_sql_strings.py >/tmp/detect_sql.log || true`
- `pre-commit run --files .github/workflows/pipeline.yml CONTRIBUTING.md scripts/detect_sql_strings.py`


------
https://chatgpt.com/codex/tasks/task_e_6890dfac1460832096379b2ac23262b1