### PR TITLE
Add comprehensive upload tests

### DIFF
--- a/tests/services/upload/test_upload_endpoint.py
+++ b/tests/services/upload/test_upload_endpoint.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+import types
+import sys
+
+import pytest
+from flask import Flask
+
+import pydantic
+sys.modules["pydantic"] = pydantic
+
+from yosai_intel_dashboard.src.infrastructure.validation.file_validator import (
+    FileValidator,
+)
+from yosai_intel_dashboard.src.services.upload_endpoint import create_upload_blueprint
+
+
+class StubProcessor:
+    def __init__(self):
+        self.validator = FileValidator(max_size_mb=1, allowed_ext=[".csv"])
+        self.called = None
+
+    def process_file_async(self, content, filename):
+        self.called = (content, filename)
+        return "job-1"
+
+    def get_job_status(self, job_id):
+        return {"status": {"done": True}}
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: types.SimpleNamespace())
+    monkeypatch.setattr(
+        "middleware.rate_limit.rate_limit", lambda *a, **k: (lambda f: f)
+    )
+    monkeypatch.setattr("flask_wtf.csrf.validate_csrf", lambda token: None)
+    processor = StubProcessor()
+    bp = create_upload_blueprint(processor, handler=None)
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test"
+    app.register_blueprint(bp)
+    return app, processor
+
+
+def test_happy_path(app):
+    app_obj, processor = app
+    client = app_obj.test_client()
+    data = {"file": (io.BytesIO(b"a,b\n1,2"), "good.csv")}
+    resp = client.post("/v1/upload", data=data, headers={"X-CSRFToken": "x"})
+    assert resp.status_code == 202
+    assert resp.get_json() == {"job_id": "job-1"}
+    assert processor.called[1] == "good.csv"
+
+
+def test_bad_extension(app):
+    app_obj, _ = app
+    client = app_obj.test_client()
+    data = {"file": (io.BytesIO(b"abc"), "bad.exe")}
+    resp = client.post("/v1/upload", data=data, headers={"X-CSRFToken": "x"})
+    assert resp.status_code == 400
+
+
+def test_oversize_file(app):
+    app_obj, _ = app
+    client = app_obj.test_client()
+    big = io.BytesIO(b"a" * (2 * 1024 * 1024))
+    data = {"file": (big, "big.csv")}
+    resp = client.post("/v1/upload", data=data, headers={"X-CSRFToken": "x"})
+    assert resp.status_code == 400
+
+
+def test_missing_file_field(app):
+    app_obj, _ = app
+    client = app_obj.test_client()
+    resp = client.post("/v1/upload", headers={"X-CSRFToken": "x"})
+    assert resp.status_code == 400
+
+
+def test_multiple_files(app):
+    app_obj, processor = app
+    client = app_obj.test_client()
+    data = {
+        "f1": (io.BytesIO(b"a"), "a.csv"),
+        "f2": (io.BytesIO(b"b"), "b.csv"),
+    }
+    resp = client.post("/v1/upload", data=data, headers={"X-CSRFToken": "x"})
+    assert resp.status_code == 202
+    assert processor.called[1] == "a.csv"

--- a/tests/services/upload/test_upload_processing.py
+++ b/tests/services/upload/test_upload_processing.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+
+from yosai_intel_dashboard.src.infrastructure.validation.file_validator import (
+    FileValidator,
+)
+
+stub_hashing = types.ModuleType("yosai_intel_dashboard.src.utils.hashing")
+stub_hashing.hash_dataframe = lambda df: "hash"
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.utils.hashing", stub_hashing
+)
+
+UPLOAD_STORE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "yosai_intel_dashboard/src/utils/upload_store.py"
+)
+spec = importlib.util.spec_from_file_location("upload_store", UPLOAD_STORE_PATH)
+upload_store = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(upload_store)  # type: ignore[arg-type]
+UploadedDataStore = upload_store.UploadedDataStore
+
+
+def test_size_limit_rejected():
+    validator = FileValidator(max_size_mb=0.001, allowed_ext=[".csv"])
+    content = b"a" * 5000
+    res = validator.validate_file_upload("big.csv", content)
+    assert not res["valid"]
+    assert "file_too_large" in res["issues"]
+
+
+def test_extension_allowlist_enforced():
+    validator = FileValidator(max_size_mb=1, allowed_ext=[".csv"])
+    res = validator.validate_file_upload("bad.exe", b"abc")
+    assert not res["valid"]
+    assert "invalid_extension" in res["issues"]
+
+
+def test_atomic_move_and_checksum(tmp_path):
+    store = UploadedDataStore(storage_dir=tmp_path)
+    df1 = pd.DataFrame({"a": [1]})
+    store.add_file("test.csv", df1)
+    path = store.get_file_path("test.csv")
+    with open(path, "rb") as f:
+        first = hashlib.sha256(f.read()).hexdigest()
+
+    df2 = pd.DataFrame({"a": [2]})
+    store.add_file("test.csv", df2)
+    with open(path, "rb") as f:
+        second = hashlib.sha256(f.read()).hexdigest()
+
+    assert first != second
+    loaded = store.load_dataframe("test.csv")
+    assert int(loaded.iloc[0]["a"]) == 2
+
+
+def test_unicode_filename_handling(tmp_path):
+    store = UploadedDataStore(storage_dir=tmp_path)
+    df = pd.DataFrame({"a": [1]})
+    name = "данные.csv"
+    store.add_file(name, df)
+    path = store.get_file_path(name)
+    assert path.exists()
+    loaded = store.load_dataframe(name)
+    assert loaded.equals(df)

