### PR TITLE
feat: add unicode helpers for upload

### DIFF
--- a/tests/test_upload_unicode_stream.py
+++ b/tests/test_upload_unicode_stream.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "stubs"))
+os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
+
+from yosai_intel_dashboard.src.services.upload.stream_upload import stream_upload
+from yosai_intel_dashboard.src.services.upload.unicode import (
+    normalize_text,
+    safe_decode_bytes,
+    safe_encode_text,
+)
+
+
+class DummyStore:
+    def __init__(self) -> None:
+        self.files = {}
+
+    def add_file(self, filename: str, data) -> None:
+        self.files[filename] = data
+
+    def get_filenames(self):
+        return list(self.files.keys())
+
+
+def test_normalize_text_decodes_surrogate_pair():
+    assert normalize_text("\ud800\udc00") == "\U00010000"
+
+
+def test_safe_decode_bytes_handles_surrogate_pair():
+    pair_bytes = b"\xed\xa0\x80\xed\xb0\x80"
+    assert safe_decode_bytes(pair_bytes) == "\U00010000"
+
+
+def test_safe_encode_text_handles_surrogate_pair_bytes():
+    pair_bytes = b"\xed\xa0\x80\xed\xb0\x80"
+    assert safe_encode_text(pair_bytes) == "\U00010000"
+
+
+def test_stream_upload_normalizes_filename_with_surrogates():
+    store = DummyStore()
+    filename = "\ud800\udc00.csv"
+    stream_upload(store, filename, object())
+    assert "\U00010000.csv" in store.get_filenames()

--- a/yosai_intel_dashboard/src/services/upload/stream_upload.py
+++ b/yosai_intel_dashboard/src/services/upload/stream_upload.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .unicode import normalize_text
+
+
+def stream_upload(store, filename: str, data: Any) -> None:
+    """Save ``data`` to ``store`` under a normalized ``filename``."""
+    safe_name = normalize_text(filename)
+    store.add_file(safe_name, data)

--- a/yosai_intel_dashboard/src/services/upload/unicode.py
+++ b/yosai_intel_dashboard/src/services/upload/unicode.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+
+def normalize_text(text: str) -> str:
+    """Return ``text`` normalized to NFC with surrogate pairs handled.
+
+    The input may contain explicit surrogate code points. Valid pairs are
+    combined into their corresponding Unicode characters while unpaired
+    surrogates are discarded.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    # Convert surrogate pairs and drop unpaired surrogates
+    text = text.encode("utf-16", "surrogatepass").decode("utf-16", "ignore")
+    return unicodedata.normalize("NFC", text)
+
+
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    """Decode ``data`` using ``encoding`` while handling surrogate pairs."""
+    try:
+        text = data.decode(encoding, errors="surrogatepass")
+    except Exception:
+        text = data.decode(encoding, errors="ignore")
+    return normalize_text(text)
+
+
+def safe_encode_text(value: Any) -> str:
+    """Return a normalized string representation of ``value``."""
+    if isinstance(value, bytes):
+        return safe_decode_bytes(value)
+    return normalize_text(value)
+
+
+__all__ = ["normalize_text", "safe_encode_text", "safe_decode_bytes"]


### PR DESCRIPTION
## Summary
- add unicode helper utilities for uploads
- ensure stream uploads normalize filenames
- test surrogate pair handling

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/upload/unicode.py yosai_intel_dashboard/src/services/upload/stream_upload.py tests/test_upload_unicode_stream.py`
- `PYTEST_ADDOPTS="--no-cov" pytest tests/test_upload_unicode_stream.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689727618b008320aea0f58252c533ea