### PR TITLE
feat(ui): add settings data hook

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useDataSaver } from './useDataSaver';
 export { default as useDarkMode } from './useDarkMode';
 export { default as useUpload } from './useUpload';
 export { default as useExportData } from './useExportData';
+export { default as useSettingsData } from './useSettingsData';

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useSettingsData.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useSettingsData.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export interface UserSettings {
+  theme: string;
+  itemsPerPage: number;
+}
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001/v1';
+const DEFAULT_SETTINGS: UserSettings = { theme: 'light', itemsPerPage: 10 };
+let cachedSettings: UserSettings | null = null;
+
+export default function useSettingsData() {
+  const [settings, setSettings] = useState<UserSettings>(cachedSettings || DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(!cachedSettings);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const fetchSettings = useCallback(async () => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setError(null);
+    if (!cachedSettings) {
+      setLoading(true);
+    }
+    try {
+      const res = await fetch(`${API_BASE_URL}/settings`, {
+        signal: controller.signal,
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        throw new Error('Failed to fetch settings');
+      }
+      const payload = await res.json();
+      const data: UserSettings = payload.data ? payload.data : payload;
+      cachedSettings = data;
+      setSettings(data);
+    } catch (err: any) {
+      if (controller.signal.aborted) return;
+      setError(err.message || 'Failed to fetch settings');
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSettings();
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, [fetchSettings]);
+
+  const refresh = useCallback(() => {
+    cachedSettings = null;
+    fetchSettings();
+  }, [fetchSettings]);
+
+  return { settings, setSettings, loading, error, refresh } as const;
+}
+

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -1,29 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { api } from '../api/client';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { ChunkGroup } from '../components/layout';
-
-interface UserSettings {
-  theme: string;
-  itemsPerPage: number;
-}
+import useSettingsData from '../hooks/useSettingsData';
 
 const Settings: React.FC = () => {
-  const [settings, setSettings] = useState<UserSettings>({
-    theme: 'light',
-    itemsPerPage: 10,
-  });
+  const { settings, setSettings } = useSettingsData();
   const [status, setStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    api
-      .get<UserSettings>('/settings')
-      .then((data) => setSettings((prev) => ({ ...prev, ...data })))
-      .catch(() => {
-        /* ignore load errors */
-      });
-  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;


### PR DESCRIPTION
## Summary
- add useSettingsData hook with abort controller and stale-while-revalidate logic
- use new hook in Settings page instead of in-component effect

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install react-scripts` *(fails: dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_689877e156c88320bdfb60b7ebf4e1ff