### PR TITLE
Downgrade sanitized query logs

### DIFF
--- a/repositories/implementations.py
+++ b/repositories/implementations.py
@@ -132,7 +132,7 @@ class PersonRepository(IPersonRepository):
             person.last_active.isoformat() if person.last_active else None,
             person.risk_score,
         )
-        logger.info("Sanitized query: %s", query)
+        logger.debug("Sanitized query: %s", query)
         await asyncio.to_thread(self.conn.execute_command, query, params)
         return person
 
@@ -155,7 +155,7 @@ class PersonRepository(IPersonRepository):
             person.risk_score,
             _sanitize(person.person_id),
         )
-        logger.info("Sanitized query: %s", query)
+        logger.debug("Sanitized query: %s", query)
         await asyncio.to_thread(self.conn.execute_command, query, params)
         return person
 
@@ -163,7 +163,7 @@ class PersonRepository(IPersonRepository):
     async def delete(self, person_id: str) -> bool:
         query = "DELETE FROM people WHERE person_id=%s"
         person_id = _sanitize(person_id)
-        logger.info("Sanitized query: %s", query)
+        logger.debug("Sanitized query: %s", query)
         await asyncio.to_thread(self.conn.execute_command, query, (person_id,))
         return True
 
@@ -245,7 +245,7 @@ class AccessEventRepository(IAccessEventRepository):
             json.dumps(event.raw_data),
             datetime.now().isoformat(),
         )
-        logger.info("Sanitized query: %s", query)
+        logger.debug("Sanitized query: %s", query)
         await asyncio.to_thread(self.conn.execute_command, query, params)
         return event
 

--- a/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/unicode_processor.py
@@ -49,7 +49,7 @@ class QueryUnicodeHandler:
                 emit_security_event(
                     SecurityEvent.VALIDATION_FAILED, {"issue": "surrogate_query"}
                 )
-                logger.info("Surrogate characters removed from query value")
+                logger.debug("Surrogate characters removed from query value")
             return processor.safe_encode_text(text)
         if isinstance(value, dict):
             return {
@@ -73,7 +73,7 @@ class QueryUnicodeHandler:
         from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 
         if contains_surrogates(query):
-            (on_surrogate or logger.info)("Surrogates detected in query")
+            (on_surrogate or logger.debug)("Surrogates detected in query")
         return cls._encode(query, processor)
 
     @classmethod
@@ -89,7 +89,7 @@ class QueryUnicodeHandler:
         processor = processor or get_unicode_processor()
 
         def _cb(text: str) -> None:
-            (on_surrogate or logger.info)("Surrogates detected in query parameters")
+            (on_surrogate or logger.debug)("Surrogates detected in query parameters")
 
         from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 

--- a/yosai_intel_dashboard/src/services/analytics_microservice/unicode_middleware.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/unicode_middleware.py
@@ -21,7 +21,7 @@ class UnicodeSanitizationMiddleware(BaseHTTPMiddleware):
                 k: UnicodeHandler.sanitize(v) for k, v in request.query_params.items()
             }
             request._query_params = request.query_params.__class__(sanitized)
-            logger.info("Sanitized query for %s", request.url.path)
+            logger.debug("Sanitized query for %s", request.url.path)
 
         if request.method in {"POST", "PUT", "PATCH"}:
             body = await request.body()
@@ -31,7 +31,7 @@ class UnicodeSanitizationMiddleware(BaseHTTPMiddleware):
                 text = ""
             cleaned = UnicodeHandler.sanitize(text)
             request._body = cleaned.encode("utf-8")
-            logger.info("Sanitized body for %s", request.url.path)
+            logger.debug("Sanitized body for %s", request.url.path)
 
         response = await call_next(request)
         return response


### PR DESCRIPTION
## Summary
- switch sanitized SQL logging in repositories to debug level
- tone down Unicode sanitization logging in middleware and helpers

## Testing
- `pytest tests/repositories -q` *(fails: ImportError: cannot import name 'show_config' from 'numpy'; SyntaxError in test_sql_injection_repo.py)*

------
https://chatgpt.com/codex/tasks/task_e_689100a1fbec8320832ef969e1bd057f