### PR TITLE
feat: allow overriding schema path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,9 @@ environment variables:
 - `YOSAI_APP_MODE` – set to `full`, `simple` or `json-safe` to select the
   startup mode for `create_app()` (default: `full`).
 
+Go-based services validate their configuration against `config/service.schema.yaml` by default.
+Set `YOSAI_SCHEMA_PATH` to override this schema location when needed.
+
 Example:
 
 ```bash

--- a/docs/migrating_base_service.md
+++ b/docs/migrating_base_service.md
@@ -18,3 +18,7 @@ introduced in `go/framework`.
 The builder configures a zap logger, Prometheus metrics collector and Jaeger
 tracer. Custom implementations can be supplied via the `WithLogger`,
 `WithMetrics` and `WithTracer` methods before calling `Build`.
+
+Configuration is validated against `config/service.schema.yaml` by default.
+Set the `YOSAI_SCHEMA_PATH` environment variable to point to a different
+schema file when needed.

--- a/go/framework/config.go
+++ b/go/framework/config.go
@@ -19,7 +19,14 @@ type Config struct {
 	TracingEndpoint string `yaml:"tracing_endpoint"`
 }
 
-var schemaPath = "../../config/service.schema.yaml"
+const defaultSchemaPath = "../../config/service.schema.yaml"
+
+func schemaPath() string {
+	if path := os.Getenv("YOSAI_SCHEMA_PATH"); path != "" {
+		return path
+	}
+	return defaultSchemaPath
+}
 
 func LoadConfig(path string) (Config, error) {
 	var cfg Config
@@ -68,7 +75,7 @@ func validateConfig(yamlData []byte) error {
 	if err != nil {
 		return err
 	}
-	loader := gojsonschema.NewReferenceLoader("file://" + schemaPath)
+	loader := gojsonschema.NewReferenceLoader("file://" + schemaPath())
 	docLoader := gojsonschema.NewBytesLoader(jsonBytes)
 	result, err := gojsonschema.Validate(loader, docLoader)
 	if err != nil {


### PR DESCRIPTION
## Summary
- allow Go framework to read config schema path from `YOSAI_SCHEMA_PATH`
- document `YOSAI_SCHEMA_PATH` usage

## Testing
- `go fmt go/framework/config.go`
- `pre-commit run --files go/framework/config.go README.md docs/migrating_base_service.md`
- `go test ./...` in go/config
- `go test ./...` in go/framework


------
https://chatgpt.com/codex/tasks/task_e_689a140dfce4832090ebbf2fd28a9e47