### PR TITLE
Include core directory in service Docker images

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -24,6 +24,8 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 COPY --from=builder /opt/venv /opt/venv
 COPY docker-entrypoint.sh ./
 COPY start_api.py ./
+COPY ../yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../core /app/core
 RUN chmod +x docker-entrypoint.sh
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../core /app/core
 COPY ../docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh \
     && rm -rf /app/yosai_intel_dashboard/tests


### PR DESCRIPTION
## Summary
- copy `yosai_intel_dashboard` and `core` into API Docker image
- copy `core` into dashboard Docker image

## Testing
- `docker build -t api-test -f api/Dockerfile .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6895488fbf648320ad80f07f4a7bf727