### PR TITLE
feat: add polite live region for totals

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -72,7 +72,7 @@ const RealTimeAnalyticsPage: React.FC = () => {
 
 
   if (!data) {
-    return <div>Waiting for analytics...</div>;
+    return <div aria-live="polite">Waiting for analytics...</div>;
   }
 
   const topUsersRaw = Array.isArray(data.top_users) ? data.top_users : [];
@@ -135,7 +135,7 @@ const RealTimeAnalyticsPage: React.FC = () => {
           )}
         </ChunkGroup>
       </ChunkGroup>
-      <ChunkGroup className="mb-4 space-y-1">
+      <ChunkGroup className="mb-4 space-y-1" role="status" aria-live="polite">
         <div>Total Events: {data.total_events ?? 0}</div>
         <div>
           Active Users:{' '}


### PR DESCRIPTION
## Summary
- wrap totals in a polite live region for screen readers
- mark waiting message as polite aria-live

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install --no-save react-scripts` *(fails: could not resolve dependency: typescript@5.9.2 vs peer typescript@^3.2.1||^4)*

------
https://chatgpt.com/codex/tasks/task_e_68972d578f448320ba0bb043c6b07979