### PR TITLE
chore: remove old dashboard

### DIFF
--- a/deprecation.yml
+++ b/deprecation.yml
@@ -2,10 +2,6 @@
   deprecated_since: 1.2.0
   removal_version: 2.0.0
   migration_path: docs/migration/legacy-auth.md
-- component: old-dashboard
-  deprecated_since: 1.5.0
-  removal_version: 2.1.0
-  migration_path: docs/migration/new-dashboard.md
 - component: database-manager
   deprecated_since: 2.4.0
   removal_version: 3.0.0

--- a/docs/deprecation_timeline.md
+++ b/docs/deprecation_timeline.md
@@ -7,11 +7,9 @@ This document summarizes features scheduled for removal and links to their migra
 | Component | Deprecated Since | Removal Version | Migration Guide |
 |-----------|-----------------|-----------------|----------------|
 | legacy-auth | 1.2.0 | 2.0.0 | [Legacy Auth Migration](migration/legacy-auth.md) |
-| old-dashboard | 1.5.0 | 2.1.0 | [New Dashboard Migration](migration/new-dashboard.md) |
 | database-manager | 2.4.0 | 3.0.0 | [Database Manager to Factory Migration](migration/database_manager_to_factory.md) |
 
 - [Legacy Auth Migration](migration/legacy-auth.md)
-- [New Dashboard Migration](migration/new-dashboard.md)
 - [Database Manager to Factory Migration](migration/database_manager_to_factory.md)
 
 

--- a/old_dashboard/__init__.py
+++ b/old_dashboard/__init__.py
@@ -1,5 +1,0 @@
-"""Deprecated old_dashboard module."""
-
-from yosai_intel_dashboard.src.utils.deprecation import warn
-
-warn("old-dashboard")


### PR DESCRIPTION
## Summary
- remove deprecated `old_dashboard` package
- drop `old-dashboard` entries from deprecation configs and docs

## Testing
- `pre-commit run --files deprecation.yml docs/deprecation_timeline.md`


------
https://chatgpt.com/codex/tasks/task_e_6891d41ba7208320b91e1c225cb293d0