### PR TITLE
feat: add export utilities and hook

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/export/ExportForm.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/export/ExportForm.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import useExportData from '../../hooks/useExportData';
+import { Button } from '../shared/Button';
+import {
+  SUPPORTED_EXPORT_TYPES,
+  normalizeColumns,
+  validateFileType,
+} from '../../utils/exportTransforms';
+
+const ExportForm: React.FC = () => {
+  const [format, setFormat] = useState<string>('csv');
+  const [columns, setColumns] = useState<string>('');
+  const { mutateAsync } = useExportData();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateFileType(format)) {
+      alert('Unsupported export format');
+      return;
+    }
+    const columnList = normalizeColumns(columns.split(','));
+    await mutateAsync({ format, columns: columnList });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Format</label>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value)}
+          className="border rounded p-2 w-full"
+        >
+          {SUPPORTED_EXPORT_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Columns (comma separated)</label>
+        <input
+          type="text"
+          value={columns}
+          onChange={(e) => setColumns(e.target.value)}
+          className="border rounded p-2 w-full"
+          placeholder="e.g. person_id,door_id,timestamp"
+        />
+      </div>
+      <Button type="submit">Export</Button>
+    </form>
+  );
+};
+
+export default ExportForm;

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
@@ -2,4 +2,4 @@ export { default as useWebSocket, WebSocketState } from './useWebSocket';
 export { default as useDataSaver } from './useDataSaver';
 export { default as useDarkMode } from './useDarkMode';
 export { default as useUpload } from './useUpload';
-
+export { default as useExportData } from './useExportData';

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { analyticsAPI } from '../api/analytics';
+import { validateFileType, ExportType } from '../utils/exportTransforms';
+
+interface ExportParams {
+  format: string;
+  dataSource?: string;
+  columns?: string[];
+}
+
+const useExportData = () =>
+  useMutation<Blob, Error, ExportParams>({
+    mutationFn: async ({ format, dataSource }: ExportParams) => {
+      if (!validateFileType(format)) {
+        throw new Error(`Unsupported export format: ${format}`);
+      }
+      return analyticsAPI.exportData(format as ExportType, dataSource);
+    },
+  });
+
+export default useExportData;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Download } from 'lucide-react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { ChunkGroup } from '../components/layout';
+import ExportForm from '../components/export/ExportForm';
 
 const Export: React.FC = () => {
   return (
-    <ChunkGroup className="page-container">
+    <ChunkGroup className="page-container space-y-4">
       <h1>Export Data</h1>
-      <p>Export functionality coming soon...</p>
+      <ExportForm />
     </ChunkGroup>
   );
 };

--- a/yosai_intel_dashboard/src/adapters/ui/utils/exportTransforms.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/utils/exportTransforms.ts
@@ -1,0 +1,17 @@
+export const SUPPORTED_EXPORT_TYPES = ['csv', 'excel', 'json'] as const;
+export type ExportType = typeof SUPPORTED_EXPORT_TYPES[number];
+
+/**
+ * Validates that a file type is supported for export.
+ */
+export function validateFileType(type: string): type is ExportType {
+  return (SUPPORTED_EXPORT_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Normalizes a list of column names by trimming whitespace,
+ * removing empties and duplicates.
+ */
+export function normalizeColumns(columns: string[]): string[] {
+  return Array.from(new Set(columns.map(c => c.trim()).filter(Boolean)));
+}


### PR DESCRIPTION
## Summary
- add helper utilities for exporting data
- run validation in export form
- check unsupported formats in useExportData hook

## Testing
- `npm test` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972d425da08320abf51618feebadeb