### PR TITLE
refactor: lazily load integration helpers

### DIFF
--- a/core/integrations/__init__.py
+++ b/core/integrations/__init__.py
@@ -1,6 +1,32 @@
-"""Integration helpers for external threat intelligence systems."""
+"""Integration helpers for external threat intelligence systems.
 
-from .stix_taxii_exporter import export_to_stix, push_to_taxii
-from .siem_connectors import send_to_siem
+Heavy dependencies (such as ``networkx``) are only required when STIX/TAXII
+exports are used.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["export_to_stix", "push_to_taxii", "send_to_siem"]
+
+_LAZY_EXPORTS = {
+    "export_to_stix": (".stix_taxii_exporter", "export_to_stix"),
+    "push_to_taxii": (".stix_taxii_exporter", "push_to_taxii"),
+    "send_to_siem": (".siem_connectors", "send_to_siem"),
+}
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from .siem_connectors import send_to_siem
+    from .stix_taxii_exporter import export_to_stix, push_to_taxii
+
+
+def __getattr__(name: str) -> Any:
+    """Load integration helpers lazily."""
+
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        module = import_module(module_name, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- lazily import STIX/TAXII and SIEM integration helpers
- document that heavy dependencies like `networkx` are only needed for STIX/TAXII exports

## Testing
- `pre-commit run --files core/integrations/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_689547871fd08320ac510f491a2dfc95