### PR TITLE
Gate core.integrations stub and test SecurityAuditLogger import

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib
 import importlib.abc
 import importlib.machinery
+import importlib.util
 import os
 import sys
 import types
@@ -378,15 +379,17 @@ def register_dependency_stubs() -> None:
     sys.modules.setdefault("pydantic", pydantic_stub)
 
     # Minimal stubs for optional security integrations
-    core_integrations_stub = _simple_module("core.integrations")
-    core_integrations_stub.__path__ = []
-    register_fallback("core.integrations", core_integrations_stub)
-    sys.modules.setdefault("core.integrations", core_integrations_stub)
-    siem_stub = _simple_module(
-        "core.integrations.siem_connectors", send_to_siem=lambda *a, **k: None
-    )
-    register_fallback("core.integrations.siem_connectors", siem_stub)
-    sys.modules.setdefault("core.integrations.siem_connectors", siem_stub)
+    # Only register when the real package is unavailable
+    if importlib.util.find_spec("yosai_intel_dashboard.src.core.integrations") is None:
+        core_integrations_stub = _simple_module("core.integrations")
+        core_integrations_stub.__path__ = []
+        register_fallback("core.integrations", core_integrations_stub)
+        sys.modules.setdefault("core.integrations", core_integrations_stub)
+        siem_stub = _simple_module(
+            "core.integrations.siem_connectors", send_to_siem=lambda *a, **k: None
+        )
+        register_fallback("core.integrations.siem_connectors", siem_stub)
+        sys.modules.setdefault("core.integrations.siem_connectors", siem_stub)
 
     # As a final fallback, provide a meta-path finder that returns empty
     # modules for any remaining missing imports.  Each stubbed module

--- a/tests/security/test_security_audit_logger_import.py
+++ b/tests/security/test_security_audit_logger_import.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+
+
+def test_security_audit_logger_imports_real_core_integrations():
+    from yosai_intel_dashboard.src.infrastructure.security import (  # noqa: F401
+        SecurityAuditLogger,
+    )
+
+    module = importlib.import_module(
+        "yosai_intel_dashboard.src.core.integrations.siem_connectors"
+    )
+    func_file = inspect.getsourcefile(module.send_to_siem)
+    assert func_file and func_file.endswith("core/integrations/siem_connectors.py")


### PR DESCRIPTION
## Summary
- Avoid overriding real `core.integrations` by registering its stub only when the package is missing
- Add regression test ensuring `SecurityAuditLogger` pulls `core.integrations.siem_connectors` from the runtime path

## Testing
- `pre-commit run --files tests/config.py tests/security/test_security_audit_logger_import.py`
- `pytest tests/security/test_audit_logger.py tests/security/test_security_audit_logger_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68959d8521488320b1db5328387b8024