### PR TITLE
feat: add configuration mixin and protocol

### DIFF
--- a/tests/fake_configuration.py
+++ b/tests/fake_configuration.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import ConfigurationMixin
 
 try:
     from yosai_intel_dashboard.src.core.interfaces.protocols import ConfigurationServiceProtocol
@@ -19,7 +20,12 @@ except Exception:  # pragma: no cover - optional deps
         def get_db_pool_size(self) -> int: ...
 
 
-class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, ConfigProviderProtocol):
+class FakeConfiguration(
+    ConfigurationMixin,
+    ConfigurationProtocol,
+    ConfigurationServiceProtocol,
+    ConfigProviderProtocol,
+):
     """Simple config for unit tests."""
 
     def __init__(self) -> None:
@@ -53,10 +59,6 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, Con
             bundle_threshold_kb=100,
             specificity_high=30,
         )
-        self.max_upload_size_mb = self.security.max_upload_mb
-        self.upload_chunk_size = self.uploads.DEFAULT_CHUNK_SIZE
-        self.ai_confidence_threshold = self.performance.ai_confidence_threshold
-
     def get_database_config(self) -> dict:
         return self.database
 
@@ -76,10 +78,10 @@ class FakeConfiguration(ConfigurationProtocol, ConfigurationServiceProtocol, Con
         return {"valid": True}
 
     def get_max_upload_size_bytes(self) -> int:
-        return self.max_upload_size_mb * 1024 * 1024
+        return self.get_max_upload_size_mb() * 1024 * 1024
 
     def validate_large_file_support(self) -> bool:
-        return self.max_upload_size_mb >= 50
+        return self.get_max_upload_size_mb() >= 50
 
     def get_max_parallel_uploads(self) -> int:
         from yosai_intel_dashboard.src.core.config import get_max_parallel_uploads

--- a/tests/stubs/config/dynamic_config.py
+++ b/tests/stubs/config/dynamic_config.py
@@ -4,6 +4,8 @@ class Security:
 
 from types import SimpleNamespace
 
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import ConfigurationMixin
+
 
 class Analytics:
     max_display_rows = 100
@@ -11,7 +13,7 @@ class Analytics:
     max_memory_mb = 1024
 
 
-class DynamicConfigManager:
+class DynamicConfigManager(ConfigurationMixin):
     def __init__(self) -> None:
         self.security = SimpleNamespace(max_upload_mb=50)
         self.performance = SimpleNamespace(ai_confidence_threshold=75)
@@ -22,10 +24,10 @@ class DynamicConfigManager:
         )
 
     def get_max_upload_size_bytes(self):
-        return self.security.max_upload_mb * 1024 * 1024
+        return self.get_max_upload_size_mb() * 1024 * 1024
 
     def validate_large_file_support(self):
-        return True
+        return self.get_max_upload_size_mb() >= 50
 
     def get_max_parallel_uploads(self):
         return self.uploads.MAX_PARALLEL_UPLOADS

--- a/tests/test_configuration_mixin.py
+++ b/tests/test_configuration_mixin.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import ConfigurationMixin
+
+
+class EmptyConfig(ConfigurationMixin):
+    pass
+
+
+class CustomConfig(ConfigurationMixin):
+    def __init__(self) -> None:
+        self.performance = SimpleNamespace(ai_confidence_threshold=0.9)
+        self.security = SimpleNamespace(max_upload_mb=123)
+        self.uploads = SimpleNamespace(DEFAULT_CHUNK_SIZE=456)
+
+
+def test_defaults():
+    cfg = EmptyConfig()
+    assert cfg.get_ai_confidence_threshold() == 0.8
+    assert cfg.get_max_upload_size_mb() == 50
+    assert cfg.get_upload_chunk_size() == 1024
+
+
+def test_overrides():
+    cfg = CustomConfig()
+    assert cfg.get_ai_confidence_threshold() == 0.9
+    assert cfg.get_max_upload_size_mb() == 123
+    assert cfg.get_upload_chunk_size() == 456

--- a/yosai_intel_dashboard/src/core/interfaces/__init__.py
+++ b/yosai_intel_dashboard/src/core/interfaces/__init__.py
@@ -8,6 +8,8 @@ from .protocols import (
     AnalyticsProviderProtocol,
     ConfigProviderProtocol,
 )
+from .config_protocol import ConfigurationProtocol
+
 # Service protocol imports are deferred to avoid heavy dependencies
 
 if TYPE_CHECKING:  # pragma: no cover - only for static typing
