### PR TITLE
Add TypeScript paths to PurgeCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,13 +2,13 @@ module.exports = {
   plugins: [
     require('postcss-import'),
     require('tailwindcss-react-native/postcss'),
-    require('tailwindcss'),
+    require('@tailwindcss/postcss'),
     require('autoprefixer'),
     process.env.NODE_ENV === 'production' &&
       require('cssnano')({ preset: 'default' }),
     process.env.NODE_ENV === 'production' &&
-      require('@fullhuman/postcss-purgecss')({
-        content: ['./**/*.py', './**/*.html', './**/*.js', './**/*.tsx'],
+      require('@fullhuman/postcss-purgecss').default({
+        content: ['./**/*.py', './**/*.html', './**/*.js', './**/*.ts', './**/*.tsx'],
         defaultExtractor: content =>
           content.match(/[^\s]*[A-Za-z0-9-_:/]+/g) || []
       })


### PR DESCRIPTION
## Summary
- include `.ts` files in PostCSS PurgeCSS content
- switch to the new `@tailwindcss/postcss` plugin and adjust PurgeCSS import

## Testing
- `npm run build-css`
- `wc -c assets/dist/main.css assets/dist/main.min.css`


------
https://chatgpt.com/codex/tasks/task_e_6890f6b1b9a48320a2c980185f65c618