### PR TITLE
Use register_handler in validation middleware

### DIFF
--- a/tools/cli_analytics_fixed.py
+++ b/tools/cli_analytics_fixed.py
@@ -3,6 +3,8 @@
 Test Analytics with callback fix applied
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -13,20 +15,6 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from yosai_intel_dashboard.src.utils.text_utils import safe_text
-
-# Apply callback patch first
-try:
-    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
-        TrulyUnifiedCallbacks as CallbackManager,
-    )
-
-    if hasattr(CallbackManager, "handle_register") and not hasattr(
-        CallbackManager, "register_handler"
-    ):
-        CallbackManager.register_handler = CallbackManager.handle_register
-        print("✅ Callback patch applied")
-except Exception as e:
-    print(f"⚠️  Callback patch failed: {safe_text(e)}")
 
 
 async def test_analytics_with_fix():

--- a/yosai_intel_dashboard/src/core/protocols/__init__.py
+++ b/yosai_intel_dashboard/src/core/protocols/__init__.py
@@ -5,6 +5,7 @@ Defines clear contracts for all major system components
 """
 """Protocol interfaces for core services used across the project."""
 
+import warnings
 from abc import abstractmethod
 from datetime import datetime
 from typing import (
@@ -18,7 +19,6 @@ from typing import (
     Tuple,
     runtime_checkable,
 )
-import warnings
 
 import pandas as pd
 
@@ -221,6 +221,7 @@ class ConfigProviderProtocol(Protocol):
 @runtime_checkable
 class ConfigurationServiceProtocol(Protocol):
     """Interface for accessing runtime configuration values."""
+
     ai_confidence_threshold: float
     max_upload_size_mb: int
     upload_chunk_size: int
@@ -433,7 +434,7 @@ class CallbackSystemProtocol(Protocol):
     """Protocol for the unified callback system."""
 
     @abstractmethod
-    def handle_register_event(
+    def register_event(
         self,
         event: CallbackEvent,
         func: Callable[..., Any],

--- a/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
+++ b/yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py
@@ -1,14 +1,20 @@
 """Flask request validation middleware."""
 
+from __future__ import annotations
+
 from typing import Callable, Optional, Protocol
 
 from flask import Response, request
 
-from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import dynamic_config
-from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.exceptions import ValidationError
 from validation.security_validator import SecurityValidator
+from yosai_intel_dashboard.src.core.exceptions import ValidationError
+from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
+from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+    dynamic_config,
+)
 
 
 class Validator(Protocol):
@@ -48,8 +54,8 @@ class ValidationMiddleware:
 
     def handle_registers(self, manager: TrulyUnifiedCallbacks) -> None:
         """Register validation hooks with the callback manager."""
-        manager.handle_register(CallbackEvent.BEFORE_REQUEST, self.validate_request)
-        manager.handle_register(CallbackEvent.AFTER_REQUEST, self.sanitize_response)
+        manager.register_handler(CallbackEvent.BEFORE_REQUEST, self.validate_request)
+        manager.register_handler(CallbackEvent.AFTER_REQUEST, self.sanitize_response)
 
     def validate_request(self) -> None:
         # Enforce maximum request body size
@@ -73,7 +79,10 @@ class ValidationMiddleware:
             ):
                 return None
             try:
-                from yosai_intel_dashboard.src.core.unicode import safe_unicode_decode, sanitize_for_utf8
+                from yosai_intel_dashboard.src.core.unicode import (
+                    safe_unicode_decode,
+                    sanitize_for_utf8,
+                )
 
                 raw_text = safe_unicode_decode(request.data, "utf-8")
                 sanitized = sanitize_for_utf8(raw_text)


### PR DESCRIPTION
## Summary
- switch validation middleware to `register_handler` for before and after request callbacks
- drop legacy `handle_register` patch in CLI analytics helper
- rename callback protocol method to `register_event`

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/security/validation_middleware.py tools/cli_analytics_fixed.py yosai_intel_dashboard/src/core/protocols/__init__.py`
- `pytest tests/security/test_validation_middleware.py tests/test_validation_middleware.py` *(fails: AttributeError: 'SecuritySettings' object has no attribute 'max_upload_mb')*


------
https://chatgpt.com/codex/tasks/task_e_689140c90a1483209c56b138e2223dd8