### PR TITLE
Ensure ROI handles non-positive cost

### DIFF
--- a/analytics/metrics/roi.ts
+++ b/analytics/metrics/roi.ts
@@ -1,5 +1,6 @@
 export const calculateROI = (revenue: number, cost: number): number => {
-  return cost === 0 ? 0 : (revenue - cost) / cost;
+  // Guard against zero or negative costs which would skew ROI
+  return cost <= 0 ? 0 : (revenue - cost) / cost;
 };
 
 export interface ABTestOutcome {

--- a/yosai_intel_dashboard/src/adapters/ui/src/roi.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/src/roi.test.ts
@@ -1,0 +1,12 @@
+import { calculateROI } from '../../../../../analytics/metrics/roi';
+
+describe('calculateROI', () => {
+  it('returns 0 when cost is 0', () => {
+    expect(calculateROI(100, 0)).toBe(0);
+  });
+
+  it('returns 0 when cost is negative', () => {
+    expect(calculateROI(100, -50)).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Prevent division by zero or negative ROI by returning 0 when cost is non-positive
- Add tests for zero and negative cost ROI calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899f95c3fa48320afbea2dd493f7618