### PR TITLE
fix: update UploadAnalyticsProcessor import path

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -137,7 +137,7 @@ def register_analytics_services(container: ServiceContainer) -> None:
         ReportGeneratorProtocol,
         UploadAnalyticsProtocol,
     )
-    from yosai_intel_dashboard.src.services.analytics.upload_analytics import UploadAnalyticsProcessor
+    from yosai_intel_dashboard.src.services.upload_processing import UploadAnalyticsProcessor
     from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
     from yosai_intel_dashboard.src.services.controllers.upload_controller import UploadProcessingController
     from yosai_intel_dashboard.src.services.controllers.protocols import UploadProcessingControllerProtocol


### PR DESCRIPTION
## Summary
- adjust service registration to import `UploadAnalyticsProcessor` from `services.upload_processing`

## Testing
- `pre-commit run --files startup/service_registration.py`
- `pytest tests/test_upload_processing_module.py::test_direct_processing_helper -q` *(fails: ImportError while loading conftest... yosai_intel_dashboard/src/core/imports/__init__.py: SyntaxError)*


------
https://chatgpt.com/codex/tasks/task_e_689120da073483208efa19c9e699411c