### PR TITLE
Parameterize database timeout configuration

### DIFF
--- a/tests/database/test_secure_exec_timeout.py
+++ b/tests/database/test_secure_exec_timeout.py
@@ -18,6 +18,14 @@ class FakePGConn:
         return "ok"
 
 
+class FakePGConnNoParam(FakePGConn):
+    def execute(self, sql, params=None):
+        if params is not None:
+            raise TypeError("no params")
+        self.executed.append((sql, params))
+        return "ok"
+
+
 class FakeSQLiteConn:
     __module__ = "sqlite3"
 
@@ -32,6 +40,20 @@ class FakeSQLiteConn:
         return "ok"
 
 
+class FakeSQLiteConnNoParam:
+    __module__ = "sqlite3"
+
+    def __init__(self):
+        self._optimizer = DummyOptimizer()
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        if params is not None:
+            raise TypeError("no params")
+        self.executed.append((sql, params))
+        return "ok"
+
+
 def test_postgres_statement_timeout(monkeypatch):
     class DS:
         query_timeout_seconds = 1
@@ -39,9 +61,9 @@ def test_postgres_statement_timeout(monkeypatch):
     monkeypatch.setattr(secure_exec, "DatabaseSettings", DS)
     conn = FakePGConn()
     secure_exec.execute_query(conn, "SELECT 1")
-    assert conn.executed[0][0] == "SET LOCAL statement_timeout = 1000"
-    assert conn.executed[1][0] == "SELECT 1"
-    assert conn.executed[2][0] == "SET LOCAL statement_timeout = DEFAULT"
+    assert conn.executed[0] == ("SET LOCAL statement_timeout = %s", (1000,))
+    assert conn.executed[1] == ("SELECT 1", None)
+    assert conn.executed[2] == ("SET LOCAL statement_timeout = DEFAULT", None)
 
 
 def test_sqlite_busy_timeout_reset(monkeypatch):
@@ -52,5 +74,29 @@ def test_sqlite_busy_timeout_reset(monkeypatch):
     conn = FakeSQLiteConn()
     with pytest.raises(TimeoutError):
         secure_exec.execute_query(conn, "SELECT 1")
-    assert conn.executed[0][0] == "PRAGMA busy_timeout = 2000"
-    assert conn.executed[-1][0] == "PRAGMA busy_timeout = 0"
+    assert conn.executed[0] == ("PRAGMA busy_timeout = ?", (2000,))
+    assert conn.executed[-1] == ("PRAGMA busy_timeout = 0", None)
+
+
+def test_postgres_statement_timeout_no_param_support(monkeypatch):
+    class DS:
+        query_timeout_seconds = 1
+
+    monkeypatch.setattr(secure_exec, "DatabaseSettings", DS)
+    conn = FakePGConnNoParam()
+    secure_exec.execute_query(conn, "SELECT 1")
+    assert conn.executed[0] == ("SET LOCAL statement_timeout = 1000", None)
+    assert conn.executed[1] == ("SELECT 1", None)
+    assert conn.executed[2] == ("SET LOCAL statement_timeout = DEFAULT", None)
+
+
+def test_sqlite_busy_timeout_no_param_support(monkeypatch):
+    class DS:
+        query_timeout_seconds = 1
+
+    monkeypatch.setattr(secure_exec, "DatabaseSettings", DS)
+    conn = FakeSQLiteConnNoParam()
+    secure_exec.execute_query(conn, "SELECT 1")
+    assert conn.executed[0] == ("PRAGMA busy_timeout = 1000", None)
+    assert conn.executed[1] == ("SELECT 1", None)
+    assert conn.executed[2] == ("PRAGMA busy_timeout = 0", None)

--- a/yosai_intel_dashboard/src/database/secure_exec.py
+++ b/yosai_intel_dashboard/src/database/secure_exec.py
@@ -117,9 +117,15 @@ def execute_query(
         ms = int(timeout_seconds * 1000)
         try:
             if db_type == "postgresql":
-                conn.execute(f"SET LOCAL statement_timeout = {ms}")
+                try:
+                    conn.execute("SET LOCAL statement_timeout = %s", (ms,))
+                except Exception:
+                    conn.execute(f"SET LOCAL statement_timeout = {int(ms)}")
             elif db_type == "sqlite":
-                conn.execute(f"PRAGMA busy_timeout = {ms}")
+                try:
+                    conn.execute("PRAGMA busy_timeout = ?", (ms,))
+                except Exception:
+                    conn.execute(f"PRAGMA busy_timeout = {int(ms)}")
         except Exception:
             pass  # pragma: no cover - best effort
     try:


### PR DESCRIPTION
## Summary
- Ensure query timeout values are sent via parameterized statements for PostgreSQL and SQLite
- Fallback to safe integer interpolation if parameterization is unsupported
- Expand tests to cover both parameterized and fallback timeout configuration paths

## Testing
- `pytest tests/database/test_secure_exec_timeout.py tests/database/test_secure_exec_performance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f4a795e4832089e27ae76ff4d9db