### PR TITLE
Use crypto.randomUUID for upload file IDs

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
@@ -26,7 +26,7 @@ const Upload: React.FC = () => {
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const newFiles: UploadedFile[] = acceptedFiles.map((file) => ({
-      id: `${Date.now()}-${Math.random()}`,
+      id: crypto.randomUUID(),
       file,
       name: file.name,
       size: file.size,


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID()` for generated upload file IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897274b9c288320af9a11002f70ec18