### PR TITLE
Harden scripts and nginx configuration

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,6 +1,7 @@
 events {}
 
 http {
+    server_tokens off;
     upstream yosai_backend {
         server yosai-app:8050;
     }

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -10,7 +10,7 @@ cmd = ["safety", "check", "--full-report", "--json"]
 for req in REQ_FILES:
     cmd.extend(["-r", req])
 
-result = subprocess.run(cmd, capture_output=True, text=True)
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
 if result.returncode not in (0, 1):
     print(result.stdout)
     print(result.stderr, file=sys.stderr)

--- a/scripts/manual_tests/check_base_services.py
+++ b/scripts/manual_tests/check_base_services.py
@@ -11,7 +11,7 @@ def safe_str(obj):
         return (
             str(obj).encode("utf-8", errors="ignore").decode("utf-8", errors="replace")
         )
-    except:
+    except Exception:
         return repr(obj)
 
 


### PR DESCRIPTION
## Summary
- clarify manual service test error handling
- add timeout to dependency audit subprocess call
- hide nginx version in config

## Testing
- `python -m py_compile scripts/manual_tests/check_base_services.py scripts/audit_dependencies.py`
- `nginx -t -c $(pwd)/deployment/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f9e9a58c8320b9f3a10124e3827f