### PR TITLE
Harden bash scripts with strict error handling

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # This script has been deprecated. Deployment is now handled by the CI/CD pipeline.
 # See docs/ci-cd.md for details.

--- a/scripts/build_css.sh
+++ b/scripts/build_css.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env sh
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 NODE_ENV=development postcss assets/css/main.css -o assets/dist/main.css
 printf '/* This file is auto-generated. Do not edit directly. */\n' | cat - assets/dist/main.css > assets/dist/main.css.tmp
 mv assets/dist/main.css.tmp assets/dist/main.css

--- a/scripts/compliance_audit.sh
+++ b/scripts/compliance_audit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "🗄️  Running compliance audit..."
 echo "No compliance audit defined. Skipping."

--- a/scripts/failover_test.sh
+++ b/scripts/failover_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "🛡️  Running failover test..."
 echo "No failover test defined. Skipping."

--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install the Python dependencies required for running the tests.
-set -e
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
 

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "📊 Running load tests..."
 python3 tests/performance/test_event_processing.py

--- a/scripts/recovery_test.sh
+++ b/scripts/recovery_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "♻️  Running recovery test..."
 echo "No recovery test defined. Skipping."

--- a/scripts/security_audit.sh
+++ b/scripts/security_audit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "🔐 Running security audit..."
 echo "No security audit implemented. Skipping."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install all Python dependencies required by the dashboard.
-set -e
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
 if [ -d "$ROOT_DIR/packages" ]; then
@@ -24,6 +24,6 @@ fi
 alembic -c "$ROOT_DIR/database/migrations/alembic.ini" upgrade head
 
 # Optionally run a single replication cycle
-if [ "$RUN_REPLICATION" = "1" ]; then
+if [ "${RUN_REPLICATION:-}" = "1" ]; then
     python3 "$ROOT_DIR/scripts/replicate_to_timescale.py" &
 fi

--- a/scripts/start_kafka.sh
+++ b/scripts/start_kafka.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Start the Kafka cluster defined in docker-compose.kafka.yml
 

--- a/yosai_intel_dashboard/src/infrastructure/security/compliance/collect_evidence.sh
+++ b/yosai_intel_dashboard/src/infrastructure/security/compliance/collect_evidence.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Collects audit evidence such as configs, logs, and system information.
-set -e
+set -euo pipefail
 OUTPUT_DIR=${1:-evidence}
 mkdir -p "$OUTPUT_DIR"
 


### PR DESCRIPTION
## Summary
- standardize bash script headers to use `/usr/bin/env bash` and `set -euo pipefail`
- ensure RUN_REPLICATION is safely defaulted in setup script

## Testing
- `shellcheck deploy.sh scripts/compliance_audit.sh scripts/security_audit.sh scripts/build_css.sh scripts/start_kafka.sh scripts/failover_test.sh scripts/install_test_deps.sh scripts/setup.sh scripts/recovery_test.sh scripts/load_test.sh scripts/fix_mac_deps.sh yosai_intel_dashboard/src/infrastructure/security/compliance/collect_evidence.sh`
- `pytest --cov= --cov-report=term --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_6898d78fbc808320a506aff455d3f0c3