### PR TITLE
feat: silence optional dependency warning

### DIFF
--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -70,9 +70,16 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         module = importlib.import_module(module_name)
         return getattr(module, attr) if attr else module
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning("Optional dependency '%s' unavailable: %s", name, exc)
-        missing_dependencies.labels(dependency=name).inc()
         value = _fallbacks.get(name) or _fallbacks.get(module_name) or fallback
+        if value is not None:
+            logger.info(
+                "Optional dependency '%s' unavailable, using fallback: %s",
+                name,
+                exc,
+            )
+        else:
+            logger.warning("Optional dependency '%s' unavailable: %s", name, exc)
+        missing_dependencies.labels(dependency=name).inc()
         if callable(value):
             return value()
         return value


### PR DESCRIPTION
## Summary
- stop logging missing dependency warnings when a fallback module is registered

## Testing
- `pytest optional_dependencies.py`
- `pip install cryptography==45.0.5`
- `python - <<'PY'
import logging
logging.basicConfig(level=logging.WARNING)
from optional_dependencies import import_optional
mod = import_optional('cryptography.fernet')
print('Module:', mod)
print('Fernet exists:', hasattr(mod, 'Fernet'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68954788ade48320b48f84f767557b1b