### PR TITLE
Extract security event dispatch helper

### DIFF
--- a/tests/test_dispatch_security_events.py
+++ b/tests/test_dispatch_security_events.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from services.analytics.security_patterns import (
+    SecurityEvent,
+    _dispatch_security_events,
+    setup_isolated_security_testing,
+)
+from services.analytics.security_patterns.pattern_detection import Threat
+
+
+def test_dispatch_security_events_with_threat():
+    class DummyFrame:
+        def __len__(self) -> int:
+            return 3
+
+    with setup_isolated_security_testing() as env:
+        prepared = DummyFrame()
+        threat = Threat("dummy", {})
+        _dispatch_security_events(prepared, [threat])
+        assert env.events[SecurityEvent.THREAT_DETECTED] == [{"threats": [threat]}]
+        assert env.events[SecurityEvent.ANALYSIS_COMPLETE] == [{"records": 3}]
+
+
+def test_dispatch_security_events_without_threat():
+    class DummyFrame:
+        def __len__(self) -> int:
+            return 2
+
+    with setup_isolated_security_testing() as env:
+        prepared = DummyFrame()
+        _dispatch_security_events(prepared, [])
+        assert env.events[SecurityEvent.THREAT_DETECTED] == []
+        assert env.events[SecurityEvent.ANALYSIS_COMPLETE] == [{"records": 2}]


### PR DESCRIPTION
## Summary
- remove unused Iterator import
- move callback dispatch into new `_dispatch_security_events`
- test security event dispatch for threat and non-threat cases

## Testing
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/test_dispatch_security_events.py`


------
https://chatgpt.com/codex/tasks/task_e_6899f95b2ba0832085dafe1b7f9a1d3e