### PR TITLE
chore: harden shell scripts and CI

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,6 +21,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           npm ci
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: ShellCheck
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files '*.sh')
+          if [ "${#files[@]}" -gt 0 ]; then shellcheck -x "${files[@]}"; else echo "No shell scripts found."; fi
       - name: Lint
         run: |
           black . --check

--- a/scripts/archived/dev-helpers.sh
+++ b/scripts/archived/dev-helpers.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../common.sh
+source "${ROOT_DIR}/common.sh"
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 
 port_forward() {
@@ -43,7 +45,7 @@ check_health() {
   local all_ok=0
   for url in "${endpoints[@]}"; do
     echo "Checking $url ..."
-    if curl -fs "$url" >/dev/null; then
+    if curl_with_timeout "$url" >/dev/null; then
       echo "✅ $url healthy"
     else
       echo "❌ $url failed"
@@ -63,7 +65,7 @@ run_load_test() {
   else
     echo "hey not installed, using curl loop" >&2
     for ((i=1;i<=total;i++)); do
-      curl -fs "$url" >/dev/null &
+      curl_with_timeout "$url" >/dev/null &
       ((i % concurrent == 0)) && wait
     done
     wait

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TIMEOUT:=30}"
+
+require_env() {
+  local var_name="$1"
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Environment variable ${var_name} is required" >&2
+    exit 1
+  fi
+}
+
+curl_with_timeout() {
+  curl --fail --silent --show-error --max-time "${TIMEOUT}" "$@"
+}

--- a/scripts/create_kafka_topics.sh
+++ b/scripts/create_kafka_topics.sh
@@ -1,52 +1,57 @@
 #!/usr/bin/env bash
-# Create Kafka topics required by the Y\xC5\x8Dsai Intel Dashboard.
+# Create Kafka topics required by the Yōsai Intel Dashboard.
 # Usage: ./scripts/create_kafka_topics.sh [broker-list]
 # Requires kafka-topics.sh from Kafka distribution in your PATH.
 
 set -euo pipefail
 
-BROKERS=${1:-localhost:9092}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+BROKERS="${1:-localhost:9092}"
 # URL of the schema registry used for Avro schemas
-SCHEMA_REGISTRY_URL=${SCHEMA_REGISTRY_URL:-http://localhost:8081}
+SCHEMA_REGISTRY_URL="${SCHEMA_REGISTRY_URL:-}"
+require_env SCHEMA_REGISTRY_URL
 
 # Default topic configuration values
-DEFAULT_SEGMENT_MS=${SEGMENT_MS:-604800000}
-DEFAULT_MAX_MESSAGE_BYTES=${MAX_MESSAGE_BYTES:-1048576}
-DEFAULT_COMPRESSION_TYPE=${COMPRESSION_TYPE:-gzip}
+DEFAULT_SEGMENT_MS="${SEGMENT_MS:-604800000}"
+DEFAULT_MAX_MESSAGE_BYTES="${MAX_MESSAGE_BYTES:-1048576}"
+DEFAULT_COMPRESSION_TYPE="${COMPRESSION_TYPE:-gzip}"
 
 create_topic() {
-  local name=$1
-  local partitions=$2
-  local retention=$3
-  local segment_ms=${4:-$DEFAULT_SEGMENT_MS}
-  local max_bytes=${5:-$DEFAULT_MAX_MESSAGE_BYTES}
-  local compression=${6:-$DEFAULT_COMPRESSION_TYPE}
-  local cleanup=${7:-}
-  echo "Creating topic $name"
+  local name="${1}"
+  local partitions="${2}"
+  local retention="${3}"
+  local segment_ms="${4:-$DEFAULT_SEGMENT_MS}"
+  local max_bytes="${5:-$DEFAULT_MAX_MESSAGE_BYTES}"
+  local compression="${6:-$DEFAULT_COMPRESSION_TYPE}"
+  local cleanup="${7:-}"
+  echo "Creating topic ${name}"
   kafka-topics.sh \
-    --bootstrap-server "$BROKERS" \
+    --bootstrap-server "${BROKERS}" \
     --create \
     --if-not-exists \
-    --topic "$name" \
-    --partitions "$partitions" \
+    --topic "${name}" \
+    --partitions "${partitions}" \
     --replication-factor 3 \
     --config min.insync.replicas=2 \
-    --config segment.ms="$segment_ms" \
-    --config retention.ms="$retention" \
-    --config max.message.bytes="$max_bytes" \
-    --config compression.type="$compression" \
-    ${cleanup:+--config cleanup.policy=$cleanup}
+    --config segment.ms="${segment_ms}" \
+    --config retention.ms="${retention}" \
+    --config max.message.bytes="${max_bytes}" \
+    --config compression.type="${compression}" \
+    ${cleanup:+--config cleanup.policy=${cleanup}}
 }
 
 # Register an Avro schema with the schema registry
 register_schema() {
-  local file=$1
-  local subject=$2
-  echo "Registering schema $file for subject $subject"
-  curl -s -X POST \
+  local file="${1}"
+  local subject="${2}"
+  echo "Registering schema ${file} for subject ${subject}"
+  curl_with_timeout -X POST \
     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-    --data "@$file" \
-    "$SCHEMA_REGISTRY_URL/subjects/$subject/versions" > /dev/null
+    --data "@${file}" \
+    "${SCHEMA_REGISTRY_URL}/subjects/${subject}/versions" > /dev/null
 }
 
 # Access control events, one week retention
@@ -74,7 +79,7 @@ create_topic system-metrics 3 $((7 * 24 * 60 * 60 * 1000))
 create_topic dead-letter 3 $((30 * 24 * 60 * 60 * 1000))
 
 # Compacted application state topic
-create_topic app-state 3 $((365 * 24 * 60 * 60 * 1000)) $DEFAULT_SEGMENT_MS $DEFAULT_MAX_MESSAGE_BYTES $DEFAULT_COMPRESSION_TYPE compact
+create_topic app-state 3 $((365 * 24 * 60 * 60 * 1000)) "${DEFAULT_SEGMENT_MS}" "${DEFAULT_MAX_MESSAGE_BYTES}" "${DEFAULT_COMPRESSION_TYPE}" compact
 
 # Audit logs, one month retention
 create_topic audit-logs 1 $((30 * 24 * 60 * 60 * 1000))

--- a/scripts/setup_k8s_dev.sh
+++ b/scripts/setup_k8s_dev.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
 # Install k3s (lightweight Kubernetes)
 if ! command -v k3s >/dev/null 2>&1; then
-  curl -sfL https://get.k3s.io | sh -
+  curl_with_timeout --location https://get.k3s.io | sh -
 fi
 
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 
 # Install Istio CLI if missing
 if ! command -v istioctl >/dev/null 2>&1; then
-  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.21.0 sh -
-  export PATH=$PATH:$(pwd)/istio-1.21.0/bin
+  curl_with_timeout --location https://istio.io/downloadIstio | ISTIO_VERSION=1.21.0 sh -
+  istio_bin="$(pwd)/istio-1.21.0/bin"
+  export PATH="${PATH}:${istio_bin}"
 fi
 
 # Install Istio control plane using the demo profile
@@ -24,11 +29,11 @@ done
 
 # Install Strimzi Kafka operator
 kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f https://strimzi.io/install/latest?namespace=kafka -n kafka
+curl_with_timeout --location "https://strimzi.io/install/latest?namespace=kafka" | kubectl apply -n kafka -f -
 
 # Install observability stack (Prometheus and Grafana via Helm)
 if ! command -v helm >/dev/null 2>&1; then
-  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+  curl_with_timeout --location https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 fi
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update


### PR DESCRIPTION
## Summary
- centralize shell helpers for timeouts and env validation
- wrap network calls with curl timeouts and quote variables
- run shellcheck in code quality workflow

## Testing
- `shellcheck scripts/setup_k3s_dev.sh scripts/setup_k8s_dev.sh scripts/create_kafka_topics.sh scripts/archived/dev-helpers.sh`
- `pre-commit run --files scripts/common.sh scripts/setup_k3s_dev.sh scripts/setup_k8s_dev.sh scripts/create_kafka_topics.sh scripts/archived/dev-helpers.sh .github/workflows/code_quality.yml`


------
https://chatgpt.com/codex/tasks/task_e_6899efc942cc83208e0df8c9c9357499