### PR TITLE
Register config alias for dynamic configuration

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -111,6 +111,11 @@ def register_core_infrastructure(container: ServiceContainer) -> None:
         protocol=ConfigProviderProtocol,
     )
     container.register_singleton(
+        "config",
+        dynamic_config,
+        protocol=ConfigProviderProtocol,
+    )
+    container.register_singleton(
         "configuration_service",
         DynamicConfigurationService,
         protocol=ConfigurationServiceProtocol,

--- a/yosai_intel_dashboard/src/infrastructure/initialization.py
+++ b/yosai_intel_dashboard/src/infrastructure/initialization.py
@@ -42,6 +42,7 @@ class ApplicationInitializer:
         assert self._container is not None
         required = [
             "config",
+            "dynamic_config",
             "callback_manager",
             "security_validator",
             "processor",


### PR DESCRIPTION
## Summary
- expose `dynamic_config` under a `config` alias in the service container for backwards compatibility
- include `dynamic_config` in the application initializer's required services check

## Testing
- `python - <<'PY'
from yosai_intel_dashboard.src.infrastructure.initialization import app_initializer
app_initializer.get_container()
PY` *(fails: ImportError: cannot import name 'RetryStrategy')*


------
https://chatgpt.com/codex/tasks/task_e_6891bb4bc18483209c86804cee1a400d