### PR TITLE
feat: sanitize error handling with safe_text

### DIFF
--- a/tools/cli_analytics_engine.py
+++ b/tools/cli_analytics_engine.py
@@ -13,6 +13,8 @@ from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadCon
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 async def test_analytics_with_mappings(verbose: bool = False) -> dict:
     try:
@@ -22,9 +24,15 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
         # Process the parquet file using pandas directly
         import pandas as pd
 
-        from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
-        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
-        from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import (
+            AnalyticsService,
+        )
+        from yosai_intel_dashboard.src.services.analytics.upload_analytics import (
+            UploadAnalyticsProcessor,
+        )
+        from yosai_intel_dashboard.src.services.device_learning_service import (
+            DeviceLearningService,
+        )
 
         parquet_path = (
             Path(UploadConfig().folder) / "Enhanced_Security_Demo.csv.parquet"
@@ -94,8 +102,8 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
                     )  # Show first 10
 
                 except Exception as e:
-                    result["analytics_service"] = {"error": str(e)}
-                    print(f"AnalyticsService failed: {e}")
+                    result["analytics_service"] = {"error": safe_text(e)}
+                    print(f"AnalyticsService failed: {safe_text(e)}")
 
                 # Test UploadAnalyticsProcessor
                 print("\n--- Testing UploadAnalyticsProcessor ---")
@@ -124,12 +132,12 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
                                 f"DataFrame analysis completed: {type(analysis_result)}"
                             )
                         except Exception as e:
-                            result["upload_analytics"]["analysis_error"] = str(e)
-                            print(f"DataFrame analysis failed: {e}")
+                            result["upload_analytics"]["analysis_error"] = safe_text(e)
+                            print(f"DataFrame analysis failed: {safe_text(e)}")
 
                 except Exception as e:
-                    result["upload_analytics"] = {"error": str(e)}
-                    print(f"UploadAnalyticsProcessor failed: {e}")
+                    result["upload_analytics"] = {"error": safe_text(e)}
+                    print(f"UploadAnalyticsProcessor failed: {safe_text(e)}")
 
                 # Test analytics functions from data_processing.analytics_engine
                 print("\n--- Testing analytics engine functions ---")
@@ -147,8 +155,8 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
                     )
 
                 except Exception as e:
-                    result["analytics_engine_functions"] = {"error": str(e)}
-                    print(f"Analytics engine functions failed: {e}")
+                    result["analytics_engine_functions"] = {"error": safe_text(e)}
+                    print(f"Analytics engine functions failed: {safe_text(e)}")
 
                 return result
 
@@ -164,11 +172,11 @@ async def test_analytics_with_mappings(verbose: bool = False) -> dict:
             }
 
     except Exception as e:
-        print(f"Error testing analytics: {e}")
+        print(f"Error testing analytics: {safe_text(e)}")
         import traceback
 
         traceback.print_exc()
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": safe_text(e)}
 
 
 def main():

--- a/tools/cli_analytics_fixed.py
+++ b/tools/cli_analytics_fixed.py
@@ -12,9 +12,13 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 # Apply callback patch first
 try:
-    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+        TrulyUnifiedCallbacks as CallbackManager,
+    )
 
     if hasattr(CallbackManager, "handle_register") and not hasattr(
         CallbackManager, "register_handler"
@@ -22,7 +26,7 @@ try:
         CallbackManager.register_handler = CallbackManager.handle_register
         print("✅ Callback patch applied")
 except Exception as e:
-    print(f"⚠️  Callback patch failed: {e}")
+    print(f"⚠️  Callback patch failed: {safe_text(e)}")
 
 
 async def test_analytics_with_fix():
@@ -31,7 +35,9 @@ async def test_analytics_with_fix():
 
         import pandas as pd
 
-        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import (
+            AnalyticsService,
+        )
 
         # Load the Enhanced Security Demo data
         parquet_path = Path("temp/uploaded_data/Enhanced_Security_Demo.csv.parquet")
@@ -52,8 +58,8 @@ async def test_analytics_with_fix():
             print(f"Health check: {health}")
 
         except Exception as e:
-            print(f"❌ AnalyticsService initialization failed: {e}")
-            return {"success": False, "error": str(e)}
+            print(f"❌ AnalyticsService initialization failed: {safe_text(e)}")
+            return {"success": False, "error": safe_text(e)}
 
         result = {"success": True, "tests": {}}
 
@@ -64,8 +70,11 @@ async def test_analytics_with_fix():
             result["tests"]["dashboard_summary"] = {"success": True, "result": summary}
             print(f"✅ Dashboard summary: {summary.get('status', 'unknown')}")
         except Exception as e:
-            result["tests"]["dashboard_summary"] = {"success": False, "error": str(e)}
-            print(f"❌ Dashboard summary failed: {e}")
+            result["tests"]["dashboard_summary"] = {
+                "success": False,
+                "error": safe_text(e),
+            }
+            print(f"❌ Dashboard summary failed: {safe_text(e)}")
 
         # Test 2: Access Pattern Analysis
         print("\n--- Access Pattern Analysis ---")
@@ -81,8 +90,11 @@ async def test_analytics_with_fix():
                 f"✅ Access patterns found: {len(access_patterns.get('patterns', []))}"
             )
         except Exception as e:
