### PR TITLE
Use SecureQueryBuilder placeholders

### DIFF
--- a/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
@@ -33,7 +33,8 @@ class AnalyticsMigration(MigrationStrategy):
         table = builder.table(self.TABLE)
         while True:
             select_sql, params = builder.build(
-                "SELECT * FROM %s OFFSET $1 LIMIT $2" % table,
+                "SELECT * FROM %s OFFSET $1 LIMIT $2",
+                table,
                 (start, self.CHUNK_SIZE),
                 logger=LOG,
             )
@@ -41,7 +42,8 @@ class AnalyticsMigration(MigrationStrategy):
             if not rows:
                 break
             insert_sql, _ = builder.build(
-                "INSERT INTO %s VALUES($1:record)" % table,
+                "INSERT INTO %s VALUES($1:record)",
+                table,
                 logger=LOG,
             )
             await self.target_pool.executemany(insert_sql, rows)

--- a/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
@@ -33,7 +33,8 @@ class EventsMigration(MigrationStrategy):
         table = builder.table(self.TABLE)
         while True:
             select_sql, params = builder.build(
-                "SELECT * FROM %s OFFSET $1 LIMIT $2" % table,
+                "SELECT * FROM %s OFFSET $1 LIMIT $2",
+                table,
                 (start, self.CHUNK_SIZE),
                 logger=LOG,
             )
@@ -41,7 +42,8 @@ class EventsMigration(MigrationStrategy):
             if not rows:
                 break
             insert_sql, _ = builder.build(
-                "INSERT INTO %s VALUES($1:record)" % table,
+                "INSERT INTO %s VALUES($1:record)",
+                table,
                 logger=LOG,
             )
             await self.target_pool.executemany(insert_sql, rows)

--- a/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
@@ -33,7 +33,8 @@ class GatewayMigration(MigrationStrategy):
         table = builder.table(self.TABLE)
         while True:
             select_sql, params = builder.build(
-                "SELECT * FROM %s OFFSET $1 LIMIT $2" % table,
+                "SELECT * FROM %s OFFSET $1 LIMIT $2",
+                table,
                 (start, self.CHUNK_SIZE),
                 logger=LOG,
             )
@@ -41,7 +42,8 @@ class GatewayMigration(MigrationStrategy):
             if not rows:
                 break
             insert_sql, _ = builder.build(
-                "INSERT INTO %s VALUES($1:record)" % table,
+                "INSERT INTO %s VALUES($1:record)",
+                table,
                 logger=LOG,
             )
             await self.target_pool.executemany(insert_sql, rows)


### PR DESCRIPTION
## Summary
- ensure SecureQueryBuilder safely injects validated table identifiers into SQL templates
- use placeholder-based SQL in gateway, analytics and events migrations
- add test covering malicious table names and adjust logging test to new builder API

## Testing
- `pytest tests/test_secure_query_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e86c343883208c06653579ebc979