### PR TITLE
feat: add testing infrastructure helpers

### DIFF
--- a/tests/infrastructure/__init__.py
+++ b/tests/infrastructure/__init__.py
@@ -1,131 +1,117 @@
+"""Utilities for constructing common objects used in tests.
+
+This module provides two small helpers:
+
+``TestInfrastructure``
+    Prepares a minimal environment so tests can run without optional
+    dependencies.  It adds ``tests/stubs`` to ``sys.path`` and ensures that
+    light‑weight stand‑ins for heavy packages such as :mod:`pyarrow`,
+    :mod:`pandas` and :mod:`numpy` are present in :data:`sys.modules`.
+
+``MockFactory``
+    Convenience factory that wires together frequently used objects like
+    :class:`SecurityValidator` or :class:`UploadAnalyticsProcessor`.
+"""
+
 from __future__ import annotations
 
 import importlib
-import os
 import sys
-from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, Iterable, Iterator
-
-
-class MockFactory:
-    """Factory responsible for installing and removing stub modules.
-
-    The factory keeps track of all modules it injects into ``sys.modules`` so
-    the original modules can be restored once tests complete.
-    """
-
-    def __init__(self) -> None:
-        self._originals: Dict[str, ModuleType | None] = {}
-        self._installed: set[str] = set()
-
-    def stub(self, name: str, module: ModuleType | None = None) -> ModuleType:
-        """Register ``module`` under ``name`` in ``sys.modules``.
-
-        If no module is provided a new empty :class:`ModuleType` is created.
-        The previous module (if any) is stored so it can be restored later.
-        """
-
-        if name not in self._originals:
-            self._originals[name] = sys.modules.get(name)
-        if module is None:
-            module = ModuleType(name.rsplit(".", 1)[-1])
-        sys.modules[name] = module
-        self._installed.add(name)
-        return module
-
-    def restore(self) -> None:
-        """Restore all modules that were previously stubbed."""
-
-        for name in list(self._installed):
-            original = self._originals.get(name)
-            if original is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = original
-        self._installed.clear()
-        self._originals.clear()
+from typing import Any, Dict
 
 
 class TestInfrastructure:
-    """Context manager that prepares a lightweight test environment.
+    """Prepare the Python environment for tests."""
 
-    On enter all stub packages located under ``tests/stubs`` are made
-    importable and registered in :data:`sys.modules` so they override any real
-    dependency.  Environment variables enabling lightweight service behaviour
-    are also set.  All changes are reverted on exit.
-    """
-
-    def __init__(
-        self,
-        factory: MockFactory,
-        *,
-        stub_packages: Iterable[str] | None = None,
-    ) -> None:
-        self.factory = factory
-        self.stub_packages = list(stub_packages or [])
+    def __init__(self) -> None:
         self._stubs_path = Path(__file__).resolve().parents[1] / "stubs"
-        self._old_sys_path: list[str] = []
 
-    def _discover_stubs(self) -> Iterable[str]:
-        if self.stub_packages:
-            return self.stub_packages
-        if not self._stubs_path.exists():
-            return []
-        names = []
-        for entry in self._stubs_path.iterdir():
-            if entry.name == "__pycache__":
+    # ------------------------------------------------------------------
+    def setup_environment(self) -> None:
+        """Register stub modules and make ``tests/stubs`` importable."""
+
+        stubs = str(self._stubs_path)
+        if stubs not in sys.path:
+            sys.path.insert(0, stubs)
+
+        for name in ("pyarrow", "pandas", "numpy"):
+            if name in sys.modules:
                 continue
-            if entry.is_dir() or entry.suffix == ".py":
-                names.append(entry.stem)
-        return names
-
-    def __enter__(self) -> MockFactory:
-        self._old_sys_path = list(sys.path)
-        stubs_str = str(self._stubs_path)
-        if stubs_str not in sys.path:
-            sys.path.insert(0, stubs_str)
-
-        for name in self._discover_stubs():
             try:
