### PR TITLE
refactor: simplify store imports

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx
@@ -7,7 +7,7 @@ jest.mock('react-router-dom', () => ({
   MemoryRouter: ({ children }: any) => <div>{children}</div>,
 }), { virtual: true });
 import Navigation, { Header, Sidebar } from './Navigation';
-import { boundStore } from '../yosai_intel_dashboard/src/adapters/ui/state/store';
+import { boundStore } from '../state/store';
 
 const MemoryRouter: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div>{children}</div>

--- a/yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx
@@ -12,7 +12,7 @@ import {
   Activity,
   LayoutDashboard
 } from 'lucide-react';
-import { useProficiencyStore } from '../yosai_intel_dashboard/src/adapters/ui/state/store';
+import { useProficiencyStore } from '../state/store';
 
 interface NavItem {
   name: string;

--- a/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/interaction/index.ts
@@ -4,4 +4,5 @@ export type { Step } from './Stepper';
 export * from './lasso';
 export * from './useLassoSelection';
 export { default as TaskLauncher } from './TaskLauncher';
-export { default as Wizard } from './Wizard';\
+export { default as Wizard } from './Wizard';
+


### PR DESCRIPTION
## Summary
- simplify proficiency store imports in Navigation components
- remove stray character in interaction index

## Testing
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'three'; Could not find a declaration file for module 'd3'; implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6ae983083208ac6a8bb98d045a1