### PR TITLE
Add accessible log links to real-time monitoring events

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
@@ -9,6 +9,7 @@ import { useWebSocket } from '../hooks';
 import { useEventStream } from '../hooks/useEventStream';
 import useResponsiveChart from '../hooks/useResponsiveChart';
 import { ChunkGroup } from '../components/layout';
+import { Link } from 'react-router-dom';
 
 interface AccessEvent {
   eventId: string;
@@ -70,6 +71,13 @@ const EventRow: React.FC<{ event: AccessEvent; showDetails: boolean }> = ({
         {new Date(event.timestamp).toLocaleTimeString()}
       </span>
     )}
+    <Link
+      to={`/logs/${event.eventId}`}
+      aria-label={`View logs for event ${event.eventId}`}
+      className="text-blue-600 underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+    >
+      View logs
+    </Link>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- add `View logs` link to each event row in real-time monitoring
- ensure link is focusable and labeled for screen readers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68972d2fddc083208d5b2ff0ec0d6ebc