### PR TITLE
Update UploadAnalyticsProcessor service path

### DIFF
--- a/yosai_intel_dashboard/src/services/registry.py
+++ b/yosai_intel_dashboard/src/services/registry.py
@@ -141,10 +141,7 @@ def register_builtin_services() -> None:
         "SecurityValidator",
         "validation.security_validator:SecurityValidator",
     )
-    register_service(
-        "UploadAnalyticsProcessor",
-        "services.analytics.upload_analytics:UploadAnalyticsProcessor",
-    )
+    register_service("UploadAnalyticsProcessor", "services.upload_processing:UploadAnalyticsProcessor")
 
     register_service(
         "AsyncFileProcessor", "services.async_file_processor:AsyncFileProcessor"


### PR DESCRIPTION
## Summary
- register UploadAnalyticsProcessor from services.upload_processing

## Testing
- `pytest yosai_intel_dashboard/tests` *(fails: ImportError: cannot import name 'ValidationError' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689120d7e9f08320965cac986bfbbee0