### PR TITLE
Handle dotted optional imports

### DIFF
--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -68,6 +68,10 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         Optional explicit fallback overriding any registered stub.
     """
 
+    module_name, _, attr = name.rpartition(".")
+    if not module_name:
+        module_name, attr = name, ""
+
     try:
         module = importlib.import_module(module_name)
         return getattr(module, attr) if attr else module
@@ -84,7 +88,6 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         if callable(value):
             return value()
         return value
-
 
 
 def is_available(name: str) -> bool:


### PR DESCRIPTION
## Summary
- parse dotted module paths in import_optional to import the base module and fetch attributes
- test cryptography.fernet fallback handling when module is missing

## Testing
- `pre-commit run --files optional_dependencies.py tests/test_optional_dependencies.py`
- `pytest tests/test_optional_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68955259fbec8320a81c92a8e262ecc8