### PR TITLE
chore: build gateway image using dedicated Dockerfile

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -196,10 +196,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build Docker image
-        run: docker build -t dashboard-image .
+      - name: Build gateway Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.gateway
+          tags: gateway-image
+          load: true
       - name: Run container security checks
-        run: tests/container/security_checks.sh dashboard-image
+        run: tests/container/security_checks.sh gateway-image
 
   release:
     needs: [trivy-scan, snyk-scan, security-scan, owasp-zap, container-security]


### PR DESCRIPTION
## Summary
- use docker/build-push-action to build gateway image from Dockerfile.gateway in container security job
- keep all GitHub Actions workflows pinned to Python 3.11

## Testing
- `act -l`

------
https://chatgpt.com/codex/tasks/task_e_689a18bef77883208db99847588d8ffc