### PR TITLE
Refactor SQL query assembly

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/monitoring_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/monitoring_router.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Query
-from monitoring.request_metrics import model_monitoring_requests_total
 
+from monitoring.request_metrics import model_monitoring_requests_total
 from yosai_intel_dashboard.src.services.timescale.manager import TimescaleDBManager
 
 # Expose routes without a version so the adapter can mount them under /v1 and
@@ -28,15 +28,16 @@ async def get_model_monitoring_events(
     await manager.connect()
     assert manager.pool is not None
 
-    query = "SELECT * FROM model_monitoring_events WHERE model_name = $1"
+    parts = ["SELECT * FROM model_monitoring_events WHERE model_name = $1"]
     params: List[Any] = [model_name]
     if start is not None:
         params.append(start)
-        query += f" AND time >= ${len(params)}"
+        parts.append(f"AND time >= ${len(params)}")
     if end is not None:
         params.append(end)
-        query += f" AND time <= ${len(params)}"
-    query += " ORDER BY time DESC"
+        parts.append(f"AND time <= ${len(params)}")
+    parts.append("ORDER BY time DESC")
+    query = " ".join(parts)
 
     rows = await manager.pool.fetch(query, *params)
     return [dict(r) for r in rows]

--- a/yosai_intel_dashboard/src/services/analytics/common_queries.py
+++ b/yosai_intel_dashboard/src/services/analytics/common_queries.py
@@ -99,14 +99,15 @@ async def fetch_access_patterns(
         ) AS sub
     """
 
-    query = hourly_query
+    parts = [hourly_query]
     params = [start_date, end_date]
     if limit is not None:
-        query += f" LIMIT ${len(params) + 1}"
+        parts.append(f"LIMIT ${len(params) + 1}")
         params.append(limit)
     if offset is not None:
-        query += f" OFFSET ${len(params) + 1}"
+        parts.append(f"OFFSET ${len(params) + 1}")
         params.append(offset)
+    query = " ".join(parts)
 
     start = time.perf_counter()
     queries_total.inc()


### PR DESCRIPTION
## Summary
- build monitoring events query by joining parts
- assemble access event queries incrementally
- append limit/offset segments via list before executing

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/api/monitoring_router.py yosai_intel_dashboard/src/core/domain/entities/access_events.py yosai_intel_dashboard/src/services/analytics/common_queries.py` *(fails: mypy)*
- `pytest tests/adapters/api/test_metrics_prometheus.py tests/adapters/api/test_cors.py tests/analytics/test_async_service.py` *(fails: ImportError: cannot import name 'Gauge' from 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6890ebfb08c08320815c26a8aea719c7