### PR TITLE
refactor: unify file processor callbacks

### DIFF
--- a/tests/doubles/test_file_processor_service.py
+++ b/tests/doubles/test_file_processor_service.py
@@ -5,16 +5,19 @@ from typing import Callable, Optional, Tuple
 import pandas as pd
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks import UnifiedCallbackRegistry
 
 
 class FileProcessorServiceStub(FileProcessorProtocol):
     """Minimal async file processor used in tests."""
 
+    def __init__(self) -> None:
+        self.callbacks = UnifiedCallbackRegistry()
+
     async def process_file(
         self,
         content: str,
         filename: str,
-        progress_callback: Optional[Callable[[str, int], None]] = None,
     ) -> pd.DataFrame:
         return pd.DataFrame()
 

--- a/tests/services/test_async_file_processor_nodisk.py
+++ b/tests/services/test_async_file_processor_nodisk.py
@@ -54,6 +54,10 @@ assert spec.loader is not None
 spec.loader.exec_module(async_mod)
 AsyncFileProcessor = async_mod.AsyncFileProcessor
 cfg = config_mod.dynamic_config
+from yosai_intel_dashboard.src.infrastructure.callbacks import (
+    CallbackType,
+    UnifiedCallbackRegistry,
+)
 
 
 def _setup_temp_patches(monkeypatch, stored_data):
@@ -98,13 +102,13 @@ def test_process_file_csv_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
 
-    proc = AsyncFileProcessor(config=cfg)
+    registry = UnifiedCallbackRegistry()
+    proc = AsyncFileProcessor(config=cfg, callback_registry=registry)
     progress = []
-    result = asyncio.run(
-        proc.process_file(
-            data_uri, "test.csv", progress_callback=lambda _f, p: progress.append(p)
-        )
+    registry.register_callback(
+        CallbackType.PROGRESS, lambda p: progress.append(p), component_id="test.csv"
     )
+    result = asyncio.run(proc.process_file(data_uri, "test.csv"))
 
     assert result.equals(expected)
     assert progress and progress[-1] == 100
@@ -129,13 +133,13 @@ def test_process_file_excel_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_excel", fake_read_excel)
 
-    proc = AsyncFileProcessor(config=cfg)
+    registry = UnifiedCallbackRegistry()
+    proc = AsyncFileProcessor(config=cfg, callback_registry=registry)
     progress = []
-    result = asyncio.run(
-        proc.process_file(
-            data_uri, "file.xlsx", progress_callback=lambda _f, p: progress.append(p)
-        )
+    registry.register_callback(
+        CallbackType.PROGRESS, lambda p: progress.append(p), component_id="file.xlsx"
     )
+    result = asyncio.run(proc.process_file(data_uri, "file.xlsx"))
 
     assert result.equals(expected)
     assert progress and progress[-1] == 100
@@ -157,13 +161,13 @@ def test_process_file_json_no_disk(monkeypatch):
 
     monkeypatch.setattr(pd, "read_json", fake_read_json)
 
-    proc = AsyncFileProcessor(config=cfg)
+    registry = UnifiedCallbackRegistry()
+    proc = AsyncFileProcessor(config=cfg, callback_registry=registry)
     progress = []
-    result = asyncio.run(
-        proc.process_file(
-            data_uri, "file.json", progress_callback=lambda _f, p: progress.append(p)
-        )
+    registry.register_callback(
+        CallbackType.PROGRESS, lambda p: progress.append(p), component_id="file.json"
     )
+    result = asyncio.run(proc.process_file(data_uri, "file.json"))
 
     assert result.equals(expected)
     assert progress and progress[-1] == 100

--- a/yosai_intel_dashboard/src/core/interfaces/protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/protocols.py
@@ -4,6 +4,8 @@
 from abc import abstractmethod
 from typing import Any, Dict, Protocol
 
+from yosai_intel_dashboard.src.core.protocols import FileProcessorProtocol
+
 from yosai_intel_dashboard.src.core.protocols import ConfigurationServiceProtocol
 
 
@@ -64,4 +66,5 @@ __all__ = [
     "AnalyticsProviderProtocol",
     "ConfigProviderProtocol",
     "ConfigurationServiceProtocol",
+    "FileProcessorProtocol",
 ]

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -116,7 +116,6 @@ class FileProcessorProtocol(Protocol):
         self,
         content: str,
         filename: str,
-        progress_callback: Optional[Callable[[str, int], None]] = None,
     ) -> pd.DataFrame:
         """Process uploaded file content into a DataFrame."""
         ...

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/__init__.py
@@ -2,6 +2,7 @@
 from .events import CallbackEvent
 from .callback_registry import CallbackRegistry, ComponentCallbackManager
 from .unified_callbacks import CallbackHandler, TrulyUnifiedCallbacks
+from .unified_callback_registry import CallbackType, UnifiedCallbackRegistry
 
 __all__ = [
     "CallbackEvent",
@@ -9,4 +10,6 @@ __all__ = [
     "ComponentCallbackManager",
     "TrulyUnifiedCallbacks",
     "CallbackHandler",
+    "CallbackType",
+    "UnifiedCallbackRegistry",
 ]

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callback_registry.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callback_registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Lightweight callback registry used for progress notifications."""
+
+from collections import defaultdict
+from enum import Enum, auto
+from typing import Callable, DefaultDict, Dict, List
+
+
+class CallbackType(Enum):
+    """Enumeration of callback types supported by the registry."""
+
+    PROGRESS = auto()
+
+
+class UnifiedCallbackRegistry:
+    """Register and trigger callbacks by ``CallbackType`` and ``component_id``."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple container
+        self._callbacks: DefaultDict[CallbackType, Dict[str, List[Callable]]]
+        self._callbacks = defaultdict(lambda: defaultdict(list))
+
+    # ------------------------------------------------------------------
+    def register_callback(
+        self, callback_type: CallbackType, callback: Callable, *, component_id: str
+    ) -> None:
+        """Register *callback* for ``callback_type`` and ``component_id``."""
+
+        self._callbacks[callback_type][component_id].append(callback)
+
+    # ------------------------------------------------------------------
+    def trigger_callback(
+        self, callback_type: CallbackType, component_id: str, *args, **kwargs
+    ) -> None:
+        """Trigger all callbacks registered for ``callback_type`` and ``component_id``."""
+
+        for cb in list(self._callbacks.get(callback_type, {}).get(component_id, [])):
+            try:
+                cb(*args, **kwargs)
+            except Exception:
+                # Best effort execution – errors should not bubble up
+                pass
+
+
+__all__ = ["CallbackType", "UnifiedCallbackRegistry"]


### PR DESCRIPTION
## Summary
- add UnifiedCallbackRegistry and CallbackType utilities
- refactor AsyncFileProcessor and FileProcessor to use callback registry instead of direct callbacks
- adjust tests and tooling for new callback registry

## Testing
- `pytest tests/test_async_file_processor.py::test_async_file_processor_progress -q` *(fails: FileNotFoundError: services/upload/protocols.py)*
- `pytest tests/test_file_processor_component.py -q` *(fails: TypeError: 'module' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec1ac9d48320bfe4765ffc316968