### PR TITLE
refactor: decouple unicode utilities

### DIFF
--- a/tests/test_callback_fix.py
+++ b/tests/test_callback_fix.py
@@ -36,7 +36,8 @@ except Exception:  # pragma: no cover
     _callback_registry = _StubRegistry()
 
 try:  # pragma: no cover
-    from yosai_intel_dashboard.src.core.unicode import safe_decode_bytes, safe_encode_text
+    from yosai_intel_dashboard.src.core.unicode import safe_decode_bytes
+    from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 except Exception:  # pragma: no cover
     def safe_encode_text(text: str) -> str:  # type: ignore[misc]
         return text.encode("utf-8", errors="ignore").decode("utf-8")

--- a/tests/test_unicode_cleaner.py
+++ b/tests/test_unicode_cleaner.py
@@ -2,9 +2,9 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.core.unicode import (
     UnicodeProcessor,
-    safe_encode_text,
     sanitize_dataframe,
 )
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 
 
 def test_clean_dataframe_removes_surrogates():

--- a/tests/test_unicode_handler_full.py
+++ b/tests/test_unicode_handler_full.py
@@ -9,10 +9,12 @@ from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import
 from yosai_intel_dashboard.src.core.unicode import (
     ChunkedUnicodeProcessor,
     UnicodeProcessor,
-    clean_unicode_text,
     safe_decode_bytes,
-    safe_encode_text,
     sanitize_dataframe,
+)
+from yosai_intel_dashboard.src.core.base_utils import (
+    clean_unicode_text,
+    safe_encode_text,
 )
 
 

--- a/tests/test_unicode_processor.py
+++ b/tests/test_unicode_processor.py
@@ -7,10 +7,10 @@ import pytest
 from yosai_intel_dashboard.src.core.unicode import (
     contains_surrogates,
     safe_decode_bytes,
-    safe_encode_text,
     safe_format_number,
     sanitize_dataframe,
 )
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 from yosai_intel_dashboard.src.infrastructure.security.unicode_security_validator import (
     UnicodeSecurityValidator,
 )

