### PR TITLE
Simplify Docker entrypoint setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,5 @@ COPY --from=builder /app /app
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
-
-# Entrypoint
-RUN chmod +x docker-entrypoint.sh
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["start_api.py"]


### PR DESCRIPTION
## Summary
- ensure Dockerfile uses a single chmod and entrypoint

## Testing
- `docker build -t yosai-test-image .` *(fails: Cannot connect to the Docker daemon)*
- `pytest -q` *(fails: 347 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68937f835f4483208c1a4fbbb71e87d8