### PR TITLE
Copy project files into runtime image with proper ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,9 @@ RUN set -eux; \
       useradd -m -u "${UID}" -g "${GID}" appuser || true; \
     fi
 WORKDIR /app
-COPY . /app
+COPY --chown=appuser:appuser . /app
 RUN chmod +x docker-entrypoint.sh \
-    && rm -rf /app/yosai_intel_dashboard/tests \
-    && chown -R appuser:appuser /app
+    && rm -rf /app/yosai_intel_dashboard/tests
 USER appuser
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- copy the entire project into `/app` after venv installation
- ensure files are owned by `appuser:appuser` and remove redundant chown

## Testing
- `pre-commit run --files Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_6899ea542104832080b2bbaaab6fefbf