### PR TITLE
Register upload services before analytics

### DIFF
--- a/startup/service_registration.py
+++ b/startup/service_registration.py
@@ -48,13 +48,18 @@ def register_upload_services(container: ServiceContainer) -> None:
 
 
 def register_all_services(container: ServiceContainer) -> None:
-    """Register all services with the container."""
+    """Register all services with the container.
+
+    Upload services are registered before analytics services so that
+    analytics components can resolve their upload dependencies.
+    """
 
     register_infrastructure_services(container)
     register_security_services(container)
     register_business_services(container)
-    register_analytics_services(container)
+    # Upload services must precede analytics to satisfy dependencies
     register_upload_services(container)
+    register_analytics_services(container)
 
 
 def register_all_application_services(container: ServiceContainer) -> None:


### PR DESCRIPTION
## Summary
- register upload services before analytics services
- document that upload services must precede analytics to satisfy dependencies

## Testing
- `python - <<'PY'
from startup.service_registration import ServiceContainer, register_all_services

container = ServiceContainer()
register_all_services(container)
container.validate_registrations()
print('Service registrations validated successfully')
PY` *(fails: cannot import name 'ConfigurationProtocol')*
- `pytest tests/test_service_integration.py::TestServiceIntegration::test_new_service_registrations -q` *(fails: ImportError: cannot import name 'ConfigurationProtocol')*

------
https://chatgpt.com/codex/tasks/task_e_6891bb4ecb788320a2c5885b864e68a0