### PR TITLE
Downgrade cryptography warning when missing

### DIFF
--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -25,6 +25,10 @@ from yosai_intel_dashboard.src.infrastructure.monitoring.missing_dependencies im
 
 logger = logging.getLogger(__name__)
 
+# Some optional packages are truly optional and should not produce
+# noisy warnings when absent.
+_NO_WARN_DEPS = {"cryptography", "cryptography.fernet"}
+
 
 # ---------------------------------------------------------------------------
 # Registry handling
@@ -70,7 +74,12 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         module = importlib.import_module(module_name)
         return getattr(module, attr) if attr else module
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning("Optional dependency '%s' unavailable: %s", name, exc)
+        log = (
+            logger.info
+            if name in _NO_WARN_DEPS or module_name in _NO_WARN_DEPS
+            else logger.warning
+        )
+        log("Optional dependency '%s' unavailable: %s", name, exc)
         missing_dependencies.labels(dependency=name).inc()
         value = _fallbacks.get(name) or _fallbacks.get(module_name) or fallback
         if callable(value):


### PR DESCRIPTION
## Summary
- avoid noisy warnings when `cryptography.fernet` is absent

## Testing
- `python - <<'PY'
import optional_dependencies
optional_dependencies.import_optional('cryptography.fernet')
PY`
- `python - <<'PY'
import logging
import optional_dependencies
logging.basicConfig(level=logging.INFO)
optional_dependencies.import_optional('cryptography.fernet')
PY`
- `pre-commit run black --files optional_dependencies.py`
- `pre-commit run isort --files optional_dependencies.py`
- `pre-commit run flake8 --files optional_dependencies.py`
- `pre-commit run mypy --files optional_dependencies.py` *(fails: numerous existing mypy errors across repository)*
- `docker run --rm -v "$PWD":/app -w /app python:3.11-slim python - <<'PY'
import optional_dependencies
optional_dependencies.import_optional('cryptography.fernet')
PY` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689549d97814832088197a510cc04fc3