### PR TITLE
refactor: centralize unicode helpers

### DIFF
--- a/yosai_intel_dashboard/src/core/base_utils.py
+++ b/yosai_intel_dashboard/src/core/base_utils.py
@@ -1,46 +1,29 @@
-"""Lightweight text processing helpers used across the project.
-
-These utilities provide safe Unicode handling without importing any other
-project modules.  They intentionally offer a small subset of the features from
-:mod:`core.unicode` so that they can be imported in low level modules without
-creating circular dependencies.
 """
-
-from __future__ import annotations
-
+Lightweight text processing helpers used across the project.
+These utilities avoid imports from other project modules to prevent
+circular dependencies.
+"""
 import re
 import unicodedata
 from typing import Any
 
-# Precompiled regular expressions for performance
 _CONTROL_RE = re.compile(r"[\x00-\x1F\x7F]")
 _SURROGATE_RE = re.compile(r"[\uD800-\uDFFF]")
 _DANGEROUS_PREFIX_RE = re.compile(r"^[=+\-@]+")
 
 
 def clean_surrogate_chars(text: str, replacement: str = "") -> str:
-    """Return ``text`` with surrogate code points removed or replaced."""
-
-    out: list[str] = []
-    i = 0
+    out, i = [], 0
     while i < len(text):
-        ch = text[i]
-        code = ord(ch)
-        # High surrogate
-        if 0xD800 <= code <= 0xDBFF:
-            if i + 1 < len(text):
-                next_code = ord(text[i + 1])
-                if 0xDC00 <= next_code <= 0xDFFF:
-                    pair = ((code - 0xD800) << 10) + (next_code - 0xDC00) + 0x10000
-                    out.append(chr(pair))
-                    i += 2
-                    continue
-            if replacement:
-                out.append(replacement)
-            i += 1
-            continue
-        # Low surrogate without preceding high surrogate
-        if 0xDC00 <= code <= 0xDFFF:
+        ch, code = text[i], ord(text[i])
+        if 0xD800 <= code <= 0xDBFF and i + 1 < len(text):
+            next_code = ord(text[i + 1])
+            if 0xDC00 <= next_code <= 0xDFFF:
+                pair = ((code - 0xD800) << 10) + (next_code - 0xDC00) + 0x10000
+                out.append(chr(pair))
+                i += 2
+                continue
+        if 0xD800 <= code <= 0xDFFF:
             if replacement:
                 out.append(replacement)
             i += 1
@@ -51,8 +34,6 @@ def clean_surrogate_chars(text: str, replacement: str = "") -> str:
 
 
 def clean_unicode_text(text: Any) -> str:
-    """Clean ``text`` of surrogates, control chars and dangerous prefixes."""
-
     if text is None:
         return ""
     if not isinstance(text, str):
@@ -73,8 +54,6 @@ def clean_unicode_text(text: Any) -> str:
 
 
 def safe_encode_text(value: Any) -> str:
-    """Return ``value`` encoded safely as Unicode text."""
-
     if isinstance(value, bytes):
         try:
             value = value.decode("utf-8", errors="surrogatepass")
@@ -83,8 +62,5 @@ def safe_encode_text(value: Any) -> str:
     return clean_unicode_text(value)
 
 
-__all__ = [
-    "safe_encode_text",
-    "clean_surrogate_chars",
-    "clean_unicode_text",
-]
+__all__ = ["safe_encode_text", "clean_surrogate_chars", "clean_unicode_text"]
+


### PR DESCRIPTION
## Summary
- add shared Unicode text helpers in `core.base_utils`
- refactor `core.unicode` to consume shared helpers rather than local implementations
- ensure unicode sanitization utilities and wrappers use shared helpers

## Testing
- `rg "core\.unicode.*safe_encode_text" -n || true`
- `rg "core\.unicode.*clean_surrogate_chars" -n || true`
- `rg "core\.unicode.*clean_unicode_text" -n || true`
- `python -m py_compile yosai_intel_dashboard/src/core/base_utils.py yosai_intel_dashboard/src/core/unicode.py`
- `pytest -q` *(fails: ImportError: cannot import name 'safe_unicode_decode', ModuleNotFoundError: No module named 'pandas', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68931b903da48320a96a3f7c1442c9ad