### PR TITLE
Refactor CSS bundling in production build

### DIFF
--- a/yosai_intel_dashboard/src/models/css_build_optimizer.py
+++ b/yosai_intel_dashboard/src/models/css_build_optimizer.py
@@ -447,14 +447,15 @@ class CSSOptimizer:
                 else:
                     remaining_lines.append(line)
 
-            parts = ["".join(remaining_lines)]
+            segments: List[str] = []
+            segments.append("".join(remaining_lines))
             for rel in imports:
                 try:
                     path = main_css.parent / rel
-                    parts.append(path.read_text(encoding="utf-8"))
+                    segments.append(path.read_text(encoding="utf-8"))
                 except Exception as exc:
                     logger.error(f"❌ Error reading {path}: {exc}")
-            bundle = "".join(parts)
+            bundle = "".join(segments)
 
             out = self.output_dir / "main.min.css"
             tmp = out.with_suffix(".tmp.css")


### PR DESCRIPTION
## Summary
- refactor build_production_css to accumulate CSS segments in a list before writing

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/models/css_build_optimizer.py`
- `pytest tests/test_css_optimizer_production.py tests/test_css_build_optimizer_utils.py` *(fails: fixture 'stub_services_registry' not found, assertion mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6891009d14d08320b8137635d367ba85