### PR TITLE
Handle invalid names in import_optional and add regression test

### DIFF
--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -68,11 +68,13 @@ def import_optional(name: str, fallback: Any | None = None) -> Any | None:
         Optional explicit fallback overriding any registered stub.
     """
 
-    module_name, _, attr = name.rpartition(".")
-    if not module_name:
-        module_name, attr = name, ""
-
+    module_name = name
+    attr = ""
     try:
+        module_name, _, attr = name.rpartition(".")
+        if not module_name:
+            module_name, attr = name, ""
+
         module = importlib.import_module(module_name)
         return getattr(module, attr) if attr else module
     except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- guard `import_optional` split logic so invalid names warn instead of crashing
- test `import_optional` with invalid objects and missing modules to ensure warning and safe fallback

## Testing
- `pre-commit run --files optional_dependencies.py tests/test_optional_dependencies.py`
- `pytest tests/test_optional_dependencies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68959d66c5b08320bd63e7fbf5edf7eb