### PR TITLE
Remove docker-compose version declaration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   dashboard:
     build:


### PR DESCRIPTION
## Summary
- remove top-level `version: "3.8"` from `docker-compose.yml`

## Testing
- `docker-compose config`
- `pytest -q` *(fails: 347 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68937f8485708320a1331f520013de40