### PR TITLE
Copy core into service Dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,6 +23,7 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
 COPY docker-entrypoint.sh ./
+COPY ../core /app/core
 COPY start_api.py ./
 RUN chmod +x docker-entrypoint.sh
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -25,6 +25,7 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
 COPY ../docker-entrypoint.sh ./
+COPY ../core /app/core
 RUN chmod +x docker-entrypoint.sh \
     && rm -rf /app/yosai_intel_dashboard/tests
 


### PR DESCRIPTION
## Summary
- include core module in API and dashboard Docker images for import

## Testing
- `docker build -t test-api -f api/Dockerfile api` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689547860b6c8320bf41df32150a2b2d