### PR TITLE
feat(analytics): load JWT secret from environment

### DIFF
--- a/tests/integration/test_analytics_microservice_metrics.py
+++ b/tests/integration/test_analytics_microservice_metrics.py
@@ -13,8 +13,8 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(SERVICES_PATH)]
 safe_import('services', services_stub)
 
-# Ensure JWT_SECRET for microservice
-os.environ.setdefault("JWT_SECRET", os.urandom(16).hex())
+# Ensure JWT_SECRET_KEY for microservice
+os.environ.setdefault("JWT_SECRET_KEY", os.urandom(16).hex())
 
 # Stub metrics and tracing instrumentation
 prom_stub = types.ModuleType("prometheus_fastapi_instrumentator")

--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -16,8 +16,8 @@ services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(SERVICES_PATH)]
 safe_import('services', services_stub)
 
-# Ensure JWT_SECRET is set for microservice import
-os.environ.setdefault("JWT_SECRET", os.urandom(16).hex())
+# Ensure JWT_SECRET_KEY is set for microservice import
+os.environ.setdefault("JWT_SECRET_KEY", os.urandom(16).hex())
 
 otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
 otel_stub.FastAPIInstrumentor = types.SimpleNamespace(
@@ -131,7 +131,7 @@ def test_requests_without_valid_token_return_401():
     assert resp.status_code == 401
 
     # Expired token
-    jwt_secret = os.environ["JWT_SECRET"]
+    jwt_secret = os.environ["JWT_SECRET_KEY"]
     bad_token = jwt.encode(
         {"sub": "svc", "iss": "gateway", "exp": int(time.time()) - 1},
         jwt_secret,

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -8,6 +8,7 @@ from yosai_intel_dashboard.src.core.imports.resolver import safe_import
 
 # Use lightweight imports
 os.environ["LIGHTWEIGHT_SERVICES"] = "1"
+os.environ.setdefault("JWT_SECRET_KEY", os.urandom(16).hex())
 
 SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
 

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
@@ -29,7 +29,7 @@ services_stub.__path__ = [str(SERVICES_PATH)]
 sys.modules["services"] = services_stub
 
 
-def load_app(jwt_secret: str = "secret") -> tuple:
+def load_app(jwt_secret: str | None = "secret") -> tuple:
 
     otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
     otel_stub.FastAPIInstrumentor = types.SimpleNamespace(
@@ -385,7 +385,10 @@ def load_app(jwt_secret: str = "secret") -> tuple:
     sys.modules.setdefault("tracing", types.ModuleType("tracing"))
     sys.modules.setdefault("hvac", types.ModuleType("hvac"))
 
-    os.environ["JWT_SECRET"] = jwt_secret
+    if jwt_secret is not None:
+        os.environ["JWT_SECRET_KEY"] = jwt_secret
+    else:
+        os.environ.pop("JWT_SECRET_KEY", None)
 
     spec = importlib.util.spec_from_file_location(
         "services.analytics_microservice.app",

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py
@@ -6,7 +6,7 @@ import types
 import pytest
 
 
-def load_app(jwt_secret: str):
+def load_app(jwt_secret: str | None):
     if "scipy" not in sys.modules:
         scipy_stub = types.ModuleType("scipy")
         scipy_stub.stats = types.ModuleType("scipy.stats")
@@ -22,7 +22,14 @@ def load_app(jwt_secret: str):
 
 
 @pytest.mark.asyncio
-async def test_startup_fails_on_placeholder():
-    module, _, _ = load_app(jwt_secret="change-me")
+async def test_startup_fails_without_secret():
+    module, _, _ = load_app(jwt_secret=None)
     with pytest.raises(RuntimeError):
         await module._startup()
+
+
+@pytest.mark.asyncio
+async def test_startup_succeeds_with_secret():
+    module, _, _ = load_app(jwt_secret="super-secret")
+    await module._startup()
+    assert module._jwt_secret() == "super-secret"


### PR DESCRIPTION
## Summary
- read JWT secret from JWT_SECRET_KEY env var and log if missing
- call JWT secret check on startup to fail fast
- add tests for JWT secret env requirements

## Testing
- `pytest --override-ini="addopts=" --override-ini="python_files=test_*.py" yosai_intel_dashboard/src/services/analytics_microservice/tests/test_startup.py -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_6899efbe3ecc83208b6809b72316fce1