### PR TITLE
chore: streamline hadolint dockerfile input

### DIFF
--- a/.github/workflows/devops-lint.yml
+++ b/.github/workflows/devops-lint.yml
@@ -19,6 +19,4 @@ jobs:
       - name: Hadolint
         uses: hadolint/hadolint-action@v3.1.0
         with:
-          dockerfile: |
-            Dockerfile
-            Dockerfile.gateway
+          dockerfile: Dockerfile,Dockerfile.gateway


### PR DESCRIPTION
## Summary
- simplify hadolint dockerfile paths into single comma-separated value

## Testing
- `pre-commit run --files .github/workflows/devops-lint.yml`

------
https://chatgpt.com/codex/tasks/task_e_689a18ba6dd88320b8568b8c9c881fce