### PR TITLE
Refactor upload endpoint to stream uploads to disk

### DIFF
--- a/tests/adapters/api/test_cors.py
+++ b/tests/adapters/api/test_cors.py
@@ -142,14 +142,10 @@ def _create_app(monkeypatch, origins):
         filenames: list[str] | None = None
 
     class UploadResponseSchema(BaseModel):
-        job_id: str
-
-    class StatusSchema(BaseModel):
-        status: str
+        results: list[str]
 
     upload_upload_stub.UploadRequestSchema = UploadRequestSchema
     upload_upload_stub.UploadResponseSchema = UploadResponseSchema
-    upload_upload_stub.StatusSchema = StatusSchema
     for name, mod in {
         "yosai_intel_dashboard.src.services.upload_endpoint": upload_stub,
         "yosai_intel_dashboard.src.services.upload.upload_endpoint": upload_upload_stub,

--- a/tests/adapters/api/test_metrics_prometheus.py
+++ b/tests/adapters/api/test_metrics_prometheus.py
@@ -106,14 +106,10 @@ def _create_app(monkeypatch):
         filenames: list[str] | None = None
 
     class UploadResponseSchema(BaseModel):
-        job_id: str
-
-    class StatusSchema(BaseModel):
-        status: str
+        results: list[str]
 
     upload_upload_stub.UploadRequestSchema = UploadRequestSchema
     upload_upload_stub.UploadResponseSchema = UploadResponseSchema
-    upload_upload_stub.StatusSchema = StatusSchema
     monkeypatch.setitem(
         sys.modules,
         "yosai_intel_dashboard.src.services.upload.upload_endpoint",

--- a/tests/adapters/api/test_startup_services.py
+++ b/tests/adapters/api/test_startup_services.py
@@ -113,14 +113,10 @@ def _create_app(monkeypatch, flags):
         filenames: list[str] | None = None
 
     class UploadResponseSchema(BaseModel):
-        job_id: str
-
-    class StatusSchema(BaseModel):
-        status: str
+        results: list[str]
 
     upload_stub.UploadRequestSchema = UploadRequestSchema
     upload_stub.UploadResponseSchema = UploadResponseSchema
-    upload_stub.StatusSchema = StatusSchema
     monkeypatch.setitem(
         sys.modules,
         "yosai_intel_dashboard.src.services.upload.upload_endpoint",

--- a/tests/integration/test_api_csrf.py
+++ b/tests/integration/test_api_csrf.py
@@ -67,14 +67,10 @@ def _create_app(monkeypatch):
         filenames: list[str] | None = None
 
     class UploadResponseSchema(BaseModel):
-        job_id: str
-
-    class StatusSchema(BaseModel):
-        status: str
+        results: list[str]
 
     upload_upload_stub.UploadRequestSchema = UploadRequestSchema
     upload_upload_stub.UploadResponseSchema = UploadResponseSchema
-    upload_upload_stub.StatusSchema = StatusSchema
     monkeypatch.setitem(
         sys.modules,
         "yosai_intel_dashboard.src.services.upload.upload_endpoint",
@@ -117,4 +113,4 @@ def test_csrf_token_and_protected_endpoint(monkeypatch):
         json={"contents": ["data:text/plain;base64,Zm8="], "filenames": ["t.txt"]},
         headers={"X-CSRFToken": token},
     )
-    assert resp.status_code == 202
+    assert resp.status_code == 200

--- a/yosai_intel_dashboard/src/adapters/api/spec.py
+++ b/yosai_intel_dashboard/src/adapters/api/spec.py
@@ -146,7 +146,7 @@ def create_flask_app() -> Flask:
         container.get("error_handler") if container.has("error_handler") else None
     )
     upload_bp = create_upload_blueprint(
-        container.get("file_processor"),
+        storage_dir="/tmp/uploads",
         file_handler=(
             container.get("file_handler") if container.has("file_handler") else None
         ),

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -1,10 +1,21 @@
-# -*- coding: utf-8 -*-
+"""Flask blueprint for handling file uploads.
+
+The previous implementation relied on an asynchronous processor and returned a
+job identifier to poll for status updates.  The blueprint now streams incoming
+files directly to a configurable storage directory and immediately returns the
+results of the upload.  Each file is validated using ``FileHandler.validator``
+before it is written to disk.  Only whitelisted extensions and MIME types are
+accepted and size limits are enforced prior to saving the file.
+"""
+
 from __future__ import annotations
 
 import base64
+from pathlib import Path
+from typing import Iterable
 
 import redis
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from flask_apispec import doc
 from flask_wtf.csrf import validate_csrf
 from pydantic import BaseModel, ConfigDict
@@ -15,6 +26,7 @@ from yosai_intel_dashboard.src.error_handling import (
     ErrorHandler,
     api_error_response,
 )
+from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadConfig
 from yosai_intel_dashboard.src.infrastructure.config.loader import (
     ConfigurationLoader,
 )
@@ -23,14 +35,26 @@ from yosai_intel_dashboard.src.utils.pydantic_decorators import (
     validate_input,
     validate_output,
 )
-from yosai_intel_dashboard.src.utils.sanitization import sanitize_text, sanitize_filename
+from yosai_intel_dashboard.src.utils.sanitization import sanitize_filename
+
 
 _service_cfg = ConfigurationLoader().get_service_config()
 redis_client = redis.Redis.from_url(_service_cfg.redis_url)
 rate_limiter = RedisRateLimiter(redis_client, {"default": {"limit": 100, "burst": 0}})
 
 
+# ---------------------------------------------------------------------------
+# Schema definitions
+# ---------------------------------------------------------------------------
+
+
 class UploadRequestSchema(BaseModel):
+    """Payload schema for uploads.
+
+    Files can either be supplied as base64 encoded strings in ``contents`` with
+    matching ``filenames`` or via a traditional multipart form upload.
+    """
+
     contents: list[str] | None = None
     filenames: list[str] | None = None
 
@@ -46,40 +70,114 @@ class UploadRequestSchema(BaseModel):
     )
 
 
+class UploadResultSchema(BaseModel):
+    """Details for a single uploaded file."""
+
+    filename: str
+    path: str
+
+
 class UploadResponseSchema(BaseModel):
-    job_id: str
+    """Response payload returned from the upload endpoint."""
+
+    results: list[UploadResultSchema]
 
     model_config = ConfigDict(
         json_schema_extra={
-            "examples": [{"job_id": "123e4567-e89b-12d3-a456-426614174000"}]
+            "examples": [
+                {
+                    "results": [
+                        {
+                            "filename": "hello.txt",
+                            "path": "/tmp/uploads/hello.txt",
+                        }
+                    ]
+                }
+            ]
         }
     )
 
 
-class StatusSchema(BaseModel):
-    status: dict
+ALLOWED_MIME_TYPES: set[str] = {
+    "text/csv",
+    "application/json",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def stream_upload(storage_dir: Path, filename: str, data: bytes) -> Path:
+    """Persist ``data`` to ``storage_dir`` using ``filename``.
+
+    The directory is created if it does not yet exist.  The function returns the
+    absolute path to the saved file.
+    """
+
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    dest = storage_dir / filename
+    with open(dest, "wb") as f:
+        f.write(data)
+    return dest
+
+
+def _decode_base64(content: str) -> tuple[str, bytes]:
+    """Return MIME type and decoded bytes from a data URL string."""
+
+    if "," not in content:
+        raise ValueError("Invalid contents")
+    header, data = content.split(",", 1)
+    mime = header.split(";")[0].replace("data:", "", 1) or "application/octet-stream"
+    return mime, base64.b64decode(data)
+
+
+# ---------------------------------------------------------------------------
+# Blueprint factory
+# ---------------------------------------------------------------------------
 
 
 def create_upload_blueprint(
-    file_processor,
+    storage_dir: str | Path,
     *,
-    file_handler=None,
+    file_handler: FileHandler | None = None,
     handler: ErrorHandler | None = None,
 ) -> Blueprint:
-    """Return a blueprint handling file uploads."""
+    """Return a blueprint handling file uploads.
+
+    Parameters
+    ----------
+    storage_dir:
+        Directory where uploaded files should be written.
+    file_handler:
+        Optional :class:`FileHandler` used to obtain the security validator.
+    handler:
+        Optional custom :class:`ErrorHandler`.
+    """
 
     upload_bp = Blueprint("upload", __name__)
     err_handler = handler or ErrorHandler()
+    storage_path = Path(storage_dir)
+
+    validator = None
+    if file_handler is not None:
+        validator = getattr(file_handler, "validator", None)
+    if validator is None:
+        validator = FileHandler().validator
+
+    cfg = UploadConfig()
 
     @upload_bp.route("/v1/upload", methods=["POST"])
     @doc(
-        description="Upload a file",
+        description="Upload one or more files",
         tags=["upload"],
         responses={
-            202: "Accepted",
+            200: "Success",
             400: "Bad Request",
             401: "Unauthorized",
-            404: "Not Found",
             500: "Internal Server Error",
         },
     )
@@ -87,35 +185,25 @@ def create_upload_blueprint(
     @validate_output(UploadResponseSchema)
     @rate_limit(rate_limiter)
     def upload_files(payload: UploadRequestSchema):
-        """Process an uploaded file.
+        """Validate and persist uploaded files."""
 
-        Validates the incoming data or multipart upload, stores the contents for
-        background processing and returns a job identifier.
-        """
         try:
             token = (
                 request.headers.get("X-CSRFToken")
                 or request.headers.get("X-CSRF-Token")
                 or request.form.get("csrf_token")
             )
-            try:
-                validate_csrf(token)
-            except Exception:
-                return api_error_response(
-                    ValueError("Invalid CSRF token"),
-                    ErrorCategory.INVALID_INPUT,
-                    handler=err_handler,
-                )
+            validate_csrf(token)
+        except Exception:
+            return api_error_response(
+                ValueError("Invalid CSRF token"),
+                ErrorCategory.INVALID_INPUT,
+                handler=err_handler,
+            )
 
-            contents = []
-            filenames = []
-            validator = getattr(file_processor, "validator", None)
-            if validator is None:
-                if file_handler is not None:
-                    validator = getattr(file_handler, "validator", None)
-                if validator is None:
-                    validator = FileHandler().validator
+        results: list[dict[str, str]] = []
 
+        try:
             if request.files:
                 for file in request.files.values():
                     if not file.filename:
@@ -124,76 +212,100 @@ def create_upload_blueprint(
                         filename = sanitize_filename(file.filename)
                     except ValueError as exc:
                         return api_error_response(
-                            exc,
+                            exc, ErrorCategory.INVALID_INPUT, handler=err_handler
+                        )
+
+                    mime = file.mimetype or "application/octet-stream"
+                    if mime not in ALLOWED_MIME_TYPES:
+                        return api_error_response(
+                            ValueError("Unsupported file type"),
                             ErrorCategory.INVALID_INPUT,
                             handler=err_handler,
                         )
-                    file_bytes = file.read()
+
+                    data = file.read()
                     try:
-                        validator.validate_file_upload(filename, file_bytes)
+                        res = validator.validate_file_upload(filename, data)
+                        if not res.valid:
+                            raise ValueError(", ".join(res.issues or []))
                     except Exception as exc:
                         return api_error_response(
-                            exc,
+                            exc, ErrorCategory.INVALID_INPUT, handler=err_handler
+                        )
+
+                    if len(data) > cfg.max_file_size_bytes:
+                        return api_error_response(
+                            ValueError("File too large"),
                             ErrorCategory.INVALID_INPUT,
                             handler=err_handler,
                         )
-                    b64 = base64.b64encode(file_bytes).decode("utf-8", errors="replace")
-                    mime = file.mimetype or "application/octet-stream"
-                    contents.append(f"data:{mime};base64,{b64}")
-                    filenames.append(filename)
+                    dest = stream_upload(storage_path, filename, data)
+                    results.append({"filename": filename, "path": str(dest)})
             else:
                 contents = payload.contents or []
-                filenames = []
-                for name in (payload.filenames or []):
+                filenames = payload.filenames or []
+                for content, name in zip(contents, filenames):
                     try:
-                        filenames.append(sanitize_filename(name))
+                        filename = sanitize_filename(name)
                     except ValueError as exc:
                         return api_error_response(
-                            exc,
+                            exc, ErrorCategory.INVALID_INPUT, handler=err_handler
+                        )
+
+                    try:
+                        mime, data = _decode_base64(content)
+                    except Exception as exc:
+                        return api_error_response(
+                            exc, ErrorCategory.INVALID_INPUT, handler=err_handler
+                        )
+
+                    if mime not in ALLOWED_MIME_TYPES:
+                        return api_error_response(
+                            ValueError("Unsupported file type"),
                             ErrorCategory.INVALID_INPUT,
                             handler=err_handler,
                         )
 
-            if not contents or not filenames:
-                return api_error_response(
-                    ValueError("No file provided"),
-                    ErrorCategory.INVALID_INPUT,
-                    handler=err_handler,
-                )
+                    try:
+                        res = validator.validate_file_upload(filename, data)
+                        if not res.valid:
+                            raise ValueError(", ".join(res.issues or []))
+                    except Exception as exc:
+                        return api_error_response(
+                            exc, ErrorCategory.INVALID_INPUT, handler=err_handler
+                        )
 
-            job_id = file_processor.process_file_async(contents[0], filenames[0])
+                    if len(data) > cfg.max_file_size_bytes:
+                        return api_error_response(
+                            ValueError("File too large"),
+                            ErrorCategory.INVALID_INPUT,
+                            handler=err_handler,
+                        )
 
-            return {"job_id": job_id}, 202
+                    dest = stream_upload(storage_path, filename, data)
+                    results.append({"filename": filename, "path": str(dest)})
 
-        except Exception as e:  # pragma: no cover - defensive
-            return api_error_response(e, ErrorCategory.INTERNAL, handler=err_handler)
+        except Exception as exc:  # pragma: no cover - defensive
+            return api_error_response(exc, ErrorCategory.INTERNAL, handler=err_handler)
 
-    @upload_bp.route("/v1/upload/status/<job_id>", methods=["GET"])
-    @doc(
-        params={
-            "job_id": {
-                "description": "Upload job id",
-                "in": "path",
-                "schema": {"type": "string"},
-            }
-        },
-        tags=["upload"],
-        responses={
-            200: "Success",
-            400: "Bad Request",
-            401: "Unauthorized",
-            404: "Not Found",
-            500: "Internal Server Error",
-        },
-    )
-    @validate_output(StatusSchema)
-    def upload_status(job_id: str):
-        """Fetch upload processing status.
+        if not results:
+            return api_error_response(
+                ValueError("No file provided"),
+                ErrorCategory.INVALID_INPUT,
+                handler=err_handler,
+            )
 
-        Looks up the current state for the provided ``job_id`` and returns the
-        processing metadata.
-        """
-        status = file_processor.get_job_status(job_id)
-        return status
+        return {"results": results}, 200
 
     return upload_bp
+
+
+__all__ = [
+    "UploadRequestSchema",
+    "UploadResultSchema",
+    "UploadResponseSchema",
+    "create_upload_blueprint",
+    "stream_upload",
+    "ALLOWED_MIME_TYPES",
+]
+

--- a/yosai_intel_dashboard/src/services/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload_endpoint.py
@@ -6,18 +6,22 @@ import warnings
 
 # Explicitly import only the public symbols from the upload endpoint module.
 from .upload.upload_endpoint import (
-    StatusSchema,
+    ALLOWED_MIME_TYPES,
     UploadRequestSchema,
     UploadResponseSchema,
+    UploadResultSchema,
     create_upload_blueprint as _create_upload_blueprint,
+    stream_upload,
 )
 
 # Re-export the imported symbols to maintain the public API of this module.
 __all__ = [
     "UploadRequestSchema",
     "UploadResponseSchema",
-    "StatusSchema",
+    "UploadResultSchema",
     "create_upload_blueprint",
+    "stream_upload",
+    "ALLOWED_MIME_TYPES",
 ]
 
 


### PR DESCRIPTION
## Summary
- accept a storage directory and stream uploaded files to disk
- validate uploads via FileHandler.validator and enforce MIME/size limits
- return per-file results instead of async job IDs

## Testing
- `pytest tests/test_upload_endpoint.py tests/test_upload_csrf.py` *(fails: ImportError: cannot import name 'ConfigDict' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6897275dd8888320ad782c02d401e087