### PR TITLE
refactor: use requestIdleCallback when available

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -33,10 +33,10 @@ const RealTimeAnalyticsPage: React.FC = () => {
   const [paused, setPaused] = useState(false);
   const bufferRef = useRef<Record<string, any>[]>([]);
   const [pending, setPending] = useState(0);
-  const scheduler =
-    (typeof window !== 'undefined' && (window as any).requestIdleCallback)
-      ? (window as any).requestIdleCallback
-      : (fn: Function) => setTimeout(fn, 0);
+  const scheduler: (cb: () => void) => void =
+    typeof window !== 'undefined' && (window as any).requestIdleCallback
+      ? (cb) => (window as any).requestIdleCallback(cb)
+      : (cb) => setTimeout(cb, 0);
 
   useEffect(() => {
     if (liveData) {

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeMonitoring.tsx
@@ -90,10 +90,10 @@ export const RealTimeMonitoring: React.FC = () => {
   const [paused, setPaused] = useState(false);
   const bufferRef = useRef<AccessEvent[]>([]);
   const [pending, setPending] = useState(0);
-  const scheduler =
-    (typeof window !== 'undefined' && (window as any).requestIdleCallback)
-      ? (window as any).requestIdleCallback
-      : (fn: Function) => setTimeout(fn, 0);
+  const scheduler: (cb: () => void) => void =
+    typeof window !== 'undefined' && (window as any).requestIdleCallback
+      ? (cb) => (window as any).requestIdleCallback(cb)
+      : (cb) => setTimeout(cb, 0);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- type scheduler callback to use requestIdleCallback when available and fall back to setTimeout

## Testing
- `npm test`
- `npm run lint` *(fails: numerous prettier issues)*

------
https://chatgpt.com/codex/tasks/task_e_68972d55a4d08320bf6923b7a098842a