### PR TITLE
Normalize uploaded dataframe headers

### DIFF
--- a/tests/test_column_unicode_normalization.py
+++ b/tests/test_column_unicode_normalization.py
@@ -1,0 +1,62 @@
+import unicodedata
+
+import pandas as pd
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.services.analytics_summary",
+    types.SimpleNamespace(summarize_dataframe=lambda df: {}),
+)
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.services.chunked_analysis",
+    types.SimpleNamespace(analyze_with_chunking=lambda df, validator, tasks: {}),
+)
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.services.upload.protocols",
+    types.SimpleNamespace(UploadAnalyticsProtocol=object),
+)
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.utils.upload_store",
+    types.SimpleNamespace(get_uploaded_data_store=lambda: types.SimpleNamespace(get_all_data=lambda: {})),
+)
+sys.modules.setdefault(
+    "validation.data_validator",
+    types.SimpleNamespace(DataValidator=object, DataValidatorProtocol=object),
+)
+
+base = Path("yosai_intel_dashboard/src").resolve()
+pkg_paths = {
+    "yosai_intel_dashboard": Path("yosai_intel_dashboard").resolve(),
+    "yosai_intel_dashboard.src": base,
+    "yosai_intel_dashboard.src.services": base / "services",
+    "yosai_intel_dashboard.src.services.analytics": base / "services" / "analytics",
+}
+for name, path in pkg_paths.items():
+    module = sys.modules.setdefault(name, types.ModuleType(name))
+    module.__path__ = [str(path)]
+
+spec = importlib.util.spec_from_file_location(
+    "yosai_intel_dashboard.src.services.analytics.upload_analytics",
+    Path("yosai_intel_dashboard/src/services/analytics/upload_analytics.py"),
+)
+upload_analytics = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = upload_analytics
+spec.loader.exec_module(upload_analytics)
+UploadAnalyticsProcessor = upload_analytics.UploadAnalyticsProcessor
+
+
+def test_clean_uploaded_dataframe_normalizes_mixed_encoding_columns() -> None:
+    df = pd.DataFrame(
+        [["d1", "2024-01-01 00:00:00", 1, 2]],
+        columns=["Device\u00A0name", "Event\u00A0time", "Caf\u00E9", "Cafe\u0301"],
+    )
+    ua = UploadAnalyticsProcessor.__new__(UploadAnalyticsProcessor)
+    cleaned = UploadAnalyticsProcessor.clean_uploaded_dataframe(ua, df)
+
+    assert "door_id" in cleaned.columns
+    assert "timestamp" in cleaned.columns
+    assert cleaned.columns[-2:] == ["café", "café"]
+    assert all(unicodedata.is_normalized("NFKC", c) for c in cleaned.columns)

--- a/yosai_intel_dashboard/src/services/analytics/unicode.py
+++ b/yosai_intel_dashboard/src/services/analytics/unicode.py
@@ -1,0 +1,20 @@
+"""Lightweight Unicode helpers for analytics services."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+def normalize_text(text: str) -> str:
+    """Return ``text`` normalised using Unicode NFKC form.
+
+    Parameters
+    ----------
+    text:
+        Input text to normalise. Non-string values are converted to string and
+        ``None`` becomes an empty string.
+    """
+
+    if text is None:
+        return ""
+    return unicodedata.normalize("NFKC", str(text))

--- a/yosai_intel_dashboard/src/services/analytics/upload_analytics.py
+++ b/yosai_intel_dashboard/src/services/analytics/upload_analytics.py
@@ -13,6 +13,7 @@ from yosai_intel_dashboard.src.services.chunked_analysis import analyze_with_chu
 from yosai_intel_dashboard.src.services.upload.protocols import UploadAnalyticsProtocol
 from yosai_intel_dashboard.src.utils.upload_store import get_uploaded_data_store
 from validation.data_validator import DataValidator, DataValidatorProtocol
+from .unicode import normalize_text
 
 
 def summarize_dataframes(dfs: List[pd.DataFrame]) -> Dict[str, Any]:
@@ -79,7 +80,10 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
             return df.copy()
 
         cleaned = df.dropna(how="all", axis=0).dropna(how="all", axis=1).copy()
-        cleaned.columns = [c.strip().lower().replace(" ", "_") for c in cleaned.columns]
+        cleaned.columns = [
+            normalize_text(c).strip().lower().replace(" ", "_")
+            for c in cleaned.columns
+        ]
         cleaned = cleaned.rename(
             columns={"device_name": "door_id", "event_time": "timestamp"}
         )
@@ -88,6 +92,7 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
                 cleaned["timestamp"], errors="coerce"
             )
         cleaned = cleaned.dropna(how="all", axis=0)
+        cleaned.columns = [normalize_text(c) for c in cleaned.columns]
         return cleaned
 
     def summarize_dataframe(self, df: pd.DataFrame) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add `normalize_text` helper using `unicodedata.normalize`
- normalize dataframe column names when cleaning uploads
- cover Unicode column normalization with unit tests

## Testing
- `pytest -o addopts= -p no:cov tests/test_column_unicode_normalization.py -q` *(fails: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68971ac530148320b79e5c7afadc4b8d