### PR TITLE
Ensure core package available in service images

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,6 +22,8 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
+COPY ../yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../core /app/core
 COPY docker-entrypoint.sh ./
 COPY start_api.py ./
 RUN chmod +x docker-entrypoint.sh

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -23,7 +23,8 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../core /app/core
 COPY ../docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh \
     && rm -rf /app/yosai_intel_dashboard/tests


### PR DESCRIPTION
## Summary
- Copy `core` module into API and dashboard Docker images
- Ensure both images set `PYTHONPATH` to include `/app`

## Testing
- `pytest tests/test_navigation_manager.py -q`
- `docker build -f api/Dockerfile -t yosai-api-test .` *(fails: Cannot connect to the Docker daemon)*
- `docker build -f dashboard/Dockerfile -t yosai-dashboard-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6895491cc5c08320af00b331847c46bd