### PR TITLE
refactor: reduce service init duplication

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/base.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+class RepositoryConfigService:
+    """Base service providing repository/config storage and logging."""
+
+    def __init__(self, repository: Any, config: Any) -> None:
+        self.repository = repository
+        self.config = config
+        self.logger = logging.getLogger(self.__class__.__module__)
+
+
+class BaseCSVProcessor(RepositoryConfigService):
+    """Base class for CSV processors needing a Japanese handler."""
+
+    def __init__(self, repository: Any, japanese_handler: Any, config: Any) -> None:
+        super().__init__(repository, config)
+        self.japanese_handler = japanese_handler

--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/column_mapper.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/column_mapper.py
@@ -1,6 +1,7 @@
 """AI powered column mapping service"""
 
-import logging
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -14,10 +15,10 @@ from yosai_intel_dashboard.src.adapters.api.plugins.ai_classification.database.c
     CSVStorageRepository,
 )
 
-logger = logging.getLogger(__name__)
+from .base import RepositoryConfigService
 
 
-class ColumnMappingService:
+class ColumnMappingService(RepositoryConfigService):
     """Suggest mappings from CSV headers to standard fields."""
 
     STANDARD_FIELDS = {
@@ -63,9 +64,7 @@ class ColumnMappingService:
     def __init__(
         self, repository: CSVStorageRepository, config: ColumnMappingConfig
     ) -> None:
-        self.repository = repository
-        self.config = config
-        self.logger = logger
+        super().__init__(repository, config)
         self.classifier: Optional[ColumnClassifier] = None
         if self.config.learning_enabled:
             self.classifier = ColumnClassifier(

--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/entry_classifier.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/entry_classifier.py
@@ -1,6 +1,7 @@
 """Device mapping and classification service - replaces entry classifier"""
 
-import logging
+from __future__ import annotations
+
 import re
 from collections import Counter
 from typing import Any, Dict, List, Optional
@@ -12,10 +13,10 @@ from yosai_intel_dashboard.src.adapters.api.plugins.ai_classification.database.c
     CSVStorageRepository,
 )
 
-logger = logging.getLogger(__name__)
+from .base import RepositoryConfigService
 
 
-class EntryClassificationService:
+class EntryClassificationService(RepositoryConfigService):
     """Device mapping for floor, entry/exit, elevator, stairwell, fire escape, and security level"""
 
     # Security level keywords (device name -> security adjustment)
@@ -75,9 +76,7 @@ class EntryClassificationService:
     def __init__(
         self, repository: CSVStorageRepository, config: EntryClassificationConfig
     ) -> None:
-        self.repository = repository
-        self.config = config
-        self.logger = logger
+        super().__init__(repository, config)
 
     def classify_entries(self, data: List[Dict], session_id: str) -> List[Dict]:
         """Main entry point - now does device mapping instead of simple entry classification"""

--- a/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/floor_estimator.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/floor_estimator.py
@@ -1,6 +1,7 @@
 """Enhanced floor estimator with comprehensive pattern detection"""
 
-import logging
+from __future__ import annotations
+
 import re
 from collections import Counter
 from typing import Any, Dict, List, Set
@@ -12,18 +13,16 @@ from yosai_intel_dashboard.src.adapters.api.plugins.ai_classification.database.c
     CSVStorageRepository,
 )
 
-logger = logging.getLogger(__name__)
+from .base import RepositoryConfigService
 
 
-class FloorEstimationService:
+class FloorEstimationService(RepositoryConfigService):
     """Enhanced floor estimation with multiple detection methods"""
 
     def __init__(
         self, repository: CSVStorageRepository, config: FloorEstimationConfig
     ) -> None:
-        self.repository = repository
-        self.config = config
-        self.logger = logger
+        super().__init__(repository, config)
 
         # Comprehensive floor detection patterns
         self.floor_patterns = [


### PR DESCRIPTION
## Summary
- DRY up AI classification services by introducing `RepositoryConfigService` and `BaseCSVProcessor` base classes
- Update CSV, column mapping, floor estimation, and entry classification services to inherit base classes and remove duplicate `__init__` logic

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/base.py yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/column_mapper.py yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/csv_processor.py yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/entry_classifier.py yosai_intel_dashboard/src/adapters/api/plugins/ai_classification/services/floor_estimator.py`
- `pytest tests/plugins/test_ai_classification_plugin.py` *(fails: fixture 'mock_auth_env' not found)*


------
https://chatgpt.com/codex/tasks/task_e_68933c2de7bc8320b0db5c350d6e53c6