### PR TITLE
feat: add upload response schemas

### DIFF
--- a/yosai_intel_dashboard/src/services/upload/schemas.py
+++ b/yosai_intel_dashboard/src/services/upload/schemas.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
+
+
+class UploadResult(BaseModel):
+    """Status information for an upload job.
+
+    The ``status`` field may contain arbitrary metadata describing the current
+    state of the upload process.
+    """
+
+    status: Dict[str, Any]
+
+    class Config:
+        json_schema_extra = {"examples": [{"status": {"state": "processing"}}]}
+
+
+class UploadResponse(BaseModel):
+    """Response returned when an upload job is accepted."""
+
+    job_id: str
+
+    class Config:
+        json_schema_extra = {
+            "examples": [
+                {"job_id": "123e4567-e89b-12d3-a456-426614174000"}
+            ]
+        }
+
+
+__all__ = ["UploadResult", "UploadResponse"]

--- a/yosai_intel_dashboard/src/services/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload_endpoint.py
@@ -6,17 +6,17 @@ import warnings
 
 # Explicitly import only the public symbols from the upload endpoint module.
 from .upload.upload_endpoint import (
-    StatusSchema,
     UploadRequestSchema,
-    UploadResponseSchema,
+    UploadResponse,
+    UploadResult,
     create_upload_blueprint as _create_upload_blueprint,
 )
 
 # Re-export the imported symbols to maintain the public API of this module.
 __all__ = [
     "UploadRequestSchema",
-    "UploadResponseSchema",
-    "StatusSchema",
+    "UploadResponse",
+    "UploadResult",
     "create_upload_blueprint",
 ]
 


### PR DESCRIPTION
## Summary
- extract upload schemas into dedicated module
- validate upload endpoints using UploadResult and UploadResponse

## Testing
- `pytest tests/test_upload_endpoint.py::test_upload_files_uses_asyncio_run -q` *(fails: TypeError: module() takes at most 2 arguments (3 given))*

------
https://chatgpt.com/codex/tasks/task_e_689727604e688320ad0ae7e6221100e6