### PR TITLE
chore: use confluent-kafka dependency

### DIFF
--- a/confluent_kafka/__init__.py
+++ b/confluent_kafka/__init__.py
@@ -1,9 +1,0 @@
-class Consumer:
-    def __init__(self, *args, **kwargs):
-        pass
-
-
-class Producer:
-    def __init__(self, *args, **kwargs):
-
-        pass

--- a/confluent_kafka/admin.py
+++ b/confluent_kafka/admin.py
@@ -1,3 +1,0 @@
-class AdminClient:
-    def __init__(self, *args, **kwargs):
-        pass

--- a/confluent_kafka/avro.py
+++ b/confluent_kafka/avro.py
@@ -1,6 +1,0 @@
-class AvroConsumer:
-    pass
-
-
-class AvroProducer:
-    pass


### PR DESCRIPTION
## Summary
- remove local `confluent_kafka` stub
- rely on `confluent-kafka` package via requirements

## Testing
- `pre-commit run --files requirements.txt`
- `pytest tests/test_dependency_recovery.py -q` *(fails: ImportError: cannot import name 'DatabaseManager')*

------
https://chatgpt.com/codex/tasks/task_e_689239ba93f4832088432491b9677a66