### PR TITLE
Handle failures in compliance audit decorator

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/compliance_setup.py
@@ -147,11 +147,17 @@ def audit_decorator(action_type: str, resource_type: str):
                         action_type=f"FAILED_{action_type}",
                         resource_type=resource_type,
                         description=f"Function {func.__name__} failed: {str(e)}",
+                        status="failure",
+                        error=str(e),
                     )
-                except:
-                    pass  # Don't let audit logging break the original exception
+                except Exception as log_err:
+                    logger.error(
+                        "Audit logging in decorator failed: %s",
+                        log_err,
+                        exc_info=True,
+                    )
 
-                raise e
+                raise
 
         return wrapper
 


### PR DESCRIPTION
## Summary
- add module-level logger
- protect audit logging in `audit_decorator` with nested `try/except`

## Testing
- `pytest yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/tests` *(fails: Required test coverage of 80% not reached. Total coverage: 0.00%)*

------
https://chatgpt.com/codex/tasks/task_e_6898d3b45cfc8320ad9e29605d64e085