### PR TITLE
Use ImportError for greeting callbacks fallback

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/greetings/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/greetings/callbacks.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from dash import Input, Output
 from dash.exceptions import PreventUpdate
 
 try:  # pragma: no cover - allow tests without full core package
-    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-except Exception:  # pragma: no cover - lightweight fallback
+    from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+        TrulyUnifiedCallbacks,
+    )
+except ImportError:  # pragma: no cover - lightweight fallback for missing dependency
+
     class TrulyUnifiedCallbacks:  # type: ignore[too-few-public-methods]
         """Minimal stub used when core package isn't available."""
 
@@ -19,6 +24,8 @@ except Exception:  # pragma: no cover - lightweight fallback
             return decorator
 
         register_handler = callback
+
+
 from yosai_intel_dashboard.src.services.greeting import GreetingService
 from yosai_intel_dashboard.src.simple_di import inject
 


### PR DESCRIPTION
## Summary
- refine greetings callbacks to only fall back when unified callbacks can't be imported
- add future annotations import to satisfy style checks

## Testing
- `SKIP=mypy,bandit pre-commit run --files yosai_intel_dashboard/src/adapters/ui/pages/greetings/callbacks.py`
- `PYTEST_ADDOPTS="" pytest --no-cov tests/test_new_page_callbacks.py -q` *(fails: fixture 'fake_dash' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a032be37883209ca70cd5d6d77f1a