### PR TITLE
Harden drift monitor and compliance audit logging

### DIFF
--- a/yosai_intel_dashboard/src/services/feature_flags/audit.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/audit.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from yosai_intel_dashboard.src.core.audit_logger import ComplianceAuditLogger
+
+logger = logging.getLogger(__name__)
 
 # This module expects an audit logger instance to be provided by the
 # application. Tests inject a dummy logger by assigning to this variable.
@@ -23,16 +26,18 @@ def log_feature_flag_created(
     """Record creation of a feature flag."""
     if audit_logger is None:
         return
-
     metadata = {"new_value": new_value, "reason": reason, "timestamp": timestamp}
-    audit_logger.log_action(
-        actor_user_id=actor_user_id,
-        action_type="FEATURE_FLAG_CREATED",
-        resource_type="feature_flag",
-        resource_id=name,
-        description=f"Feature flag {name} created",
-        metadata=metadata,
-    )
+    try:
+        audit_logger.log_action(
+            actor_user_id=actor_user_id,
+            action_type="FEATURE_FLAG_CREATED",
+            resource_type="feature_flag",
+            resource_id=name,
+            description=f"Feature flag {name} created",
+            metadata=metadata,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to audit feature flag creation")
 
 
 def log_feature_flag_updated(
@@ -54,14 +59,17 @@ def log_feature_flag_updated(
         "reason": reason,
         "timestamp": timestamp,
     }
-    audit_logger.log_action(
-        actor_user_id=actor_user_id,
-        action_type="FEATURE_FLAG_UPDATED",
-        resource_type="feature_flag",
-        resource_id=name,
-        description=f"Feature flag {name} updated",
-        metadata=metadata,
-    )
+    try:
+        audit_logger.log_action(
+            actor_user_id=actor_user_id,
+            action_type="FEATURE_FLAG_UPDATED",
+            resource_type="feature_flag",
+            resource_id=name,
+            description=f"Feature flag {name} updated",
+            metadata=metadata,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to audit feature flag update")
 
 
 def log_feature_flag_deleted(
@@ -75,16 +83,18 @@ def log_feature_flag_deleted(
     """Record deletion of a feature flag."""
     if audit_logger is None:
         return
-
     metadata = {"old_value": old_value, "reason": reason, "timestamp": timestamp}
-    audit_logger.log_action(
-        actor_user_id=actor_user_id,
-        action_type="FEATURE_FLAG_DELETED",
-        resource_type="feature_flag",
-        resource_id=name,
-        description=f"Feature flag {name} deleted",
-        metadata=metadata,
-    )
+    try:
+        audit_logger.log_action(
+            actor_user_id=actor_user_id,
+            action_type="FEATURE_FLAG_DELETED",
+            resource_type="feature_flag",
+            resource_id=name,
+            description=f"Feature flag {name} deleted",
+            metadata=metadata,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to audit feature flag deletion")
 
 
 def get_feature_flag_audit_history(name: str, limit: int = 50) -> List[Dict[str, Any]]:
@@ -92,10 +102,13 @@ def get_feature_flag_audit_history(name: str, limit: int = 50) -> List[Dict[str,
     if audit_logger is None:
         return []
 
-    logs = audit_logger.search_audit_logs(
-        resource_type="feature_flag",
-        resource_id=name,
-        limit=limit,
-    )
+    try:
+        logs = audit_logger.search_audit_logs(
+            resource_type="feature_flag",
+            resource_id=name,
+            limit=limit,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to fetch feature flag audit history")
+        return []
     return logs[:limit] if logs else []
-

--- a/yosai_intel_dashboard/src/services/feature_flags/audit.py
+++ b/yosai_intel_dashboard/src/services/feature_flags/audit.py
@@ -28,14 +28,23 @@ def log_feature_flag_created(
         return
     metadata = {"new_value": new_value, "reason": reason, "timestamp": timestamp}
     try:
-        audit_logger.log_action(
-            actor_user_id=actor_user_id,
-            action_type="FEATURE_FLAG_CREATED",
-            resource_type="feature_flag",
-            resource_id=name,
-            description=f"Feature flag {name} created",
-            metadata=metadata,
-        )
+        if hasattr(audit_logger, "log_feature_flag_created"):
+            audit_logger.log_feature_flag_created(
+                name=name,
+                new_value=new_value,
+                actor_user_id=actor_user_id,
+                reason=reason,
+                timestamp=timestamp,
+            )
+        else:
+            audit_logger.log_action(
+                actor_user_id=actor_user_id,
+                action_type="FEATURE_FLAG_CREATED",
+                resource_type="feature_flag",
+                resource_id=name,
+                description=f"Feature flag {name} created",
+                metadata=metadata,
+            )
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to audit feature flag creation")
 
@@ -60,14 +69,24 @@ def log_feature_flag_updated(
         "timestamp": timestamp,
     }
     try:
-        audit_logger.log_action(
-            actor_user_id=actor_user_id,
-            action_type="FEATURE_FLAG_UPDATED",
-            resource_type="feature_flag",
-            resource_id=name,
-            description=f"Feature flag {name} updated",
-            metadata=metadata,
-        )
+        if hasattr(audit_logger, "log_feature_flag_updated"):
+            audit_logger.log_feature_flag_updated(
+                name=name,
+                old_value=old_value,
+                new_value=new_value,
+                actor_user_id=actor_user_id,
+                reason=reason,
+                timestamp=timestamp,
+            )
+        else:
+            audit_logger.log_action(
+                actor_user_id=actor_user_id,
+                action_type="FEATURE_FLAG_UPDATED",
+                resource_type="feature_flag",
+                resource_id=name,
+                description=f"Feature flag {name} updated",
+                metadata=metadata,
+            )
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to audit feature flag update")
 
@@ -85,14 +104,23 @@ def log_feature_flag_deleted(
         return
     metadata = {"old_value": old_value, "reason": reason, "timestamp": timestamp}
     try:
-        audit_logger.log_action(
-            actor_user_id=actor_user_id,
-            action_type="FEATURE_FLAG_DELETED",
-            resource_type="feature_flag",
-            resource_id=name,
-            description=f"Feature flag {name} deleted",
-            metadata=metadata,
-        )
+        if hasattr(audit_logger, "log_feature_flag_deleted"):
+            audit_logger.log_feature_flag_deleted(
+                name=name,
+                old_value=old_value,
+                actor_user_id=actor_user_id,
+                reason=reason,
+                timestamp=timestamp,
+            )
+        else:
+            audit_logger.log_action(
+                actor_user_id=actor_user_id,
+                action_type="FEATURE_FLAG_DELETED",
+                resource_type="feature_flag",
+                resource_id=name,
+                description=f"Feature flag {name} deleted",
+                metadata=metadata,
+            )
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to audit feature flag deletion")
 


### PR DESCRIPTION
## Summary
- guard drift monitor evaluations and alert checks with logging
- prevent audit logging failures from breaking feature flag operations
- add unit test covering audit log error handling

## Testing
- `SKIP=mypy,bandit pre-commit run --files yosai_intel_dashboard/src/services/monitoring/drift_monitor.py yosai_intel_dashboard/src/services/feature_flags/audit.py tests/test_feature_flag_audit.py`
- `PYTHONPATH=. PANDAS_NO_ARROW=1 pytest -c /dev/null --rootdir=. tests/test_feature_flag_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d3b69718832086d2d08c1f1d5c0c