### PR TITLE
Implement configurable DI container with settings lookups

### DIFF
--- a/tests/di/test_infrastructure_container.py
+++ b/tests/di/test_infrastructure_container.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import types
+
+
+def load_module(monkeypatch):
+    module_name = "yosai_intel_dashboard.src.infrastructure.di"
+    settings = types.SimpleNamespace(
+        get_database_config=lambda: {"db": 1},
+        get_analytics_config=lambda: {"ana": 2},
+    )
+    fake_config = types.SimpleNamespace(get_config=lambda: settings)
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.infrastructure.config", fake_config
+    )
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_builtin_config_lookups(monkeypatch):
+    di = load_module(monkeypatch)
+    assert di.container.get("config").get_database_config() == {"db": 1}
+    assert di.container.get("database_config") == {"db": 1}
+    assert di.container.get("analytics_config") == {"ana": 2}
+
+
+def test_register_and_helpers(monkeypatch):
+    di = load_module(monkeypatch)
+    di.register_singleton("foo", 42)
+    assert di.container.get("foo") == 42
+
+    di.register_factory("bar", lambda c: {"n": 1})
+    assert di.container.get("bar") == {"n": 1}
+
+    di.configure_database(lambda c: "dbsvc")
+    di.configure_analytics(lambda c: "anasvc")
+    assert di.container.get("database_service") == "dbsvc"
+    assert di.container.get("analytics_service") == "anasvc"

--- a/yosai_intel_dashboard/src/infrastructure/di/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/di/__init__.py
@@ -1,4 +1,96 @@
-"""Dependency injection helpers."""
-from .service_container import ServiceContainer
+"""Application-wide dependency injection container utilities."""
+from __future__ import annotations
 
-__all__ = ["ServiceContainer"]
+from typing import Any, Callable, Optional
+
+from .service_container import (
+    CircularDependencyError,
+    DependencyInjectionError,
+    ServiceContainer,
+    ServiceLifetime,
+)
+
+
+def get_settings() -> Any:
+    """Load configuration settings.
+
+    Falls back to a minimal object with required accessors if the full
+    configuration system cannot be loaded (for example when optional
+    dependencies are missing during tests).
+    """
+    try:  # pragma: no cover - best effort
+        from ..config import get_config
+
+        return get_config()
+    except Exception:  # pragma: no cover - defensive fallback
+        class _Fallback:
+            def get_database_config(self) -> dict:  # type: ignore[return-value]
+                return {}
+
+            def get_analytics_config(self) -> dict:  # type: ignore[return-value]
+                return {}
+
+        return _Fallback()
+
+
+# Global container instance -------------------------------------------------
+container = ServiceContainer()
+_settings = get_settings()
+
+# Pre-register common configuration lookups
+container.register_singleton("config", _settings)
+container.register_transient(
+    "database_config", object, factory=lambda _c: _settings.get_database_config()
+)
+container.register_transient(
+    "analytics_config", object, factory=lambda _c: _settings.get_analytics_config()
+)
+
+
+def register_singleton(
+    key: str,
+    implementation: Any,
+    *,
+    protocol: Optional[type] = None,
+) -> ServiceContainer:
+    """Convenience wrapper to register a singleton service."""
+    return container.register_singleton(key, implementation, protocol=protocol)
+
+
+def register_factory(
+    key: str,
+    factory: Callable[[ServiceContainer], Any],
+    *,
+    protocol: Optional[type] = None,
+) -> ServiceContainer:
+    """Register a factory that creates a new instance on each resolution."""
+    return container.register_transient(key, object, protocol=protocol, factory=factory)
+
+
+def configure_database(
+    factory: Callable[[ServiceContainer], Any]
+) -> ServiceContainer:
+    """Helper to register the database service factory."""
+    return register_factory("database_service", factory)
+
+
+def configure_analytics(
+    factory: Callable[[ServiceContainer], Any]
+) -> ServiceContainer:
+    """Helper to register the analytics service factory."""
+    return register_factory("analytics_service", factory)
+
+
+__all__ = [
+    "container",
+    "register_singleton",
+    "register_factory",
+    "configure_database",
+    "configure_analytics",
+    "get_settings",
+    # Re-export core classes for backward compatibility
+    "ServiceContainer",
+    "ServiceLifetime",
+    "DependencyInjectionError",
+    "CircularDependencyError",
+]


### PR DESCRIPTION
## Summary
- implement infrastructure DI container that loads settings via `get_settings`
- expose helper registration functions and default lookups for config, database, and analytics settings
- add tests for new DI container helpers

## Testing
- `pytest tests/di/test_infrastructure_container.py tests/di/test_service_container.py tests/di/test_dependency_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68910c9940308320ac8f2ba802a9c520