### PR TITLE
refactor: replace ioutil with os

### DIFF
--- a/go/framework/config.go
+++ b/go/framework/config.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -23,7 +22,7 @@ var schemaPath = "../../config/service.schema.yaml"
 
 func LoadConfig(path string) (Config, error) {
 	var cfg Config
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return cfg, err
 	}


### PR DESCRIPTION
## Summary
- replace deprecated `ioutil.ReadFile` with `os.ReadFile` in framework config
- remove unused `io/ioutil` import and format the file

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a140c10e88320928faf7b1cdb2abf