### PR TITLE
docs: reference rollback script path

### DIFF
--- a/docs/distributed_state.md
+++ b/docs/distributed_state.md
@@ -47,6 +47,6 @@ Then point the service at this file:
 export FEATURE_FLAG_SOURCE=/path/to/feature_flags.json
 ```
 
-Run `scripts/rollback.sh` to flip the Kubernetes service selector back to
+Run `./scripts/rollback.sh` to flip the Kubernetes service selector back to
 the previous deployment.  The dashboard will then operate as a
 self‑contained monolith until the microservices are re‑enabled.

--- a/docs/operations_guide.md
+++ b/docs/operations_guide.md
@@ -216,7 +216,7 @@ kubectl rollout status deployment/yosai-dashboard -n yosai-dev
 #### Manual rollback script
 
 ```bash
-scripts/rollback.sh [service] [namespace]
+./scripts/rollback.sh [service] [namespace]
 ```
 
 The script switches the service selector between blue and green deployments. It

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -6,14 +6,14 @@ This project uses a blue/green deployment strategy so that old and new versions 
 2. Verify the new pods are healthy.
 3. Switch the service selector from blue to green:
    ```bash
-   scripts/rollback.sh
+   ./scripts/rollback.sh
    ```
 4. Monitor the deployment. If problems occur, run the script again to switch back to the previous color.
 
 The script accepts the service name and namespace as optional arguments:
 
 ```bash
-scripts/rollback.sh <service> <namespace>
+./scripts/rollback.sh <service> <namespace>
 ```
 
 By default it operates on the `yosai-dashboard` service in the `default` namespace.


### PR DESCRIPTION
## Summary
- show rollback command as ./scripts/rollback.sh in docs

## Testing
- `pre-commit run --files docs/operations_guide.md docs/rollback.md docs/distributed_state.md`

------
https://chatgpt.com/codex/tasks/task_e_689239d69de48320a1164ea6b22b9289