### PR TITLE
Require cryptography for Fernet-based features

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -39,7 +39,7 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography==45.0.5
+cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -39,7 +39,7 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography==45.0.5
+cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography==45.0.5
+cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0


### PR DESCRIPTION
## Summary
- require `cryptography>=41` so Fernet is available

## Testing
- `pytest tests/test_database_config_serialization.py`
- `pytest tests/test_database_config_serialization.py tests/test_secure_config_manager.py` *(fails: NameError: name '_SECURITYCONFIG_SESSIONTIMEOUTBYROLEENTRY' is not defined)*
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6895489347b8832087eae9c613557318