### PR TITLE
feat: make cryptography optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ The test suite relies on extra packages defined in `requirements-dev.txt`. Insta
 - `pandas`
 - `psutil`
 - `hvac`
-- `cryptography`
+- (optional) `cryptography` — enables encrypted configuration support
 - `selenium`
 - `requests`
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -39,7 +39,6 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -39,7 +39,6 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
 hvac==2.3.0
-cryptography>=41
 kafka-python==2.2.15
 hyperloglog==0.0.14
 pulsar-client==3.8.0


### PR DESCRIPTION
## Summary
- document `cryptography` as an optional dependency for encrypted config support
- remove `cryptography` from base requirements

## Testing
- `pre-commit run --files README.md requirements.txt dashboard/requirements.txt api/requirements.txt`
- `pytest tests/test_optional_dependencies.py tests/test_secure_config_manager.py tests/test_database_config_serialization.py -q` *(fails: NameError: name 'module_name' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6895525e77d08320b7853e925c5275af