### PR TITLE
feat(upload): add result schemas and use for validation

### DIFF
--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -49,7 +49,7 @@ from yosai_intel_dashboard.src.infrastructure.config.app_config import UploadCon
 from yosai_intel_dashboard.src.services.upload.upload_endpoint import (
     ALLOWED_MIME_TYPES,
     UploadRequestSchema,
-    UploadResponseSchema,
+    UploadResponse,
     stream_upload,
 )
 from yosai_intel_dashboard.src.infrastructure.monitoring.request_metrics import (
@@ -231,7 +231,7 @@ def _register_upload_endpoints(
 
     @service.app.post(
         "/v1/upload",
-        response_model=UploadResponseSchema,
+        response_model=UploadResponse,
         status_code=200,
         dependencies=[Depends(verify_csrf)],
     )

--- a/yosai_intel_dashboard/src/services/upload/schemas.py
+++ b/yosai_intel_dashboard/src/services/upload/schemas.py
@@ -1,32 +1,35 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
-
 from pydantic import BaseModel
 
 
 class UploadResult(BaseModel):
-    """Status information for an upload job.
+    """Details for a single uploaded file."""
 
-    The ``status`` field may contain arbitrary metadata describing the current
-    state of the upload process.
-    """
-
-    status: Dict[str, Any]
-
-    class Config:
-        json_schema_extra = {"examples": [{"status": {"state": "processing"}}]}
-
-
-class UploadResponse(BaseModel):
-    """Response returned when an upload job is accepted."""
-
-    job_id: str
+    filename: str
+    path: str
 
     class Config:
         json_schema_extra = {
             "examples": [
-                {"job_id": "123e4567-e89b-12d3-a456-426614174000"}
+                {"filename": "hello.txt", "path": "/tmp/uploads/hello.txt"}
+            ]
+        }
+
+
+class UploadResponse(BaseModel):
+    """Response payload returned from the upload endpoint."""
+
+    results: list[UploadResult]
+
+    class Config:
+        json_schema_extra = {
+            "examples": [
+                {
+                    "results": [
+                        {"filename": "hello.txt", "path": "/tmp/uploads/hello.txt"}
+                    ]
+                }
             ]
         }
 

--- a/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload/upload_endpoint.py
@@ -17,7 +17,7 @@ import redis
 from flask import Blueprint, request
 from flask_apispec import doc
 from flask_wtf.csrf import validate_csrf
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from middleware.rate_limit import RedisRateLimiter, rate_limit
 from yosai_intel_dashboard.src.error_handling import (
@@ -30,6 +30,7 @@ from yosai_intel_dashboard.src.infrastructure.config.loader import (
 )
 from yosai_intel_dashboard.src.services.data_processing.file_handler import FileHandler
 from yosai_intel_dashboard.src.services.upload.file_validator import FileValidator
+from yosai_intel_dashboard.src.services.upload.schemas import UploadResponse, UploadResult
 from yosai_intel_dashboard.src.utils.pydantic_decorators import (
     validate_input,
     validate_output,
@@ -67,32 +68,6 @@ class UploadRequestSchema(BaseModel):
         }
 
 
-class UploadResultSchema(BaseModel):
-    """Details for a single uploaded file."""
-
-    filename: str
-    path: str
-
-
-class UploadResponseSchema(BaseModel):
-    """Response payload returned from the upload endpoint."""
-
-    results: list[UploadResultSchema]
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [
-                {
-                    "results": [
-                        {
-                            "filename": "hello.txt",
-                            "path": "/tmp/uploads/hello.txt",
-                        }
-                    ]
-                }
-            ]
-        }
-    )
 
 
 ALLOWED_MIME_TYPES: set[str] = {
@@ -179,7 +154,7 @@ def create_upload_blueprint(
         },
     )
     @validate_input(UploadRequestSchema)
-    @validate_output(UploadResponseSchema)
+    @validate_output(UploadResponse)
     @rate_limit(rate_limiter)
     def upload_files(payload: UploadRequestSchema):
         """Validate and persist uploaded files."""
@@ -287,8 +262,8 @@ def create_upload_blueprint(
 
 __all__ = [
     "UploadRequestSchema",
-    "UploadResultSchema",
-    "UploadResponseSchema",
+    "UploadResult",
+    "UploadResponse",
     "create_upload_blueprint",
     "stream_upload",
     "ALLOWED_MIME_TYPES",

--- a/yosai_intel_dashboard/src/services/upload_endpoint.py
+++ b/yosai_intel_dashboard/src/services/upload_endpoint.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import warnings
 
 # Explicitly import only the public symbols from the upload endpoint module.
+from .upload.schemas import UploadResponse, UploadResult
 from .upload.upload_endpoint import (
     ALLOWED_MIME_TYPES,
     UploadRequestSchema,
-    UploadResponseSchema,
-    UploadResultSchema,
     create_upload_blueprint as _create_upload_blueprint,
     stream_upload,
 )
@@ -17,8 +16,8 @@ from .upload.upload_endpoint import (
 # Re-export the imported symbols to maintain the public API of this module.
 __all__ = [
     "UploadRequestSchema",
-    "UploadResponseSchema",
-    "UploadResultSchema",
+    "UploadResponse",
+    "UploadResult",
     "create_upload_blueprint",
     "stream_upload",
     "ALLOWED_MIME_TYPES",


### PR DESCRIPTION
## Summary
- add UploadResult and UploadResponse Pydantic models with examples
- apply new schemas for upload endpoint responses and re-export in wrapper
- update adapter to use UploadResponse model

## Testing
- `pytest tests/test_upload_csrf.py -q` *(fails: `_SECURITYCONFIG_SESSIONTIMEOUTBYROLEENTRY` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ce6e50c83208e6d8e0fda8669da