### PR TITLE
feat: validate analytics source and summary

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics/schemas.py
+++ b/yosai_intel_dashboard/src/services/analytics/schemas.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Pydantic models for analytics service I/O."""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AnalyticsQueryV1(BaseModel):
+    """Input model for analytics queries."""
+
+    source: str = Field(..., description="Analytics data source")
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    @field_validator("source")
+    @classmethod
+    def _normalize_source(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in {"sample", "uploaded", "database"}:
+            raise ValueError(
+                "source must be one of: sample, uploaded, database"
+            )
+        return normalized
+
+
+class AnalyticsSummaryV1(BaseModel):
+    """Output model for analytics summaries."""
+
+    status: str
+    message: Optional[str] = None
+    total_rows: Optional[int] = None
+
+    model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
## Summary
- add AnalyticsQueryV1 and AnalyticsSummaryV1 pydantic models
- validate and normalize analytics source and output

## Testing
- `pytest tests/test_analytics_integration.py -q` *(fails: TypeError: '_LazyModule' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68971ac3ec4483208a7d1936f6c2e63d