### PR TITLE
feat: add analytics schemas and unicode helpers

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics/unicode.py
+++ b/yosai_intel_dashboard/src/services/analytics/unicode.py
@@ -3,18 +3,35 @@
 from __future__ import annotations
 
 import unicodedata
+from typing import Any
 
 
 def normalize_text(text: str) -> str:
-    """Return ``text`` normalised using Unicode NFKC form.
+    """Return ``text`` normalized to NFC with surrogate pairs handled."""
 
-    Parameters
-    ----------
-    text:
-        Input text to normalise. Non-string values are converted to string and
-        ``None`` becomes an empty string.
-    """
+    if not isinstance(text, str):
+        text = str(text)
+    # Convert surrogate pairs and drop unpaired surrogates
+    text = text.encode("utf-16", "surrogatepass").decode("utf-16", "ignore")
+    return unicodedata.normalize("NFC", text)
 
-    if text is None:
-        return ""
-    return unicodedata.normalize("NFKC", str(text))
+
+def safe_decode_bytes(data: bytes, encoding: str = "utf-8") -> str:
+    """Decode ``data`` using ``encoding`` while handling surrogate pairs."""
+
+    try:
+        text = data.decode(encoding, errors="surrogatepass")
+    except Exception:
+        text = data.decode(encoding, errors="ignore")
+    return normalize_text(text)
+
+
+def safe_encode_text(value: Any) -> str:
+    """Return a normalized string representation of ``value``."""
+
+    if isinstance(value, bytes):
+        return safe_decode_bytes(value)
+    return normalize_text(value)
+
+
+__all__ = ["normalize_text", "safe_decode_bytes", "safe_encode_text"]


### PR DESCRIPTION
## Summary
- add Pydantic schemas for analytics queries and summaries with UTC date ranges
- include lightweight unicode normalization and safe encode/decode helpers
- validate and normalize analytics sources and column names before processing

## Testing
- `pytest tests/services/analytics/test_analytics_service.py -k test_summarize_dataframe_schema_unicode_and_utc -q` *(fails: collected 0 items / 1 skipped)*
- `SKIP=mypy,bandit pre-commit run --files yosai_intel_dashboard/src/services/analytics/schemas.py yosai_intel_dashboard/src/services/analytics/unicode.py yosai_intel_dashboard/src/services/analytics/analytics_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689a1d650d7883209bc361819055beae