### PR TITLE
Add unicode-safe upload helpers and tests

### DIFF
--- a/src/services/upload/__init__.py
+++ b/src/services/upload/__init__.py
@@ -1,0 +1,11 @@
+"""Upload service utilities."""
+
+from .stream_upload import stream_upload
+from .unicode import normalize_text, safe_decode_bytes, safe_encode_text
+
+__all__ = [
+    "stream_upload",
+    "normalize_text",
+    "safe_decode_bytes",
+    "safe_encode_text",
+]

--- a/src/services/upload/stream_upload.py
+++ b/src/services/upload/stream_upload.py
@@ -1,0 +1,12 @@
+"""Helpers for streaming file uploads."""
+from __future__ import annotations
+
+from typing import Any
+
+from .unicode import normalize_text
+
+
+def stream_upload(store, filename: str, data: Any) -> None:
+    """Save ``data`` to ``store`` under a normalized ``filename``."""
+    safe_name = normalize_text(filename)
+    store.add_file(safe_name, data)

--- a/src/services/upload/unicode.py
+++ b/src/services/upload/unicode.py
@@ -1,0 +1,39 @@
+"""Unicode helpers for upload services.
+
+This module provides safe text normalization and encoding helpers that
+can handle inputs containing explicit surrogate pairs.  Valid pairs are
+combined into their corresponding Unicode characters while unpaired
+surrogates are discarded.
+"""
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+
+def normalize_text(text: Any) -> str:
+    """Return ``text`` normalized to NFC with surrogate pairs handled."""
+    if not isinstance(text, str):
+        text = str(text)
+    # Convert surrogate pairs and drop unpaired surrogates
+    text = text.encode("utf-16", "surrogatepass").decode("utf-16", "ignore")
+    return unicodedata.normalize("NFC", text)
+
+
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    """Decode ``data`` using ``encoding`` while handling surrogate pairs."""
+    try:
+        text = data.decode(encoding, errors="surrogatepass")
+    except Exception:
+        text = data.decode(encoding, errors="ignore")
+    return normalize_text(text)
+
+
+def safe_encode_text(value: Any) -> str:
+    """Return a normalized string representation of ``value``."""
+    if isinstance(value, bytes):
+        return safe_decode_bytes(value)
+    return normalize_text(value)
+
+
+__all__ = ["normalize_text", "safe_encode_text", "safe_decode_bytes"]

--- a/tests/test_upload_unicode_stream.py
+++ b/tests/test_upload_unicode_stream.py
@@ -7,8 +7,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent / "stubs"))
 os.environ.setdefault("LIGHTWEIGHT_SERVICES", "1")
 
-from yosai_intel_dashboard.src.services.upload.stream_upload import stream_upload
-from yosai_intel_dashboard.src.services.upload.unicode import (
+from src.services.upload.stream_upload import stream_upload
+from src.services.upload.unicode import (
     normalize_text,
     safe_decode_bytes,
     safe_encode_text,


### PR DESCRIPTION
## Summary
- add unicode helper module for safe encoding/decoding
- normalize filenames in stream_upload
- test surrogate pair handling and filename normalization

## Testing
- `pytest tests/test_upload_unicode_stream.py -q --override-ini="addopts=" -p no:cov`

------
https://chatgpt.com/codex/tasks/task_e_689a1ce89c948320b84a2d37d1b9072e