### PR TITLE
refactor: remove console logs from upload and tighten mapping types

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
@@ -36,14 +36,12 @@ const Upload: React.FC = () => {
     multiple: true,
   });
 
-  const handleColumnMappingConfirm = (mappings: Record<string, string>) => {
-    console.log("Column mappings confirmed:", mappings);
+  const handleColumnMappingConfirm = (_mappings: Record<string, string>) => {
     setShowColumnMapping(false);
     setCurrentFile(null);
   };
 
-  const handleDeviceMappingConfirm = (mappings: Record<string, any>) => {
-    console.log("Device mappings confirmed:", mappings);
+  const handleDeviceMappingConfirm = (_mappings: Record<string, unknown>) => {
     setShowDeviceMapping(false);
     setCurrentFile(null);
   };


### PR DESCRIPTION
## Summary
- remove temporary console logging from upload confirmation handlers
- strengthen device mapping handler to use `Record<string, unknown>`

## Testing
- `npm test -- components/upload/Upload.test.tsx` *(no tests found)*
- `npx eslint components/upload/Upload.tsx` *(errors: Strings must use singlequote, prettier/prettier)*

------
https://chatgpt.com/codex/tasks/task_e_689a032c45f88320ac4340c73a97265e