### PR TITLE
Configure security validator via service config

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import (
     ConfigurationProtocol,
@@ -10,9 +11,12 @@ from yosai_intel_dashboard.src.core.interfaces.protocols import (
     SecurityServiceProtocol,
     StorageProtocol,
 )
-from yosai_intel_dashboard.src.infrastructure.di.service_container import ServiceContainer
-from yosai_intel_dashboard.src.services.metadata_enhancement_engine import register_metadata_services
-import warnings
+from yosai_intel_dashboard.src.infrastructure.di.service_container import (
+    ServiceContainer,
+)
+from yosai_intel_dashboard.src.services.metadata_enhancement_engine import (
+    register_metadata_services,
+)
 
 
 def register_all_application_services(container: ServiceContainer) -> None:
@@ -24,8 +28,12 @@ def register_all_application_services(container: ServiceContainer) -> None:
     register_metadata_services(container)
     register_security_services(container)
     register_export_services(container)
-    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-    from yosai_intel_dashboard.src.services.upload.service_registration import register_upload_services
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+        dynamic_config,
+    )
+    from yosai_intel_dashboard.src.services.upload.service_registration import (
+        register_upload_services,
+    )
 
     register_upload_services(container, config=dynamic_config)
 
@@ -48,13 +56,15 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigValidator,
         create_config_manager,
     )
+    from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
+    from yosai_intel_dashboard.src.core.logging import LoggingService
     from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
         DatabaseConnectionFactory,
         DatabaseSettings,
     )
-    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-    from yosai_intel_dashboard.src.core.interfaces import ConfigProviderProtocol
-    from yosai_intel_dashboard.src.core.logging import LoggingService
+    from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+        dynamic_config,
+    )
     from yosai_intel_dashboard.src.services.configuration_service import (
         ConfigurationServiceProtocol,
         DynamicConfigurationService,
@@ -85,6 +95,7 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=LoggingProtocol,
     )
     from yosai_intel_dashboard.src.error_handling import ErrorHandler
+
     container.register_singleton("error_handler", ErrorHandler)
     container.register_singleton(
         "database_connection_factory",
@@ -109,7 +120,9 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=StorageProtocol,
     )
 
-    from yosai_intel_dashboard.src.infrastructure.config.cache_manager import get_cache_manager
+    from yosai_intel_dashboard.src.infrastructure.config.cache_manager import (
+        get_cache_manager,
+    )
 
     container.register_singleton(
         "cache_manager",
@@ -125,10 +138,20 @@ def register_analytics_services(container: ServiceContainer) -> None:
         EventBusProtocol,
         StorageProtocol,
     )
+    from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
+        MappingServiceProtocol,
+        UploadDataServiceProtocol,
+        get_database_analytics_retriever,
+    )
     from yosai_intel_dashboard.src.mapping.factories.service_factory import (
         create_mapping_service,
     )
-    from yosai_intel_dashboard.src.services.analytics.calculator import create_calculator
+    from yosai_intel_dashboard.src.services.analytics.analytics_service import (
+        AnalyticsService,
+    )
+    from yosai_intel_dashboard.src.services.analytics.calculator import (
+        create_calculator,
+    )
     from yosai_intel_dashboard.src.services.analytics.protocols import (
         CalculatorProtocol,
         DataLoadingProtocol,
@@ -137,21 +160,27 @@ def register_analytics_services(container: ServiceContainer) -> None:
         ReportGeneratorProtocol,
         UploadAnalyticsProtocol,
     )
-    from yosai_intel_dashboard.src.services.upload_processing import UploadAnalyticsProcessor
-    from yosai_intel_dashboard.src.services.analytics.analytics_service import AnalyticsService
-    from yosai_intel_dashboard.src.services.controllers.upload_controller import UploadProcessingController
-    from yosai_intel_dashboard.src.services.controllers.protocols import UploadProcessingControllerProtocol
-    from yosai_intel_dashboard.src.services.data_loading_service import DataLoadingService
+    from yosai_intel_dashboard.src.services.controllers.protocols import (
+        UploadProcessingControllerProtocol,
+    )
+    from yosai_intel_dashboard.src.services.controllers.upload_controller import (
+        UploadProcessingController,
+    )
+    from yosai_intel_dashboard.src.services.data_loading_service import (
+        DataLoadingService,
+    )
     from yosai_intel_dashboard.src.services.data_processing.processor import Processor
