### PR TITLE
feat: improve analytics accessibility

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.css
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.css
@@ -52,6 +52,11 @@
   cursor: pointer;
 }
 
+.source-select:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
+}
+
 .export-button {
   display: flex;
   align-items: center;
@@ -65,6 +70,11 @@
   font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s ease;
+}
+
+.export-button:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
 }
 
 .export-button:hover {

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Analytics.tsx
@@ -126,6 +126,7 @@ const Analytics: React.FC = () => {
         <h1>Security Analytics</h1>
         <ChunkGroup className="header-actions">
           <select
+            aria-label="Select data source"
             value={sourceType}
             onChange={(e) => setSourceType(e.target.value)}
             className="source-select"
@@ -135,7 +136,11 @@ const Analytics: React.FC = () => {
             <option value="endpoint">Endpoint</option>
             <option value="network">Network</option>
           </select>
-          <button onClick={handleExport} className="export-button">
+          <button
+            aria-label="Export analytics as CSV"
+            onClick={handleExport}
+            className="export-button"
+          >
             <Download size={20} />
             Export CSV
           </button>
@@ -185,9 +190,9 @@ const Analytics: React.FC = () => {
           >
             <section className="patterns-section">
               <h2>Top Security Patterns</h2>
-              <ChunkGroup className="patterns-list" limit={9}>
+              <ChunkGroup className="patterns-list" limit={9} role="list">
                 {analyticsData.patterns.map((pattern, index) => (
-                  <div key={index} className="pattern-item">
+                  <div key={index} className="pattern-item" role="listitem">
                     <div className="pattern-info">
                       <span className="pattern-name">{pattern.pattern}</span>
                       <span className="pattern-count">
@@ -210,9 +215,9 @@ const Analytics: React.FC = () => {
 
             <section className="devices-section">
               <h2>Device Distribution</h2>
-              <ChunkGroup className="device-grid" limit={9}>
+              <ChunkGroup className="device-grid" limit={9} role="list">
                 {analyticsData.device_distribution.map((device, index) => (
-                  <div key={index} className="device-card">
+                  <div key={index} className="device-card" role="listitem">
                     <span className="device-name">{device.device}</span>
                     <span className="device-count">{device.count}</span>
                   </div>


### PR DESCRIPTION
## Summary
- improve screen reader support for analytics filters and export actions
- mark pattern and device sections with list semantics
- highlight select and export controls when focused for accessibility

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: could not resolve dependency for react-scripts@5.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68971ac044348320af67c2af6fbff541