### PR TITLE
Introduce ConfigurationLoader and unify service config usage

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -46,6 +46,7 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigManager,
         ConfigTransformer,
         ConfigValidator,
+        ConfigurationLoader,
         create_config_manager,
     )
     from yosai_intel_dashboard.src.infrastructure.config.database_manager import (
@@ -68,6 +69,11 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         ConfigManager,
         protocol=ConfigurationProtocol,
         factory=lambda c: create_config_manager(container=c),
+    )
+    container.register_singleton(
+        "configuration_loader",
+        ConfigurationLoader,
+        protocol=ConfigurationProtocol,
     )
     container.register_singleton(
         "dynamic_config",

--- a/tests/test_service_config_loader.py
+++ b/tests/test_service_config_loader.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from yosai_intel_dashboard.src.infrastructure.config.config_loader import ServiceSettings, load_service_config
+from yosai_intel_dashboard.src.infrastructure.config.loader import (
+    ConfigurationLoader,
+    ServiceSettings,
+)
 
 
 def test_load_service_config_defaults(monkeypatch):
@@ -14,7 +17,7 @@ def test_load_service_config_defaults(monkeypatch):
     ]:
         monkeypatch.delenv(var, raising=False)
 
-    cfg = load_service_config()
+    cfg = ConfigurationLoader().get_service_config()
     assert cfg.redis_url == ServiceSettings.redis_url
     assert cfg.cache_ttl == ServiceSettings.cache_ttl
     assert cfg.model_dir == ServiceSettings.model_dir
@@ -31,7 +34,7 @@ def test_load_service_config_overrides(monkeypatch):
     monkeypatch.setenv("MODEL_REGISTRY_BUCKET", "bucket")
     monkeypatch.setenv("MLFLOW_URI", "http://mlflow")
 
-    cfg = load_service_config()
+    cfg = ConfigurationLoader().get_service_config()
     assert cfg.redis_url == "redis://example:6380/1"
     assert cfg.cache_ttl == 123
     assert cfg.model_dir == Path("/tmp/models")

--- a/yosai_intel_dashboard/src/infrastructure/config/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/__init__.py
@@ -13,6 +13,7 @@ from .database_connection_factory import DatabaseConnectionFactory, RetryStrateg
 from .dynamic_config import DynamicConfigManager, dynamic_config
 from .environment_processor import EnvironmentProcessor
 from .hierarchical_loader import HierarchicalLoader
