### PR TITLE
feat: add real-time analytics event type

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useRealTimeAnalyticsData.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useRealTimeAnalyticsData.ts
@@ -1,0 +1,18 @@
+export interface RealTimeAnalyticsEvent {
+  total_events?: number;
+  active_users?: number;
+  unique_users?: number;
+  active_doors?: number;
+  unique_doors?: number;
+  top_users?: {
+    user_id: string;
+    count: number;
+  }[];
+  top_doors?: {
+    door_id: string;
+    count: number;
+  }[];
+  access_patterns?: Record<string, number>;
+  [key: string]: any;
+}
+

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { useRealTimeAnalytics } from '../hooks/useRealTimeAnalytics';
+import type { RealTimeAnalyticsEvent } from '../hooks/useRealTimeAnalyticsData';
 import { AccessibleVisualization } from '../components/accessibility';
 import { ChunkGroup } from '../components/layout';
 
@@ -29,9 +30,9 @@ const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'];
 
 const RealTimeAnalyticsPage: React.FC = () => {
   const { data: liveData } = useRealTimeAnalytics();
-  const [data, setData] = useState<Record<string, any> | null>(null);
+  const [data, setData] = useState<RealTimeAnalyticsEvent | null>(null);
   const [paused, setPaused] = useState(false);
-  const bufferRef = useRef<Record<string, any>[]>([]);
+  const bufferRef = useRef<RealTimeAnalyticsEvent[]>([]);
   const [pending, setPending] = useState(0);
   const scheduler =
     (typeof window !== 'undefined' && (window as any).requestIdleCallback)


### PR DESCRIPTION
## Summary
- define `RealTimeAnalyticsEvent` describing real-time analytics payloads
- use `RealTimeAnalyticsEvent` for component state and buffer in `RealTimeAnalyticsPage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68972d55aeb08320a28cca3a94b82c47