### PR TITLE
refactor: use typed ExtendedWebSocket in hooks

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/extendedWebSocket.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/extendedWebSocket.ts
@@ -1,0 +1,7 @@
+export interface ExtendedWebSocket extends WebSocket {
+  on?: (event: string, listener: (...args: unknown[]) => void) => void;
+  pong?: () => void;
+}
+
+export default ExtendedWebSocket;
+


### PR DESCRIPTION
## Summary
- define `ExtendedWebSocket` interface with optional `on` and `pong`
- cast sockets to `ExtendedWebSocket` and remove `(ws as any)`

## Testing
- `npx jest yosai_intel_dashboard/src/adapters/ui/hooks/useWebSocket.test.ts yosai_intel_dashboard/src/adapters/ui/hooks/useEventSocket.test.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a032b72e08320945914cf6afb7b5b