-            result["tests"]["access_patterns"] = {"success": False, "error": str(e)}
-            print(f"❌ Access patterns failed: {e}")
+            result["tests"]["access_patterns"] = {
+                "success": False,
+                "error": safe_text(e),
+            }
+            print(f"❌ Access patterns failed: {safe_text(e)}")
 
         # Test 3: Anomaly Detection
         print("\n--- Anomaly Detection ---")
@@ -96,8 +108,11 @@ async def test_analytics_with_fix():
                 f"✅ Anomalies detected: {len(anomalies) if isinstance(anomalies, list) else 'N/A'}"
             )
         except Exception as e:
-            result["tests"]["anomaly_detection"] = {"success": False, "error": str(e)}
-            print(f"❌ Anomaly detection failed: {e}")
+            result["tests"]["anomaly_detection"] = {
+                "success": False,
+                "error": safe_text(e),
+            }
+            print(f"❌ Anomaly detection failed: {safe_text(e)}")
 
         # Test 4: Data Processing
         print("\n--- Data Processing ---")
@@ -109,18 +124,21 @@ async def test_analytics_with_fix():
             }
             print(f"✅ Data processed: {len(processed)} rows")
         except Exception as e:
-            result["tests"]["data_processing"] = {"success": False, "error": str(e)}
-            print(f"❌ Data processing failed: {e}")
+            result["tests"]["data_processing"] = {
+                "success": False,
+                "error": safe_text(e),
+            }
+            print(f"❌ Data processing failed: {safe_text(e)}")
 
         print("\n=== ANALYTICS TESTING WITH FIX COMPLETE ===")
         return result
 
     except Exception as e:
-        print(f"Analytics testing failed: {e}")
+        print(f"Analytics testing failed: {safe_text(e)}")
         import traceback
 
         traceback.print_exc()
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": safe_text(e)}
 
 
 def main():

--- a/tools/cli_async_processor.py
+++ b/tools/cli_async_processor.py
@@ -18,6 +18,8 @@ from typing import Any, Dict
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 def setup_logging(verbose: bool = False) -> None:
     """Configure logging for CLI tool"""
