### PR TITLE
docs: add upload endpoint notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1405,6 +1405,7 @@ The running application exposes Swagger-based API docs at `http://<host>:<port>/
 - State stores: [docs/state_management.md](docs/state_management.md)
 - Ops reference: [docs/operations_guide.md](docs/operations_guide.md)
 - Callback migration: [docs/migration_callback_system.md](docs/migration_callback_system.md)
+- Upload endpoint notes: [docs/pr/Upload_PR.md](docs/pr/Upload_PR.md)
 
 Update the spec by running `go run ./api/openapi` which writes `docs/api/v2/openapi.json` for the UI.
 

--- a/docs/pr/Upload_PR.md
+++ b/docs/pr/Upload_PR.md
@@ -1,0 +1,49 @@
+# Upload Endpoint PR Notes
+
+## New Endpoint
+- `POST /api/v2/uploads/results` creates a new results entry for an uploaded file.
+- Accepts multipart form data with the file payload and optional metadata.
+- Returns the created result record once processing completes.
+
+## Schemas
+**UploadResult**
+```json
+{
+  "id": 1,
+  "filename": "report.csv",
+  "status": "processed",
+  "created_at": "2024-05-01T12:00:00Z"
+}
+```
+
+**UploadRequest**
+```json
+{
+  "file": "<binary>",
+  "metadata": { "source": "client" }
+}
+```
+
+## Migration Notes
+- Adds a new `uploads` table with columns `id`, `filename`, `status`, `created_at`.
+- Foreign key to `users` table associates uploads with the submitting user.
+- Run the migration with `alembic upgrade head` after deploying.
+
+## Example `results[]` Payload
+```json
+{
+  "results": [
+    { "id": 1, "status": "processed", "duration_ms": 345 },
+    { "id": 2, "status": "failed", "duration_ms": 120 }
+  ]
+}
+```
+
+## Running Tests
+```bash
+# Backend tests
+pytest tests/test_upload_endpoint.py -q
+
+# Lint updated docs
+pre-commit run --files docs/pr/Upload_PR.md README.md
+```


### PR DESCRIPTION
## Summary
- document new `/api/v2/uploads/results` endpoint with request/response schemas and migration guidance
- show example `results[]` payload and commands for running backend tests and linting
- link upload endpoint notes from the README

## Testing
- `pre-commit run --files docs/pr/Upload_PR.md README.md`
- `pytest -q` *(fails: Required test coverage of 80% not reached. Total coverage: 2.31%)*

------
https://chatgpt.com/codex/tasks/task_e_6897276613688320b440deed2bcc16fe