### PR TITLE
Downgrade feast to align protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,9 +64,10 @@ opentelemetry-exporter-jaeger==1.21.0
 opentelemetry-exporter-zipkin==1.21.0
 pika==1.3.2
 boto3==1.34.103
+protobuf==3.20.3
 
 strawberry-graphql[fastapi]
-feast==0.49.0
+feast==0.30.2
 tenacity==8.2.3
 shap==0.44.1
 lime==0.2.0.1


### PR DESCRIPTION
## Summary
- downgrade feast to 0.30.2 to avoid protobuf conflicts
- pin protobuf to 3.20.3 for compatibility with opentelemetry zipkin exporter

## Testing
- `pre-commit run --files requirements.txt`
- `pytest` (fails: ModuleNotFoundError: No module named 'yosai_intel_dashboard.src.services.analytics.controllers')
- `docker-compose build` (fails: ConnectionRefusedError(111, 'Connection refused'))

------
https://chatgpt.com/codex/tasks/task_e_68937f81d0a48320848846f22e1c9577