### PR TITLE
Harden context provider utilities and add cleanup for Timescale store

### DIFF
--- a/analytics/context_storage.py
+++ b/analytics/context_storage.py
@@ -78,3 +78,20 @@ class TimescaleContextStore:
                 "INSERT INTO environmental_context (ts, payload) VALUES (NOW(), %s)",
                 [Json(data)],
             )
+
+    def close(self) -> None:
+        """Close the underlying database connection if it exists."""
+
+        if self._conn is not None:
+            try:
+                self._conn.close()  # type: ignore[call-arg]
+            finally:
+                self._conn = None
+
+    # Support usage as a context manager to guarantee cleanup
+    def __enter__(self) -> "TimescaleContextStore":  # pragma: no cover - simple
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - simple
+        self.close()
+        return False

--- a/intel_analysis_service/tests/test_context_providers_validation.py
+++ b/intel_analysis_service/tests/test_context_providers_validation.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from analytics.context_providers import (
+    ContextProviderError,
+    fetch_local_events,
+    fetch_social_signals,
+)
+
+
+def test_fetch_local_events_invalid_city() -> None:
+    with pytest.raises(ValueError):
+        fetch_local_events("<script>")
+
+
+def test_fetch_social_signals_invalid_topic() -> None:
+    with pytest.raises(ValueError):
+        fetch_social_signals("bad!topic")
+
+
+def test_fetch_local_events_bad_content_type() -> None:
+    fake_resp = SimpleNamespace(
+        headers={"Content-Type": "text/html"},
+        content=b"{}",
+        json=lambda: {"events": []},
+        raise_for_status=lambda: None,
+    )
+    with patch("analytics.context_providers.requests.get", return_value=fake_resp), \
+        patch.dict("analytics.context_providers.os.environ", {"EVENTS_API_URL": "http://x"}):
+        with pytest.raises(ContextProviderError):
+            fetch_local_events("City")

--- a/intel_analysis_service/tests/test_context_storage_close.py
+++ b/intel_analysis_service/tests/test_context_storage_close.py
@@ -1,0 +1,26 @@
+class DummyConn:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_close_resets_connection() -> None:
+    from analytics.context_storage import TimescaleContextStore
+
+    store = TimescaleContextStore("dsn")
+    store._conn = DummyConn()
+    store.close()
+    assert store._conn is None
+    assert store._conn is None or getattr(store._conn, "closed", True)
+
+
+def test_context_manager_closes() -> None:
+    from analytics.context_storage import TimescaleContextStore
+
+    store = TimescaleContextStore("dsn")
+    store._conn = DummyConn()
+    with store:
+        pass
+    assert store._conn is None

--- a/intel_analysis_service/tests/test_graph_lof.py
+++ b/intel_analysis_service/tests/test_graph_lof.py
@@ -1,0 +1,14 @@
+import networkx as nx
+
+from analytics.graph_analysis.algorithms import graph_lof
+
+
+def test_graph_lof_empty_graph() -> None:
+    G = nx.Graph()
+    assert graph_lof(G) == {}
+
+
+def test_graph_lof_single_node() -> None:
+    G = nx.Graph()
+    G.add_node("A")
+    assert graph_lof(G) == {}


### PR DESCRIPTION
## Summary
- validate city/topic inputs and enforce response safety for context providers
- add close method and context manager support to TimescaleContextStore
- add unit tests for context providers, TimescaleContextStore and graph_lof small graphs

## Testing
- `PYTHONPATH=. pytest intel_analysis_service/tests/test_graph_lof.py intel_analysis_service/tests/test_context_providers_validation.py intel_analysis_service/tests/test_context_storage_close.py --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68973561851c83208f284f101bdf20bb