### PR TITLE
refactor: import callback_context directly from dash

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 """Device learning feature callbacks."""
 
 import pandas as pd
-from dash import html
-from dash._callback_context import callback_context
+from dash import callback_context, html
 from dash.dependencies import Input, Output
 
 from yosai_intel_dashboard.src.core.interfaces.service_protocols import (

--- a/yosai_intel_dashboard/src/services/upload/helpers.py
+++ b/yosai_intel_dashboard/src/services/upload/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -12,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def get_trigger_id() -> str:
     """Return the triggered Dash callback identifier."""
-    from dash._callback_context import callback_context
+    from dash import callback_context
 
     ctx = callback_context
     return ctx.triggered[0]["prop_id"] if ctx.triggered else ""


### PR DESCRIPTION
## Summary
- replace private dash callback_context import with public API
- ensure helper module uses future annotations for style

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/pages/device_learning/callbacks.py yosai_intel_dashboard/src/services/upload/helpers.py`
- `pytest -o addopts="" tests/test_device_learning_service.py tests/callbacks/test_upload_callbacks_split.py` *(fails: ImportError: cannot import name 'DatabaseManager' ...)*
- `python - <<'PY'
from dash import callback_context
print('callback_context import ok:', callback_context is not None)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a032d5be88320bb87e24dfd5ac502