### PR TITLE
chore: relax numpy constraints

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,7 +11,7 @@ cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
 pandas==2.1.4
-numpy==1.26.4
+numpy>=1.23,<2.0
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -11,7 +11,7 @@ cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
 pandas==2.1.4
-numpy==1.26.4
+numpy>=1.23,<2.0
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ websockets==11.0.3
 plotly==5.15.0
 dash-bootstrap-components==1.6.0
 pandas==2.1.4
-numpy==1.26.4
+numpy>=1.23,<2.0
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0

--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -122,7 +122,7 @@ install_compatible_packages() {
     
     # Install NumPy first with compatible version
     print_info "Installing compatible NumPy version..."
-    pip3 install "numpy>=1.21.6,<1.28.0"
+    pip3 install "numpy>=1.23,<2.0"
     
     # Install SciPy
     print_info "Installing SciPy..."
@@ -163,7 +163,7 @@ install_project_requirements() {
         
         cat > requirements_fixed.txt << 'EOF'
 # Core dependencies with compatible versions
-numpy>=1.21.6,<1.28.0
+numpy>=1.23,<2.0
 scipy>=1.7.0,<1.12.0
 pandas>=1.3.0
 scikit-learn>=1.0.0


### PR DESCRIPTION
## Summary
- relax numpy pin to `>=1.23,<2.0` across requirements
- update Mac dependency helper to match numpy range

## Testing
- `pre-commit run --files requirements.txt api/requirements.txt dashboard/requirements.txt scripts/fix_mac_deps.sh`
- `pytest -q` *(fails: Required test coverage of 80% not reached. Total coverage: 2.29%)*

------
https://chatgpt.com/codex/tasks/task_e_689a18b697bc8320b9af775d390db793