### PR TITLE
Fix pip isolation failures and npm peer-dep conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install dependencies
+          cache: 'pip'
+      - name: Prepare pip build tools
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          python -m pip install -U pip setuptools wheel
+      - name: Install Python deps (prefer wheels; fallback)
+        env:
+          PIP_PREFER_BINARY: "1"
+          PIP_ONLY_BINARY: ":all:"
+        shell: bash
+        run: |
+          set -euo pipefail
+          (pip install -r requirements.txt || pip install --no-build-isolation -r requirements.txt)
+          if [ -f requirements-dev.txt ]; then
+            (pip install -r requirements-dev.txt || pip install --no-build-isolation -r requirements-dev.txt)
+          fi
+      - name: Pip debug (on failure)
+        if: ${{ failure() }}
+        run: |
+          pip --version
+          python -m pip debug
+          pip freeze | sed -n '1,200p'
       - name: Run pytest
         run: pytest --cov
 
@@ -28,8 +45,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: npm
+          cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        env:
+          NPM_CONFIG_LEGACY_PEER_DEPS: "true"
+        run: |
+          npm ci --no-audit --prefer-offline
       - name: Run vitest
         run: npx vitest run --coverage

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -19,34 +19,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - uses: actions/setup-node@v4
+      # --- Node toolchain for frontend lint/tests ---
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/requirements*.txt', '**/constraints*.txt') }}
-          restore-keys: |
-            pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
-      - name: Install dependencies
+      - name: Install Node deps (CI-safe)
+        env:
+          NPM_CONFIG_LEGACY_PEER_DEPS: "true"
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt || true
-          [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
-          pip install pre-commit
-          if [ -f package-lock.json ]; then
-            npm ci
-          elif [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn --frozen-lockfile
+          npm ci --no-audit --prefer-offline
+      # --- Python toolchain for lint/tests ---
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Prepare pip build tools
+        run: |
+          python -m pip install -U pip setuptools wheel
+      - name: Install Python deps (prefer wheels; fallback)
+        env:
+          PIP_PREFER_BINARY: "1"
+          PIP_ONLY_BINARY: ":all:"
+        shell: bash
+        run: |
+          set -euo pipefail
+          (pip install -r requirements.txt || pip install --no-build-isolation -r requirements.txt)
+          if [ -f requirements-dev.txt ]; then
+            (pip install -r requirements-dev.txt || pip install --no-build-isolation -r requirements-dev.txt)
           fi
+      # Collect logs if anything above fails
+      - name: Upload npm/pip logs (always)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs-code_quality
+          path: |
+            ~/.npm/_logs/**
+            ~/.cache/pip/log/debug.log
+          if-no-files-found: ignore
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: ShellCheck

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -247,23 +247,27 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Fork PR noop
-      if: ${{ github.event.pull_request.head.repo.fork }}
-      run: 'echo "Fork PR: secret-protected job skipped (noop)."'
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: npm
-    - run: npm ci
-    - name: Semantic release
-      uses: cycjimmy/semantic-release-action@v4
-      with:
-        semantic_version: 21
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fork PR noop
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: 'echo "Fork PR: secret-protected job skipped (noop)."'
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install Node deps (CI-safe)
+        env:
+          NPM_CONFIG_LEGACY_PEER_DEPS: "true"
+        run: |
+          npm ci --no-audit --prefer-offline
+      - name: Semantic release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 21
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-dev:
     needs: release


### PR DESCRIPTION
## Summary
- prefer binary wheels with fallback to no-build isolation
- run npm ci in legacy peer-deps mode with cached toolchains
- upload pip/npm logs on code-quality failures

## Testing
- `pre-commit run --files .github/workflows/code_quality.yml .github/workflows/ci.yml .github/workflows/pipeline.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a825f2074832094510807dcb7c8ee