--- a/yosai_intel_dashboard/src/adapters/ui/pages/__tests__/Upload.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/__tests__/Upload.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UploadPage from '../Upload';
+import { api } from '../../api/client';
+
+jest.mock('../../api/client');
+
+const mockPost = api.post as jest.MockedFunction<typeof api.post>;
+const mockGet = api.get as jest.MockedFunction<typeof api.get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Upload page', () => {
+  it('allows drag and drop to add a file', async () => {
+    const { container } = render(<UploadPage />);
+    const dropzone = screen.getByRole('button', { name: /file upload drop zone/i });
+    const file = new File(['content'], 'sample.csv', { type: 'text/csv' });
+
+    fireEvent.drop(dropzone, {
+      dataTransfer: { files: [file] },
+    });
+    expect(await screen.findByText('sample.csv')).toBeInTheDocument();
+  });
+
+  it('opens file dialog on keyboard activation', async () => {
+    const { container } = render(<UploadPage />);
+    const dropzone = screen.getByRole('button', { name: /file upload drop zone/i });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = jest.spyOn(input, 'click');
+
+    fireEvent.keyDown(dropzone, { key: 'Enter' });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('shows progress updates while uploading', async () => {
+    jest.useFakeTimers();
+    const { container } = render(<UploadPage />);
+    const file = new File(['data'], 'prog.csv', { type: 'text/csv' });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await screen.findByText('prog.csv');
+
+    mockPost.mockResolvedValue({ job_id: '1' } as any);
+    mockGet
+      .mockResolvedValueOnce({ progress: 25, done: false } as any)
+      .mockResolvedValueOnce({ progress: 100, done: true } as any);
+
+    const btn = screen.getByRole('button', { name: /upload all/i });
+    await userEvent.click(btn);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '25'),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100'),
+    );
+    jest.useRealTimers();
+  });
+
+  it('allows canceling a file', async () => {
+    const { container } = render(<UploadPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'remove.csv', { type: 'text/csv' });
+    fireEvent.change(input, { target: { files: [file] } });
+    await screen.findByText('remove.csv');
+    fireEvent.click(screen.getByText(/remove/i));
+    expect(screen.queryByText('remove.csv')).not.toBeInTheDocument();
+  });
+
+  it('displays error message when upload fails', async () => {
+    const { container } = render(<UploadPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'err.csv', { type: 'text/csv' });
+    fireEvent.change(input, { target: { files: [file] } });
+    await screen.findByText('err.csv');
+
+    mockPost.mockRejectedValue(new Error('fail'));
+
+    const btn = screen.getByRole('button', { name: /upload all/i });
+    await userEvent.click(btn);
+
+    await waitFor(() =>
+      expect(screen.getByText('fail')).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Upload page tests for drag/drop, keyboard access, progress, cancellation, and error states
- add upload processing tests for validation, atomic replace, checksums, and Unicode filenames
- add upload endpoint tests for happy path and various error scenarios

## Testing
- `pre-commit run --files tests/services/upload/test_upload_processing.py tests/services/upload/test_upload_endpoint.py yosai_intel_dashboard/src/adapters/ui/pages/__tests__/Upload.test.tsx`
- `pytest tests/services/upload/test_upload_processing.py tests/services/upload/test_upload_endpoint.py` *(fails: ImportError: cannot import name 'create_config_manager')*
- `npm test -- yosai_intel_dashboard/src/adapters/ui/pages/__tests__/Upload.test.tsx` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972764da008320a3e33d82d71bbfe7