### PR TITLE
Refactor graph dashboard to presentational component

### DIFF
--- a/graph_dashboard/src/components/GraphDashboard.tsx
+++ b/graph_dashboard/src/components/GraphDashboard.tsx
@@ -1,66 +1,49 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ForceGraph2D from 'react-force-graph';
 import ForceGraph3D from 'react-force-graph-3d';
 import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 import Heatmap from 'heatmap.js';
-import { request, gql } from 'graphql-request';
 import { AccessibleVisualization } from '../../../components/accessibility';
 
-type Node = { id: string; label: string; properties?: Record<string, string> };
-type Edge = { source: string; target: string; weight?: number };
-type Graph = { nodes: Node[]; edges: Edge[] };
+export type Node = { id: string; label: string; properties?: Record<string, string> };
+export type Edge = { source: string; target: string; weight?: number };
+export type Graph = { nodes: Node[]; edges: Edge[] };
 
-const GRAPHQL_ENDPOINT = '/ui/graphql';
+type GraphDashboardProps = {
+  graph: Graph;
+  is3D: boolean;
+  labelFilter: string;
+  onToggle3D: () => void;
+  onFilterChange: (value: string) => void;
+  onExport: (format: string) => void;
+};
 
-export const GraphDashboard: React.FC = () => {
-  const [graph, setGraph] = useState<Graph>({ nodes: [], edges: [] });
-  const [is3D, setIs3D] = useState(false);
-  const [labelFilter, setLabelFilter] = useState('');
+const GraphDashboardComponent: React.FC<GraphDashboardProps> = ({
+  graph,
+  is3D,
+  labelFilter,
+  onToggle3D,
+  onFilterChange,
+  onExport,
+}) => {
   const heatmapRef = useRef<HTMLDivElement>(null);
-  const [heatmapInstance, setHeatmapInstance] = useState<any>(null);
+  const heatmapInstanceRef = useRef<any>(null);
 
-  const fetchGraph = async () => {
-    const query = gql`
-      query($label: String) {
-        graph(label: $label) {
-          nodes { id label }
-          edges { source target weight }
-        }
-      }
-    `;
-    const data = await request<{ graph: Graph }>(GRAPHQL_ENDPOINT, query, { label: labelFilter || null });
-    setGraph(data.graph);
-    if (heatmapInstance) {
-      heatmapInstance.setData({
+  useEffect(() => {
+    if (heatmapRef.current && !heatmapInstanceRef.current) {
+      heatmapInstanceRef.current = Heatmap.create({ container: heatmapRef.current });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (heatmapInstanceRef.current) {
+      heatmapInstanceRef.current.setData({
         max: 5,
-        data: data.graph.nodes.map((n, i) => ({ x: i * 10, y: i * 10, value: 1 })),
+        data: graph.nodes.map((n, i) => ({ x: i * 10, y: i * 10, value: 1 })),
       });
     }
-  };
-
-  useEffect(() => {
-    fetchGraph();
-  }, [labelFilter]);
-
-  useEffect(() => {
-    if (heatmapRef.current && !heatmapInstance) {
-      const instance = Heatmap.create({ container: heatmapRef.current });
-      setHeatmapInstance(instance);
-    }
-  }, [heatmapRef, heatmapInstance]);
-
-  const exportGraph = async (format: string) => {
-    const query = gql`
-      query($fmt: String!) { exportGraph(format: $fmt) }
-    `;
-    const data = await request<{ exportGraph: string }>(GRAPHQL_ENDPOINT, query, { fmt: format });
-    const blob = new Blob([data.exportGraph], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `graph.${format}.json`;
-    a.click();
-  };
+  }, [graph]);
 
   const graphVisualization = is3D ? (
     <ForceGraph3D graphData={graph} />
@@ -84,26 +67,20 @@ export const GraphDashboard: React.FC = () => {
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 10 }}>
-        <button
-          onClick={() => setIs3D(!is3D)}
-          aria-label="Toggle 3D view"
-        >
+        <button onClick={onToggle3D} aria-label="Toggle 3D view">
           {is3D ? '2D' : '3D'}
         </button>
         <input
           placeholder="Filter by label"
           aria-label="Filter nodes by label"
           value={labelFilter}
-          onChange={(e) => setLabelFilter(e.target.value)}
+          onChange={(e) => onFilterChange(e.target.value)}
           style={{ marginLeft: 10 }}
         />
-        <button onClick={() => exportGraph('gephi')} aria-label="Export Gephi">
+        <button onClick={() => onExport('gephi')} aria-label="Export Gephi">
           Export Gephi
         </button>
-        <button
-          onClick={() => exportGraph('cytoscape')}
-          aria-label="Export Cytoscape"
-        >
+        <button onClick={() => onExport('cytoscape')} aria-label="Export Cytoscape">
           Export Cytoscape
         </button>
         <div style={{ width: 200, marginTop: 10 }}>
@@ -118,3 +95,5 @@ export const GraphDashboard: React.FC = () => {
     </div>
   );
 };
+
+export const GraphDashboard = React.memo(GraphDashboardComponent);

--- a/graph_dashboard/src/index.tsx
+++ b/graph_dashboard/src/index.tsx
@@ -1,9 +1,58 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { GraphDashboard } from './components/GraphDashboard';
+import { GraphDashboard, Graph } from './components/GraphDashboard';
+import { request, gql } from 'graphql-request';
+
+const GRAPHQL_ENDPOINT = '/ui/graphql';
+
+const App: React.FC = () => {
+  const [graph, setGraph] = useState<Graph>({ nodes: [], edges: [] });
+  const [is3D, setIs3D] = useState(false);
+  const [labelFilter, setLabelFilter] = useState('');
+
+  const fetchGraph = async (label: string) => {
+    const query = gql`
+      query($label: String) {
+        graph(label: $label) {
+          nodes { id label }
+          edges { source target weight }
+        }
+      }
+    `;
+    const data = await request<{ graph: Graph }>(GRAPHQL_ENDPOINT, query, { label: label || null });
+    setGraph(data.graph);
+  };
+
+  useEffect(() => {
+    fetchGraph(labelFilter);
+  }, [labelFilter]);
+
+  const exportGraph = async (format: string) => {
+    const query = gql`
+      query($fmt: String!) { exportGraph(format: $fmt) }
+    `;
+    const data = await request<{ exportGraph: string }>(GRAPHQL_ENDPOINT, query, { fmt: format });
+    const blob = new Blob([data.exportGraph], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `graph.${format}.json`;
+    a.click();
+  };
+
+  return (
+    <GraphDashboard
+      graph={graph}
+      is3D={is3D}
+      labelFilter={labelFilter}
+      onToggle3D={() => setIs3D(!is3D)}
+      onFilterChange={setLabelFilter}
+      onExport={exportGraph}
+    />
+  );
+};
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(<GraphDashboard />);
+  root.render(<App />);
 }


### PR DESCRIPTION
## Summary
- refactor GraphDashboard to accept external graph data and handlers
- wrap GraphDashboard with React.memo for performance
- move data fetching/export logic into App container

## Testing
- `npx --yes react-scripts test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689727786f848320aa56e92c3bc213b0