+from .loader import ConfigurationLoader, ServiceSettings
 from .proto_adapter import to_dataclasses
 from .protocols import (
     ConfigLoaderProtocol,
@@ -119,6 +120,8 @@ __all__ = [
     "HierarchicalLoader",
     "ConfigTransformer",
     "UnifiedLoader",
+    "ConfigurationLoader",
+    "ServiceSettings",
     "to_dataclasses",
     "ConfigLoaderProtocol",
     "ConfigValidatorProtocol",

--- a/yosai_intel_dashboard/src/infrastructure/config/loader.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/loader.py
@@ -1,0 +1,85 @@
+"""Aggregate configuration from files and environment variables.
+
+This module provides :class:`ConfigurationLoader` which loads configuration
+data from the standard configuration files and overlays any environment based
+settings.  It exposes a :meth:`get_service_config` helper that returns a
+``ServiceSettings`` dataclass used by a number of microservices.  The loader
+also inherits :class:`ConfigurationMixin` so that it satisfies the
+``ConfigurationProtocol`` used throughout the codebase.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .base_loader import BaseConfigLoader
+from .config_loader import ServiceSettings
+from .configuration_mixin import ConfigurationMixin
+from .environment import select_config_file
+
+
+class ConfigurationLoader(ConfigurationMixin, BaseConfigLoader):
+    """Loader that merges file based configuration with environment settings."""
+
+    log = logging.getLogger(__name__)
+
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self.config_path = config_path
+        self._config = self._load_config()
+        # Expose top level keys as attributes so ConfigurationMixin can access
+        # nested sections using attribute lookups.
+        for key, value in self._config.items():
+            setattr(self, key, value)
+
+    # ------------------------------------------------------------------
+    def _load_config(self, config_path: Optional[str] = None) -> Dict[str, Any]:
+        """Load configuration data from file or ``YOSAI_CONFIG_JSON``."""
+
+        path = select_config_file(config_path or self.config_path)
+        data: Dict[str, Any] = {}
+        if path and path.exists():
+            try:
+                data = self.load_file(path)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.log.warning("Failed to load %s: %s", path, exc)
+
+        env_json = os.getenv("YOSAI_CONFIG_JSON")
+        if env_json:
+            try:
+                env_data = json.loads(env_json)
+                data.update(env_data)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.log.warning("Failed to parse YOSAI_CONFIG_JSON: %s", exc)
+
+        return data
+
+    # ------------------------------------------------------------------
+    def get_service_config(self) -> ServiceSettings:
+        """Return ``ServiceSettings`` populated from config and environment."""
+
+        cfg = self._config.get("service", {})
+        return ServiceSettings(
+            redis_url=os.getenv("REDIS_URL", cfg.get("redis_url", ServiceSettings.redis_url)),
+            cache_ttl=int(
+                os.getenv("CACHE_TTL", cfg.get("cache_ttl", ServiceSettings.cache_ttl))
+            ),
+            model_dir=Path(
+                os.getenv("MODEL_DIR", cfg.get("model_dir", ServiceSettings.model_dir))
+            ),
+            registry_db=os.getenv(
+                "MODEL_REGISTRY_DB", cfg.get("registry_db", ServiceSettings.registry_db)
+            ),
+            registry_bucket=os.getenv(
+                "MODEL_REGISTRY_BUCKET",
+                cfg.get("registry_bucket", ServiceSettings.registry_bucket),
+            ),
+            mlflow_uri=os.getenv("MLFLOW_URI", cfg.get("mlflow_uri")),
+        )
+
+
+__all__ = ["ConfigurationLoader", "ServiceSettings"]
+

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -40,8 +40,8 @@ from yosai_intel_dashboard.src.infrastructure.config import (
     get_app_config,
     get_database_config,
 )
-from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
-    load_service_config,
+from yosai_intel_dashboard.src.infrastructure.config.loader import (
+    ConfigurationLoader,
 )
 from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
     register_health_check,
@@ -71,7 +71,7 @@ app = service.app
 app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(UnicodeSanitizationMiddleware)
 
-service_cfg = load_service_config()
+service_cfg = ConfigurationLoader().get_service_config()
 app_cfg = get_app_config()
 
 # Configure a Redis backed rate limiter

--- a/yosai_intel_dashboard/src/services/event-ingestion/app.py
+++ b/yosai_intel_dashboard/src/services/event-ingestion/app.py
@@ -17,8 +17,8 @@ from yosai_framework.errors import ServiceError
 from yosai_framework.service import BaseService
 from yosai_intel_dashboard.src.core.security import RateLimiter
 from yosai_intel_dashboard.src.error_handling.middleware import ErrorHandlingMiddleware
-from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
-    load_service_config,
+from yosai_intel_dashboard.src.infrastructure.config.loader import (
+    ConfigurationLoader,
 )
 from yosai_intel_dashboard.src.infrastructure.discovery.health_check import (
     register_health_check,
@@ -90,7 +90,7 @@ async def _consume_loop() -> None:
 @app.on_event("startup")
 async def startup() -> None:
     # Load environment driven settings
-    load_service_config()
+    ConfigurationLoader().get_service_config()
     service.initialize()
     asyncio.create_task(
         trace_async_operation("consume_loop", "ingest", _consume_loop())

--- a/yosai_intel_dashboard/src/services/feature_flags.py
+++ b/yosai_intel_dashboard/src/services/feature_flags.py
@@ -38,8 +38,8 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - simplified fallback
     RedisFeatureFlagStore = InMemoryFeatureFlagStore
 
-from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
-    load_service_config,
+from yosai_intel_dashboard.src.infrastructure.config.loader import (
+    ConfigurationLoader,
 )
 
 from ..repository import (
@@ -79,7 +79,7 @@ class FeatureFlagManager:
         redis_url: str | None = None,
         cache_repo: FeatureFlagCacheRepository | None = None,
     ) -> None:
-        cfg = load_service_config()
+        cfg = ConfigurationLoader().get_service_config()
         redis_url = redis_url or cfg.redis_url
         try:
             self._store = RedisFeatureFlagStore(redis_url=redis_url)

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -15,8 +15,8 @@ from yosai_intel_dashboard.src.error_handling import (
     ErrorHandler,
     api_error_response,
 )
-from yosai_intel_dashboard.src.infrastructure.config.config_loader import (
-    load_service_config,
+from yosai_intel_dashboard.src.infrastructure.config.loader import (
+    ConfigurationLoader,
 )
 from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.utils.pydantic_decorators import (
@@ -25,7 +25,7 @@ from yosai_intel_dashboard.src.utils.pydantic_decorators import (
 )
 from yosai_intel_dashboard.src.utils.sanitization import sanitize_text
 
-_service_cfg = load_service_config()
+_service_cfg = ConfigurationLoader().get_service_config()
 redis_client = redis.Redis.from_url(_service_cfg.redis_url)
 rate_limiter = RedisRateLimiter(redis_client, {"default": {"limit": 100, "burst": 0}})
 


### PR DESCRIPTION
## Summary
- add `ConfigurationLoader` to merge file and environment settings with helper `get_service_config`
- register the loader in core infrastructure so services can resolve it from DI container
- refactor feature flag manager and service endpoints to pull settings via `ConfigurationLoader`

## Testing
- `pytest tests/test_service_config_loader.py -q` *(fails: NameError: name 'ModuleType' is not defined in tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_689131ac53a88320ba084dbcfe599224