-                module = importlib.import_module(f"tests.stubs.{name}")
-            except Exception:
-                module = ModuleType(name)
-            self.factory.stub(name, module)
-
-        os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
-        return self.factory
-
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - cleanup
-        self.factory.restore()
-        os.environ.pop("LIGHTWEIGHT_SERVICES", None)
-        stubs_str = str(self._stubs_path)
-        if stubs_str in sys.path:
-            sys.path.remove(stubs_str)
-        sys.path[:] = self._old_sys_path
+                importlib.import_module(name)
+            except Exception:  # pragma: no cover - best effort
+                try:
+                    sys.modules[name] = importlib.import_module(f"tests.stubs.{name}")
+                except Exception:  # pragma: no cover - defensive
+                    sys.modules[name] = ModuleType(name)
 
 
-mock_factory = MockFactory()
+class MockFactory:
+    """Factory that exposes common building blocks for tests."""
+
+    # ------------------------------------------------------------------
+    def security_validator(self):
+        from validation.security_validator import SecurityValidator
+
+        return SecurityValidator()
+
+    # ------------------------------------------------------------------
+    def processor(self, validator=None):
+        from yosai_intel_dashboard.src.services.data_processing.processor import (
+            Processor,
+        )
+
+        validator = validator or self.security_validator()
+        return Processor(validator=validator)
+
+    # ------------------------------------------------------------------
+    def callback_manager(self, event_bus=None, validator=None):
+        from yosai_intel_dashboard.src.core.events import EventBus
+        from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+            TrulyUnifiedCallbacks,
+        )
+
+        event_bus = event_bus or EventBus()
+        validator = validator or self.security_validator()
+        return TrulyUnifiedCallbacks(event_bus=event_bus, security_validator=validator)
+
+    # ------------------------------------------------------------------
+    def upload_processor(self):
+        from yosai_intel_dashboard.src.core.events import EventBus
+        from yosai_intel_dashboard.src.infrastructure.config.dynamic_config import (
+            dynamic_config,
+        )
+        from yosai_intel_dashboard.src.services.analytics.upload_analytics import (
+            UploadAnalyticsProcessor,
+        )
+
+        validator = self.security_validator()
+        processor = self.processor(validator)
+        event_bus = EventBus()
+        callbacks = self.callback_manager(event_bus, validator)
+        return UploadAnalyticsProcessor(
+            validator, processor, callbacks, dynamic_config.analytics, event_bus
+        )
+
+    # ------------------------------------------------------------------
+    def dataframe(self, columns: Dict[str, Any]):
+        from tests.utils.builders import DataFrameBuilder
+
+        builder = DataFrameBuilder()
+        for name, values in columns.items():
+            builder.add_column(name, values)
+        return builder.build()
 
 
-@contextmanager
-def setup_test_environment() -> Iterator[MockFactory]:
-    """Prepare a lightweight environment for tests.
+# ----------------------------------------------------------------------
+def uploaded_data(valid_df):
+    """Return a typical uploaded data mapping used in tests."""
 
-    The context manager installs stub packages and yields the global
-    :class:`MockFactory` so tests can register additional stubs if required.
-    All changes are reverted when the context exits.
-    """
+    import pandas as pd
 
-    infra = TestInfrastructure(mock_factory)
-    with infra:
-        yield mock_factory
+    return {"empty.csv": pd.DataFrame(), "valid.csv": valid_df}
 
 
-__all__ = [
-    "MockFactory",
-    "TestInfrastructure",
-    "setup_test_environment",
-    "mock_factory",
-]
+__all__ = ["TestInfrastructure", "MockFactory", "uploaded_data"]


### PR DESCRIPTION
## Summary
- add TestInfrastructure for loading stub modules during tests
- provide MockFactory for common objects like validators and processors
- include helper utilities for uploaded data scenarios

## Testing
- `pytest tests/infrastructure -q`
- `pre-commit run --files tests/infrastructure/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6891b35070d483208e780941bd39af52