### PR TITLE
refactor: unify startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app /app
 
-CMD ["python", "-m", "yosai_intel_dashboard.src.services.main"]
+CMD ["python", "start_api.py"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["python", "-m", "yosai_intel_dashboard.src.services.main"]
+    command: ["python", "start_api.py"]
     volumes:
       - .:/app
     environment:

--- a/helm/yosai-intel/templates/deployment.yaml
+++ b/helm/yosai-intel/templates/deployment.yaml
@@ -33,8 +33,6 @@ spec:
           env:
             - name: PYTHONPATH
               value: {{ .Values.pythonPath | quote }}
-            - name: MODULE_PATH
-              value: {{ .Values.modulePath | quote }}
             - name: ENABLE_LEGACY_IMPORTS
               value: {{ .Values.enableLegacyImports | quote }}
           livenessProbe:

--- a/helm/yosai-intel/values.yaml
+++ b/helm/yosai-intel/values.yaml
@@ -29,7 +29,6 @@ resources:
     memory: 512Mi
 
 pythonPath: "/app:/app/yosai_intel_dashboard/src"
-modulePath: "yosai_intel_dashboard.src.services.main"
 enableLegacyImports: "true"
 probes:
   liveness: "/health/live"

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -28,5 +28,4 @@ data:
   TIMESCALE_DB_NAME: "yosai_timescale"
   TIMESCALE_DB_USER: "postgres"
   PYTHONPATH: "/app:/app/yosai_intel_dashboard/src"
-  MODULE_PATH: "yosai_intel_dashboard.src.services.main"
   ENABLE_LEGACY_IMPORTS: "true"

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -27,8 +27,6 @@ spec:
           env:
             - name: PYTHONPATH
               value: "/app:/app/yosai_intel_dashboard/src"
-            - name: MODULE_PATH
-              value: "yosai_intel_dashboard.src.services.main"
             - name: ENABLE_LEGACY_IMPORTS
               value: "true"
           readinessProbe:

--- a/k8s/canary/deployment.yaml
+++ b/k8s/canary/deployment.yaml
@@ -54,8 +54,6 @@ spec:
               value: "6379"
             - name: PYTHONPATH
               value: "/app:/app/yosai_intel_dashboard/src"
-            - name: MODULE_PATH
-              value: "yosai_intel_dashboard.src.services.main"
             - name: ENABLE_LEGACY_IMPORTS
               valueFrom:
                 configMapKeyRef:

--- a/k8s/production/configmap.yaml
+++ b/k8s/production/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: yosai-prod
 data:
   PYTHONPATH: "/app:/app/yosai_intel_dashboard/src"
-  MODULE_PATH: "yosai_intel_dashboard.src.services.main"
   ENABLE_LEGACY_IMPORTS: "true"

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -64,8 +64,6 @@ spec:
               value: "6379"
             - name: PYTHONPATH
               value: "/app:/app/yosai_intel_dashboard/src"
-            - name: MODULE_PATH
-              value: "yosai_intel_dashboard.src.services.main"
             - name: ENABLE_LEGACY_IMPORTS
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary
- run start_api.py as the sole entrypoint
- drop MODULE_PATH from Helm and Kubernetes configs

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml helm/yosai-intel/values.yaml helm/yosai-intel/templates/deployment.yaml k8s/base/configmap.yaml k8s/base/deployment.yaml k8s/production/configmap.yaml k8s/production/deployment.yaml k8s/canary/deployment.yaml`
- `pytest` *(fails: cannot import name 'object_count'...)*

------
https://chatgpt.com/codex/tasks/task_e_689239a4f76c83208a2c9a337e37140b