### PR TITLE
Remove unreachable fallback in upload data retrieval

### DIFF
--- a/yosai_intel_dashboard/src/services/upload/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_processing.py
@@ -133,9 +133,6 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
         store = get_uploaded_data_store()
         return store.get_all_data()
 
-        return {}
-
-
 # Expose commonly used methods at module level for convenience
 get_analytics_from_uploaded_data = (
     UploadAnalyticsProcessor.get_analytics_from_uploaded_data


### PR DESCRIPTION
## Summary
- drop dead `return {}` after returning store data in `UploadAnalyticsProcessor.load_uploaded_data`

## Testing
- `pytest tests/test_upload_processing_module.py -q` *(fails: TypeError: '_LazyModule' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6891b33b82488320b1883344649bf4a1