### PR TITLE
Respect reduced-motion preference in charts

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/security/RiskDashboard.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/security/RiskDashboard.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 import { usePreferencesStore } from '../../state';
 import { useNetworkStatus } from '../../lib/network';
 
@@ -33,6 +34,7 @@ const RiskDashboard: React.FC<RiskDashboardProps> = ({
   history,
   factors,
 }) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
   const [displayScore, setDisplayScore] = useState(score);
   const [expanded, setExpanded] = useState(false);
   const { saveData } = usePreferencesStore();
@@ -118,7 +120,12 @@ const RiskDashboard: React.FC<RiskDashboardProps> = ({
               <XAxis dataKey="name" />
               <YAxis />
               <Tooltip />
-              <Bar dataKey="value" barSize={20} fill="#3b82f6" />
+              <Bar
+                dataKey="value"
+                barSize={20}
+                fill="#3b82f6"
+                isAnimationActive={!prefersReducedMotion}
+              />
               <Line type="monotone" dataKey="benchmark" stroke="#ef4444" />
             </ComposedChart>
           </ResponsiveContainer>

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/usePrefersReducedMotion.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Detects the user's reduced motion preference.
+ * Returns true when the user has requested reduced motion.
+ */
+const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+    handleChange();
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export default usePrefersReducedMotion;

--- a/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/RealTimeAnalyticsPage.tsx
@@ -23,12 +23,14 @@ import { Badge } from '../components/ui/badge';
 import { useRealTimeAnalytics } from '../hooks/useRealTimeAnalytics';
 import { AccessibleVisualization } from '../components/accessibility';
 import { ChunkGroup } from '../components/layout';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300'];
 
 const RealTimeAnalyticsPage: React.FC = () => {
   const { data: liveData } = useRealTimeAnalytics();
+  const prefersReducedMotion = usePrefersReducedMotion();
   const [data, setData] = useState<Record<string, any> | null>(null);
   const [paused, setPaused] = useState(false);
   const bufferRef = useRef<Record<string, any>[]>([]);
@@ -163,7 +165,11 @@ const RealTimeAnalyticsPage: React.FC = () => {
                 <XAxis dataKey="user_id" />
                 <YAxis />
                 <Tooltip />
-                <Bar dataKey="count" fill="#8884d8" />
+                <Bar
+                  dataKey="count"
+                  fill="#8884d8"
+                  isAnimationActive={!prefersReducedMotion}
+                />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -186,7 +192,11 @@ const RealTimeAnalyticsPage: React.FC = () => {
                 <XAxis dataKey="door_id" />
                 <YAxis />
                 <Tooltip />
-                <Bar dataKey="count" fill="#82ca9d" />
+                <Bar
+                  dataKey="count"
+                  fill="#82ca9d"
+                  isAnimationActive={!prefersReducedMotion}
+                />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -205,7 +215,13 @@ const RealTimeAnalyticsPage: React.FC = () => {
           <div className="mb-4" style={{ width: '100%', height: 300 }}>
             <ResponsiveContainer>
               <PieChart>
-                <Pie data={patterns} dataKey="count" nameKey="pattern" label>
+              <Pie
+                data={patterns}
+                dataKey="count"
+                nameKey="pattern"
+                label
+                isAnimationActive={!prefersReducedMotion}
+              >
 
                   {patterns.map((_, i) => (
                     <Cell key={i} fill={COLORS[i % COLORS.length]} />


### PR DESCRIPTION
## Summary
- detect user reduced motion preference with a reusable hook
- disable animations in Recharts Bar and Pie based on preference

## Testing
- `npm test`
- `npm run lint` *(fails: prettier violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68972d5863e883209cc21beb025aadb4