### PR TITLE
Centralize env settings usage for upload and DB

### DIFF
--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -25,7 +25,7 @@ protobuf schema and the `YosaiConfig` loader.
 | `user` | `user` | `DB_USER` |
 | `password` | `` | `DB_PASSWORD` |
 | `url` | `` | `DATABASE_URL` |
-| `connection_timeout` | `30` | `` |
+| `connection_timeout` | `30` | `DB_TIMEOUT` |
 | `initial_pool_size` | `10` | `` |
 | `max_pool_size` | `20` | `` |
 | `async_pool_min_size` | `10` | `` |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from typing import Callable, Iterator, List
+from types import ModuleType, SimpleNamespace
 
 # Make project package importable
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -22,7 +23,7 @@ setup_common_fallbacks()
 
 import pytest
 
-from tests.import_helpers import safe_import
+from yosai_intel_dashboard.src.core.imports.resolver import safe_import
 from yosai_intel_dashboard.src.database.types import DatabaseConnection
 
 try:

--- a/yosai_intel_dashboard/src/infrastructure/config/environment_processor.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/environment_processor.py
@@ -8,6 +8,7 @@ import os
 import re
 from typing import Any, Mapping, Optional
 from .constants import RateLimitConfig
+from .settings import get_settings
 
 
 class EnvironmentProcessor:
@@ -49,6 +50,8 @@ class EnvironmentProcessor:
     # ------------------------------------------------------------------
     def apply(self, config: Any) -> None:
         """Apply overrides to ``config`` in-place."""
+        settings = get_settings(reload=True)
+
         if hasattr(config, "app"):
             app = config.app
             if host := self.env.get("YOSAI_HOST"):
@@ -74,7 +77,7 @@ class EnvironmentProcessor:
                 db.host = host
             if (port := self._to_int("DB_PORT")) is not None:
                 db.port = port
-            if (timeout := self._to_int("DB_TIMEOUT")) is not None:
+            if (timeout := settings.database.connection_timeout) is not None:
                 db.connection_timeout = timeout
             if user := self.env.get("DB_USER"):
                 db.user = user
@@ -94,7 +97,7 @@ class EnvironmentProcessor:
             if hasattr(sec, "rate_limit_window_minutes"):
                 if (v := self._to_int("RATE_LIMIT_WINDOW")) is not None:
                     sec.rate_limit_window_minutes = v
-            if (val := self._to_int("MAX_UPLOAD_MB")) is not None:
+            if (val := settings.security.max_upload_mb) is not None:
                 if val < 50 and hasattr(sec, "max_file_size_mb"):
                     print(
                         "WARNING: MAX_UPLOAD_MB="
@@ -139,7 +142,7 @@ class EnvironmentProcessor:
             perf = config.performance
             if (v := self._to_int("DB_POOL_SIZE")) is not None:
                 perf.db_pool_size = v
-            if (v := self._to_int("AI_CONFIDENCE_THRESHOLD")) is not None:
+            if (v := settings.performance.ai_confidence_threshold) is not None:
                 perf.ai_confidence_threshold = v
             if (v := self._to_int("MEMORY_THRESHOLD_MB")) is not None:
                 perf.memory_usage_threshold_mb = v

--- a/yosai_intel_dashboard/src/infrastructure/config/settings.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/settings.py
@@ -16,16 +16,19 @@ class DatabaseSettings:
     user: str
     password: str
     name: str
+    connection_timeout: Optional[int]
 
     @classmethod
     def from_env(cls) -> "DatabaseSettings":
         """Create settings from environment variables."""
+        timeout = os.getenv("DB_TIMEOUT")
         return cls(
             host=os.getenv("DB_HOST", "localhost"),
             port=int(os.getenv("DB_PORT", "5432")),
             user=os.getenv("DB_USER", "postgres"),
             password=os.getenv("DB_PASSWORD", ""),
             name=os.getenv("DB_NAME", "app"),
+            connection_timeout=int(timeout) if timeout is not None else None,
         )
 
 
@@ -37,16 +40,19 @@ class SecuritySettings:
     jwt_algorithm: str
     cors_origins: List[str]
     csrf_enabled: bool
+    max_upload_mb: Optional[int]
 
     @classmethod
     def from_env(cls) -> "SecuritySettings":
         """Create settings from environment variables."""
         origins = [o for o in os.getenv("CORS_ORIGINS", "").split(",") if o]
+        max_upload = os.getenv("MAX_UPLOAD_MB")
         return cls(
             secret_key=os.getenv("SECRET_KEY", "change-me"),
             jwt_algorithm=os.getenv("JWT_ALGORITHM", "HS256"),
             cors_origins=origins,
             csrf_enabled=os.getenv("CSRF_ENABLED", "true").lower() == "true",
+            max_upload_mb=int(max_upload) if max_upload is not None else None,
         )
 
 
@@ -69,6 +75,18 @@ class AnalyticsSettings:
 
 
 @dataclass
+class PerformanceSettings:
+    """Performance tuning configuration."""
+
+    ai_confidence_threshold: Optional[int]
+
+    @classmethod
+    def from_env(cls) -> "PerformanceSettings":
+        value = os.getenv("AI_CONFIDENCE_THRESHOLD")
+        return cls(ai_confidence_threshold=int(value) if value is not None else None)
+
+
+@dataclass
 class AppSettings:
     """Top level application configuration."""
 
@@ -76,6 +94,7 @@ class AppSettings:
     database: DatabaseSettings
     security: SecuritySettings
     analytics: AnalyticsSettings
+    performance: PerformanceSettings
     name: str = "Yōsai Intel Dashboard"
 
     @classmethod
@@ -86,6 +105,7 @@ class AppSettings:
             database=DatabaseSettings.from_env(),
             security=SecuritySettings.from_env(),
             analytics=AnalyticsSettings.from_env(),
+            performance=PerformanceSettings.from_env(),
             name=os.getenv("APP_NAME", "Yōsai Intel Dashboard"),
         )
 
@@ -122,6 +142,7 @@ __all__ = [
     "DatabaseSettings",
     "SecuritySettings",
     "AnalyticsSettings",
+    "PerformanceSettings",
     "AppSettings",
     "ConfigManager",
     "get_settings",


### PR DESCRIPTION
## Summary
- add optional settings for DB timeout, max upload size, and AI confidence threshold
- read these settings via `get_settings()` inside dynamic config and environment processor
- document DB_TIMEOUT environment override

## Testing
- `pytest tests/infrastructure/config/test_configuration_mixin.py tests/test_config_validator.py tests/test_configuration_mixin.py -q` *(fails: TypeError: 'module' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_68912dc9bc488320b2c72ddcc613c377