### PR TITLE
refine column alias detection

### DIFF
--- a/yosai_intel_dashboard/src/services/enhanced_column_classifier.py
+++ b/yosai_intel_dashboard/src/services/enhanced_column_classifier.py
@@ -3,6 +3,8 @@ Enhanced ML column classifier with heuristic fallbacks.
 Replaces plugins/ai_classification/services/column_mapper.py
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from pathlib import Path
@@ -28,10 +30,15 @@ class EnhancedColumnClassifier:
         self.logger = logging.getLogger(__name__)
 
         # Standard field patterns for heuristic fallback
+        #
+        # User and device identifiers are intentionally matched only against
+        # specific aliases to avoid overly broad detections:
+        #   - ``user_id``: matches "person", "user", or "employee"
+        #   - ``device_id``: matches "device" or "door"
         self.field_patterns = {
-            "device_id": [r"door", r"device", r"reader", r"panel", r"id"],
+            "device_id": [r"device", r"door"],
             "timestamp": [r"time", r"date", r"when", r"stamp", r"created"],
-            "user_id": [r"user", r"person", r"employee", r"card", r"token"],
+            "user_id": [r"person", r"user", r"employee"],
             "event_type": [r"event", r"action", r"type", r"status", r"result"],
             "floor": [r"floor", r"level", r"story"],
             "location": [r"location", r"place", r"area", r"zone"],

--- a/yosai_intel_dashboard/src/utils/ai_column_mapper.py
+++ b/yosai_intel_dashboard/src/utils/ai_column_mapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -80,9 +81,9 @@ class AIColumnMapperAdapter:
 
 
 if __name__ == "__main__":
-    import pandas as pd
     from example_ai_adapter import ComponentPluginAdapter
 
+    logging.basicConfig(level=logging.INFO)
     data = {
         "Time": ["2023-01-01 12:00"],
         "利用者ID": ["A1"],
@@ -92,4 +93,5 @@ if __name__ == "__main__":
     frame = pd.DataFrame(data)
     mapper = AIColumnMapperAdapter(ComponentPluginAdapter(), use_japanese=True)
     result = mapper.map_and_standardize(frame)
-    print(result.columns.tolist())
+    logger = logging.getLogger(__name__)
+    logger.info(result.columns.tolist())


### PR DESCRIPTION
## Summary
- narrow heuristic alias lists for user and device columns and document the rules
- use logging instead of print in AI column mapper example

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/enhanced_column_classifier.py yosai_intel_dashboard/src/utils/ai_column_mapper.py`

------
https://chatgpt.com/codex/tasks/task_e_68910b7d4550832089f0a685b683085b