### PR TITLE
chore: clean imports in event processor command

### DIFF
--- a/yosai_intel_dashboard/src/services/event_processing/cmd/processor/main.go
+++ b/yosai_intel_dashboard/src/services/event_processing/cmd/processor/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"time"
 
 	framework "github.com/WSG23/yosai-framework"
 	"github.com/sony/gobreaker"
@@ -12,7 +11,6 @@ import (
 	"github.com/WSG23/yosai-event-processing/internal/handlers"
 	"github.com/WSG23/yosai-event-processing/internal/kafka"
 	"github.com/WSG23/yosai-event-processing/internal/repository"
-	"github.com/sony/gobreaker"
 )
 
 func main() {
@@ -45,7 +43,6 @@ func main() {
 			}
 			return c.ConsecutiveFailures >= uint32(t)
 		},
-
 	}
 	handler := handlers.NewEventHandler(repository.NewMemoryTokenStore(), settings)
 	go func() {


### PR DESCRIPTION
## Summary
- remove duplicate gobreaker import from event processor
- format imports

## Testing
- `go build ./...` *(fails: pattern circuitbreakers_schema.json: no matching files found; replacement directory ../../resilience does not exist; replacement directory ../../go/framework does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a1411aaa88320b8be12b792822bde