### PR TITLE
feat(upload): support per-file cancellation

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/FilePreview.test.tsx
@@ -27,3 +27,17 @@ test('remove button is focusable and supports keyboard activation', () => {
   fireEvent.keyUp(button, { key: ' ', code: 'Space' });
   expect(onRemove).toHaveBeenCalledTimes(2);
 });
+
+test('cancel button invokes callback when uploading', () => {
+  const onCancel = jest.fn();
+  render(
+    <FilePreview
+      file={{ ...file, status: 'uploading' }}
+      onRemove={() => {}}
+      onCancel={onCancel}
+    />,
+  );
+  const cancelButton = screen.getByText('Cancel');
+  fireEvent.click(cancelButton);
+  expect(onCancel).toHaveBeenCalledTimes(1);
+});

--- a/yosai_intel_dashboard/src/adapters/ui/src/useUpload.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/src/useUpload.test.ts
@@ -17,4 +17,18 @@ describe('useUpload', () => {
 
     expect(typeof result.current.files[0].id).toBe('string');
   });
+
+  it('updates file status to error on cancel', () => {
+    const { result } = renderHook(() => useUpload());
+    const file = new File(['data'], 'test.csv', { type: 'text/csv' });
+    act(() => {
+      result.current.onDrop([file]);
+    });
+    const id = result.current.files[0].id;
+    act(() => {
+      result.current.cancelUpload(id);
+    });
+    expect(result.current.files[0].status).toBe('error');
+    expect(result.current.files[0].error).toBe('Cancelled');
+  });
 });


### PR DESCRIPTION
## Summary
- track AbortController instances per file in `useUpload`
- expose `cancelUpload` and add tests for cancel functionality
- test `FilePreview` cancel button

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3421cde88320924695ce5e646338