--- a/tests/test_unicode_wrappers.py
+++ b/tests/test_unicode_wrappers.py
@@ -9,11 +9,13 @@ from yosai_intel_dashboard.src.core.unicode import (
 from yosai_intel_dashboard.src.core.unicode import (
     UnicodeSQLProcessor,
     clean_unicode_surrogates,
-    clean_unicode_text,
     contains_surrogates,
-    safe_encode_text,
     sanitize_dataframe,
     sanitize_unicode_input,
+)
+from yosai_intel_dashboard.src.core.base_utils import (
+    clean_unicode_text,
+    safe_encode_text,
 )
 from yosai_intel_dashboard.src.infrastructure.config.database_exceptions import (
     UnicodeEncodingError,

--- a/tools/validate_unicode_cleanup.py
+++ b/tools/validate_unicode_cleanup.py
@@ -13,10 +13,10 @@ from yosai_intel_dashboard.src.core.unicode import UnicodeProcessor
 # Ensure project root is importable
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from yosai_intel_dashboard.src.core.unicode import (
+from yosai_intel_dashboard.src.core.unicode import sanitize_dataframe
+from yosai_intel_dashboard.src.core.base_utils import (
     clean_unicode_text,
     safe_encode_text,
-    sanitize_dataframe,
 )
 
 

--- a/tools/validate_unicode_migration.py
+++ b/tools/validate_unicode_migration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from yosai_intel_dashboard.src.core.unicode import clean_unicode_text, safe_encode_text
+from yosai_intel_dashboard.src.core.base_utils import clean_unicode_text, safe_encode_text
 
 
 def main() -> None:

--- a/unicode_toolkit/__init__.py
+++ b/unicode_toolkit/__init__.py
@@ -6,10 +6,12 @@ from yosai_intel_dashboard.src.core.unicode import (
     UnicodeProcessor,
     UnicodeSQLProcessor,
     clean_unicode_surrogates,
-    clean_unicode_text,
-    safe_encode_text,
     sanitize_dataframe,
     sanitize_unicode_input,
+)
+from yosai_intel_dashboard.src.core.base_utils import (
+    clean_unicode_text,
+    safe_encode_text,
 )
 from yosai_intel_dashboard.src.infrastructure.security.unicode_security_validator import (
     UnicodeSecurityValidator as UnicodeValidator,

--- a/unicode_toolkit/helpers.py
+++ b/unicode_toolkit/helpers.py
@@ -9,7 +9,7 @@ from yosai_intel_dashboard.src.core.unicode import (
     UnicodeSQLProcessor,
 )
 from yosai_intel_dashboard.src.core.unicode import clean_unicode_surrogates as _clean_unicode_surrogates
-from yosai_intel_dashboard.src.core.unicode import safe_encode_text as _safe_encode_text
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text as _safe_encode_text
 from yosai_intel_dashboard.src.core.unicode import (
     sanitize_dataframe,
 )

--- a/yosai_intel_dashboard/src/core/base_utils.py
+++ b/yosai_intel_dashboard/src/core/base_utils.py
@@ -1,0 +1,90 @@
+"""Lightweight text processing helpers used across the project.
+
+These utilities provide safe Unicode handling without importing any other
+project modules.  They intentionally offer a small subset of the features from
+:mod:`core.unicode` so that they can be imported in low level modules without
+creating circular dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+
+# Precompiled regular expressions for performance
+_CONTROL_RE = re.compile(r"[\x00-\x1F\x7F]")
+_SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
+_DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
+
+
+def clean_surrogate_chars(text: str, replacement: str = "") -> str:
+    """Return ``text`` with surrogate code points removed or replaced."""
+
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        code = ord(ch)
+        # High surrogate
+        if 0xD800 <= code <= 0xDBFF:
+            if i + 1 < len(text):
+                next_code = ord(text[i + 1])
+                if 0xDC00 <= next_code <= 0xDFFF:
+                    pair = ((code - 0xD800) << 10) + (next_code - 0xDC00) + 0x10000
+                    out.append(chr(pair))
+                    i += 2
+                    continue
+            if replacement:
+                out.append(replacement)
+            i += 1
+            continue
+        # Low surrogate without preceding high surrogate
+        if 0xDC00 <= code <= 0xDFFF:
+            if replacement:
+                out.append(replacement)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def clean_unicode_text(text: Any) -> str:
+    """Clean ``text`` of surrogates, control chars and dangerous prefixes."""
+
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+    text = clean_surrogate_chars(text)
+    try:
+        text = unicodedata.normalize("NFKC", text)
+    except Exception:
+        pass
+    text = _SURROGATE_RE.sub("", text)
+    text = _CONTROL_RE.sub("", text)
+    text = _DANGEROUS_PREFIX_RE.sub("", text)
+    try:
+        text.encode("utf-8")
+    except UnicodeEncodeError:
+        text = text.encode("utf-8", "ignore").decode("utf-8", "ignore")
+    return text
+
+
+def safe_encode_text(value: Any) -> str:
+    """Return ``value`` encoded safely as Unicode text."""
+
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8", errors="surrogatepass")
+        except Exception:
+            value = value.decode("utf-8", errors="ignore")
+    return clean_unicode_text(value)
+
+
+__all__ = [
+    "safe_encode_text",
+    "clean_surrogate_chars",
+    "clean_unicode_text",
+]

--- a/yosai_intel_dashboard/src/core/unicode.py
+++ b/yosai_intel_dashboard/src/core/unicode.py
@@ -28,6 +28,11 @@ from yosai_intel_dashboard.src.infrastructure.security.unicode_security_validato
     UnicodeSecurityValidator,
 )
 
+from .base_utils import (
+    clean_surrogate_chars,
+    clean_unicode_text,
+    safe_encode_text,
+)
 from .exceptions import SecurityError
 from .security_patterns import (
     PATH_TRAVERSAL_PATTERNS,
@@ -342,17 +347,6 @@ try:  # optional Cython speedup
 except Exception:  # pragma: no cover - extension not built
     pass
 
-
-# ---------------------------------------------------------------------------
-# Preferred public API
-
-
-def clean_unicode_text(text: str) -> str:
-    """Clean ``text`` of surrogates, controls and dangerous prefixes."""
-
-    return _unicode_validator.validate_and_sanitize(text)
-
-
 def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
     """Decode bytes safely, removing unsafe Unicode characters."""
 
@@ -369,13 +363,6 @@ def safe_decode_text(data: bytes, encoding: str = "utf-8") -> str:
     """Safely decode byte data to text."""
 
     return UnicodeProcessor.safe_decode_text(data, encoding)
-
-
-def safe_encode_text(text: Any) -> str:
-    """Return ``text`` encoded safely as Unicode text."""
-
-    return UnicodeProcessor.safe_encode_text(text)
-
 
 def safe_encode(value: Any) -> str:
     """Alias for :func:`UnicodeProcessor.safe_encode`."""
@@ -423,13 +410,6 @@ def safe_unicode_encode(value: Any) -> str:
         stacklevel=2,
     )
     return safe_encode(value)
-
-
-def clean_surrogate_chars(text: str, replacement: str = "") -> str:
-    """Return ``text`` with surrogate code points removed or replaced."""
-
-    return UnicodeProcessor.clean_surrogate_chars(text, replacement)
-
 
 def clean_unicode_surrogates(text: str, replacement: str = "") -> str:
     """Alias for :func:`clean_surrogate_chars`."""

--- a/yosai_intel_dashboard/src/models/ml/base_model.py
+++ b/yosai_intel_dashboard/src/models/ml/base_model.py
@@ -14,7 +14,8 @@ from typing import Any, Dict, Optional
 import joblib
 from packaging.version import Version
 
-from yosai_intel_dashboard.src.core.unicode import clean_unicode_text, contains_surrogates
+from yosai_intel_dashboard.src.core.base_utils import clean_unicode_text
+from yosai_intel_dashboard.src.core.unicode import contains_surrogates
 from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,

--- a/yosai_intel_dashboard/src/services/upload/__init__.py
+++ b/yosai_intel_dashboard/src/services/upload/__init__.py
@@ -11,7 +11,7 @@ set.
 import os
 
 from yosai_intel_dashboard.src.core.interfaces.protocols import FileProcessorProtocol
-from yosai_intel_dashboard.src.core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 from unicode_toolkit import decode_upload_content
 from validation.security_validator import SecurityValidator
 

--- a/yosai_intel_dashboard/src/utils/assets_debug.py
+++ b/yosai_intel_dashboard/src/utils/assets_debug.py
@@ -16,7 +16,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
-from yosai_intel_dashboard.src.core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/create_navbar_assets.py
+++ b/yosai_intel_dashboard/src/utils/create_navbar_assets.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     PIL_AVAILABLE = False
 
-from yosai_intel_dashboard.src.core.unicode import safe_encode_text
+from yosai_intel_dashboard.src.core.base_utils import safe_encode_text
 
 logger = logging.getLogger(__name__)
 

--- a/yosai_intel_dashboard/src/utils/text_utils.py
+++ b/yosai_intel_dashboard/src/utils/text_utils.py
@@ -4,7 +4,7 @@ Text utilities for safe text handling
 
 from typing import Any, Union
 
-from yosai_intel_dashboard.src.core.unicode import clean_surrogate_chars
+from yosai_intel_dashboard.src.core.base_utils import clean_surrogate_chars
 
 
 def safe_text(text: Union[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- add standalone `core.base_utils` with surrogate and encoding helpers
- refactor unicode module and utilities to use `core.base_utils`
- update tests and helper tools for new utility location

## Testing
- `python -m py_compile yosai_intel_dashboard/src/core/base_utils.py yosai_intel_dashboard/src/core/unicode.py yosai_intel_dashboard/src/utils/text_utils.py yosai_intel_dashboard/src/utils/assets_debug.py yosai_intel_dashboard/src/utils/create_navbar_assets.py yosai_intel_dashboard/src/services/upload/__init__.py yosai_intel_dashboard/src/models/ml/base_model.py tools/validate_unicode_migration.py tools/validate_unicode_cleanup.py unicode_toolkit/__init__.py unicode_toolkit/helpers.py tests/test_callback_fix.py tests/test_unicode_handler_full.py tests/test_unicode_wrappers.py tests/test_unicode_processor.py tests/test_unicode_cleaner.py`
- `pytest tests/test_unicode_cleaner.py tests/test_unicode_processor.py tests/test_unicode_wrappers.py tests/test_callback_fix.py -q` *(fails: object() takes no arguments; missing validator APIs; callback registry missing attribute)*

------
https://chatgpt.com/codex/tasks/task_e_6892ae513080832095f031ca251449df