### PR TITLE
feat: enforce env-based database credentials

### DIFF
--- a/tests/test_base_database_service.py
+++ b/tests/test_base_database_service.py
@@ -18,13 +18,17 @@ def _install_fake_module(monkeypatch, name, factory_attr):
 
 def test_postgresql_connection(monkeypatch):
     conn = _install_fake_module(monkeypatch, "psycopg2", "connect")
-    service = BaseDatabaseService(DatabaseSettings(type="postgresql"))
+    service = BaseDatabaseService(
+        DatabaseSettings(type="postgresql", user="user", password="pass")
+    )
     assert service.connection is conn
 
 
 def test_mysql_connection(monkeypatch):
     conn = _install_fake_module(monkeypatch, "pymysql", "connect")
-    service = BaseDatabaseService(DatabaseSettings(type="mysql"))
+    service = BaseDatabaseService(
+        DatabaseSettings(type="mysql", user="user", password="pass")
+    )
     assert service.connection is conn
 
 
@@ -33,7 +37,9 @@ def test_mongodb_connection(monkeypatch):
     conn = object()
     module.MongoClient = lambda *a, **k: conn
     safe_import('pymongo', module)
-    service = BaseDatabaseService(DatabaseSettings(type="mongodb"))
+    service = BaseDatabaseService(
+        DatabaseSettings(type="mongodb", user="user", password="pass")
+    )
     assert service.connection is conn
 
 
@@ -42,10 +48,14 @@ def test_redis_connection(monkeypatch):
     conn = object()
     module.Redis = lambda *a, **k: conn
     safe_import('redis', module)
-    service = BaseDatabaseService(DatabaseSettings(type="redis"))
+    service = BaseDatabaseService(
+        DatabaseSettings(type="redis", user="user", password="pass")
+    )
     assert service.connection is conn
 
 
 def test_unsupported_type():
     with pytest.raises(ValueError):
-        BaseDatabaseService(DatabaseSettings(type="invalid"))
+        BaseDatabaseService(
+            DatabaseSettings(type="invalid", user="user", password="pass")
+        )

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,6 +1,7 @@
 import pytest
 
-from config import DatabaseSettings
+from yosai_intel_dashboard.src.infrastructure.config.schema import DatabaseSettings
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 from yosai_intel_dashboard.src.infrastructure.config.connection_pool import DatabaseConnectionPool
 from yosai_intel_dashboard.src.infrastructure.config.database_manager import MockConnection
 from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import PoolExhaustedError
@@ -13,7 +14,7 @@ def factory():
 
 
 def test_database_config_default_pool_sizes():
-    cfg = DatabaseSettings()
+    cfg = DatabaseSettings(user="user", password="pass")
     fake_cfg = FakeConfiguration()
     assert cfg.initial_pool_size == fake_cfg.get_db_pool_size()
     assert cfg.max_pool_size == cfg.initial_pool_size * 2
@@ -31,3 +32,8 @@ def test_database_config_default_pool_sizes():
         pool.get_connection()
     for c in conns:
         pool.release_connection(c)
+
+
+def test_database_settings_requires_credentials():
+    with pytest.raises(ConfigurationError):
+        DatabaseSettings(user="user", password="", type="postgresql")


### PR DESCRIPTION
## Summary
- source app debug setting from `YOSAI_DEBUG` env var
- require database `DB_USER`/`DB_PASSWORD` env vars and validate presence
- add tests for credential requirements

## Testing
- `python - <<'PY'
import pydantic
import prometheus_client
import pytest
res = pytest.main(['tests/test_database_config.py::test_database_settings_requires_credentials', '-vv'])
print('exit', res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891009bda448320b23447b1e0f2fa7a