### PR TITLE
refactor: migrate analytics events to callback system

### DIFF
--- a/tests/analytics/test_async_api.py
+++ b/tests/analytics/test_async_api.py
@@ -2,7 +2,11 @@ import json
 
 from fastapi.testclient import TestClient
 
-from yosai_intel_dashboard.src.services.analytics.async_api import app, event_bus
+from yosai_intel_dashboard.src.services.analytics.async_api import app
+from yosai_intel_dashboard.src.infrastructure.callbacks import (
+    CallbackType,
+    trigger_callback,
+)
 
 
 def test_health_endpoint():
@@ -21,7 +25,7 @@ def test_chart_bad_type():
 def test_websocket_updates():
     client = TestClient(app)
     with client.websocket_connect("/ws/analytics") as ws:
-        event_bus.emit("analytics_update", {"a": 1})
+        trigger_callback(CallbackType.ANALYTICS_UPDATE, {"a": 1})
         data = ws.receive_text()
         assert json.loads(data)["a"] == 1
 

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
@@ -1,12 +1,23 @@
 """Unified callback utilities and registry."""
-from .events import CallbackEvent
+from .events import CallbackEvent, CallbackType
 from .callback_registry import CallbackRegistry, ComponentCallbackManager
 from .unified_callbacks import CallbackHandler, TrulyUnifiedCallbacks
+from .dispatcher import (
+    register_callback,
+    unregister_callback,
+    trigger_callback,
+    _callbacks,
+)
 
 __all__ = [
     "CallbackEvent",
+    "CallbackType",
     "CallbackRegistry",
     "ComponentCallbackManager",
     "TrulyUnifiedCallbacks",
     "CallbackHandler",
+    "register_callback",
+    "unregister_callback",
+    "trigger_callback",
+    "_callbacks",
 ]

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/dispatcher.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/dispatcher.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Lightweight public interface for the callback system.
+
+This module exposes convenience functions that wrap a module level instance of
+:class:`TrulyUnifiedCallbacks`.  It allows legacy code to register and trigger
+callbacks without needing to manage a coordinator instance directly.
+"""
+
+from typing import Any, Callable
+
+from .events import CallbackEvent, CallbackType
+from .unified_callbacks import TrulyUnifiedCallbacks
+
+
+_callbacks = TrulyUnifiedCallbacks()
+
+
+def register_callback(
+    event: CallbackType,
+    func: Callable[..., Any],
+    *,
+    component_id: str | None = None,
+    **kwargs: Any,
+) -> None:
+    """Register ``func`` for ``event``.
+
+    ``component_id`` is currently advisory and stored only for API compatibility
+    with the legacy event bus based subscription system.
+    """
+
+    _callbacks.register_callback(event, func, **kwargs)
+
+
+def unregister_callback(event: CallbackType, func: Callable[..., Any]) -> None:
+    """Remove a previously registered callback."""
+
+    _callbacks.unregister_callback(event, func)
+
+
+def trigger_callback(event: CallbackType, *args: Any, **kwargs: Any) -> list[Any]:
+    """Trigger callbacks registered for ``event``.
+
+    The list of results returned by the callbacks is forwarded to the caller for
+    introspection during testing.
+    """
+
+    return _callbacks.trigger_event(event, *args, **kwargs)
+
+
+__all__ = ["register_callback", "unregister_callback", "trigger_callback", "_callbacks"]

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/events.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/events.py
@@ -25,10 +25,14 @@ class CallbackEvent(Enum):
     UI_UPDATE = auto()
     SYSTEM_ERROR = auto()
     SYSTEM_WARNING = auto()
+    ANALYTICS_UPDATE = auto()
+    WEBSOCKET_HEARTBEAT = auto()
     THREAT_DETECTED = auto()
     ANOMALY_DETECTED = auto()
     SCORE_CALCULATED = auto()
     VALIDATION_FAILED = auto()
 
+CallbackType = CallbackEvent
 
-__all__ = ["CallbackEvent"]
+
+__all__ = ["CallbackEvent", "CallbackType"]

--- a/yosai_intel_dashboard/src/services/analytics/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/publisher.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from src.common.events import EventBus
 from yosai_intel_dashboard.src.services.event_publisher import publish_event
+from yosai_intel_dashboard.src.services.analytics.core.interfaces import EventBusProtocol
 
 
 class Publisher:
     """Publish analytics updates to an event bus."""
 
-    def __init__(self, event_bus: EventBus | None) -> None:
+    def __init__(self, event_bus: Any | None = None) -> None:
         self.event_bus = event_bus
 
     def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:

--- a/yosai_intel_dashboard/src/services/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/event_publisher.py
@@ -1,22 +1,27 @@
 import logging
 from typing import Dict
 
-from src.common.events import EventBus
-
 logger = logging.getLogger(__name__)
 
 
 def publish_event(
-    event_bus: EventBus | None,
+    event_bus: Any | None,
     payload: Dict[str, Any],
     event: str = "analytics_update",
 ) -> None:
-    """Safely publish ``payload`` to ``event_bus`` if available."""
-    if event_bus:
-        try:
-            event_bus.emit(event, payload)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.debug("Event bus publish failed: %s", exc)
+    """Trigger a callback for ``event`` if registered."""
+    try:
+        from yosai_intel_dashboard.src.infrastructure.callbacks import (
+            CallbackType,
+            trigger_callback,
+        )
+
+        cb_event = CallbackType[event.upper()]
+        trigger_callback(cb_event, payload)
+    except KeyError:
+        logger.debug("Unknown callback event: %s", event)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("Callback dispatch failed: %s", exc)
 
 
 __all__ = ["publish_event"]


### PR DESCRIPTION
## Summary
- add global callback dispatcher and new CallbackType events
- update analytics services and websocket server to use register/trigger callbacks
- switch tests and publishers from EventBus to callback-driven flow

## Testing
- `pytest tests/analytics/test_async_api.py tests/test_websocket_server.py tests/test_websocket_data_provider.py -q` *(fails: ImportError while loading conftest)*
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/callbacks/events.py yosai_intel_dashboard/src/infrastructure/callbacks/dispatcher.py yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py yosai_intel_dashboard/src/services/analytics/cached_analytics.py yosai_intel_dashboard/src/services/analytics/async_api.py yosai_intel_dashboard/src/services/websocket_server.py yosai_intel_dashboard/src/services/event_publisher.py yosai_intel_dashboard/src/services/analytics/publisher.py yosai_intel_dashboard/src/services/websocket_data_provider.py tests/test_websocket_server.py tests/test_websocket_data_provider.py tests/analytics/test_async_api.py -q` *(command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec1ba31c8320b45b5d1c9897f836