### PR TITLE
refactor: extract upload logic to reusable hook

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
@@ -1,155 +1,27 @@
-import React, { useState, useCallback } from "react";
-import { useDropzone } from "react-dropzone";
+import React, { useState } from "react";
 import { Upload as UploadIcon } from "lucide-react";
 import { FilePreview } from "./FilePreview";
 import { ColumnMappingModal } from "./ColumnMappingModal";
 import { DeviceMappingModal } from "./DeviceMappingModal";
-import { UploadedFile, ProcessingStatus as Status } from "./types";
-import { api } from "../../api/client";
-
-
-const CONCURRENCY_LIMIT = parseInt(
-  process.env.REACT_APP_UPLOAD_CONCURRENCY || "3",
-  10,
-);
-
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5001";
+import { UploadedFile, FileData } from "./types";
+import useUpload from "../../hooks/useUpload";
 
 const Upload: React.FC = () => {
-  const [files, setFiles] = useState<UploadedFile[]>([]);
-  const [uploading, setUploading] = useState(false);
+  const {
+    files,
+    uploading,
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    removeFile,
+    uploadAllFiles,
+  } = useUpload();
+
   const [showColumnMapping, setShowColumnMapping] = useState(false);
   const [showDeviceMapping, setShowDeviceMapping] = useState(false);
   const [currentFile, setCurrentFile] = useState<UploadedFile | null>(null);
   const [fileData, setFileData] = useState<FileData | null>(null);
   const [devices, setDevices] = useState<string[]>([]);
-
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    const newFiles: UploadedFile[] = acceptedFiles.map((file) => ({
-      id: `${Date.now()}-${Math.random()}`,
-      file,
-      name: file.name,
-      size: file.size,
-      type: file.type,
-      status: "pending" as Status,
-      progress: 0,
-    }));
-    setFiles((prev) => [...prev, ...newFiles]);
-  }, []);
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    accept: {
-      "text/csv": [".csv"],
-      "application/vnd.ms-excel": [".xls"],
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
-        ".xlsx",
-      ],
-    },
-    multiple: true,
-  });
-
-  const removeFile = (id: string) => {
-    setFiles((prev) => prev.filter((f) => f.id !== id));
-  };
-
-  const uploadFile = async (uploadedFile: UploadedFile) => {
-    const formData = new FormData();
-    formData.append("file", uploadedFile.file);
-
-    setFiles((prev) =>
-      prev.map((f) =>
-        f.id === uploadedFile.id
-          ? {
-              ...f,
-              status: "uploading" as Status,
-              progress: 0,
-              error: undefined,
-            }
-          : f,
-      ),
-    );
-
-    try {
-      const response = await api.post<{ job_id: string }>(
-        `${API_URL}/api/v1/upload`,
-        formData,
-      );
-      const { job_id } = response;
-
-      const poll = setInterval(async () => {
-        try {
-          const res = await api.get<{ progress?: number; done: boolean }>(
-            `${API_URL}/api/v1/upload/status/${job_id}`,
-          );
-          const progress = res.progress ?? 0;
-          setFiles((prev) =>
-            prev.map((f) =>
-              f.id === uploadedFile.id ? { ...f, progress } : f,
-            ),
-          );
-          if (res.done) {
-            clearInterval(poll);
-            setFiles((prev) =>
-              prev.map((f) =>
-                f.id === uploadedFile.id
-                  ? { ...f, status: "completed" as Status, progress: 100 }
-                  : f,
-              ),
-            );
-          }
-        } catch (err) {
-          clearInterval(poll);
-          setFiles((prev) =>
-            prev.map((f) =>
-              f.id === uploadedFile.id
-                ? {
-                    ...f,
-                    status: "error" as Status,
-                    error: "Processing failed",
-                  }
-                : f,
-            ),
-          );
-        }
-      }, 1000);
-    } catch (error) {
-      console.error("Upload error:", error);
-      setFiles((prev) =>
-        prev.map((f) =>
-          f.id === uploadedFile.id
-            ? {
-                ...f,
-                status: "error" as Status,
-                error: (error as Error).message || "Unknown error",
-              }
-            : f,
-        ),
-      );
-    }
-  };
-
-  const uploadAllFiles = async () => {
-    setUploading(true);
-    const pendingFiles = files.filter(
-      (f) => f.status === "pending" || f.status === "error",
-    );
-    let index = 0;
-
-    const uploadNext = async (): Promise<void> => {
-      if (index >= pendingFiles.length) return;
-      const next = pendingFiles[index++];
-      await uploadFile(next);
-      await uploadNext();
-    };
-
-    const workers = Array.from(
-      { length: Math.min(CONCURRENCY_LIMIT, pendingFiles.length) },
-      () => uploadNext(),
-    );
-    await Promise.all(workers);
-    setUploading(false);
-  };
 
   const handleColumnMappingConfirm = (mappings: Record<string, string>) => {
     console.log("Column mappings confirmed:", mappings);

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
@@ -1,0 +1,150 @@
+import { useState, useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+import { UploadedFile, ProcessingStatus as Status } from "../components/upload/types";
+import { api } from "../api/client";
+
+const CONCURRENCY_LIMIT = parseInt(
+  process.env.REACT_APP_UPLOAD_CONCURRENCY || "3",
+  10,
+);
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5001";
+
+export const useUpload = () => {
+  const [files, setFiles] = useState<UploadedFile[]>([]);
+  const [uploading, setUploading] = useState(false);
+
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    const newFiles: UploadedFile[] = acceptedFiles.map((file) => ({
+      id: `${Date.now()}-${Math.random()}`,
+      file,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      status: "pending" as Status,
+      progress: 0,
+    }));
+    setFiles((prev) => [...prev, ...newFiles]);
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "text/csv": [".csv"],
+      "application/vnd.ms-excel": [".xls"],
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+        ".xlsx",
+      ],
+    },
+    multiple: true,
+  });
+
+  const removeFile = (id: string) => {
+    setFiles((prev) => prev.filter((f) => f.id !== id));
+  };
+
+  const uploadFile = async (uploadedFile: UploadedFile) => {
+    const formData = new FormData();
+    formData.append("file", uploadedFile.file);
+
+    setFiles((prev) =>
+      prev.map((f) =>
+        f.id === uploadedFile.id
+          ? { ...f, status: "uploading" as Status, progress: 0, error: undefined }
+          : f,
+      ),
+    );
+
+    try {
+      const response = await api.post<{ job_id: string }>(
+        `${API_URL}/api/v1/upload`,
+        formData,
+      );
+      const { job_id } = response;
+
+      const poll = setInterval(async () => {
+        try {
+          const res = await api.get<{ progress?: number; done: boolean }>(
+            `${API_URL}/api/v1/upload/status/${job_id}`,
+          );
+          const progress = res.progress ?? 0;
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.id === uploadedFile.id ? { ...f, progress } : f,
+            ),
+          );
+          if (res.done) {
+            clearInterval(poll);
+            setFiles((prev) =>
+              prev.map((f) =>
+                f.id === uploadedFile.id
+                  ? { ...f, status: "completed" as Status, progress: 100 }
+                  : f,
+              ),
+            );
+          }
+        } catch (err) {
+          clearInterval(poll);
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.id === uploadedFile.id
+                ? {
+                    ...f,
+                    status: "error" as Status,
+                    error: "Processing failed",
+                  }
+                : f,
+            ),
+          );
+        }
+      }, 1000);
+    } catch (error) {
+      console.error("Upload error:", error);
+      setFiles((prev) =>
+        prev.map((f) =>
+          f.id === uploadedFile.id
+            ? {
+                ...f,
+                status: "error" as Status,
+                error: (error as Error).message || "Unknown error",
+              }
+            : f,
+        ),
+      );
+    }
+  };
+
+  const uploadAllFiles = async () => {
+    setUploading(true);
+    const pendingFiles = files.filter(
+      (f) => f.status === "pending" || f.status === "error",
+    );
+    let index = 0;
+
+    const uploadNext = async (): Promise<void> => {
+      if (index >= pendingFiles.length) return;
+      const next = pendingFiles[index++];
+      await uploadFile(next);
+      await uploadNext();
+    };
+
+    const workers = Array.from(
+      { length: Math.min(CONCURRENCY_LIMIT, pendingFiles.length) },
+      () => uploadNext(),
+    );
+    await Promise.all(workers);
+    setUploading(false);
+  };
+
+  return {
+    files,
+    uploading,
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    removeFile,
+    uploadAllFiles,
+  };
+};
+
+export default useUpload;


### PR DESCRIPTION
## Summary
- add `useUpload` hook managing file list, drag-and-drop, upload concurrency, and polling
- simplify `Upload` component to focus on rendering via the new hook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897274c17e483209aa529d5b4d39732