### PR TITLE
Add items per page validation

### DIFF
--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -159,6 +159,10 @@ msgstr "インシデント通知"
 msgid "Weak-Signal Live Feed"
 msgstr "ウィークシグナルライブフィード"
 
+# Validation messages
+msgid "Items per page must be between 1 and 100."
+msgstr "ページごとのアイテム数は1から100の間で指定してください。"
+
 msgid "News Scraping"
 msgstr "ニューススクレイピング"
 

--- a/yosai_intel_dashboard/src/adapters/api/settings_endpoint.py
+++ b/yosai_intel_dashboard/src/adapters/api/settings_endpoint.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from filelock import FileLock
 from flask import Blueprint, jsonify, request
 from flask_apispec import doc
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
+from flask_babel import lazy_gettext as _
 
 from yosai_intel_dashboard.src.error_handling import ErrorCategory, ErrorHandler, api_error_response
 from yosai_intel_dashboard.src.utils.pydantic_decorators import validate_input, validate_output
@@ -18,6 +19,14 @@ handler = ErrorHandler()
 class SettingsSchema(BaseModel):
     theme: str | None = None
     itemsPerPage: int | None = None
+
+    @validator("itemsPerPage")
+    def validate_items_per_page(cls, v):
+        if v is None:
+            return v
+        if not 1 <= v <= 100:
+            raise ValueError(_("Items per page must be between 1 and 100."))
+        return v
 
 
 SETTINGS_FILE = Path(

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -73,6 +73,8 @@ const Settings: React.FC = () => {
               type="number"
               id="itemsPerPage"
               name="itemsPerPage"
+              min={1}
+              max={100}
               value={settings.itemsPerPage}
               onChange={handleChange}
               className="border rounded p-2 w-full"


### PR DESCRIPTION
## Summary
- enforce 1-100 range on itemsPerPage in settings API
- limit items per page input to 1-100
- add Japanese translation for range error

## Testing
- `pytest tests/api/test_settings_endpoint.py::test_get_and_update_settings -q --override-ini="addopts="` *(fails: module 'api.settings_endpoint.settings_bp' has no attribute 'register')*

------
https://chatgpt.com/codex/tasks/task_e_689877e3dec88320b1a9c20c2a7668e8