### PR TITLE
feat: add streaming upload support

### DIFF
--- a/yosai_intel_dashboard/src/services/upload/upload_processing.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_processing.py
@@ -1,15 +1,100 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+import hashlib
+import mimetypes
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Dict
 
 import pandas as pd
 
-from .protocols import UploadAnalyticsProtocol, UploadSecurityProtocol
-from ..protocols.processor import ProcessorProtocol
-from ...infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from ...infrastructure.config.constants import AnalyticsConstants
-from ...core.protocols import EventBusProtocol
+from unicode_toolkit import safe_encode_text
 from yosai_intel_dashboard.src.utils.upload_store import get_uploaded_data_store
+
+from ...core.protocols import EventBusProtocol
+from ...infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
+from ...infrastructure.config.constants import (
+    AnalyticsConstants,
+    FileProcessingLimits,
+)
+from ..protocols.processor import ProcessorProtocol
+from .protocols import UploadAnalyticsProtocol, UploadSecurityProtocol
+
+
+@dataclass
+class UploadResult:
+    """Metadata returned after successfully streaming an upload."""
+
+    filename: str
+    bytes: int
+    sha256: str
+    content_type: str
+
+    @property
+    def contentType(self) -> str:  # pragma: no cover - alias for camelCase access
+        return self.content_type
+
+
+def stream_upload(
+    source: BinaryIO,
+    destination: str | Path,
+    filename: str,
+    *,
+    max_bytes: int = FileProcessingLimits.MAX_FILE_UPLOAD_SIZE_MB * 1024 * 1024,
+    allowed_extensions: set[str] | None = None,
+    chunk_size: int = 1024 * 1024,
+) -> UploadResult:
+    """Stream ``source`` to ``destination`` enforcing limits and return metadata.
+
+    The function writes the uploaded content to a temporary file while
+    calculating its SHA-256 hash. Once streaming finishes successfully the
+    temporary file is atomically moved to the final destination.
+    """
+
+    allowed = allowed_extensions or {".csv", ".json", ".xlsx"}
+
+    dest_dir = Path(destination)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_name = safe_encode_text(Path(filename).name).replace(" ", "_")
+    ext = Path(safe_name).suffix.lower()
+    if ext not in allowed:
+        raise ValueError(f"Unsupported file extension: {ext}")
+
+    hasher = hashlib.sha256()
+    total = 0
+
+    with tempfile.NamedTemporaryFile(dir=dest_dir, delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        while True:
+            chunk = source.read(chunk_size)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                tmp.close()
+                try:
+                    tmp_path.unlink()
+                finally:
+                    pass
+                raise ValueError("file too large")
+            hasher.update(chunk)
+            tmp.write(chunk)
+
+    final_path = dest_dir / safe_name
+    os.replace(tmp_path, final_path)
+
+    content_type = mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
+
+    return UploadResult(
+        filename=safe_name,
+        bytes=total,
+        sha256=hasher.hexdigest(),
+        content_type=content_type,
+    )
+
 
 class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
     """Process and analyze uploaded access control data."""
@@ -53,9 +138,7 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
             columns={"device_name": "door_id", "event_time": "timestamp"}
         )
         if "timestamp" in cleaned.columns:
-            cleaned["timestamp"] = pd.to_datetime(
-                cleaned["timestamp"], errors="coerce"
-            )
+            cleaned["timestamp"] = pd.to_datetime(cleaned["timestamp"], errors="coerce")
         cleaned = cleaned.dropna(how="all", axis=0)
         return cleaned
 
@@ -74,7 +157,6 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
                     "start": str(ts.min().date()),
                     "end": str(ts.max().date()),
                 }
-
 
         return {
             "rows": int(df.shape[0]),
@@ -143,6 +225,7 @@ class UploadAnalyticsProcessor(UploadAnalyticsProtocol):
         store = get_uploaded_data_store()
         return store.get_all_data()
 
+
 # Expose commonly used methods at module level for convenience
 get_analytics_from_uploaded_data = (
     UploadAnalyticsProcessor.get_analytics_from_uploaded_data
@@ -151,6 +234,8 @@ clean_uploaded_dataframe = UploadAnalyticsProcessor.clean_uploaded_dataframe
 summarize_dataframe = UploadAnalyticsProcessor.summarize_dataframe
 
 __all__ = [
+    "UploadResult",
+    "stream_upload",
     "UploadAnalyticsProcessor",
     "get_analytics_from_uploaded_data",
     "clean_uploaded_dataframe",


### PR DESCRIPTION
## Summary
- add `stream_upload` helper to stream uploaded files to disk while validating extension and size
- provide `UploadResult` model returning filename, byte count, SHA-256 and content type
- export new helper and model from upload processing module

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/upload/upload_processing.py` *(fails: mypy found module-wide type errors)*
- `pytest tests/test_uploaded_helpers.py -q` *(fails: 0 tests run, coverage requirement not met)*

------
https://chatgpt.com/codex/tasks/task_e_6897274f8060832099474b386bb276df