@@ -20,6 +22,7 @@ __all__ = [
     "ConfigurationProviderProtocol",
     "AnalyticsProviderProtocol",
     "ConfigProviderProtocol",
+    "ConfigurationProtocol",
     "UploadValidatorProtocol",
     "ExportServiceProtocol",
     "DoorMappingServiceProtocol",

--- a/yosai_intel_dashboard/src/core/interfaces/config_protocol.py
+++ b/yosai_intel_dashboard/src/core/interfaces/config_protocol.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ConfigurationProtocol(Protocol):
+    """Minimal protocol for accessing runtime configuration values."""
+
+    def get_ai_confidence_threshold(self) -> float:
+        """Return the configured AI confidence threshold."""
+        ...
+
+    def get_max_upload_size_mb(self) -> int:
+        """Return the maximum allowed upload size in megabytes."""
+        ...
+
+    def get_upload_chunk_size(self) -> int:
+        """Return the configured upload chunk size in bytes."""
+        ...
+
+
+__all__ = ["ConfigurationProtocol"]

--- a/yosai_intel_dashboard/src/infrastructure/config/base_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/base_config.py
@@ -1,19 +1,11 @@
-"""Backward compatible re-exports for configuration dataclasses."""
+"""Compatibility exports for configuration dataclasses and mixins."""
 
-from .base import (
-    AnalyticsConfig,
-    AppConfig,
-    CacheConfig,
-    Config,
-    DatabaseConfig,
-    MonitoringConfig,
-    RetrainingConfig,
-    SampleFilesConfig,
-    SecretValidationConfig,
-    SecurityConfig,
-)
+from __future__ import annotations
+
+from .configuration_mixin import ConfigurationMixin
 
 __all__ = [
+    "ConfigurationMixin",
     "AppConfig",
     "DatabaseConfig",
     "SecurityConfig",
@@ -25,3 +17,12 @@ __all__ = [
     "SecretValidationConfig",
     "Config",
 ]
+
+
+def __getattr__(name: str):
+    module = __import__(
+        "yosai_intel_dashboard.src.infrastructure.config.base", fromlist=[name]
+    )
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import ConfigurationMixin
 
 from .base import CacheConfig, Config
 from .config_transformer import ConfigTransformer
@@ -35,7 +36,7 @@ from .schema import (
 from .unified_loader import UnifiedLoader
 
 
-class ConfigManager(ConfigurationProtocol):
+class ConfigManager(ConfigurationMixin, ConfigurationProtocol):
     """Orchestrate loading, validating and transforming configuration."""
 
     def __init__(
@@ -90,6 +91,11 @@ class ConfigManager(ConfigurationProtocol):
 
         self.validation = self.validator.run_checks(cfg)
         self.config = ConfigSchema.from_dataclass(cfg)
+        # expose common sections directly for mixin helpers
+        self.security = self.config.security
+        self.uploads = self.config.uploads
+        # some configurations may provide performance settings
+        self.performance = getattr(self.config, "performance", None)
 
     def get_database_config(self) -> DatabaseSettings:
         """Get database configuration."""

--- a/yosai_intel_dashboard/src/infrastructure/config/configuration_mixin.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/configuration_mixin.py
@@ -1,0 +1,41 @@
+"""Shared configuration helpers."""
+
+from __future__ import annotations
+
+
+class ConfigurationMixin:
+    """Mixin providing helper accessors for common configuration values."""
+
+    AI_CONFIDENCE_DEFAULT: float = 0.8
+    MAX_UPLOAD_SIZE_DEFAULT: int = 50
+    UPLOAD_CHUNK_SIZE_DEFAULT: int = 1024
+
+    def get_ai_confidence_threshold(self) -> float:
+        perf = getattr(self, "performance", None)
+        if perf and hasattr(perf, "ai_confidence_threshold"):
+            return float(perf.ai_confidence_threshold)
+        return float(
+            getattr(self, "ai_confidence_threshold", self.AI_CONFIDENCE_DEFAULT)
+        )
+
+    def get_max_upload_size_mb(self) -> int:
+        security = getattr(self, "security", None)
+        if security and hasattr(security, "max_upload_mb"):
+            return int(security.max_upload_mb)
+        upload = getattr(self, "upload", None)
+        if upload and hasattr(upload, "max_file_size_mb"):
+            return int(upload.max_file_size_mb)
+        return int(
+            getattr(self, "max_upload_size_mb", self.MAX_UPLOAD_SIZE_DEFAULT)
+        )
+
+    def get_upload_chunk_size(self) -> int:
+        uploads = getattr(self, "uploads", None)
+        if uploads and hasattr(uploads, "DEFAULT_CHUNK_SIZE"):
+            return int(uploads.DEFAULT_CHUNK_SIZE)
+        return int(
+            getattr(self, "upload_chunk_size", self.UPLOAD_CHUNK_SIZE_DEFAULT)
+        )
+
+
+__all__ = ["ConfigurationMixin"]

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 from .app_config import UploadConfig
 from .base_loader import BaseConfigLoader
+from .configuration_mixin import ConfigurationMixin
 from .constants import (
     AnalyticsConstants,
     CSSConstants,
@@ -18,12 +19,11 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
-from yosai_intel_dashboard.src.core.utils import get_max_upload_size_mb
 
 logger = logging.getLogger(__name__)
 
 
-class DynamicConfigManager(BaseConfigLoader):
+class DynamicConfigManager(ConfigurationMixin, BaseConfigLoader):
     """Loads constants and applies environment overrides."""
 
     def __init__(self) -> None:
@@ -329,9 +329,6 @@ class DynamicConfigManager(BaseConfigLoader):
     def get_security_level(self) -> int:
         return self.security.pbkdf2_iterations
 
-    def get_max_upload_size(self) -> int:
-        return get_max_upload_size_mb(self)
-
     def get_db_pool_size(self) -> int:
         return self.performance.db_pool_size
 
@@ -346,11 +343,11 @@ class DynamicConfigManager(BaseConfigLoader):
 
     def get_max_upload_size_bytes(self) -> int:
         """Get maximum upload size in bytes."""
-        return get_max_upload_size_mb(self) * 1024 * 1024
+        return self.get_max_upload_size_mb() * 1024 * 1024
 
     def validate_large_file_support(self) -> bool:
         """Check if configuration supports 50MB+ files."""
-        return get_max_upload_size_mb(self) >= 50
+        return self.get_max_upload_size_mb() >= 50
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)


### PR DESCRIPTION
## Summary
- add minimal ConfigurationProtocol and mixin for shared config access
- refactor config managers and test utilities to use ConfigurationMixin
- cover default and override behavior with new tests

## Testing
- `pytest tests/test_configuration_mixin.py tests/test_config_helpers.py tests/test_config_utils.py tests/test_config_resolvers.py`
- `pytest tests/test_configuration_mixin.py tests/test_config_helpers.py tests/test_upload_service_env.py` *(fails: TypeError: 'module' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_6890e2fde0848320a830fac3fe33659f