### PR TITLE
chore: improve common.sh sourcing

### DIFF
--- a/scripts/archived/dev-helpers.sh
+++ b/scripts/archived/dev-helpers.sh
@@ -8,7 +8,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../common.sh
-source "${ROOT_DIR}/common.sh"
+COMMON_SH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../common.sh"
+if [ -f "$COMMON_SH" ]; then . "$COMMON_SH"; else
+  echo "Warning: common.sh not found at $COMMON_SH; continuing without it." >&2
+fi
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 
 port_forward() {

--- a/scripts/create_kafka_topics.sh
+++ b/scripts/create_kafka_topics.sh
@@ -5,9 +5,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=common.sh
-source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=./common.sh
+COMMON_SH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/common.sh"
+if [ -f "$COMMON_SH" ]; then . "$COMMON_SH"; else
+  echo "Warning: common.sh not found at $COMMON_SH; continuing without it." >&2
+fi
 
 BROKERS="${1:-localhost:9092}"
 # URL of the schema registry used for Avro schemas

--- a/scripts/setup_k3s_dev.sh
+++ b/scripts/setup_k3s_dev.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=common.sh
-source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=./common.sh
+COMMON_SH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/common.sh"
+if [ -f "$COMMON_SH" ]; then . "$COMMON_SH"; else
+  echo "Warning: common.sh not found at $COMMON_SH; continuing without it." >&2
+fi
 
 # Install k3s (lightweight Kubernetes)
 if ! command -v k3s >/dev/null 2>&1; then

--- a/scripts/setup_k8s_dev.sh
+++ b/scripts/setup_k8s_dev.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=common.sh
-source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=./common.sh
+COMMON_SH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/common.sh"
+if [ -f "$COMMON_SH" ]; then . "$COMMON_SH"; else
+  echo "Warning: common.sh not found at $COMMON_SH; continuing without it." >&2
+fi
 
 # Install k3s (lightweight Kubernetes)
 if ! command -v k3s >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add conditional common.sh loading with fallback warning in create_kafka_topics and dev setup scripts
- ensure archived dev helper loads common.sh robustly

## Testing
- `shellcheck -x scripts/create_kafka_topics.sh`
- `shellcheck -x scripts/setup_k8s_dev.sh`
- `shellcheck -x scripts/setup_k3s_dev.sh`
- `shellcheck -x scripts/archived/dev-helpers.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a18bd4a3c8320b440ac2c68a204c5