### PR TITLE
feat(ui): improve remove button accessibility

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FilePreview } from './FilePreview';
 
-const file = { id: '1', file: new File(['d'], 'file.csv'), status: 'ready', progress: 10 };
+const file = {
+  id: '1',
+  file: new File(['d'], 'file.csv'),
+  status: 'ready',
+  progress: 10,
+};
 
 test('renders file name', () => {
   render(<FilePreview file={file} onRemove={() => {}} />);
@@ -11,10 +16,14 @@ test('renders file name', () => {
 test('remove button is focusable and supports keyboard activation', () => {
   const onRemove = jest.fn();
   render(<FilePreview file={file} onRemove={onRemove} />);
-  const button = screen.getByRole('button', { name: `Remove ${file.file.name}` });
+  const button = screen.getByRole('button', {
+    name: `Remove ${file.file.name}`,
+  });
   button.focus();
   expect(button).toHaveFocus();
   fireEvent.keyDown(button, { key: 'Enter', code: 'Enter' });
   fireEvent.keyUp(button, { key: 'Enter', code: 'Enter' });
-  expect(onRemove).toHaveBeenCalled();
+  fireEvent.keyDown(button, { key: ' ', code: 'Space' });
+  fireEvent.keyUp(button, { key: ' ', code: 'Space' });
+  expect(onRemove).toHaveBeenCalledTimes(2);
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
@@ -27,13 +27,22 @@ export const FilePreview: React.FC<Props> = ({ file, onRemove, onCancel }) => {
                 Cancel
               </button>
             )}
-            <button onClick={onRemove} className="text-red-500 text-xs">Remove</button>
+            <button
+              onClick={onRemove}
+              className="text-red-500 text-xs"
+              aria-label={`Remove ${file.file.name}`}
+            >
+              Remove
+            </button>
           </div>
-
         </div>
         <ProgressBar progress={file.progress} className="mt-2" />
         {file.error && (
-          <p role="alert" aria-live="assertive" className="text-xs text-red-500 mt-1">
+          <p
+            role="alert"
+            aria-live="assertive"
+            className="text-xs text-red-500 mt-1"
+          >
             {file.error}
           </p>
         )}


### PR DESCRIPTION
## Summary
- add descriptive aria-label to FilePreview remove button
- expand tests to verify keyboard activation

## Testing
- `npm run lint -- yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx` *(fails: Cannot find package 'eslint-plugin-prettier')*
- `npx eslint yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx`
- `npm test`
- `cd yosai_intel_dashboard/src/adapters/ui && npx react-scripts test ../components/upload/FilePreview.test.tsx --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ce308248320a481a5b00ec5a3b1