### PR TITLE
Use logger instead of print in SIEM connector

### DIFF
--- a/tests/core/test_siem_connectors.py
+++ b/tests/core/test_siem_connectors.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import logging
+
+from yosai_intel_dashboard.src.core.integrations.siem_connectors import send_to_siem
+
+
+def test_send_to_siem_logs_event(caplog):
+    event = {"type": "auth", "user": "alice"}
+    with caplog.at_level(logging.INFO):
+        send_to_siem(event, "splunk")
+    assert any(
+        rec.levelno == logging.INFO
+        and rec.name == "yosai_intel_dashboard.src.core.integrations.siem_connectors"
+        and rec.getMessage() == f"Sending event to splunk: {event}"
+        for rec in caplog.records
+    )

--- a/yosai_intel_dashboard/src/core/integrations/siem_connectors.py
+++ b/yosai_intel_dashboard/src/core/integrations/siem_connectors.py
@@ -1,6 +1,11 @@
 """Connectors for pushing events to common SIEM systems."""
 
+from __future__ import annotations
+
+import logging
 from typing import Dict
+
+logger = logging.getLogger(__name__)
 
 
 def send_to_siem(event: Dict, system: str) -> None:
@@ -12,6 +17,6 @@ def send_to_siem(event: Dict, system: str) -> None:
 
     if system.lower() not in {"splunk", "qradar", "elk"}:
         raise ValueError(f"Unknown SIEM system: {system}")
-    # In real code this would send the event. For now we simply print it so
+    # In real code this would send the event. For now we simply log the event so
     # tests and examples can observe the behaviour without side effects.
-    print(f"Sending event to {system}: {event}")
+    logger.info("Sending event to %s: %s", system, event)


### PR DESCRIPTION
## Summary
- use a module-level logger in `siem_connectors` and log events instead of printing
- add a unit test asserting that `send_to_siem` emits a log record

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/core/integrations/siem_connectors.py tests/core/test_siem_connectors.py`
- `pytest tests/core/test_siem_connectors.py tests/security/test_audit_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_68959d7140dc83208f9721613c86876f