### PR TITLE
Copy core directory into service images

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 COPY --from=builder /opt/venv /opt/venv
 COPY docker-entrypoint.sh ./
 COPY start_api.py ./
+COPY ../core /app/core
 RUN chmod +x docker-entrypoint.sh
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app/yosai_intel_dashboard /app/yosai_intel_dashboard
+COPY ../core /app/core
 COPY ../docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh \
     && rm -rf /app/yosai_intel_dashboard/tests


### PR DESCRIPTION
## Summary
- ensure `core` package is included in API and dashboard Docker images to prevent ModuleNotFoundError

## Testing
- `pre-commit run --files api/Dockerfile dashboard/Dockerfile`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689549d7db688320881723ac435dd8d5