### PR TITLE
Add real-time analytics event streaming route

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/analytics_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/analytics_router.py
@@ -18,6 +18,9 @@ from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
 from yosai_intel_dashboard.src.services.analytics.proficiency_endpoint import (
     router as proficiency_router,
 )
+from yosai_intel_dashboard.src.components.analytics.real_time_dashboard import (
+    router as realtime_router,
+)
 from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsService
 from yosai_intel_dashboard.src.services.security import require_permission
 
@@ -30,6 +33,7 @@ cfg = get_cache_config()
 _cache_manager = InMemoryCacheManager(CacheConfig(timeout_seconds=cfg.ttl))
 _cached_service = CachedAnalyticsService(_cache_manager)
 router.include_router(proficiency_router)
+router.include_router(realtime_router)
 
 
 async def init_cache_manager() -> None:

--- a/yosai_intel_dashboard/src/components/analytics/__init__.py
+++ b/yosai_intel_dashboard/src/components/analytics/__init__.py
@@ -1,0 +1,3 @@
+"""Analytics components for realtime dashboard streaming."""
+
+__all__ = []

--- a/yosai_intel_dashboard/src/components/analytics/real_time_dashboard.py
+++ b/yosai_intel_dashboard/src/components/analytics/real_time_dashboard.py
@@ -1,0 +1,41 @@
+"""Real-time analytics event streaming for the dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+
+class AnalyticsEvent(BaseModel):
+    """Schema for analytics events sent to the client."""
+
+    type: str
+    payload: dict[str, Any] | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+router = APIRouter(prefix="/real-time", tags=["analytics"])
+
+
+async def _heartbeat_stream() -> AsyncIterator[str]:
+    """Yield heartbeat events indefinitely."""
+
+    while True:
+        event = AnalyticsEvent(type="heartbeat")
+        yield f"data: {event.model_dump_json()}\n\n"
+        await asyncio.sleep(5)
+
+
+@router.get("/events", response_class=StreamingResponse)
+async def stream_events() -> StreamingResponse:
+    """Stream analytics events to the client with periodic heartbeats."""
+
+    return StreamingResponse(_heartbeat_stream(), media_type="text/event-stream")
+
+
+__all__ = ["AnalyticsEvent", "router", "stream_events"]


### PR DESCRIPTION
## Summary
- add Pydantic `AnalyticsEvent` model and heartbeat stream for real-time analytics
- expose `/analytics/real-time/events` SSE endpoint with UTC timestamps

## Testing
- `pytest tests/test_real_time_performance_tracker.py::test_tracker_records_latency_and_throughput -q -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_68972d5a19688320852d144ada337d2a