### PR TITLE
Add export data worker and hook

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
@@ -2,4 +2,5 @@ export { default as useWebSocket, WebSocketState } from './useWebSocket';
 export { default as useDataSaver } from './useDataSaver';
 export { default as useDarkMode } from './useDarkMode';
 export { default as useUpload } from './useUpload';
+export { default as useExportData } from './useExportData';
 

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useExportData.ts
@@ -1,0 +1,73 @@
+import { useCallback, useState } from 'react';
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001/v1';
+
+const useExportData = () => {
+  const [exporting, setExporting] = useState(false);
+
+  const exportData = useCallback(
+    async (format: 'csv' | 'excel' | 'json', dataSource?: string) => {
+      setExporting(true);
+      const worker = new Worker(
+        new URL('../utils/exportWorker.ts', import.meta.url),
+        { type: 'module' }
+      );
+
+      try {
+        const params = new URLSearchParams({ format });
+        if (dataSource) params.append('data_source', dataSource);
+
+        const response = await fetch(
+          `${API_BASE_URL}/analytics/export?${params.toString()}`,
+          { credentials: 'include' }
+        );
+
+        const contentType =
+          response.headers.get('Content-Type') || 'application/octet-stream';
+        const disposition = response.headers.get('Content-Disposition') || '';
+        let filename = `export.${format}`;
+        const match = disposition.match(/filename="?([^";]+)"?/);
+        if (match && match[1]) {
+          filename = match[1];
+        }
+
+        worker.onmessage = (ev: MessageEvent<{ blob: Blob }>) => {
+          const { blob } = ev.data;
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = filename;
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+          worker.terminate();
+          setExporting(false);
+        };
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error('Streaming not supported');
+        }
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) {
+            worker.postMessage({ chunk: value });
+          }
+        }
+        worker.postMessage({ done: true, mimeType: contentType });
+      } catch (err) {
+        worker.terminate();
+        setExporting(false);
+        throw err;
+      }
+    },
+    []
+  );
+
+  return { exportData, exporting } as const;
+};
+
+export default useExportData;

--- a/yosai_intel_dashboard/src/adapters/ui/utils/exportWorker.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/utils/exportWorker.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-restricted-globals */
+// Web Worker for assembling streamed chunks into a single Blob
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+let chunks: BlobPart[] = [];
+
+ctx.onmessage = (
+  e: MessageEvent<{ chunk?: Uint8Array; done?: boolean; mimeType?: string }>
+) => {
+  const { chunk, done, mimeType } = e.data;
+
+  if (chunk) {
+    // Store received chunk
+    chunks.push(chunk);
+  }
+
+  if (done) {
+    const blob = new Blob(chunks, { type: mimeType });
+    ctx.postMessage({ blob });
+    // Reset for possible future use
+    chunks = [];
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- implement exportWorker to combine streamed chunks into Blob
- add useExportData hook spawning worker and handling downloads
- export new hook from hooks index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68972d452a5c83208aedc8edf46a9cd6