### PR TITLE
feat: add abortable upload polling hook

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useWebSocket, WebSocketState } from './useWebSocket';
 export { default as useDataSaver } from './useDataSaver';
 export { default as useDarkMode } from './useDarkMode';
+export { default as useUpload } from './useUpload';
 

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { useUpload } from './useUpload';
+import { api } from '../api/client';
+
+describe('useUpload', () => {
+  it('aborts polling on cancel', async () => {
+    jest.useFakeTimers();
+    const get = jest.spyOn(api, 'get').mockResolvedValue({ progress: 0, done: false } as any);
+    const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { result } = renderHook(() => useUpload());
+    const promise = result.current.pollStatus('1', 'job', jest.fn());
+
+    await Promise.resolve();
+    expect(get).toHaveBeenCalledTimes(1);
+
+    result.current.cancel('1');
+    await expect(promise).rejects.toThrow();
+
+    jest.runOnlyPendingTimers();
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(clearSpy).toHaveBeenCalled();
+
+    get.mockRestore();
+    clearSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('aborts polling on unmount', async () => {
+    jest.useFakeTimers();
+    const get = jest.spyOn(api, 'get').mockResolvedValue({ progress: 0, done: false } as any);
+    const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { result, unmount } = renderHook(() => useUpload());
+    const promise = result.current.pollStatus('1', 'job', jest.fn());
+
+    await Promise.resolve();
+    expect(get).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await expect(promise).rejects.toThrow();
+
+    jest.runOnlyPendingTimers();
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(clearSpy).toHaveBeenCalled();
+
+    get.mockRestore();
+    clearSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});
+

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { api } from '../api/client';
+
+interface ProgressResponse {
+  progress?: number;
+  done: boolean;
+}
+
+export const useUpload = () => {
+  const controllers = useRef<Record<string, AbortController>>({});
+  const timeouts = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const pollStatus = async (
+    id: string,
+    jobId: string,
+    onProgress: (p: number) => void,
+  ): Promise<void> => {
+    const controller = new AbortController();
+    controllers.current[id] = controller;
+    const signal = controller.signal;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async (): Promise<void> => {
+      const res = await api.get<ProgressResponse>(
+        `/api/v1/upload/status/${jobId}`,
+        { signal },
+      );
+      onProgress(res.progress ?? 0);
+      if (!res.done) {
+        await new Promise<void>((resolve, reject) => {
+          timeout = setTimeout(resolve, 1000);
+          timeouts.current[id] = timeout!;
+          const onAbort = () => {
+            if (timeout) clearTimeout(timeout);
+            reject(new DOMException('Aborted', 'AbortError'));
+          };
+          if (signal.aborted) {
+            onAbort();
+          } else {
+            signal.addEventListener('abort', onAbort, { once: true });
+          }
+        });
+        await poll();
+      }
+    };
+
+    try {
+      await poll();
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      delete timeouts.current[id];
+      delete controllers.current[id];
+    }
+  };
+
+  const cancel = (id: string) => {
+    controllers.current[id]?.abort();
+  };
+
+  useEffect(() => {
+    return () => {
+      Object.values(controllers.current).forEach((c) => c.abort());
+      Object.values(timeouts.current).forEach((t) => clearTimeout(t));
+    };
+  }, []);
+
+  return { pollStatus, cancel };
+};
+
+export default useUpload;
+


### PR DESCRIPTION
## Summary
- add `useUpload` hook with recursive polling and abortable timers
- export `useUpload` from hooks index
- test `useUpload` cancel and unmount behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897274d125483208ef0199371dcc334