### PR TITLE
Add container security check script and CI stage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -191,8 +191,18 @@ jobs:
           name: secret-scan-report
           path: secret-scan-report.json
 
+  container-security:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t dashboard-image .
+      - name: Run container security checks
+        run: tests/container/security_checks.sh dashboard-image
+
   release:
-    needs: [trivy-scan, snyk-scan, security-scan, owasp-zap]
+    needs: [trivy-scan, snyk-scan, security-scan, owasp-zap, container-security]
 
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/tests/container/security_checks.sh
+++ b/tests/container/security_checks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${1:-}"
+if [[ -z "$IMAGE" ]]; then
+  echo "Usage: $0 <docker-image>" >&2
+  exit 1
+fi
+
+# 1. Confirm container runs as UID 1000
+CONTAINER_UID=$(docker run --rm "$IMAGE" id -u)
+if [[ "$CONTAINER_UID" != "1000" ]]; then
+  echo "Container UID is $CONTAINER_UID but expected 1000" >&2
+  exit 1
+fi
+
+echo "UID check passed"
+
+# 2. Check for unexpected writable directories
+WRITABLE=$(docker run --rm "$IMAGE" sh -c "find / -xdev -type d -writable 2>/dev/null")
+if [[ -n "$WRITABLE" ]]; then
+  echo "Writable directories:\n$WRITABLE"
+fi
+# Fail if any writable directories besides /tmp or /var/tmp are present
+BAD=$(docker run --rm "$IMAGE" sh -c "find / -xdev -type d -writable ! -path '/tmp' ! -path '/var/tmp' 2>/dev/null")
+if [[ -n "$BAD" ]]; then
+  echo "Unexpected writable directories found:\n$BAD" >&2
+  exit 1
+fi
+
+echo "Writable directory check passed"
+
+# 3. Inspect image layers for secrets
+if docker history --no-trunc "$IMAGE" | grep -iE 'secret|password|token|key'; then
+  echo "Potential secrets found in image history" >&2
+  exit 1
+fi
+
+echo "No secrets detected in image layers"


### PR DESCRIPTION
## Summary
- add `tests/container/security_checks.sh` to validate image UID, writable directories, and layer history
- run new container security job in CI before release

## Testing
- `pre-commit run --files tests/container/security_checks.sh .github/workflows/pipeline.yml`
- `tests/container/security_checks.sh alpine` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6899efd454c083208647098987cd33e8