### PR TITLE
chore: split service dockerfiles

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+WORKDIR /app
+
+# Install system packages
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends build-essential curl \ 
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY ../requirements.txt ./
+RUN python -m venv /opt/venv \
+    && . /opt/venv/bin/activate \
+    && grep -v '^apache-flink' requirements.txt > requirements.filtered \
+    && pip install --no-cache-dir -r requirements.filtered
+
+FROM python:3.11-slim
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
+
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh \
+    && rm -rf /app/yosai_intel_dashboard/tests
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["python", "-m", "yosai_intel_dashboard.src.app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   dashboard:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: dashboard/Dockerfile
     command: ["python", "-m", "yosai_intel_dashboard.src.app"]
     ports:
       - "8050:8050"
@@ -24,7 +24,7 @@ services:
   api:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: api/Dockerfile
     command: ["python", "start_api.py"]
     ports:
       - "8000:8000"

--- a/yosai_intel_dashboard/src/adapters/api/Dockerfile
+++ b/yosai_intel_dashboard/src/adapters/api/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+WORKDIR /app
+
+# Install system packages
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends build-essential curl \ 
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY ../requirements.txt ./
+RUN python -m venv /opt/venv \
+    && . /opt/venv/bin/activate \
+    && grep -v '^apache-flink' requirements.txt > requirements.filtered \
+    && pip install --no-cache-dir -r requirements.filtered
+
+FROM python:3.11-slim
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
+
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../docker-entrypoint.sh ./
+COPY ../start_api.py ./
+RUN chmod +x docker-entrypoint.sh \
+    && rm -rf /app/yosai_intel_dashboard/tests
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["start_api.py"]


### PR DESCRIPTION
## Summary
- add service-specific Dockerfile for dashboard
- add API Dockerfile that copies start_api.py
- point docker-compose services at their respective Dockerfiles

## Testing
- `pre-commit run --files docker-compose.yml dashboard/Dockerfile yosai_intel_dashboard/src/adapters/api/Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_6894df23ae90832080f1b641e386de52