### PR TITLE
chore: deprecate legacy deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# This script has been deprecated. Deployment is now handled by the CI/CD pipeline.
-# See docs/ci-cd.md for details.
+# DEPRECATED: This script is not used. Deployment is handled by CI/CD (see docs/ci-cd.md).
 
 echo "Deployment is handled by the CI/CD pipeline. See docs/ci-cd.md."
 exit 1


### PR DESCRIPTION
## Summary
- clarify deploy.sh is unused and deployment handled via CI/CD

## Testing
- `pre-commit run --files deploy.sh`
- `pytest` *(fails: unrecognized arguments: --cov=. --cov-report=html --cov-report=term-missing --cov-fail-under=80 --randomly-seed=1234 --disable-socket --allow-hosts=127.0.0.1,localhost)*

------
https://chatgpt.com/codex/tasks/task_e_6898d7912cdc83209f499484cc535c37