### PR TITLE
docs: document requirements usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The project uses two primary requirement files to manage Python dependencies:
 - `requirements-dev.txt` – extends the base requirements with development and test tools.
 
 Service-specific and test-only requirement files have been removed to avoid version drift. Add new dependencies to one of the files above as appropriate.
+See [docs/requirements.md](docs/requirements.md) for details on installing them.
 
 5. **Set up environment:**
     ```bash

--- a/docs/column_verification.md
+++ b/docs/column_verification.md
@@ -32,6 +32,6 @@ ID `save-column-mappings` writes the selected mappings using
 - `dash-bootstrap-components`
 - `pandas`
 
-These packages are listed in `requirements-ui.txt` and `requirements.txt`.
-Ensure they are installed before enabling the component.
+These packages are included in the core `requirements.txt` file.
+Ensure it is installed before enabling the component.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,21 @@
+# Python requirements
+
+The project uses two requirement files to manage Python dependencies.
+
+- `requirements.txt` – core runtime packages required for the application and services.
+- `requirements-dev.txt` – includes `-r requirements.txt` and adds development and testing tools.
+
+Install the base dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+For development or running the test suite install the extended set:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+These files replace older service-specific requirement lists that caused version drift.
+Add new dependencies to one of them as appropriate.


### PR DESCRIPTION
## Summary
- document `requirements.txt` and `requirements-dev.txt` as the only Python requirement files
- drop outdated `requirements-ui.txt` reference in column verification documentation
- link dependency docs from README

## Testing
- `pre-commit run --files docs/requirements.md docs/column_verification.md README.md`
- `pytest -q` *(fails: 329 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689239c10bcc8320a8b393e24403a169