### PR TITLE
fix: ensure cryptography support

### DIFF
--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -62,14 +62,21 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         Optional explicit fallback overriding any registered stub.
     """
 
-    module_name = name
-    attr = None
-    if "." in name:
-        module_name, attr = name.rsplit(".", 1)
     try:
-        module = importlib.import_module(module_name)
-        return getattr(module, attr) if attr else module
-    except Exception as exc:  # pragma: no cover - defensive
+        # Attempt to import the full dotted path first.  This handles real
+        # modules like ``cryptography.fernet`` correctly without relying on
+        # package attributes.
+        return importlib.import_module(name)
+    except Exception as exc:
+        module_name = name
+        attr = None
+        if "." in name:
+            module_name, attr = name.rsplit(".", 1)
+            try:
+                module = importlib.import_module(module_name)
+                return getattr(module, attr) if attr else module
+            except Exception as exc_attr:  # pragma: no cover - defensive
+                exc = exc_attr
         logger.warning("Optional dependency '%s' unavailable: %s", name, exc)
         missing_dependencies.labels(dependency=name).inc()
         value = _fallbacks.get(name) or _fallbacks.get(module_name) or fallback

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography==45.0.5
+cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0


### PR DESCRIPTION
## Summary
- ensure `cryptography` is installed by default
- handle fully qualified module imports in `optional_dependencies`

## Testing
- `python - <<'PY'
from optional_dependencies import import_optional
import logging
logging.basicConfig(level=logging.DEBUG)
mod = import_optional('cryptography.fernet')
print(mod)
PY`
- `pytest tests/test_database_config_serialization.py tests/test_secure_config_manager.py` *(fails: `_SECURITYCONFIG_SESSIONTIMEOUTBYROLEENTRY` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6895491fc95083208e72397b62300584