### PR TITLE
Document upload results endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1408,7 +1408,7 @@ The running application exposes Swagger-based API docs at `http://<host>:<port>/
 - State stores: [docs/state_management.md](docs/state_management.md)
 - Ops reference: [docs/operations_guide.md](docs/operations_guide.md)
 - Callback migration: [docs/migration_callback_system.md](docs/migration_callback_system.md)
-- Upload endpoint notes: [docs/pr/Upload_PR.md](docs/pr/Upload_PR.md)
+- Upload results endpoint documentation: [docs/pr/Upload_PR.md](docs/pr/Upload_PR.md)
 
 Update the spec by running `go run ./api/openapi` which writes `docs/api/v2/openapi.json` for the UI.
 

--- a/docs/pr/Upload_PR.md
+++ b/docs/pr/Upload_PR.md
@@ -1,10 +1,53 @@
-# Upload Pull Request
+# Upload Results Endpoint
 
-Use the following commands before uploading your pull request to verify formatting, linting, and tests for both the backend and frontend:
+This document summarizes the new `/api/v1/results/upload` endpoint, associated schema, migration notes, and test commands.
+
+## Endpoint Summary
+
+`POST /api/v1/results/upload`
+
+Accepts an array of result objects via the `results[]` field and returns a 202 response once the upload is queued for processing.
+
+### Example `results[]` Payload
+
+```json
+{
+  "results": [
+    {
+      "result_id": 1,
+      "device_id": "door-123",
+      "status": "processed",
+      "timestamp": "2024-07-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+## Schema
+
+| Field       | Type    | Notes                            |
+|-------------|---------|----------------------------------|
+| result_id   | integer | Unique identifier for the result |
+| device_id   | string  | Source device identifier         |
+| status      | string  | Processing state                 |
+| timestamp   | string  | ISO‑8601 formatted datetime      |
+
+## Migration Notes
+
+1. A new `results` table stores uploaded result records.
+2. Apply the migration:
+
+```sh
+alembic upgrade head
+```
+
+## Test Commands
+
+Run the following commands before opening a pull request to verify formatting, linting, and tests for both backend and frontend:
 
 ```sh
 python -m pip install -r requirements-dev.txt
-black .
+black --check .
 ruff check .
 pytest -q
 npm install


### PR DESCRIPTION
## Summary
- document the new `/api/v1/results/upload` endpoint with schema, migration notes, and example payload
- link upload results endpoint documentation from README

## Testing
- `ruff check docs/pr/Upload_PR.md README.md` (errors: SyntaxError: Expected a statement)
- `pytest -q --override-ini=addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_689a1cebc09883208528d5a456f2f302