### PR TITLE
feat: add configuration mixin and protocol

### DIFF
--- a/tests/infrastructure/config/test_configuration_mixin.py
+++ b/tests/infrastructure/config/test_configuration_mixin.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import (
+    ConfigurationMixin,
+)
+
+
+class DummyConfig(ConfigurationMixin):
+    pass
+
+
+# AI confidence threshold ------------------------------------------------------
+
+
+def test_ai_confidence_threshold_default():
+    assert DummyConfig().get_ai_confidence_threshold() == 0.8
+
+
+def test_ai_confidence_threshold_performance():
+    cfg = DummyConfig()
+    cfg.performance = SimpleNamespace(ai_confidence_threshold=0.9)
+    assert cfg.get_ai_confidence_threshold() == 0.9
+
+
+def test_ai_confidence_threshold_direct():
+    cfg = DummyConfig()
+    cfg.ai_confidence_threshold = 0.91
+    assert cfg.get_ai_confidence_threshold() == 0.91
+
+
+def test_ai_confidence_threshold_alt_name():
+    cfg = DummyConfig()
+    cfg.ai_threshold = 0.77
+    assert cfg.get_ai_confidence_threshold() == 0.77
+
+
+# Maximum upload size ----------------------------------------------------------
+
+
+def test_max_upload_size_default():
+    assert DummyConfig().get_max_upload_size_mb() == 50
+
+
+def test_max_upload_size_security():
+    cfg = DummyConfig()
+    cfg.security = SimpleNamespace(max_upload_mb=100)
+    assert cfg.get_max_upload_size_mb() == 100
+
+
+def test_max_upload_size_direct():
+    cfg = DummyConfig()
+    cfg.max_upload_size_mb = 66
+    assert cfg.get_max_upload_size_mb() == 66
+
+
+def test_max_upload_size_alt_name():
+    cfg = DummyConfig()
+    cfg.max_size_mb = 70
+    assert cfg.get_max_upload_size_mb() == 70
+
+
+def test_max_upload_size_upload_attr():
+    cfg = DummyConfig()
+    cfg.upload = SimpleNamespace(max_file_size_mb=80)
+    assert cfg.get_max_upload_size_mb() == 80
+
+
+# Upload chunk size ------------------------------------------------------------
+
+
+def test_upload_chunk_size_default():
+    assert DummyConfig().get_upload_chunk_size() == 1024
+
+
+def test_upload_chunk_size_uploads():
+    cfg = DummyConfig()
+    cfg.uploads = SimpleNamespace(DEFAULT_CHUNK_SIZE=2048)
+    assert cfg.get_upload_chunk_size() == 2048
+
+
+def test_upload_chunk_size_direct():
+    cfg = DummyConfig()
+    cfg.upload_chunk_size = 256
+    assert cfg.get_upload_chunk_size() == 256
+
+
+def test_upload_chunk_size_alt_name():
+    cfg = DummyConfig()
+    cfg.chunk_size = 128
+    assert cfg.get_upload_chunk_size() == 128

--- a/tests/stubs/config/dynamic_config.py
+++ b/tests/stubs/config/dynamic_config.py
@@ -4,6 +4,10 @@ class Security:
 
 from types import SimpleNamespace
 
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import (
+    ConfigurationMixin,
+)
+
 
 class Analytics:
     max_display_rows = 100
@@ -11,7 +15,7 @@ class Analytics:
     max_memory_mb = 1024
 
 
-class DynamicConfigManager:
+class DynamicConfigManager(ConfigurationMixin):
     def __init__(self) -> None:
         self.security = SimpleNamespace(max_upload_mb=50)
         self.performance = SimpleNamespace(ai_confidence_threshold=75)
@@ -22,10 +26,10 @@ class DynamicConfigManager:
         )
 
     def get_max_upload_size_bytes(self):
-        return self.security.max_upload_mb * 1024 * 1024
+        return self.get_max_upload_size_mb() * 1024 * 1024
 
     def validate_large_file_support(self):
-        return True
+        return self.get_max_upload_size_mb() >= 50
 
     def get_max_parallel_uploads(self):
         return self.uploads.MAX_PARALLEL_UPLOADS

