### PR TITLE
feat: add progressive disclosure to usage dashboard

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/UsageDashboard.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/UsageDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
+import ProgressiveSection from '../components/ProgressiveSection';
 import {
   snapshot as getSnapshot,
   onUsageUpdate,
@@ -17,6 +18,20 @@ const UsageDashboard: React.FC = () => {
     };
   }, []);
 
+  const adoptionTotal = Object.values(stats.adoption).reduce(
+    (sum, c) => sum + c,
+    0,
+  );
+  const errorTotal = Object.values(stats.errors).reduce((sum, c) => sum + c, 0);
+  const userCount = Object.keys(stats.proficiency).length;
+  const avgProficiency =
+    userCount === 0
+      ? 0
+      : Math.round(
+          Object.values(stats.proficiency).reduce((sum, l) => sum + l, 0) /
+            userCount,
+        );
+
   return (
     <ErrorBoundary>
       <div className="usage-dashboard">
@@ -24,29 +39,85 @@ const UsageDashboard: React.FC = () => {
 
         <section>
           <h2>Adoption</h2>
-          <ul>
-            {Object.entries(stats.adoption).map(([feature, count]) => (
-              <li key={feature}>{feature}: {count}</li>
-            ))}
-          </ul>
+          <p>
+            {adoptionTotal} interactions across{' '}
+            {Object.keys(stats.adoption).length} features
+          </p>
+          <ProgressiveSection
+            title="Show adoption details"
+            id="adoption-details"
+            className="mt-2"
+          >
+            <ul>
+              {Object.entries(stats.adoption).map(([feature, count]) => (
+                <li key={feature}>
+                  <details>
+                    <summary>
+                      {feature}: {count}
+                    </summary>
+                    <div className="ml-4 text-sm text-gray-600">
+                      Feature {feature} has been used {count} times.
+                    </div>
+                  </details>
+                </li>
+              ))}
+            </ul>
+          </ProgressiveSection>
         </section>
 
-        <section>
+        <section className="mt-4">
           <h2>Errors</h2>
-          <ul>
-            {Object.entries(stats.errors).map(([feature, count]) => (
-              <li key={feature}>{feature}: {count}</li>
-            ))}
-          </ul>
+          <p>
+            {errorTotal} errors across {Object.keys(stats.errors).length}{' '}
+            features
+          </p>
+          <ProgressiveSection
+            title="Show error details"
+            id="error-details"
+            className="mt-2"
+          >
+            <ul>
+              {Object.entries(stats.errors).map(([feature, count]) => (
+                <li key={feature}>
+                  <details>
+                    <summary>
+                      {feature}: {count}
+                    </summary>
+                    <div className="ml-4 text-sm text-gray-600">
+                      {count} errors reported for {feature}.
+                    </div>
+                  </details>
+                </li>
+              ))}
+            </ul>
+          </ProgressiveSection>
         </section>
 
-        <section>
+        <section className="mt-4">
           <h2>Proficiency Levels</h2>
-          <ul>
-            {Object.entries(stats.proficiency).map(([user, level]) => (
-              <li key={user}>{user}: {level}</li>
-            ))}
-          </ul>
+          <p>
+            Tracking {userCount} users. Average level: {avgProficiency}
+          </p>
+          <ProgressiveSection
+            title="Show proficiency details"
+            id="proficiency-details"
+            className="mt-2"
+          >
+            <ul>
+              {Object.entries(stats.proficiency).map(([user, level]) => (
+                <li key={user}>
+                  <details>
+                    <summary>
+                      {user}: {level}
+                    </summary>
+                    <div className="ml-4 text-sm text-gray-600">
+                      User {user} proficiency level is {level}.
+                    </div>
+                  </details>
+                </li>
+              ))}
+            </ul>
+          </ProgressiveSection>
         </section>
       </div>
     </ErrorBoundary>

--- a/yosai_intel_dashboard/src/adapters/ui/src/UsageDashboard.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/src/UsageDashboard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import UsageDashboard from '../pages/UsageDashboard';
+
+jest.mock('../services/analytics/usage', () => ({
+  snapshot: () => ({
+    adoption: { featureA: 10 },
+    errors: { featureB: 2 },
+    proficiency: { user1: 3 },
+  }),
+  onUsageUpdate: () => () => {},
+}));
+
+describe('UsageDashboard progressive disclosure', () => {
+  test('reveals adoption details and drill-down info on demand', () => {
+    render(<UsageDashboard />);
+
+    const toggle = screen.getByRole('button', {
+      name: /show adoption details/i,
+    });
+    const content = document.getElementById('adoption-details');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(content).toHaveAttribute('hidden');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(content).not.toHaveAttribute('hidden');
+
+    const featureSummary = screen.getByText('featureA: 10');
+    const details = featureSummary.closest('details');
+    expect(details).not.toHaveAttribute('open');
+    fireEvent.click(featureSummary);
+    expect(details).toHaveAttribute('open');
+  });
+});


### PR DESCRIPTION
## Summary
- streamline usage dashboard with progressive sections and drill-down details
- add unit test for adoption drill-down interaction

## Testing
- `npm test -- UsageDashboard.test.tsx`
- `npx eslint yosai_intel_dashboard/src/adapters/ui/pages/UsageDashboard.tsx yosai_intel_dashboard/src/adapters/ui/src/UsageDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68933d2a8294832085eb8026a8298841