### PR TITLE
feat: add roles and live regions for status messages

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/Export/ExportForm.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Export/ExportForm.tsx
@@ -98,9 +98,9 @@ const ExportForm: React.FC<Props> = ({ onExport, progress, status, onCancel }) =
         )}
       </div>
       {status !== 'idle' && (
-        <div className="mt-4" role="status" aria-live="polite">
+        <div className="mt-4">
           {status === 'exporting' && (
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2" role="status" aria-live="polite">
               <progress
                 value={progress}
                 max="100"
@@ -113,8 +113,16 @@ const ExportForm: React.FC<Props> = ({ onExport, progress, status, onCancel }) =
               <span>{progress}%</span>
             </div>
           )}
-          {status === 'completed' && <p className="text-green-600">Export complete.</p>}
-          {status === 'error' && <p className="text-red-600">Export failed.</p>}
+          {status === 'completed' && (
+            <p role="status" aria-live="polite" className="text-green-600">
+              Export complete.
+            </p>
+          )}
+          {status === 'error' && (
+            <p role="alert" aria-live="assertive" className="text-red-600">
+              Export failed.
+            </p>
+          )}
         </div>
       )}
     </form>

--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/alert.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/alert.test.tsx
@@ -8,4 +8,6 @@ test('renders alert description', () => {
     </Alert>
   );
   expect(screen.getByText('text')).toBeInTheDocument();
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveAttribute('aria-live', 'assertive');
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/ui/alert.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ui/alert.tsx
@@ -1,3 +1,28 @@
 import React from 'react';
-export const Alert: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = '' }) => <div className={`border rounded-lg p-4 ${className}`}>{children}</div>;
-export const AlertDescription: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = '' }) => <div className={className}>{children}</div>;
+
+interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Alert: React.FC<AlertProps> = ({ children, className = '', ...props }) => (
+  <div
+    role="alert"
+    aria-live="assertive"
+    className={`border rounded-lg p-4 ${className}`}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+interface AlertDescriptionProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const AlertDescription: React.FC<AlertDescriptionProps> = ({ children, className = '', ...props }) => (
+  <div className={className} {...props}>
+    {children}
+  </div>
+);

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/ColumnMappingModal.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/ColumnMappingModal.tsx
@@ -185,7 +185,11 @@ export const ColumnMappingModal: React.FC<Props> = ({
 
             {/* Errors */}
             {errors.length > 0 && (
-              <div className="mt-4 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
+              <div
+                className="mt-4 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg"
+                role="alert"
+                aria-live="assertive"
+              >
                 <p className="font-medium text-red-800 dark:text-red-200 mb-2">
                   Please fix the following issues:
                 </p>

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
@@ -32,7 +32,11 @@ export const FilePreview: React.FC<Props> = ({ file, onRemove, onCancel }) => {
 
         </div>
         <ProgressBar progress={file.progress} className="mt-2" />
-        {file.error && <p className="text-xs text-red-500 mt-1">{file.error}</p>}
+        {file.error && (
+          <p role="alert" aria-live="assertive" className="text-xs text-red-500 mt-1">
+            {file.error}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -85,8 +85,16 @@ const Settings: React.FC = () => {
           >
             {status === 'saving' ? 'Saving...' : 'Save'}
           </button>
-          {status === 'success' && <p className="text-green-600">Settings saved.</p>}
-          {status === 'error' && <p className="text-red-600">{error}</p>}
+          {status === 'success' && (
+            <p role="status" aria-live="polite" className="text-green-600">
+              Settings saved.
+            </p>
+          )}
+          {status === 'error' && (
+            <p role="alert" aria-live="assertive" className="text-red-600">
+              {error}
+            </p>
+          )}
         </ChunkGroup>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add ARIA roles and live regions for success and error messages in settings and export workflows
- surface file upload and column mapping errors to screen readers
- ensure Alert component uses role="alert" with live updates and update tests

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_689877e505448320904e80c8452fcc75