@@ -47,12 +49,12 @@ async def process_file_with_service(
         logger.info(f"Processing file with AsyncFileProcessor: {file_path}")
 
         # Import and create AsyncFileProcessor
-        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import (
-            AsyncFileProcessor,
-        )
         from yosai_intel_dashboard.src.infrastructure.callbacks import (
             CallbackType,
             UnifiedCallbackRegistry,
+        )
+        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import (
+            AsyncFileProcessor,
         )
 
         registry = UnifiedCallbackRegistry()
@@ -109,14 +111,14 @@ async def process_file_with_service(
         return result
 
     except Exception as e:
-        logger.error(f"AsyncFileProcessor failed: {str(e)}")
+        logger.error(f"AsyncFileProcessor failed: {safe_text(e)}")
         if verbose:
             logger.error(traceback.format_exc())
 
         return {
             "success": False,
             "processor": "AsyncFileProcessor",
-            "error": str(e),
+            "error": safe_text(e),
             "error_type": type(e).__name__,
             "file_path": file_path,
             "traceback": traceback.format_exc() if verbose else None,

--- a/tools/cli_file_processor.py
+++ b/tools/cli_file_processor.py
@@ -18,6 +18,8 @@ from typing import Any, Dict
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 def setup_logging(verbose: bool = False) -> None:
     """Configure logging for CLI tool"""
@@ -130,13 +132,13 @@ def process_file_simple(file_path: str, verbose: bool = False) -> Dict[str, Any]
         return result
 
     except Exception as e:
-        logger.error(f"Error processing file: {str(e)}")
+        logger.error(f"Error processing file: {safe_text(e)}")
         if verbose:
             logger.error(traceback.format_exc())
 
         return {
             "success": False,
-            "error": str(e),
+            "error": safe_text(e),
             "error_type": type(e).__name__,
             "file_path": file_path,
             "traceback": traceback.format_exc() if verbose else None,

--- a/tools/cli_mapping_explorer.py
+++ b/tools/cli_mapping_explorer.py
@@ -13,6 +13,8 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 def setup_logging(verbose: bool = False) -> None:
     level = logging.DEBUG if verbose else logging.INFO
@@ -31,7 +33,9 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
         # Process file first
         import base64
 
-        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import AsyncFileProcessor
+        from yosai_intel_dashboard.src.services.data_processing.async_file_processor import (
+            AsyncFileProcessor,
+        )
 
         path = Path(file_path)
         filename = path.name
@@ -54,7 +58,9 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
 
         # Explore AI Suggestions in detail
         logger.info("=== AI SUGGESTIONS DETAILED ===")
-        from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import get_ai_column_suggestions
+        from yosai_intel_dashboard.src.services.data_enhancer.mapping_utils import (
+            get_ai_column_suggestions,
+        )
 
         suggestions = get_ai_column_suggestions(df)
 
@@ -63,7 +69,9 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
 
         # Explore DeviceLearningService methods with correct parameters
         logger.info("=== DEVICE LEARNING SERVICE EXPLORATION ===")
-        from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
+        from yosai_intel_dashboard.src.services.device_learning_service import (
+            DeviceLearningService,
+        )
 
         device_service = DeviceLearningService()
 
@@ -85,8 +93,8 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
                     "value": str(learned_mappings)[:200],
                 }
         except Exception as e:
-            logger.warning(f"get_learned_mappings failed: {e}")
-            result["learned_mappings"] = {"error": str(e)}
+            logger.warning(f"get_learned_mappings failed: {safe_text(e)}")
+            result["learned_mappings"] = {"error": safe_text(e)}
 
         # Test get_user_device_mappings with filename
         try:
@@ -103,8 +111,8 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
                     "value": str(user_device_mappings)[:200],
                 }
         except Exception as e:
-            logger.warning(f"get_user_device_mappings failed: {e}")
-            result["user_device_mappings"] = {"error": str(e)}
+            logger.warning(f"get_user_device_mappings failed: {safe_text(e)}")
+            result["user_device_mappings"] = {"error": safe_text(e)}
 
         # Test other available methods
         available_methods = [
@@ -117,8 +125,8 @@ async def explore_mapping_services(file_path: str, verbose: bool = False) -> dic
         return result
 
     except Exception as e:
-        logger.error(f"Exploration failed: {e}")
-        return {"success": False, "error": str(e)}
+        logger.error(f"Exploration failed: {safe_text(e)}")
+        return {"success": False, "error": safe_text(e)}
 
 
 def main():

--- a/tools/cli_mapping_tester.py
+++ b/tools/cli_mapping_tester.py
@@ -17,6 +17,8 @@ from typing import Any, Dict
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 def setup_logging(verbose: bool = False) -> None:
     """Configure logging for CLI tool"""
@@ -91,8 +93,11 @@ async def test_mapping_service(
             }
 
         except Exception as ai_error:
-            logger.warning(f"AI suggestions failed: {ai_error}")
-            result["ai_suggestions"] = {"success": False, "error": str(ai_error)}
+            logger.warning(f"AI suggestions failed: {safe_text(ai_error)}")
+            result["ai_suggestions"] = {
+                "success": False,
+                "error": safe_text(ai_error),
+            }
 
         # Step 3: Test Device Learning Service
         logger.info("=== STEP 3: Device Learning Service ===")
@@ -128,8 +133,11 @@ async def test_mapping_service(
                 }
 
         except Exception as device_error:
-            logger.warning(f"Device learning failed: {device_error}")
-            result["device_learning"] = {"success": False, "error": str(device_error)}
+            logger.warning(f"Device learning failed: {safe_text(device_error)}")
+            result["device_learning"] = {
+                "success": False,
+                "error": safe_text(device_error),
+            }
 
         # Step 4: Test Mapping Application (if not suggest-only)
         if not suggest_only:
@@ -155,23 +163,23 @@ async def test_mapping_service(
                     }
 
             except Exception as app_error:
-                logger.warning(f"Mapping application failed: {app_error}")
+                logger.warning(f"Mapping application failed: {safe_text(app_error)}")
                 result["mapping_application"] = {
                     "success": False,
-                    "error": str(app_error),
+                    "error": safe_text(app_error),
                 }
 
         logger.info("=== MAPPING SERVICE PIPELINE COMPLETE ===")
         return result
 
     except Exception as e:
-        logger.error(f"Mapping service pipeline failed: {str(e)}")
+        logger.error(f"Mapping service pipeline failed: {safe_text(e)}")
         if verbose:
             logger.error(traceback.format_exc())
 
         return {
             "success": False,
-            "error": str(e),
+            "error": safe_text(e),
             "error_type": type(e).__name__,
             "file_path": file_path,
             "traceback": traceback.format_exc() if verbose else None,

--- a/tools/step2_add_missing_methods.py
+++ b/tools/step2_add_missing_methods.py
@@ -9,6 +9,8 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 def add_missing_analytics_methods():
     """Add missing methods to UploadAnalyticsProcessor"""
@@ -17,7 +19,9 @@ def add_missing_analytics_methods():
 
     try:
         # First, let's check what methods are currently in UploadAnalyticsProcessor
-        from yosai_intel_dashboard.src.services.upload_processing import UploadAnalyticsProcessor
+        from yosai_intel_dashboard.src.services.upload_processing import (
+            UploadAnalyticsProcessor,
+        )
 
         processor = UploadAnalyticsProcessor()
         current_methods = [
@@ -56,7 +60,7 @@ def add_missing_analytics_methods():
                     return result
 
                 except Exception as e:
-                    return {"status": "error", "message": str(e)}
+                    return {"status": "error", "message": safe_text(e)}
 
             UploadAnalyticsProcessor.get_analytics_from_uploaded_data = (
                 get_analytics_from_uploaded_data
@@ -113,7 +117,7 @@ def add_missing_analytics_methods():
                 f"✅ get_analytics_from_uploaded_data: {analytics_result.get('status', 'unknown')}"
             )
         except Exception as e:
-            print(f"❌ get_analytics_from_uploaded_data failed: {e}")
+            print(f"❌ get_analytics_from_uploaded_data failed: {safe_text(e)}")
 
         # Test clean_uploaded_dataframe
         try:
@@ -123,7 +127,7 @@ def add_missing_analytics_methods():
             cleaned_df = test_processor.clean_uploaded_dataframe(test_df)
             print(f"✅ clean_uploaded_dataframe: {len(cleaned_df)} rows processed")
         except Exception as e:
-            print(f"❌ clean_uploaded_dataframe failed: {e}")
+            print(f"❌ clean_uploaded_dataframe failed: {safe_text(e)}")
 
         # Test summarize_dataframe
         try:
@@ -132,13 +136,13 @@ def add_missing_analytics_methods():
                 f"✅ summarize_dataframe: {summary['rows']} rows, {summary['columns']} columns"
             )
         except Exception as e:
-            print(f"❌ summarize_dataframe failed: {e}")
+            print(f"❌ summarize_dataframe failed: {safe_text(e)}")
 
         print("\n🎉 Step 2 completed successfully!")
         return True
 
     except Exception as e:
-        print(f"Step 2 failed: {e}")
+        print(f"Step 2 failed: {safe_text(e)}")
         import traceback
 
         traceback.print_exc()

--- a/tools/test_analytics_both_fixes.py
+++ b/tools/test_analytics_both_fixes.py
@@ -11,6 +11,8 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
+
 
 # Apply BOTH fixes
 def apply_both_fixes():
@@ -18,7 +20,9 @@ def apply_both_fixes():
 
     # Step 1: Callback fix
     try:
-        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks as CallbackManager
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+            TrulyUnifiedCallbacks as CallbackManager,
+        )
 
         if hasattr(CallbackManager, "handle_register") and not hasattr(
             CallbackManager, "register_handler"
@@ -26,11 +30,13 @@ def apply_both_fixes():
             CallbackManager.register_handler = CallbackManager.handle_register
             print("✅ Step 1: Callback patch applied")
     except Exception as e:
-        print(f"⚠️  Step 1: Callback patch failed: {e}")
+        print(f"⚠️  Step 1: Callback patch failed: {safe_text(e)}")
 
     # Step 2: Missing methods fix
     try:
-        from yosai_intel_dashboard.src.services.upload_processing import UploadAnalyticsProcessor
+        from yosai_intel_dashboard.src.services.upload_processing import (
+            UploadAnalyticsProcessor,
+        )
 
         # Add missing methods if they don't exist
         if not hasattr(UploadAnalyticsProcessor, "get_analytics_from_uploaded_data"):
@@ -47,7 +53,7 @@ def apply_both_fixes():
                     result["status"] = "success"
                     return result
                 except Exception as e:
-                    return {"status": "error", "message": str(e)}
+                    return {"status": "error", "message": safe_text(e)}
 
             UploadAnalyticsProcessor.get_analytics_from_uploaded_data = (
                 get_analytics_from_uploaded_data
@@ -69,7 +75,7 @@ def apply_both_fixes():
         print("✅ Step 2: Missing methods patch applied")
 
     except Exception as e:
-        print(f"⚠️  Step 2: Missing methods patch failed: {e}")
+        print(f"⚠️  Step 2: Missing methods patch failed: {safe_text(e)}")
 
 
 async def test_analytics_comprehensive():
@@ -80,7 +86,9 @@ async def test_analytics_comprehensive():
 
         import pandas as pd
 
-        from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
+        from yosai_intel_dashboard.src.services.analytics.analytics_service import (
+            AnalyticsService,
+        )
 
         # Load the Enhanced Security Demo data
         parquet_path = Path("temp/uploaded_data/Enhanced_Security_Demo.csv.parquet")
@@ -142,19 +150,19 @@ async def test_analytics_comprehensive():
             except Exception as e:
                 result["tests"][test_name.lower().replace(" ", "_")] = {
                     "success": False,
-                    "error": str(e),
+                    "error": safe_text(e),
                 }
-                print(f"❌ {test_name}: {e}")
+                print(f"❌ {test_name}: {safe_text(e)}")
 
         print("\n=== COMPREHENSIVE TEST COMPLETE ===")
         return result
 
     except Exception as e:
-        print(f"Comprehensive test failed: {e}")
+        print(f"Comprehensive test failed: {safe_text(e)}")
         import traceback
 
         traceback.print_exc()
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": safe_text(e)}
 
 
 def main():

--- a/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/database_manager.py
@@ -21,6 +21,7 @@ from database.replicated_connection import ReplicatedDatabaseConnection
 from database.secure_exec import execute_batch, execute_command, execute_query
 from database.types import DatabaseConnection, DBRows
 from yosai_intel_dashboard.src.core.unicode import UnicodeSQLProcessor
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints
     from .connection_pool import DatabaseConnectionPool
@@ -221,7 +222,7 @@ class PostgreSQLConnection:
                 execute_command(cursor, "CREATE EXTENSION IF NOT EXISTS timescaledb;")
                 self._connection.commit()
         except psycopg2.Error as e:
-            sanitized = _scrub_password(str(e), self.config.password)
+            sanitized = _scrub_password(safe_text(e), self.config.password)
             logger.error("Failed to connect to PostgreSQL: %s", sanitized)
             raise DatabaseError(f"PostgreSQL connection failed: {sanitized}") from e
 
@@ -240,7 +241,7 @@ class PostgreSQLConnection:
                 rows = cursor.fetchall()
                 return [dict(row) for row in rows]
         except psycopg2.Error as e:
-            sanitized = _scrub_password(str(e), self.config.password)
+            sanitized = _scrub_password(safe_text(e), self.config.password)
             logger.error("PostgreSQL query error: %s", sanitized)
             raise DatabaseError(f"Query failed: {sanitized}") from e
 
@@ -258,7 +259,7 @@ class PostgreSQLConnection:
 
             self._connection.commit()
         except psycopg2.Error as e:
-            sanitized = _scrub_password(str(e), self.config.password)
+            sanitized = _scrub_password(safe_text(e), self.config.password)
             logger.error("PostgreSQL command error: %s", sanitized)
             self._connection.rollback()
             raise DatabaseError(f"Command failed: {sanitized}") from e
@@ -273,7 +274,7 @@ class PostgreSQLConnection:
                 execute_batch(cursor, command, params_seq)
             self._connection.commit()
         except psycopg2.Error as e:
-            sanitized = _scrub_password(str(e), self.config.password)
+            sanitized = _scrub_password(safe_text(e), self.config.password)
             logger.error("PostgreSQL batch error: %s", sanitized)
             self._connection.rollback()
             raise DatabaseError(f"Batch failed: {sanitized}") from e

--- a/yosai_intel_dashboard/src/services/analytics/database_analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/database_analytics_service.py
@@ -6,8 +6,13 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCacheManager, cache_with_lock
 from database.secure_exec import execute_query
+from yosai_intel_dashboard.src.core.cache_manager import (
+    CacheConfig,
+    InMemoryCacheManager,
+    cache_with_lock,
+)
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
 
 _cache_manager = InMemoryCacheManager(CacheConfig())
 
@@ -69,8 +74,12 @@ class DatabaseAnalyticsService:
             breakdown = []
         else:
             total_events = int(df_summary["count"].sum())
-            success_events = df_summary[df_summary["status"] == "success"]["count"].sum()
-            success_rate = round((success_events / total_events) * 100, 2) if total_events else 0
+            success_events = df_summary[df_summary["status"] == "success"][
+                "count"
+            ].sum()
+            success_rate = (
+                round((success_events / total_events) * 100, 2) if total_events else 0
+            )
             breakdown = df_summary.to_dict("records")
 
         hourly_data = df_hourly.to_dict("records") if not df_hourly.empty else []
@@ -129,8 +138,8 @@ class DatabaseAnalyticsService:
             finally:
                 self.database_manager.release_connection(connection)
         except Exception as e:  # pragma: no cover - best effort
-            logger.error("Database analytics error: %s", e)
-            return {"status": "error", "message": str(e)}
+            logger.error("Database analytics error: %s", safe_text(e))
+            return {"status": "error", "message": safe_text(e)}
 
 
 __all__ = ["DatabaseAnalyticsService"]

--- a/yosai_intel_dashboard/src/services/data_enhancer/app.py
+++ b/yosai_intel_dashboard/src/services/data_enhancer/app.py
@@ -21,6 +21,7 @@ from dash import dcc, html
 
 from yosai_intel_dashboard.src.core.unicode import clean_unicode_surrogates
 from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
 
 from .config import (
     AI_COLUMN_SERVICE_AVAILABLE,
@@ -112,14 +113,14 @@ class EnhancedFileProcessor:
                 except UnicodeDecodeError:
                     continue
                 except Exception as e:
-                    logger.error(f"Error with {encoding}: {str(e)}")
+                    logger.error(f"Error with {encoding}: {safe_text(e)}")
                     continue
 
             return None, "Could not decode file with any supported encoding"
 
         except Exception as e:
-            logger.error(f"File processing error: {str(e)}")
-            return None, f"Error processing file: {str(e)}"
+            logger.error(f"File processing error: {safe_text(e)}")
+            return None, f"Error processing file: {safe_text(e)}"
 
 
 class MultiBuildingDataEnhancer:
@@ -1072,7 +1073,7 @@ def handle_enhanced_column_mapping(n_clicks):
             ai_status = dbc.Alert(status_msg, color="info")
         except Exception as e:
             suggestions = {}
-            ai_status = dbc.Alert(f"AI service error: {str(e)}", color="warning")
+            ai_status = dbc.Alert(f"AI service error: {safe_text(e)}", color="warning")
     else:
         suggestions = {}
         ai_status = ""
@@ -1134,7 +1135,9 @@ def get_device_suggestions(df: pd.DataFrame) -> Tuple[Dict[str, Dict], Any]:
         ai_status = dbc.Alert(status_msg, color="info")
     except Exception as e:  # pragma: no cover - best effort
         suggestions = {}
-        ai_status = dbc.Alert(f"AI device service error: {str(e)}", color="warning")
+        ai_status = dbc.Alert(
+            f"AI device service error: {safe_text(e)}", color="warning"
+        )
     return suggestions, ai_status
 
 
@@ -1499,7 +1502,7 @@ def handle_enhanced_data_enhancement(n_clicks, *mapping_values):
         return status, preview, 100
 
     except Exception as e:
-        error_msg = dbc.Alert(f"Enhancement error: {str(e)}", color="danger")
+        error_msg = dbc.Alert(f"Enhancement error: {safe_text(e)}", color="danger")
         return error_msg, "", 80
 
 

--- a/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
+++ b/yosai_intel_dashboard/src/services/upload/utils/file_parser.py
@@ -8,22 +8,29 @@ import io
 import logging
 from typing import Any, Dict, Tuple
 
-
 import pandas as pd
 
-from yosai_intel_dashboard.src.infrastructure.config.constants import DEFAULT_CHUNK_SIZE
-from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
 from yosai_intel_dashboard.src.core.performance import get_performance_monitor
 from yosai_intel_dashboard.src.core.protocols import ConfigurationProtocol
 
 # Core processing imports only - NO UI COMPONENTS
-from yosai_intel_dashboard.src.core.unicode import safe_format_number, safe_unicode_decode, sanitize_for_utf8
+from yosai_intel_dashboard.src.core.unicode import (
+    safe_format_number,
+    safe_unicode_decode,
+    sanitize_for_utf8,
+)
+from yosai_intel_dashboard.src.infrastructure.config.constants import (
+    DEFAULT_CHUNK_SIZE,
+)
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+    dynamic_config,
+)
 from yosai_intel_dashboard.src.services.data_processing.file_processor import (
+    dataframe_from_bytes,
     decode_contents,
     validate_metadata,
-    dataframe_from_bytes,
 )
-
+from yosai_intel_dashboard.src.utils.text_utils import safe_text
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +106,14 @@ def process_uploaded_file(
         logger.error(
             "File processing error for %s: %s",
             safe_encode_text(filename),
-            e,
+            safe_text(e),
         )
-        return {"status": "error", "error": str(e), "data": None, "filename": filename}
+        return {
+            "status": "error",
+            "error": safe_text(e),
+            "data": None,
+            "filename": filename,
+        }
 
 
 def create_file_preview(

--- a/yosai_intel_dashboard/src/utils/text_utils.py
+++ b/yosai_intel_dashboard/src/utils/text_utils.py
@@ -28,6 +28,12 @@ def safe_text(text: Union[str, Any]) -> str:
     return clean_surrogate_chars(repr(text))
 
 
+# Backwards compatibility alias
+def safe_str(text: Union[str, Any]) -> str:
+    """Alias for :func:`safe_text` for legacy imports."""
+    return safe_text(text)
+
+
 def sanitize_text_for_dash(text: Union[str, Any]) -> str:
     """
     Sanitize text specifically for Dash components
@@ -88,4 +94,10 @@ def truncate_text(text: str, max_length: int = 100, suffix: str = "...") -> str:
     return text[: max_length - len(suffix)] + suffix
 
 
-__all__ = ["safe_text", "sanitize_text_for_dash", "format_file_size", "truncate_text"]
+__all__ = [
+    "safe_text",
+    "safe_str",
+    "sanitize_text_for_dash",
+    "format_file_size",
+    "truncate_text",
+]


### PR DESCRIPTION
## Summary
- add safe_str alias and expose in text utilities
- use safe_text for error logging in analytics and upload services
- sanitize CLI error handling to avoid raw str(e)

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/utils/text_utils.py yosai_intel_dashboard/src/services/analytics/database_analytics_service.py yosai_intel_dashboard/src/services/data_enhancer/app.py yosai_intel_dashboard/src/services/upload/utils/file_parser.py yosai_intel_dashboard/src/infrastructure/config/database_manager.py tools/test_analytics_both_fixes.py tools/cli_analytics_engine.py tools/cli_mapping_explorer.py tools/step2_add_missing_methods.py tools/cli_analytics_fixed.py tools/cli_mapping_tester.py tools/cli_file_processor.py tools/cli_async_processor.py` *(fails: flake8 module level import not at top of file, undefined names, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6d4a1048320ae4b5a4cdac60bb6