### PR TITLE
test: ensure optional dependency stubs are loaded

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -102,6 +102,13 @@ lightweight stubs for optional dependencies. It reads `TEST_SECRET_KEY` and
 defaults when they are absent. Importing it manually is rarely necessary, but it
 can be handy when running individual files.
 
+`tests/infrastructure.TestInfrastructure.setup_environment()` performs a similar
+bootstrapping step for integration tests. It appends the `tests/stubs`
+directory to `sys.path` and injects stub modules such as `pyarrow`, `pandas` and
+`numpy` into `sys.modules` when they are missing. New stubs can be provided by
+dropping a module or package into `tests/stubs` or by calling
+`tests.infrastructure.mock_factory.stub("name")` inside a test.
+
 Without one of these steps you may encounter `ModuleNotFoundError` during test
 collection.
 


### PR DESCRIPTION
## Summary
- add `setup_environment` to `TestInfrastructure` to append `tests/stubs` to `sys.path` and auto register core stubs like `pyarrow`, `pandas` and `numpy`
- document registering additional stub modules for tests

## Testing
- `pre-commit run --files tests/infrastructure/__init__.py docs/test_setup.md` *(fails: mypy finds 769 errors; bandit fails)*
- `pytest tests/infrastructure/test_database_manager.py::test_database_manager_success -q`
- `pytest tests/infrastructure/test_redis_clients.py::test_clients_use_distinct_dbs -q`
- `pytest tests/integration/test_upload_pipeline.py::test_upload_pipeline_filters_empty_and_returns_stats -q` *(fails: TypeError: 'module' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_6891b356d0748320af813486d8dfdc61