### PR TITLE
refactor: centralize configuration access

### DIFF
--- a/src/websocket/metrics.py
+++ b/src/websocket/metrics.py
@@ -18,8 +18,24 @@ from typing import Dict
 
 from src.common.events import EventBus
 
-from prometheus_client import REGISTRY, Counter, start_http_server
-from prometheus_client.core import CollectorRegistry
+try:
+    from prometheus_client import REGISTRY, Counter, start_http_server
+    from prometheus_client.core import CollectorRegistry
+except Exception:  # pragma: no cover - optional dependency
+    class _DummyRegistry:
+        _names_to_collectors: Dict[str, object] = {}
+
+    REGISTRY = _DummyRegistry()
+
+    def start_http_server(*_, **__):  # type: ignore[no-redef]
+        return None
+
+    class Counter:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            self._value = type("V", (), {"get": lambda self: 0})()
+
+        def inc(self, *args, **kwargs) -> None:
+            pass
 
 _event_bus: EventBus | None = None
 _metrics_started = False

--- a/yosai_intel_dashboard/src/core/utils/config_helpers.py
+++ b/yosai_intel_dashboard/src/core/utils/config_helpers.py
@@ -10,10 +10,7 @@ is not provided.
 
 from typing import Any
 
-from src.common.config import ConfigService
-from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import (
-    ConfigurationMixin,
-)
+from src.common.config import ConfigService, ConfigurationMixin
 
 
 _default_cfg = ConfigService()

--- a/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/config_manager.py
@@ -137,6 +137,40 @@ class ConfigManager(ConfigurationMixin, ConfigurationProtocol):
         """Get configuration for a specific plugin."""
         return self.config.plugin_settings.get(name, {})
 
+    # Convenience properties for legacy service components -----------------
+    @property
+    def metrics_interval(self) -> float:
+        monitoring = self.get_monitoring_config()
+        return float(
+            getattr(
+                monitoring,
+                "metrics_interval_seconds",
+                getattr(monitoring, "metrics_interval", 1.0),
+            )
+        )
+
+    @property
+    def ping_interval(self) -> float:
+        monitoring = self.get_monitoring_config()
+        return float(getattr(monitoring, "health_check_interval", 30.0))
+
+    @property
+    def ping_timeout(self) -> float:
+        monitoring = self.get_monitoring_config()
+        return float(getattr(monitoring, "health_check_timeout", 10.0))
+
+    @property
+    def ai_confidence_threshold(self) -> float:
+        return float(self.get_ai_confidence_threshold())
+
+    @property
+    def max_upload_size_mb(self) -> int:
+        return int(self.get_max_upload_size_mb())
+
+    @property
+    def upload_chunk_size(self) -> int:
+        return int(self.get_upload_chunk_size())
+
     def get_upload_config(self) -> Dict[str, Any]:
         """Get upload configuration settings."""
         return vars(self.config.uploads)

--- a/yosai_intel_dashboard/src/services/common/config_utils.py
+++ b/yosai_intel_dashboard/src/services/common/config_utils.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import (
-    ConfigurationMixin,
-)
+from src.common.config import ConfigService, ConfigurationMixin
 
 
 def create_config_methods(cls: Any) -> Any:
@@ -16,7 +14,7 @@ def create_config_methods(cls: Any) -> Any:
 
 def common_init(self: Any, config: Any | None = None) -> None:
     """Initialize configuration defaults."""
-    self.config = config or {}
+    self.config = config or ConfigService()
     mixin = ConfigurationMixin()
     self.max_size_mb = mixin.get_max_upload_size_mb(self.config)
     self.ai_threshold = mixin.get_ai_confidence_threshold(self.config)

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -17,9 +17,11 @@ from src.common.mixins import LoggingMixin, SerializationMixin
 from yosai_intel_dashboard.src.services.analytics_summary import (
     generate_sample_analytics,
 )
-from yosai_intel_dashboard.src.infrastructure.callbacks import (
-    CallbackType,
+from yosai_intel_dashboard.src.infrastructure.callbacks.dispatcher import (
     trigger_callback,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import (
+    CallbackEvent as CallbackType,
 )
 
 

--- a/yosai_intel_dashboard/src/services/websocket_server.py
+++ b/yosai_intel_dashboard/src/services/websocket_server.py
@@ -14,11 +14,13 @@ from websockets import WebSocketServerProtocol, serve
 from src.common.base import BaseComponent
 from src.common.config import ConfigProvider, ConfigService
 from src.websocket import metrics as websocket_metrics
-from yosai_intel_dashboard.src.infrastructure.callbacks import (
-    CallbackType,
+from yosai_intel_dashboard.src.infrastructure.callbacks.dispatcher import (
     register_callback,
     unregister_callback,
     trigger_callback,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import (
+    CallbackEvent as CallbackType,
 )
 
 from .websocket_pool import WebSocketConnectionPool


### PR DESCRIPTION
## Summary
- centralize shared configuration helpers
- expose config manager properties for service defaults
- handle optional Prometheus dependency for websocket metrics

## Testing
- `pytest tests/common/test_config_service.py tests/test_config_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68910c9c0814832098ba6c753427e24f