### PR TITLE
Use PATCH with CSRF token and typed headers

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { api } from '../api/client';
+import { api, csrfHeader } from '../api/client';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { ChunkGroup } from '../components/layout';
 
@@ -34,7 +34,7 @@ const Settings: React.FC = () => {
     e.preventDefault();
     setStatus('saving');
     api
-      .put('/settings', settings)
+      .patch('/settings', settings, { headers: csrfHeader() })
       .then(() => {
         setStatus('success');
         setError(null);

--- a/yosai_intel_dashboard/src/adapters/ui/src/apiClientHeaders.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/src/apiClientHeaders.test.ts
@@ -1,0 +1,25 @@
+import { api } from '../api/client';
+
+describe('api helper headers', () => {
+  it('includes auth and CSRF headers in requests', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'success', data: {} }),
+    }) as any;
+
+    await api.patch('/test', {}, {
+      headers: { Authorization: 'Bearer t', 'X-CSRF-Token': 'c' },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer t',
+          'X-CSRF-Token': 'c',
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add typed auth and CSRF header helpers in API client
- send settings updates via PATCH including CSRF token
- test that requests include auth and CSRF headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689877e2867883209f6bf007589a98fa