### PR TITLE
chore(upload): ensure FileData type imported

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/Upload.tsx
@@ -4,7 +4,10 @@ import { Upload as UploadIcon } from "lucide-react";
 import { FilePreview } from "./FilePreview";
 import { ColumnMappingModal } from "./ColumnMappingModal";
 import { DeviceMappingModal } from "./DeviceMappingModal";
-import { UploadedFile, FileData } from "./types";
+import {
+  FileData,
+  UploadedFile,
+} from "./types";
 import useUpload from "../../hooks/useUpload";
 
 const Upload: React.FC = () => {


### PR DESCRIPTION
## Summary
- ensure FileData and UploadedFile types imported from local definitions in Upload component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1cdd54c88320833f526165d01e01