### PR TITLE
test: enforce deterministic order and block network

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -120,14 +120,19 @@ required:
 pytest --cov --cov-fail-under=80
 ```
 
+### Deterministic Test Order
+
+The test suite employs [`pytest-randomly`](https://pypi.org/project/pytest-randomly/)
+to shuffle tests while keeping results reproducible. A fixed seed of `1234` is
+configured in `pytest.ini` so failures can be replicated exactly.
+
 ### Network Isolation
 
 The test suite uses [`pytest-socket`](https://pypi.org/project/pytest-socket/)
-to prevent outbound network calls. By default all network access is blocked
-during tests. Local connections to `localhost` or `127.0.0.1` are permitted for
-services that bind to the loopback interface. External hosts must not be
-contacted; if a test requires network access it should mock the interaction
-instead of performing a real request.
+to prevent outbound network calls. `pytest.ini` enables `--disable-socket` and
+allows only `localhost` and `127.0.0.1` via `--allow-hosts`. External hosts must
+not be contacted; if a test requires network access it should mock the
+interaction instead of performing a real request.
 
 ### Memory Profiling
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,8 @@ pyOpenSSL==25.1.0
 SQLAlchemy==2.0.41
 click==8.1.8
 pytest-cov==6.2.1
+pytest-randomly==3.15.0
+pytest-socket==0.6.0
 hvac==2.3.0
 kafka-python==2.2.15
 hyperloglog==0.0.14


### PR DESCRIPTION
## Summary
- add pytest-randomly and pytest-socket to test dependencies
- document deterministic test order and network isolation

## Testing
- `pre-commit run --files requirements.txt docs/test_setup.md`
- `pytest -q` *(fails: Coverage failure: total of 2 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_689a1cfaa94083208fb0718eef4cc96c