### PR TITLE
refactor: load secrets from env in tests

### DIFF
--- a/tests/adapters/api/test_cors.py
+++ b/tests/adapters/api/test_cors.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 import types
 
@@ -175,7 +176,10 @@ def _create_app(monkeypatch, origins):
 
 @pytest.mark.unit
 def test_allowed_origin(monkeypatch):
-    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv(
+        "SECRET_KEY",
+        os.environ.get("SECRET_KEY", os.urandom(16).hex()),
+    )
     app = _create_app(monkeypatch, ["https://allowed.com"])
     client = TestClient(app)
     resp = client.get("/v1/csrf-token", headers={"Origin": "https://allowed.com"})
@@ -184,7 +188,10 @@ def test_allowed_origin(monkeypatch):
 
 @pytest.mark.unit
 def test_blocked_origin(monkeypatch):
-    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv(
+        "SECRET_KEY",
+        os.environ.get("SECRET_KEY", os.urandom(16).hex()),
+    )
     app = _create_app(monkeypatch, ["https://allowed.com"])
     client = TestClient(app)
     resp = client.get("/v1/csrf-token", headers={"Origin": "https://other.com"})

--- a/tests/adapters/api/test_metrics_prometheus.py
+++ b/tests/adapters/api/test_metrics_prometheus.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 import types
 
@@ -192,7 +193,10 @@ def _create_app(monkeypatch):
 
 @pytest.mark.unit
 def test_metrics_endpoint_records_upload(monkeypatch):
-    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv(
+        "SECRET_KEY",
+        os.environ.get("SECRET_KEY", os.urandom(16).hex()),
+    )
     app = _create_app(monkeypatch)
     client = TestClient(app)
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -26,7 +26,10 @@ def set_test_environment() -> None:
     """Populate minimal environment variables for tests."""
     os.environ.setdefault("YOSAI_ENV", "testing")
     os.environ.setdefault("FLASK_ENV", "testing")
-    os.environ.setdefault("SECRET_KEY", "testing")
+    os.environ.setdefault(
+        "SECRET_KEY",
+        os.environ.get("TEST_SECRET_KEY", os.urandom(32).hex()),
+    )
     # enable lightweight implementations for optional services
     os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -25,9 +25,14 @@ security:
     monkeypatch.setenv("SECRET_VAR", secret)
     monkeypatch.setenv("SECRET_KEY", secret)
     # required env vars
-    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.setenv(
+        "DB_PASSWORD", os.environ.get("DB_PASSWORD", os.urandom(16).hex())
+    )
     monkeypatch.setenv("AUTH0_CLIENT_ID", "cid")
-    monkeypatch.setenv("AUTH0_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv(
+        "AUTH0_CLIENT_SECRET",
+        os.environ.get("AUTH0_CLIENT_SECRET", os.urandom(16).hex()),
+    )
     monkeypatch.setenv("AUTH0_DOMAIN", "domain")
     monkeypatch.setenv("AUTH0_AUDIENCE", "aud")
 

--- a/tests/test_config_production_secrets.py
+++ b/tests/test_config_production_secrets.py
@@ -17,7 +17,7 @@ def set_env(monkeypatch, secret: str) -> None:
     monkeypatch.setenv("SECRET_KEY", secret)
     monkeypatch.setenv("DB_PASSWORD", secret)
     for var in REQUIRED_AUTH_VARS:
-        monkeypatch.setenv(var, "value")
+        monkeypatch.setenv(var, os.environ.get(var, os.urandom(16).hex()))
 
 
 def test_invalid_secrets_raise(monkeypatch):

--- a/tests/test_database_config_serialization.py
+++ b/tests/test_database_config_serialization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -66,6 +67,7 @@ def _load_database_config():
 
 
 DatabaseConfig = _load_database_config()
+TEST_PASSWORD = os.environ.get("DB_PASSWORD", os.urandom(16).hex())
 
 
 def test_database_config_round_trip():
@@ -75,7 +77,7 @@ def test_database_config_round_trip():
         port=5432,
         name="test",
         user="u",
-        password="pw",
+        password=TEST_PASSWORD,
     )
     cfg_dict = cfg.to_dict()
     new_cfg = DatabaseConfig.from_dict(cfg_dict)
@@ -83,7 +85,7 @@ def test_database_config_round_trip():
 
 
 def test_database_config_exclude_password():
-    cfg = DatabaseConfig(password="secret")
+    cfg = DatabaseConfig(password=TEST_PASSWORD)
     cfg_dict = cfg.to_dict(include_password=False)
     assert "password" not in cfg_dict
     new_cfg = DatabaseConfig.from_dict(cfg_dict)
@@ -92,7 +94,7 @@ def test_database_config_exclude_password():
 
 def test_database_config_encrypt_round_trip():
     key = Fernet.generate_key().decode()
-    cfg = DatabaseConfig(password="topsecret")
+    cfg = DatabaseConfig(password=TEST_PASSWORD)
     cfg_dict = cfg.to_dict(fernet_key=key)
     new_cfg = DatabaseConfig.from_dict(cfg_dict, fernet_key=key)
     assert new_cfg == cfg

--- a/tests/test_secret_health.py
+++ b/tests/test_secret_health.py
@@ -23,7 +23,10 @@ except Exception:  # pragma: no cover
 
 def test_secrets_health_endpoint(monkeypatch):
     monkeypatch.setenv("YOSAI_ENV", "development")
-    monkeypatch.setenv("SECRET_KEY", "testkey")
+    monkeypatch.setenv(
+        "SECRET_KEY",
+        os.environ.get("SECRET_KEY", os.urandom(16).hex()),
+    )
     app = create_app(mode="simple")
     server = app.server
     rules = [r.rule for r in server.url_map.iter_rules()]


### PR DESCRIPTION
## Summary
- replace hardcoded secrets in tests with environment-driven values
- centralize database config password for serialization tests
- rely on env for required auth vars in production config tests

## Testing
- `python scripts/security_scan_secrets.py && echo OK`
- `pytest tests/config.py tests/adapters/api/test_metrics_prometheus.py tests/adapters/api/test_cors.py tests/test_secret_health.py tests/test_config_loader.py tests/test_database_config_serialization.py tests/test_config_production_secrets.py -q` *(fails: 'module' object is not iterable)*


------
https://chatgpt.com/codex/tasks/task_e_6890f49a9ca88320bc3cb7d083e07707