### PR TITLE
feat: expand upload analytics summary

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -253,6 +253,8 @@ def register_dependency_stubs() -> None:
         "prometheus_client",
         REGISTRY=types.SimpleNamespace(_names_to_collectors={}),
         Counter=_Counter,
+        Gauge=_Counter,
+        Histogram=_Counter,
         core=prom_core,
     )
     register_stub("prometheus_client", prom_client)

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -97,7 +97,7 @@ def test_get_real_uploaded_data_no_files(monkeypatch):
 def test_service_receives_config(monkeypatch):
     """Provided config should be stored on the service instance."""
 
-    import yosai_intel_dashboard.src.services as services.analytics_service as mod
+    import yosai_intel_dashboard.src.services.analytics_service as mod
 
     # ensure a fresh global instance
     mod._analytics_service = None
@@ -143,3 +143,5 @@ def test_summarize_dataframe_basic():
     assert summary["date_range"] == {"start": "2024-01-01", "end": "2024-01-02"}
     assert summary["top_users"][0]["user_id"] == "u1"
     assert summary["top_users"][0]["count"] == 2
+    assert summary["top_doors"][0]["door_id"] == "d1"
+    assert summary["top_doors"][0]["count"] == 2

--- a/yosai_intel_dashboard/src/services/upload/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_processing.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, Dict, List
+
+import pandas as pd
 
 from yosai_intel_dashboard.src.services.upload.protocols import UploadAnalyticsProtocol
 
@@ -43,6 +45,77 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
             "total_events": total_events,
             "active_users": len(users),
             "active_doors": len(doors),
+        }
+
+    # ------------------------------------------------------------------
+    def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Return analytics summary for ``df``.
+
+        Computes event counts, unique entity counts, access result
+        distribution, date range and top users/doors. Missing columns and
+        empty dataframes are handled gracefully.
+        """
+
+        if df.empty:
+            return {
+                "total_events": 0,
+                "active_users": 0,
+                "active_doors": 0,
+                "unique_users": 0,
+                "unique_doors": 0,
+                "access_patterns": {},
+                "date_range": {"start": "Unknown", "end": "Unknown"},
+                "top_users": [],
+                "top_doors": [],
+            }
+
+        total_events = len(df)
+
+        def _unique(col: str) -> int:
+            return int(df[col].nunique(dropna=True)) if col in df.columns else 0
+
+        active_users = _unique("person_id")
+        active_doors = _unique("door_id")
+
+        access_patterns = (
+            df["access_result"].value_counts().to_dict()
+            if "access_result" in df.columns
+            else {}
+        )
+
+        date_range = {"start": "Unknown", "end": "Unknown"}
+        if "timestamp" in df.columns:
+            valid_ts = pd.to_datetime(df["timestamp"], errors="coerce").dropna()
+            if not valid_ts.empty:
+                date_range = {
+                    "start": str(valid_ts.min().date()),
+                    "end": str(valid_ts.max().date()),
+                }
+
+        top_users: List[Dict[str, Any]] = []
+        if "person_id" in df.columns:
+            user_counts = df["person_id"].value_counts().head(10)
+            top_users = [
+                {"user_id": uid, "count": int(cnt)} for uid, cnt in user_counts.items()
+            ]
+
+        top_doors: List[Dict[str, Any]] = []
+        if "door_id" in df.columns:
+            door_counts = df["door_id"].value_counts().head(10)
+            top_doors = [
+                {"door_id": did, "count": int(cnt)} for did, cnt in door_counts.items()
+            ]
+
+        return {
+            "total_events": total_events,
+            "active_users": active_users,
+            "active_doors": active_doors,
+            "unique_users": active_users,
+            "unique_doors": active_doors,
+            "access_patterns": access_patterns,
+            "date_range": date_range,
+            "top_users": top_users,
+            "top_doors": top_doors,
         }
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend UploadAnalyticsProcessor with detailed summarization metrics
- validate analytics summary including top users/doors and access results

## Testing
- `pytest tests/test_uploaded_helpers.py::test_summarize_dataframe tests/test_uploaded_helpers.py::test_summarize_dataframe_handles_missing_columns_and_empty tests/test_analytics_service.py::test_summarize_dataframe_basic -q` *(failed: _RegistryEntry() takes no arguments)*


------
https://chatgpt.com/codex/tasks/task_e_68910b7c0854832088076a78768f59ed