### PR TITLE
Add dash bootstrap components and harden graph LOF

### DIFF
--- a/analytics/graph_analysis/algorithms.py
+++ b/analytics/graph_analysis/algorithms.py
@@ -9,10 +9,9 @@ instance.
 from __future__ import annotations
 
 from collections import defaultdict
+from itertools import combinations
 from statistics import mean, stdev
 from typing import Dict, Iterable, List, Sequence, Tuple
-
-from itertools import combinations
 
 import networkx as nx
 from sklearn.neighbors import LocalOutlierFactor
@@ -125,7 +124,10 @@ def graph_lof(graph: GraphModel | nx.Graph, n_neighbors: int = 5) -> Dict[str, f
 
     G = _to_nx(graph)
     features = [[d] for _, d in G.degree()]
-    lof = LocalOutlierFactor(n_neighbors=min(n_neighbors, len(features) - 1))
+    if len(features) <= 1:
+        return {}
+    n_neighbors = max(1, min(n_neighbors, len(features) - 1))
+    lof = LocalOutlierFactor(n_neighbors=n_neighbors)
     lof.fit(features)
     return {node: score for node, score in zip(G.nodes(), lof.negative_outlier_factor_)}
 
@@ -239,9 +241,7 @@ def deviation_from_group_norms(
         m = mean(degrees)
         s = stdev(degrees)
         if s:
-            outliers.extend(
-                n for n, d in zip(community, degrees) if abs(d - m) > 2 * s
-            )
+            outliers.extend(n for n, d in zip(community, degrees) if abs(d - m) > 2 * s)
     return outliers
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask-Caching==2.0.2
 cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
+dash-bootstrap-components==1.6.0
 pandas==2.1.4
 numpy==1.26.4
 Authlib==1.6.1

--- a/tests/graph/test_graph_analysis.py
+++ b/tests/graph/test_graph_analysis.py
@@ -7,10 +7,13 @@ pytest.importorskip("sklearn")
 
 from services.analytics.graph_analysis import (
     GraphModel,
+    Node,
+    NodeType,
     build_graph_from_logs,
 )
 from services.analytics.graph_analysis.algorithms import (
     betweenness_centrality,
+    graph_lof,
     louvain_communities,
     risk_propagation,
     shortest_path,
@@ -59,3 +62,12 @@ def test_algorithms_basic():
     assert path[0] == "alice"
     scores = risk_propagation(graph, {"alice": 1.0})
     assert scores["door1"] < 1.0
+
+
+def test_graph_lof_handles_small_graphs():
+    empty_graph = GraphModel()
+    assert graph_lof(empty_graph) == {}
+
+    single = GraphModel()
+    single.add_node(Node("a", NodeType.PERSON))
+    assert graph_lof(single) == {}


### PR DESCRIPTION
## Summary
- add missing dash-bootstrap-components to requirements
- handle graphs with <=1 node in `graph_lof`
- test LOF behavior on empty and single-node graphs

## Testing
- `pre-commit run --files requirements.txt analytics/graph_analysis/algorithms.py tests/graph/test_graph_analysis.py`
- `(script) graph_lof(GraphModel())`


------
https://chatgpt.com/codex/tasks/task_e_6897356df5ac83208d3a450b4e7d00f1