### PR TITLE
refactor: remove callback patch and update config

### DIFF
--- a/tools/cli_analytics_fixed.py
+++ b/tools/cli_analytics_fixed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test Analytics with callback fix applied
+Test Analytics without callback patch
 """
 
 import asyncio
@@ -12,26 +12,17 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from yosai_intel_dashboard.src.utils.text_utils import safe_text
 
-# Apply callback patch first
-try:
-    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
-        TrulyUnifiedCallbacks as CallbackManager,
-    )
-
-    if hasattr(CallbackManager, "handle_register") and not hasattr(
-        CallbackManager, "register_handler"
-    ):
-        CallbackManager.register_handler = CallbackManager.handle_register
-        print("✅ Callback patch applied")
-except Exception as e:
-    print(f"⚠️  Callback patch failed: {safe_text(e)}")
-
-
-async def test_analytics_with_fix():
+def safe_text(value: object) -> str:
     try:
-        print("=== TESTING ANALYTICS WITH CALLBACK FIX ===")
+        return str(value)
+    except Exception:
+        return "<unprintable>"
+
+
+async def test_analytics():
+    try:
+        print("=== TESTING ANALYTICS SERVICE ===")
 
         import pandas as pd
 
@@ -130,7 +121,7 @@ async def test_analytics_with_fix():
             }
             print(f"❌ Data processing failed: {safe_text(e)}")
 
-        print("\n=== ANALYTICS TESTING WITH FIX COMPLETE ===")
+        print("\n=== ANALYTICS TESTING COMPLETE ===")
         return result
 
     except Exception as e:
@@ -143,7 +134,7 @@ async def test_analytics_with_fix():
 
 def main():
     logging.basicConfig(level=logging.INFO)
-    result = asyncio.run(test_analytics_with_fix())
+    result = asyncio.run(test_analytics())
     print("\n" + "=" * 50)
     print("FINAL RESULTS:")
     print(json.dumps(result, indent=2, default=str))

--- a/yosai_intel_dashboard/src/infrastructure/config/settings.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/settings.py
@@ -23,6 +23,9 @@ class DatabaseSettings:
         default_factory=lambda: int(os.getenv("DB_MAX_CONNECTIONS", "10"))
     )
     timeout: float = field(default_factory=lambda: float(os.getenv("DB_TIMEOUT", "30")))
+    connection_timeout: int = field(
+        default_factory=lambda: int(os.getenv("DB_CONNECTION_TIMEOUT", "30"))
+    )
 
 
 
@@ -44,6 +47,9 @@ class SecuritySettings:
     csrf_enabled: bool = field(
         default_factory=lambda: os.getenv("CSRF_ENABLED", "true").lower() == "true"
     )
+    max_upload_mb: int = field(
+        default_factory=lambda: int(os.getenv("MAX_UPLOAD_MB", "50"))
+    )
 
 
 
@@ -62,12 +68,13 @@ class AnalyticsSettings:
 class PerformanceSettings:
     """Performance tuning configuration."""
 
-    ai_confidence_threshold: Optional[int]
-
-    @classmethod
-    def from_env(cls) -> "PerformanceSettings":
-        value = os.getenv("AI_CONFIDENCE_THRESHOLD")
-        return cls(ai_confidence_threshold=int(value) if value is not None else None)
+    ai_confidence_threshold: Optional[int] = field(
+        default_factory=lambda: (
+            int(os.getenv("AI_CONFIDENCE_THRESHOLD"))
+            if os.getenv("AI_CONFIDENCE_THRESHOLD") is not None
+            else None
+        )
+    )
 
 
 @dataclass
@@ -80,6 +87,7 @@ class AppSettings:
     database: DatabaseSettings = field(default_factory=DatabaseSettings)
     security: SecuritySettings = field(default_factory=SecuritySettings)
     analytics: AnalyticsSettings = field(default_factory=AnalyticsSettings)
+    performance: PerformanceSettings = field(default_factory=PerformanceSettings)
     name: str = field(
         default_factory=lambda: os.getenv("APP_NAME", "Yōsai Intel Dashboard")
     )


### PR DESCRIPTION
## Summary
- remove runtime callback patch from analytics CLI
- add missing config defaults for connection timeout, upload limits, and performance settings

## Testing
- `python tools/cli_analytics_fixed.py` *(fails: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_689140ca96108320b14e1b48769b7eeb