### PR TITLE
feat: implement export data workflow

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/Export/ExportForm.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Export/ExportForm.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import type { ExportOptions } from '../../hooks/useExportData';
+
+interface Props {
+  onExport: (options: ExportOptions) => void;
+  progress: number;
+  status: 'idle' | 'exporting' | 'completed' | 'error';
+  onCancel: () => void;
+}
+
+const ExportForm: React.FC<Props> = ({ onExport, progress, status, onCancel }) => {
+  const [fileType, setFileType] = useState('csv');
+  const [columns, setColumns] = useState('');
+  const [timezone, setTimezone] = useState('UTC');
+  const [locale, setLocale] = useState('en-US');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const opts: ExportOptions = {
+      fileType,
+      columns: columns.split(',').map((c) => c.trim()).filter(Boolean),
+      timezone,
+      locale,
+    };
+    onExport(opts);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block mb-1">File Type</label>
+        <select
+          value={fileType}
+          onChange={(e) => setFileType(e.target.value)}
+          className="border p-1 rounded"
+        >
+          <option value="csv">CSV</option>
+          <option value="json">JSON</option>
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Columns (comma separated)</label>
+        <input
+          type="text"
+          value={columns}
+          onChange={(e) => setColumns(e.target.value)}
+          className="border p-1 rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Timezone</label>
+        <input
+          type="text"
+          value={timezone}
+          onChange={(e) => setTimezone(e.target.value)}
+          className="border p-1 rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Locale</label>
+        <input
+          type="text"
+          value={locale}
+          onChange={(e) => setLocale(e.target.value)}
+          className="border p-1 rounded w-full"
+        />
+      </div>
+      <div className="flex items-center space-x-2">
+        <button type="submit" className="btn btn-primary" disabled={status === 'exporting'}>
+          Export
+        </button>
+        {status === 'exporting' && (
+          <button type="button" className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
+      {status !== 'idle' && (
+        <div className="mt-4">
+          {status === 'exporting' && (
+            <div className="flex items-center space-x-2">
+              <progress value={progress} max="100" className="flex-1" />
+              <span>{progress}%</span>
+            </div>
+          )}
+          {status === 'completed' && <p className="text-green-600">Export complete.</p>}
+          {status === 'error' && <p className="text-red-600">Export failed.</p>}
+        </div>
+      )}
+    </form>
+  );
+};
+
+export default ExportForm;

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
@@ -2,4 +2,5 @@ export { default as useWebSocket, WebSocketState } from './useWebSocket';
 export { default as useDataSaver } from './useDataSaver';
 export { default as useDarkMode } from './useDarkMode';
 export { default as useUpload } from './useUpload';
+export { default as useExportData } from './useExportData';
 

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
@@ -1,0 +1,98 @@
+import { useState, useRef, useCallback } from 'react';
+
+export interface ExportOptions {
+  fileType: string;
+  columns: string[];
+  timezone: string;
+  locale: string;
+}
+
+type ExportStatus = 'idle' | 'exporting' | 'completed' | 'error';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';
+
+export const useExportData = () => {
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState<ExportStatus>('idle');
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const startExport = useCallback(async (options: ExportOptions) => {
+    setStatus('exporting');
+    setProgress(0);
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    try {
+      const response = await fetch(`${API_URL}/api/v1/export`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(options),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error('Export failed');
+      }
+
+      const contentLength = response.headers.get('content-length');
+      const total = contentLength ? parseInt(contentLength, 10) : 0;
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('Readable stream not supported');
+      }
+      const chunks: Uint8Array[] = [];
+      let received = 0;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          chunks.push(value);
+          received += value.length;
+          if (total) {
+            setProgress(Math.round((received / total) * 100));
+          }
+        }
+      }
+
+      // Create a blob from the chunks and trigger download
+      const blob = new Blob(chunks, { type: 'application/octet-stream' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      const ext = options.fileType || 'dat';
+      link.download = `export.${ext}`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      setProgress(100);
+      setStatus('completed');
+    } catch (err) {
+      if ((err as any)?.name === 'AbortError') {
+        setStatus('idle');
+      } else {
+        console.error(err);
+        setStatus('error');
+      }
+    } finally {
+      controllerRef.current = null;
+    }
+  }, []);
+
+  const cancelExport = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  return {
+    startExport,
+    progress,
+    status,
+    cancelExport,
+  };
+};
+
+export default useExportData;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Export.tsx
@@ -2,12 +2,24 @@ import React from 'react';
 import { Download } from 'lucide-react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { ChunkGroup } from '../components/layout';
+import ExportForm from '../components/Export/ExportForm';
+import { useExportData } from '../hooks';
 
 const Export: React.FC = () => {
+  const { startExport, progress, status, cancelExport } = useExportData();
+
   return (
     <ChunkGroup className="page-container">
-      <h1>Export Data</h1>
-      <p>Export functionality coming soon...</p>
+      <h1 className="mb-4 flex items-center space-x-2">
+        <Download />
+        <span>Export Data</span>
+      </h1>
+      <ExportForm
+        onExport={startExport}
+        progress={progress}
+        status={status}
+        onCancel={cancelExport}
+      />
     </ChunkGroup>
   );
 };


### PR DESCRIPTION
## Summary
- add `useExportData` hook to stream exports and track progress
- create `ExportForm` component for selecting export options and cancelling
- update Export page to use hook and form within `ChunkGroup`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68972d4330d4832083950452e55b6a87