### PR TITLE
refactor: centralize service configuration

### DIFF
--- a/docs/unified_config.md
+++ b/docs/unified_config.md
@@ -32,3 +32,12 @@ When loading configuration directly via `UnifiedLoader` the loader applies
 message. This mirrors the behaviour of the traditional dataclass configuration
 pipeline.
 
+## Accessing configuration in services
+
+Services should obtain settings through the helper functions exposed by the
+configuration module rather than reading environment variables directly. Use
+`get_app_config()` for application level settings and `get_database_config()`
+for database connection details. These configuration objects can then be
+passed into service constructors, keeping configuration concerns separated from
+business logic and making the codebase easier to test.
+

--- a/yosai_intel_dashboard/src/infrastructure/config/schema.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/schema.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
-
 from database.utils import parse_connection_string
+from yosai_intel_dashboard.src.core.exceptions import ConfigurationError
 
 from .app_config import UploadConfig
 from .base import Config as DataclassConfig
@@ -32,6 +31,9 @@ class AppSettings(BaseModel):
     port: int = DEFAULT_APP_PORT
     secret_key: str = Field(default_factory=lambda: require_env_var("SECRET_KEY"))
     environment: str = "development"
+    jwt_secret_path: str | None = Field(
+        default=None, json_schema_extra={"env": "JWT_SECRET_PATH"}
+    )
 
 
 class DatabaseSettings(BaseModel):

--- a/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
@@ -6,8 +6,11 @@ from typing import Any
 import asyncpg
 import redis.asyncio as aioredis
 
-from yosai_intel_dashboard.src.services.common.async_db import close_pool
 from yosai_intel_dashboard.models.ml import ModelRegistry
+from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
+    ServiceSettings,
+)
+from yosai_intel_dashboard.src.services.common.async_db import close_pool
 
 
 class AnalyticsService:
@@ -18,15 +21,13 @@ class AnalyticsService:
         redis: aioredis.Redis,
         pool: asyncpg.pool.Pool,
         model_registry: ModelRegistry,
-        *,
-        cache_ttl: int = 300,
-        model_dir: Path | None = None,
+        cfg: ServiceSettings,
     ) -> None:
         self.redis = redis
         self.pool = pool
         self.model_registry = model_registry
-        self.cache_ttl = cache_ttl
-        self.model_dir = model_dir or Path("model_store")
+        self.cache_ttl = cfg.cache_ttl
+        self.model_dir = Path(cfg.model_dir)
         self.models: dict[str, Any] = {}
 
     async def close(self) -> None:

--- a/yosai_intel_dashboard/src/services/security/jwt_service.py
+++ b/yosai_intel_dashboard/src/services/security/jwt_service.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import os
 import time
 
 from jose import jwt
 
+from yosai_intel_dashboard.src.infrastructure.config import get_app_config
 from yosai_intel_dashboard.src.services.common.secrets import (
     get_secret,
     invalidate_secret,
 )
 
-JWT_SECRET_PATH_ENV = "JWT_SECRET_PATH"
 _JWT_SECRET_TTL = 300  # seconds
 
 _cached_secret: str | None = None
@@ -19,9 +18,9 @@ _cache_expires_at: float = 0.0
 
 def _read_jwt_secret() -> str:
     """Read the current JWT secret from Vault."""
-    secret_path = os.getenv(JWT_SECRET_PATH_ENV)
+    secret_path = get_app_config().jwt_secret_path
     if not secret_path:
-        raise RuntimeError("JWT_SECRET_PATH not configured")
+        raise RuntimeError("JWT secret path not configured")
     return get_secret(secret_path)
 
 
@@ -40,7 +39,7 @@ def invalidate_jwt_secret_cache() -> None:
     global _cached_secret, _cache_expires_at
     _cached_secret = None
     _cache_expires_at = 0.0
-    secret_path = os.getenv(JWT_SECRET_PATH_ENV)
+    secret_path = get_app_config().jwt_secret_path
     if secret_path:
         invalidate_secret(secret_path)
 

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import base64
-import os
-import redis
+from __future__ import annotations
 
+import base64
+
+import redis
 from flask import Blueprint, jsonify, request
 from flask_apispec import doc
 from flask_wtf.csrf import validate_csrf
@@ -14,13 +15,18 @@ from yosai_intel_dashboard.src.error_handling import (
     ErrorHandler,
     api_error_response,
 )
+from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
+    load_service_config,
+)
 from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.utils.pydantic_decorators import (
     validate_input,
     validate_output,
 )
 from yosai_intel_dashboard.src.utils.sanitization import sanitize_text
-redis_client = redis.Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+
+_service_cfg = load_service_config()
+redis_client = redis.Redis.from_url(_service_cfg.redis_url)
 rate_limiter = RedisRateLimiter(redis_client, {"default": {"limit": 100, "burst": 0}})
 
 
@@ -32,9 +38,7 @@ class UploadRequestSchema(BaseModel):
         json_schema_extra={
             "examples": [
                 {
-                    "contents": [
-                        "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="
-                    ],
+                    "contents": ["data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="],
                     "filenames": ["hello.txt"],
                 }
             ]
@@ -47,9 +51,7 @@ class UploadResponseSchema(BaseModel):
 
     model_config = ConfigDict(
         json_schema_extra={
-            "examples": [
-                {"job_id": "123e4567-e89b-12d3-a456-426614174000"}
-            ]
+            "examples": [{"job_id": "123e4567-e89b-12d3-a456-426614174000"}]
         }
     )
 


### PR DESCRIPTION
## Summary
- replace env lookups with config getters in analytics microservice
- wire configuration objects into feature flag manager and upload endpoint
- document unified configuration flow

## Testing
- `pre-commit run --files docs/unified_config.md yosai_intel_dashboard/src/infrastructure/config/schema.py yosai_intel_dashboard/src/services/analytics_microservice/app.py yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py yosai_intel_dashboard/src/services/security/jwt_service.py yosai_intel_dashboard/src/services/feature_flags.py yosai_intel_dashboard/src/services/upload/upload_endpoint.py`
- `pytest yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68910cc96c6083208eda35e42253faa2