### PR TITLE
chore: deprecate deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-if [[ "${1:-}" == "--dry-run" ]]; then
-  echo "[DRY RUN] Would deploy image tag $(git rev-parse --short HEAD)"
-  exit 0
-fi
+# This script has been deprecated. Deployment is now handled by the CI/CD pipeline.
+# See docs/ci-cd.md for details.
 
-if [[ "${GENERATE_INDEX_MIGRATIONS:-}" == "1" ]]; then
-  echo "Generating index migration script"
-  python3 services/query_optimizer_cli.py migrate "SELECT 1" migrations/generated_indexes.sql || true
-fi
-
-echo "Deploying image tag $(git rev-parse --short HEAD)"
-# Placeholder for real deployment commands
-
-if [[ -n "${CDN_DISTRIBUTION_ID:-}" ]]; then
-  echo "Invalidating CDN distribution $CDN_DISTRIBUTION_ID"
-  aws cloudfront create-invalidation --distribution-id "$CDN_DISTRIBUTION_ID" --paths "/*"
-fi
-
+echo "Deployment is handled by the CI/CD pipeline. See docs/ci-cd.md."
+exit 1


### PR DESCRIPTION
## Summary
- replace obsolete deploy.sh with notice to use CI/CD pipeline

## Testing
- `pre-commit run --files deploy.sh`

------
https://chatgpt.com/codex/tasks/task_e_6891d425e634832081ab661e97beab68