### PR TITLE
feat: enable cancelling uploads

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
@@ -18,3 +18,14 @@ test('remove button is focusable and supports keyboard activation', () => {
   fireEvent.keyUp(button, { key: 'Enter', code: 'Enter' });
   expect(onRemove).toHaveBeenCalled();
 });
+
+test('invokes onCancel when cancel button clicked', () => {
+  const onCancel = jest.fn();
+  const uploadingFile = { ...file, status: 'uploading' };
+  render(
+    <FilePreview file={uploadingFile} onRemove={() => {}} onCancel={onCancel} />,
+  );
+  const button = screen.getByRole('button', { name: `Cancel ${file.file.name}` });
+  fireEvent.click(button);
+  expect(onCancel).toHaveBeenCalled();
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx
@@ -23,11 +23,21 @@ export const FilePreview: React.FC<Props> = ({ file, onRemove, onCancel }) => {
           <span className="font-medium text-sm">{file.file.name}</span>
           <div className="flex gap-2">
             {file.status === 'uploading' && onCancel && (
-              <button onClick={onCancel} className="text-red-500 text-xs">
+              <button
+                onClick={onCancel}
+                className="text-red-500 text-xs"
+                aria-label={`Cancel ${file.file.name}`}
+              >
                 Cancel
               </button>
             )}
-            <button onClick={onRemove} className="text-red-500 text-xs">Remove</button>
+            <button
+              onClick={onRemove}
+              className="text-red-500 text-xs"
+              aria-label={`Remove ${file.file.name}`}
+            >
+              Remove
+            </button>
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- track per-file abort controllers and polling timers, exposing `cancelUpload`
- add cancel button to FilePreview with accessible labels
- test cancellation behavior for hook and component
- use browser-compatible timer types

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.tsx yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx`
- `npm test -- components/upload/FilePreview.test.tsx hooks/useUpload.test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ce1fa448320b6db294795b2aa11