### PR TITLE
Handle optional Redis dependency for core

### DIFF
--- a/yosai_intel_dashboard/src/core/__init__.py
+++ b/yosai_intel_dashboard/src/core/__init__.py
@@ -35,10 +35,6 @@ from .hierarchical_cache_manager import (
     HierarchicalCacheConfig,
     HierarchicalCacheManager,
 )
-from .intelligent_multilevel_cache import (
-    IntelligentMultiLevelCache,
-    create_intelligent_cache_manager,
-)
 from .memory_manager import MemoryManager
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -106,6 +102,14 @@ _LAZY_EXPORTS = {
     "cache_with_lock": ("..infrastructure.cache.cache_manager", "cache_with_lock"),
     "BaseDatabaseService": (".base_database_service", "BaseDatabaseService"),
     "deprecated": (".deprecation", "deprecated"),
+    "IntelligentMultiLevelCache": (
+        ".intelligent_multilevel_cache",
+        "IntelligentMultiLevelCache",
+    ),
+    "create_intelligent_cache_manager": (
+        ".intelligent_multilevel_cache",
+        "create_intelligent_cache_manager",
+    ),
 }
 
 

--- a/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
+++ b/yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py
@@ -12,12 +12,41 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
-import redis.asyncio as aioredis
+from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import CacheConfig
+
+try:
+    import redis.asyncio as aioredis
+except ImportError:  # pragma: no cover - Redis optional
+
+    class _RedisStub:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def set(self, *args, **kwargs) -> bool:
+            return True
+
+        async def setex(self, *args, **kwargs) -> bool:
+            return True
+
+        async def delete(self, *args, **kwargs) -> bool:
+            return True
+
+        async def flushdb(self, *args, **kwargs) -> bool:
+            return True
+
+        async def ping(self, *args, **kwargs) -> bool:
+            return True
+
+        async def close(self) -> None:
+            return None
+
+    class _RedisModuleStub:
+        Redis = _RedisStub
+
+    aioredis = _RedisModuleStub()  # type: ignore[misc, assignment]
 
 # expose async redis under original name for backward compatibility
 redis = aioredis
-
-from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import CacheConfig
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/tests/test_core_import_without_redis.py
+++ b/yosai_intel_dashboard/tests/test_core_import_without_redis.py
@@ -1,0 +1,14 @@
+"""Ensure core package imports without Redis installed."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_core_import_without_redis(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "redis", None)
+    monkeypatch.setitem(sys.modules, "redis.asyncio", None)
+    sys.modules.pop("yosai_intel_dashboard.src.core", None)
+    module = importlib.import_module("yosai_intel_dashboard.src.core")
+    assert module


### PR DESCRIPTION
## Summary
- add redis asyncio stub to IntelligentMultiLevelCache when redis isn't installed
- defer core's cache exports with lazy imports
- test importing core without redis present

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/intelligent_multilevel_cache.py yosai_intel_dashboard/src/core/__init__.py yosai_intel_dashboard/tests/test_core_import_without_redis.py` *(mypy and bandit reported existing issues)*
- `pytest yosai_intel_dashboard/tests/test_core_import_without_redis.py`


------
https://chatgpt.com/codex/tasks/task_e_68910cc5c5a88320b151ea0c567f38d6