--- a/yosai_intel_dashboard/src/core/interfaces/configuration_protocol.py
+++ b/yosai_intel_dashboard/src/core/interfaces/configuration_protocol.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Protocol for configuration objects exposing common getters."""
+
+from typing import Protocol
+
+
+class ConfigurationProtocol(Protocol):
+    """Standard interface for configuration getters.
+
+    Implementations provide accessors for commonly used configuration values
+    while hiding their underlying structure.  This helps decouple components
+    from the concrete configuration implementation.
+    """
+
+    def get_ai_confidence_threshold(self) -> float:
+        """Return the AI confidence threshold."""
+        ...
+
+    def get_max_upload_size_mb(self) -> int:
+        """Return maximum upload size in megabytes."""
+        ...
+
+    def get_upload_chunk_size(self) -> int:
+        """Return default upload chunk size in bytes."""
+        ...
+
+
+__all__ = ["ConfigurationProtocol"]

--- a/yosai_intel_dashboard/src/infrastructure/config/configuration_mixin.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/configuration_mixin.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Mixin providing access to common configuration values."""
+
+from typing import Any
+
+
+class ConfigurationMixin:
+    """Provide standard getters for configuration values.
+
+    The mixin looks for values across several possible attribute names and
+    locations to maintain compatibility with different configuration objects.
+    """
+
+    def _get_attr(self, obj: Any, names: tuple[str, ...]) -> Any | None:
+        for name in names:
+            if hasattr(obj, name):
+                return getattr(obj, name)
+        return None
+
+    # AI confidence threshold -------------------------------------------------
+    def get_ai_confidence_threshold(self) -> float:
+        """Return the AI confidence threshold with fallbacks."""
+        # Check nested performance object
+        perf = getattr(self, "performance", None)
+        if perf is not None:
+            value = self._get_attr(perf, ("ai_confidence_threshold", "ai_threshold"))
+            if value is not None:
+                return float(value)
+        # Direct attributes
+        value = self._get_attr(self, ("ai_confidence_threshold", "ai_threshold"))
+        if value is not None:
+            return float(value)
+        return 0.8
+
+    # Maximum upload size -----------------------------------------------------
+    def get_max_upload_size_mb(self) -> int:
+        """Return maximum upload size in megabytes with fallbacks."""
+        sec = getattr(self, "security", None)
+        if sec is not None:
+            value = self._get_attr(
+                sec,
+                ("max_upload_mb", "max_upload_size_mb", "max_size_mb"),
+            )
+            if value is not None:
+                return int(value)
+        # Root level attributes
+        value = self._get_attr(
+            self, ("max_upload_size_mb", "max_upload_mb", "max_size_mb")
+        )
+        if value is not None:
+            return int(value)
+        # Upload sub-object
+        upload = getattr(self, "upload", None)
+        if upload is not None:
+            value = self._get_attr(upload, ("max_file_size_mb",))
+            if value is not None:
+                return int(value)
+        return 50
+
+    # Upload chunk size -------------------------------------------------------
+    def get_upload_chunk_size(self) -> int:
+        """Return default upload chunk size with fallbacks."""
+        uploads = getattr(self, "uploads", None)
+        if uploads is not None:
+            value = self._get_attr(
+                uploads, ("DEFAULT_CHUNK_SIZE", "chunk_size", "upload_chunk_size")
+            )
+            if value is not None:
+                return int(value)
+        value = self._get_attr(self, ("upload_chunk_size", "chunk_size"))
+        if value is not None:
+            return int(value)
+        return 1024
+
+
+__all__ = ["ConfigurationMixin"]

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -18,12 +18,14 @@ from .constants import (
     UploadLimits,
 )
 from .environment import select_config_file
-from yosai_intel_dashboard.src.core.utils import get_max_upload_size_mb
+from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import (
+    ConfigurationMixin,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class DynamicConfigManager(BaseConfigLoader):
+class DynamicConfigManager(ConfigurationMixin, BaseConfigLoader):
     """Loads constants and applies environment overrides."""
 
     def __init__(self) -> None:
@@ -330,7 +332,7 @@ class DynamicConfigManager(BaseConfigLoader):
         return self.security.pbkdf2_iterations
 
     def get_max_upload_size(self) -> int:
-        return get_max_upload_size_mb(self)
+        return self.get_max_upload_size_mb()
 
     def get_db_pool_size(self) -> int:
         return self.performance.db_pool_size
@@ -346,11 +348,11 @@ class DynamicConfigManager(BaseConfigLoader):
 
     def get_max_upload_size_bytes(self) -> int:
         """Get maximum upload size in bytes."""
-        return get_max_upload_size_mb(self) * 1024 * 1024
+        return self.get_max_upload_size_mb() * 1024 * 1024
 
     def validate_large_file_support(self) -> bool:
         """Check if configuration supports 50MB+ files."""
-        return get_max_upload_size_mb(self) >= 50
+        return self.get_max_upload_size_mb() >= 50
 
     def get_max_parallel_uploads(self) -> int:
         return getattr(self.uploads, "MAX_PARALLEL_UPLOADS", 4)


### PR DESCRIPTION
## Summary
- add `ConfigurationProtocol` for common configuration getters
- implement `ConfigurationMixin` with fallbacks for ai confidence, upload limits and chunk sizes
- refactor config classes to use mixin and add dedicated tests

## Testing
- `grep -r "def get_ai_confidence_threshold\|def get_max_upload_size_mb\|def get_upload_chunk_size" . --include="*.py" | grep -v test_configuration_mixin.py`
- `pytest tests/infrastructure/config/test_configuration_mixin.py -v`
- `pytest tests/ -k "config" -v` *(fails: ImportError: module object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_6890e5434af483208b5c34d3038bb042