### PR TITLE
Optimize risk propagation

### DIFF
--- a/yosai_intel_dashboard/src/services/intel_analysis_service/core/risk_propagation.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/core/risk_propagation.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Dict, Iterable, Tuple
 
+try:  # NumPy is optional; fall back to pure Python if unavailable.
+    import numpy as np
+except Exception:  # pragma: no cover - only executed when numpy missing
+    np = None
+
 TrustLink = Tuple[str, str, float]
 
 
@@ -39,16 +44,45 @@ def propagate_risk(
         Fraction of risk that remains after each hop.
     """
 
-    adjacency: Dict[str, Dict[str, float]] = defaultdict(dict)
-    for src, dst, trust in trust_links:
-        adjacency[src][dst] = trust
+    edges = list(trust_links)
+
+    if np is not None:
+        nodes = {n for n in base_risks}
+        for s, d, _ in edges:
+            nodes.add(s)
+            nodes.add(d)
+        idx = {n: i for i, n in enumerate(nodes)}
+
+        src_idx = np.fromiter((idx[s] for s, _, _ in edges), dtype=np.int64)
+        dst_idx = np.fromiter((idx[d] for _, d, _ in edges), dtype=np.int64)
+        trust_arr = np.fromiter((t for _, _, t in edges), dtype=float)
+
+        risks_arr = np.zeros(len(nodes), dtype=float)
+        for name, score in base_risks.items():
+            risks_arr[idx[name]] = score
+
+        for _ in range(iterations):
+            new_risk = risks_arr.copy()
+            transmitted = risks_arr[src_idx] * (1.0 - trust_arr) * decay
+            np.add.at(new_risk, dst_idx, transmitted)
+            risks_arr = new_risk
+
+        return {node: risks_arr[i] for node, i in idx.items() if risks_arr[i]}
+
+    by_source: Dict[str, list[Tuple[str, float]]] = defaultdict(list)
+    for src, dst, trust in edges:
+        by_source[src].append((dst, trust))
 
     risks = dict(base_risks)
     for _ in range(iterations):
         new_risks = dict(risks)
-        for src, neighbours in adjacency.items():
-            for dst, trust in neighbours.items():
-                transmitted = risks.get(src, 0.0) * (1.0 - trust) * decay
+        for src, neighbours in by_source.items():
+            src_risk = risks.get(src, 0.0)
+            if not src_risk:
+                continue
+            transmitted_base = src_risk * decay
+            for dst, trust in neighbours:
+                transmitted = transmitted_base * (1.0 - trust)
                 new_risks[dst] = new_risks.get(dst, 0.0) + transmitted
         risks = new_risks
 
@@ -56,4 +90,3 @@ def propagate_risk(
 
 
 __all__ = ["propagate_risk", "TrustLink"]
-

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_core_modules.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_core_modules.py
@@ -1,5 +1,7 @@
 """Tests for the intel analysis core modules."""
 
+from __future__ import annotations
+
 import pathlib
 import sys
 
@@ -46,4 +48,3 @@ def test_risk_propagation() -> None:
     links = [("a", "b", 0.2), ("b", "c", 0.5)]
     risks = propagate_risk(base, links, iterations=2, decay=1.0)
     assert risks["b"] > 0.0 and risks["c"] > 0.0
-


### PR DESCRIPTION
## Summary
- pre-compute trust edges and optionally vectorize risk propagation using NumPy
- group transmissions by source to reduce repeated lookups
- ensure test module uses `from __future__ import annotations`

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/intel_analysis_service/core/risk_propagation.py yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_core_modules.py`
- `pytest yosai_intel_dashboard/src/services/intel_analysis_service/tests/test_core_modules.py` *(fails: ImportError: cannot import name 'cluster_users_by_coaccess')*

------
https://chatgpt.com/codex/tasks/task_e_6890f4c752188320ae05b244f58cbbcb