### PR TITLE
Simplify risk score result creation

### DIFF
--- a/analytics/risk_scoring.py
+++ b/analytics/risk_scoring.py
@@ -78,25 +78,8 @@ def _context_modifier(context: Optional[Dict[str, object]]) -> float:
 
 
 def _make_result(score: float, level: str) -> RiskScoreResult:
-    """Instantiate :class:`RiskScoreResult` with fallbacks.
-
-    Some unit tests stub modules which can accidentally replace
-    :class:`RiskScoreResult` with a plain ``object``.  This helper ensures a
-    usable dataclass instance is returned regardless of such stubbing.
-    """
-
-    global RiskScoreResult  # allow reassignment if necessary
-    try:
-        return RiskScoreResult(score=score, level=level)  # type: ignore[arg-type]
-    except TypeError:
-
-        @dataclass
-        class _RiskScoreResult:
-            score: float
-            level: str
-
-        RiskScoreResult = _RiskScoreResult  # type: ignore
-        return RiskScoreResult(score=score, level=level)
+    """Return a :class:`RiskScoreResult` with the given values."""
+    return RiskScoreResult(score=score, level=level)
 
 
 def calculate_risk_score(


### PR DESCRIPTION
## Summary
- simplify `_make_result` by directly returning `RiskScoreResult`

## Testing
- `pytest tests/test_risk_scoring.py -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6899f95a88088320a53b76b8ce034ead