### PR TITLE
chore: add image tagging and security context defaults

### DIFF
--- a/docs/timescale_integration.md
+++ b/docs/timescale_integration.md
@@ -59,10 +59,15 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
           restartPolicy: OnFailure
           containers:
             - name: replicate-to-timescale
-              image: yosai-intel-dashboard:latest
+              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              imagePullPolicy: IfNotPresent
               command: ["python", "scripts/replicate_to_timescale.py"]
 ```
 

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,13 +15,19 @@ spec:
       labels:
         app: yosai-dashboard
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       initContainers:
         - name: setup-symlinks
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           command: ["python", "scripts/create_symlinks.py"]
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
           env:

--- a/k8s/bluegreen/dashboard-blue.yaml
+++ b/k8s/bluegreen/dashboard-blue.yaml
@@ -17,9 +17,14 @@ spec:
         app: yosai-dashboard
         color: blue
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
           env:

--- a/k8s/bluegreen/dashboard-green.yaml
+++ b/k8s/bluegreen/dashboard-green.yaml
@@ -17,9 +17,14 @@ spec:
         app: yosai-dashboard
         color: green
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
           env:

--- a/k8s/canary/deployment.yaml
+++ b/k8s/canary/deployment.yaml
@@ -16,13 +16,19 @@ spec:
         app: yosai-dashboard
         track: canary
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       initContainers:
         - name: setup-symlinks
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           command: ["python", "scripts/create_symlinks.py"]
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
           env:

--- a/k8s/microservices/analytics-service.yaml
+++ b/k8s/microservices/analytics-service.yaml
@@ -18,12 +18,18 @@ spec:
         app.kubernetes.io/part-of: yosai-microservices
         app.kubernetes.io/component: analytics
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: analytics-service
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
           ports:

--- a/k8s/microservices/api-gateway.yaml
+++ b/k8s/microservices/api-gateway.yaml
@@ -22,12 +22,18 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: api-gateway
-          image: yosai-gateway:latest
+          image: yosai-gateway:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           ports:
             - containerPort: 8080

--- a/k8s/microservices/event-ingestion.yaml
+++ b/k8s/microservices/event-ingestion.yaml
@@ -18,12 +18,18 @@ spec:
         app.kubernetes.io/part-of: yosai-microservices
         app.kubernetes.io/component: ingestion
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: event-ingestion
-          image: event-ingestion:latest
+          image: event-ingestion:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
           ports:

--- a/k8s/microservices/secret-rotation-cronjob.yaml
+++ b/k8s/microservices/secret-rotation-cronjob.yaml
@@ -8,10 +8,15 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
           restartPolicy: OnFailure
           containers:
             - name: rotate-secrets
-              image: yosai-intel-dashboard:latest
+              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              imagePullPolicy: IfNotPresent
               command: ["python", "scripts/vault_rotate.py"]
               envFrom:
                 - configMapRef:

--- a/k8s/microservices/timescale-replication-cronjob.yaml
+++ b/k8s/microservices/timescale-replication-cronjob.yaml
@@ -8,10 +8,15 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
           restartPolicy: OnFailure
           containers:
             - name: replicate-to-timescale
-              image: yosai-intel-dashboard:latest
+              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              imagePullPolicy: IfNotPresent
               command: ["python", "scripts/replicate_to_timescale.py"]
               envFrom:
                 - configMapRef:

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -26,13 +26,19 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8050"
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       initContainers:
         - name: setup-symlinks
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           command: ["python", "scripts/create_symlinks.py"]
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
           env:

--- a/k8s/services/analytics-service.yaml
+++ b/k8s/services/analytics-service.yaml
@@ -37,12 +37,18 @@ spec:
       labels:
         app: analytics-service
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: analytics-service
-          image: yosai-intel-dashboard:latest
+          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           command: ["python", "-m", "uvicorn", "services.analytics_microservice.app:app", "--host", "0.0.0.0", "--port", "8001"]
           ports:

--- a/k8s/services/api-gateway.yaml
+++ b/k8s/services/api-gateway.yaml
@@ -41,12 +41,18 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: api-gateway
-          image: yosai-gateway:latest
+          image: yosai-gateway:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           ports:
             - containerPort: 8080

--- a/k8s/services/bluegreen-template.yaml
+++ b/k8s/services/bluegreen-template.yaml
@@ -18,9 +18,14 @@ spec:
         app: example-service
         color: blue
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: example-service
-          image: example:latest
+          image: example:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
 ---
@@ -43,9 +48,14 @@ spec:
         app: example-service
         color: green
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: example-service
-          image: example:latest
+          image: example:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
 ---

--- a/k8s/services/canary-template.yaml
+++ b/k8s/services/canary-template.yaml
@@ -18,9 +18,14 @@ spec:
         app: example-service
         track: stable
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: example-service
-          image: example:latest
+          image: example:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
 ---
@@ -43,9 +48,14 @@ spec:
         app: example-service
         track: canary
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: example-service
-          image: example:new
+          image: example:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
 ---

--- a/k8s/services/event-ingestion.yaml
+++ b/k8s/services/event-ingestion.yaml
@@ -37,12 +37,18 @@ spec:
       labels:
         app: event-ingestion
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: event-ingestion
-          image: event-ingestion:latest
+          image: event-ingestion:${IMAGE_TAG:-v0.1.0}
+          imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
           command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
           ports:


### PR DESCRIPTION
## Summary
- parameterize container images with `${IMAGE_TAG:-v0.1.0}` and add `imagePullPolicy: IfNotPresent`
- enforce pod-level security contexts and harmonize container UID/GID to 1000
- update deployment templates and docs with new image and security settings

## Testing
- `pytest -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6898d793ea208320acf893a6416db519