### PR TITLE
feat: add settings translations

### DIFF
--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "settings.title"
+msgstr "Settings"
+
+msgid "settings.theme"
+msgstr "Theme"
+
+msgid "settings.theme_light"
+msgstr "Light"
+
+msgid "settings.theme_dark"
+msgstr "Dark"
+
+msgid "settings.items_per_page"
+msgstr "Items Per Page"
+
+msgid "settings.save"
+msgstr "Save"
+
+msgid "settings.saving"
+msgstr "Saving..."
+
+msgid "settings.saved"
+msgstr "Settings saved."

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -186,3 +186,27 @@ msgstr "グラフは利用不可"
 
 msgid "Summary cards not available"
 msgstr "サマリーカードは利用不可"
+
+msgid "settings.title"
+msgstr "設定"
+
+msgid "settings.theme"
+msgstr "テーマ"
+
+msgid "settings.theme_light"
+msgstr "ライト"
+
+msgid "settings.theme_dark"
+msgstr "ダーク"
+
+msgid "settings.items_per_page"
+msgstr "ページあたりの項目数"
+
+msgid "settings.save"
+msgstr "保存"
+
+msgid "settings.saving"
+msgstr "保存中..."
+
+msgid "settings.saved"
+msgstr "設定が保存されました。"

--- a/yosai_intel_dashboard/src/adapters/ui/components/navigation/navItems.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/navigation/navItems.tsx
@@ -7,6 +7,7 @@ import {
   faDownload,
   faCog,
 } from '@fortawesome/free-solid-svg-icons';
+import { t } from '../../i18n';
 
 export interface NavItem {
   path: string;
@@ -39,6 +40,6 @@ export const navItems: NavItem[] = [
   { path: '/analytics', label: 'Analytics', icon: AnalyticsIcon },
   { path: '/graphs', label: 'Graphs', icon: GraphsIcon },
   { path: '/export', label: 'Export', icon: ExportIcon },
-  { path: '/settings', label: 'Settings', icon: SettingsIcon },
+  { path: '/settings', label: t('settings.title'), icon: SettingsIcon },
 ];
 

--- a/yosai_intel_dashboard/src/adapters/ui/i18n.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/i18n.ts
@@ -1,0 +1,7 @@
+export function t(key: string): string {
+  const translator = (window as any).t;
+  if (typeof translator === 'function') {
+    return translator(key);
+  }
+  return key;
+}

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Settings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { api } from '../api/client';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { ChunkGroup } from '../components/layout';
+import { t } from '../i18n';
 
 interface UserSettings {
   theme: string;
@@ -47,12 +48,12 @@ const Settings: React.FC = () => {
 
   return (
     <div className="page-container">
-      <h1 className="mb-4">Settings</h1>
+      <h1 className="mb-4">{t('settings.title')}</h1>
       <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
         <ChunkGroup>
           <div>
             <label htmlFor="theme" className="block font-semibold mb-1">
-              Theme
+              {t('settings.theme')}
             </label>
             <select
               id="theme"
@@ -61,13 +62,13 @@ const Settings: React.FC = () => {
               onChange={handleChange}
               className="border rounded p-2 w-full"
             >
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
+              <option value="light">{t('settings.theme_light')}</option>
+              <option value="dark">{t('settings.theme_dark')}</option>
             </select>
           </div>
           <div>
             <label htmlFor="itemsPerPage" className="block font-semibold mb-1">
-              Items Per Page
+              {t('settings.items_per_page')}
             </label>
             <input
               type="number"
@@ -83,9 +84,11 @@ const Settings: React.FC = () => {
             className="px-4 py-2 bg-blue-600 text-white rounded"
             disabled={status === 'saving'}
           >
-            {status === 'saving' ? 'Saving...' : 'Save'}
+            {status === 'saving' ? t('settings.saving') : t('settings.save')}
           </button>
-          {status === 'success' && <p className="text-green-600">Settings saved.</p>}
+          {status === 'success' && (
+            <p className="text-green-600">{t('settings.saved')}</p>
+          )}
           {status === 'error' && <p className="text-red-600">{error}</p>}
         </ChunkGroup>
       </form>


### PR DESCRIPTION
## Summary
- translate settings UI using `t('settings.*')`
- provide English and Japanese translation entries
- add simple translation helper and apply to navigation label

## Testing
- `npm test`
- `npm run lint` *(fails: prettier formatting issues across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689877e6b0008320a5815c98db70d513