### PR TITLE
Handle empty uploaded analytics

### DIFF
--- a/tests/test_upload_processing_no_data.py
+++ b/tests/test_upload_processing_no_data.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal pandas stub
+pd_stub = types.SimpleNamespace(DataFrame=object)
+sys.modules["pandas"] = pd_stub
+
+# Stub utils.upload_store
+tils_pkg = types.ModuleType("yosai_intel_dashboard.src.utils")
+tils_pkg.__path__ = []
+upload_store_mod = types.ModuleType("upload_store")
+
+
+def _store():
+    class Store:
+        def get_all_data(self):
+            return {}
+    return Store()
+
+upload_store_mod.get_uploaded_data_store = _store
+sys.modules["yosai_intel_dashboard.src.utils"] = tils_pkg
+sys.modules["yosai_intel_dashboard.src.utils.upload_store"] = upload_store_mod
+
+# Prepare package hierarchy to support relative imports without executing __init__
+root = Path(__file__).resolve().parents[1]
+package_paths = {
+    "yosai_intel_dashboard": root / "yosai_intel_dashboard",
+    "yosai_intel_dashboard.src": root / "yosai_intel_dashboard/src",
+    "yosai_intel_dashboard.src.services": root / "yosai_intel_dashboard/src/services",
+    "yosai_intel_dashboard.src.services.upload": root / "yosai_intel_dashboard/src/services/upload",
+}
+for name, path in package_paths.items():
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        mod.__path__ = [str(path)]
+        sys.modules[name] = mod
+
+module_name = "yosai_intel_dashboard.src.services.upload.upload_processing"
+file_path = package_paths["yosai_intel_dashboard.src.services.upload"] / "upload_processing.py"
+spec = importlib.util.spec_from_file_location(module_name, file_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+UploadAnalyticsProcessor = module.UploadAnalyticsProcessor
+
+
+def test_get_analytics_from_uploaded_data_no_data(monkeypatch):
+    proc = UploadAnalyticsProcessor(object(), object(), object(), object(), object())
+    monkeypatch.setattr(proc, "load_uploaded_data", lambda: {})
+    assert proc.get_analytics_from_uploaded_data() == {"status": "no_data"}

--- a/yosai_intel_dashboard/src/services/upload/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_processing.py
@@ -31,6 +31,8 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
         """Load uploaded data and return aggregated analytics."""
         try:
             data = self._load_data()
+            if not data:
+                return {"status": "no_data"}
             stats = self._process_uploaded_data_directly(data)
             return self._format_results(stats)
         except Exception as exc:  # pragma: no cover - best effort
@@ -102,6 +104,7 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
                 "active_users": 0,
                 "active_doors": 0,
                 "date_range": {"start": "Unknown", "end": "Unknown"},
+                "status": "no_data",
             }
 
 


### PR DESCRIPTION
## Summary
- return `{"status": "no_data"}` when uploaded data store is empty
- mark statistics results with `no_data` status when no frames provided
- add regression test for empty analytics processing

## Testing
- `pytest tests/test_upload_processing_no_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891b33d42548320b486ad08526fffe9