### PR TITLE
chore: refine docker ignore patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,14 @@ cypress/
 
 # Tests
 tests/
+
+# IDE and generated directories
+.idea/
+.vscode/
+node_modules/
+coverage/
+htmlcov/
+.pytest_cache/
+docs/
+examples/
+unit_tests/


### PR DESCRIPTION
## Summary
- reduce Docker build context by excluding IDE, docs, examples, and test artifacts

## Testing
- `pre-commit run --files .dockerignore`
- `docker-compose build` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_6894d18f70208320ad854332ee79f46a