### PR TITLE
feat: support missing prometheus metrics gracefully

### DIFF
--- a/tests/database/test_metrics_without_prometheus_client.py
+++ b/tests/database/test_metrics_without_prometheus_client.py
@@ -1,0 +1,29 @@
+import builtins
+import importlib
+import sys
+
+
+def test_metrics_import_without_prometheus_client(monkeypatch):
+    """Module should load even when ``prometheus_client`` is absent."""
+    monkeypatch.delitem(sys.modules, "prometheus_client", raising=False)
+    monkeypatch.delitem(
+        sys.modules, "yosai_intel_dashboard.src.database.metrics", raising=False
+    )
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "prometheus_client":
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    metrics = importlib.import_module("yosai_intel_dashboard.src.database.metrics")
+
+    assert "Counter" in metrics.__all__
+    assert metrics.Counter.__module__ == "yosai_intel_dashboard.src.database.metrics"
+
+    metrics.queries_total.inc()
+    metrics.pool_utilization.set(1)
+    metrics.query_execution_seconds.observe(0.1)

--- a/yosai_intel_dashboard/src/database/metrics.py
+++ b/yosai_intel_dashboard/src/database/metrics.py
@@ -4,7 +4,40 @@ Import ``queries_total`` and ``query_errors_total`` to track how many
 database queries were executed and how many failed.
 """
 
-from prometheus_client import Counter, Gauge, Histogram
+try:  # pragma: no cover - exercised in tests
+    from prometheus_client import Counter, Gauge, Histogram
+except ImportError:  # pragma: no cover - exercised in tests
+    class _MetricStub:
+        """Fallback metric that ignores all operations."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - trivial
+            pass
+
+        # "labels" returns ``self`` so chained calls still succeed.
+        def labels(self, *args, **kwargs):
+            return self
+
+        # The following methods intentionally perform no action.
+        def inc(self, *args, **kwargs) -> None:  # pragma: no cover - no logic
+            pass
+
+        def dec(self, *args, **kwargs) -> None:  # pragma: no cover - no logic
+            pass
+
+        def set(self, *args, **kwargs) -> None:  # pragma: no cover - no logic
+            pass
+
+        def observe(self, *args, **kwargs) -> None:  # pragma: no cover - no logic
+            pass
+
+    class Counter(_MetricStub):
+        pass
+
+    class Gauge(_MetricStub):
+        pass
+
+    class Histogram(_MetricStub):
+        pass
 
 queries_total = Counter("database_queries_total", "Total database queries executed")
 query_errors_total = Counter(
@@ -31,6 +64,9 @@ health_check_retries_total = Counter(
 )
 
 __all__ = [
+    "Counter",
+    "Gauge",
+    "Histogram",
     "queries_total",
     "query_errors_total",
     "query_execution_seconds",


### PR DESCRIPTION
## Summary
- add no-op metric stubs when prometheus_client isn't installed
- expose Counter, Gauge and Histogram stubs and existing metrics
- test database metrics import without prometheus_client

## Testing
- `pytest tests/database/test_metrics_without_prometheus_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68910cc8056c8320ac6db41bd81318ce