### PR TITLE
Remove obsolete callback patch entry

### DIFF
--- a/scripts/remove_runtime_patches.py
+++ b/scripts/remove_runtime_patches.py
@@ -13,7 +13,6 @@ PATCH_FILES = [
     Path("tools/step2_add_missing_methods.py"),
     Path("tools/step2_final_fix.py"),
     Path("tools/test_analytics_both_fixes.py"),
-    Path("tools/apply_callback_patch.py"),
 ]
 
 EXPECTED_UPLOAD_METHODS = [


### PR DESCRIPTION
## Summary
- drop `tools/apply_callback_patch.py` from runtime patch removal list

## Testing
- `rg apply_callback_patch`
- `python scripts/remove_runtime_patches.py --dry-run --skip-verify --no-backup`

------
https://chatgpt.com/codex/tasks/task_e_6891c013b1988320b2df5ebe59a028f4