-    from yosai_intel_dashboard.src.services.data_processing_service import DataProcessingService
-    from yosai_intel_dashboard.src.core.interfaces.service_protocols import (
-        MappingServiceProtocol,
-        UploadDataServiceProtocol,
-        get_database_analytics_retriever,
+    from yosai_intel_dashboard.src.services.data_processing_service import (
+        DataProcessingService,
     )
     from yosai_intel_dashboard.src.services.protocols.processor import ProcessorProtocol
     from yosai_intel_dashboard.src.services.publishing_service import PublishingService
-    from yosai_intel_dashboard.src.services.report_generation_service import ReportGenerationService
+    from yosai_intel_dashboard.src.services.report_generation_service import (
+        ReportGenerationService,
+    )
+    from yosai_intel_dashboard.src.services.upload_processing import (
+        UploadAnalyticsProcessor,
+    )
 
     container.register_singleton(
         "data_processing_service",
@@ -218,6 +247,7 @@ def register_analytics_services(container: ServiceContainer) -> None:
         protocol=PublishingProtocol,
         factory=lambda c: PublishingService(c.get("event_bus")),
     )
+
     def _create_analytics_service(c):
         factory = c.get("database_connection_factory")
         db_conn = factory.create() if factory else None
@@ -251,17 +281,33 @@ def register_analytics_services(container: ServiceContainer) -> None:
 
 
 def register_security_services(container: ServiceContainer) -> None:
+    from config.configuration_loader import ConfigurationLoader
     from validation.security_validator import SecurityValidator
+    from yosai_intel_dashboard.src.infrastructure.cache import redis_client
+
+    def _create_validator(_: ServiceContainer) -> SecurityValidator:
+        cfg = ConfigurationLoader.get_service_config("security")
+        rate_limit = getattr(cfg, "rate_limit_requests", None)
+        window = getattr(cfg, "rate_limit_window_minutes", None)
+        window_seconds = window * 60 if window is not None else None
+        return SecurityValidator(
+            redis_client=redis_client,
+            rate_limit=rate_limit,
+            window_seconds=window_seconds,
+        )
 
     container.register_singleton(
         "security_validator",
         SecurityValidator,
         protocol=SecurityServiceProtocol,
+        factory=_create_validator,
     )
 
 
 def register_export_services(container: ServiceContainer) -> None:
-    from yosai_intel_dashboard.src.core.interfaces.protocols import ExportServiceProtocol
+    from yosai_intel_dashboard.src.core.interfaces.protocols import (
+        ExportServiceProtocol,
+    )
     from yosai_intel_dashboard.src.services.export_service import ExportService
 
     container.register_transient(
@@ -274,7 +320,9 @@ def register_export_services(container: ServiceContainer) -> None:
 def register_learning_services(container: ServiceContainer) -> None:
     """Register device learning service with the container."""
 
-    from yosai_intel_dashboard.src.services.device_learning_service import create_device_learning_service
+    from yosai_intel_dashboard.src.services.device_learning_service import (
+        create_device_learning_service,
+    )
 
     container.register_singleton(
         "device_learning_service",

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -8,6 +8,7 @@ from .base import Config, RetrainingConfig
 from .config_manager import ConfigManager, get_config, reload_config
 from .config_transformer import ConfigTransformer
 from .config_validator import ConfigValidator, ValidationResult
+from .configuration_loader import ConfigurationLoader
 from .constants import CSSConstants, PerformanceConstants, SecurityConstants
 from .database_connection_factory import DatabaseConnectionFactory, RetryStrategy
 from .dynamic_config import DynamicConfigManager, dynamic_config
@@ -31,7 +32,6 @@ from .secure_config_manager import SecureConfigManager
 from .secure_db import execute_secure_query
 from .unicode_handler import UnicodeHandler
 from .unified_loader import UnifiedLoader
-from .database_connection_factory import DatabaseConnectionFactory
 
 
 def create_config_manager(
@@ -136,6 +136,7 @@ __all__ = [
     # Dynamic configuration
     "dynamic_config",
     "DynamicConfigManager",
+    "ConfigurationLoader",
     # Constants
     "SecurityConstants",
     "PerformanceConstants",
@@ -144,7 +145,6 @@ __all__ = [
     "execute_secure_query",
     "UnicodeHandler",
     "DatabaseConnectionFactory",
-
 ]
 
 

--- a/yosai_intel_dashboard/src/infrastructure/config/configuration_loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/configuration_loader.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .dynamic_config import dynamic_config
+
+
+class ConfigurationLoader:
+    """Provide access to configuration sections for services."""
+
+    @staticmethod
+    def get_service_config(name: str) -> Any:
+        """Return configuration section for the given service name.
+
+        Parameters
+        ----------
+        name:
+            Name of the configuration section. For example ``"security"``.
+
+        Returns
+        -------
+        Any
+            The configuration object for the requested service.
+
+        Raises
+        ------
+        KeyError
+            If the requested configuration section does not exist.
+        """
+
+        try:
+            return getattr(dynamic_config, name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown service configuration: {name}") from exc


### PR DESCRIPTION
## Summary
- add `ConfigurationLoader` utility to expose service-level config
- register `security_validator` via factory using security service config

## Testing
- `pre-commit run --files startup/service_registration.py config/configuration_loader.py config/__init__.py`
- `pytest tests/test_service_integration.py::TestServiceIntegration::test_upload_uses_security_protocol -q` *(fails: NameError: name 'ModuleType' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689131afeb9483209c43b7969b9fb1bd