### PR TITLE
feat: register unified callback manager

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -100,6 +100,21 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=EventBusProtocol,
     )
 
+    from yosai_intel_dashboard.src.core.protocols import CallbackSystemProtocol
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+        TrulyUnifiedCallbacks,
+    )
+
+    container.register_singleton(
+        "callback_manager",
+        TrulyUnifiedCallbacks,
+        protocol=CallbackSystemProtocol,
+        factory=lambda c: TrulyUnifiedCallbacks(
+            security_validator=c.get("security_validator"),
+            event_bus=c.get("event_bus", EventBusProtocol),
+        ),
+    )
+
     # Register generic file storage service for analytics
     from yosai_intel_dashboard.src.core.storage.file_storage import FileStorageService
 


### PR DESCRIPTION
## Summary
- expose TrulyUnifiedCallbacks via ServiceContainer

## Testing
- `pytest tests/test_callback_manager.py tests/test_callback_manager_events.py -q` *(fails: ModuleType not defined in conftest)*

------
https://chatgpt.com/codex/tasks/task_e_689131ad3b2c832081577b6364809ddb