### PR TITLE
Improve dependency error handling in API startup

### DIFF
--- a/start_api.py
+++ b/start_api.py
@@ -31,6 +31,14 @@ def main() -> None:
         from yosai_intel_dashboard.src.core.env_validation import validate_required_env
         from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
         from yosai_intel_dashboard.src.infrastructure.config.constants import API_PORT
+    except ModuleNotFoundError as exc:
+        missing_pkg = getattr(exc, "name", None) or str(exc)
+        logger.error(
+            "Missing required dependency '%s'. "
+            "Install it with 'pip install -r requirements.txt' and try again.",
+            missing_pkg,
+        )
+        raise SystemExit(1)
     except ImportError as exc:
         logger.error(
             "Failed to import dependencies (possible circular import): %s", exc


### PR DESCRIPTION
## Summary
- catch missing modules at API startup and suggest installing dependencies

## Testing
- `pre-commit run --files start_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68959d83484483208d7087e4903808fa