### PR TITLE
Add body size limit middleware to API

### DIFF
--- a/api/middleware/__init__.py
+++ b/api/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Middleware utilities for the API service."""
+
+from .body_size_limit import BodySizeLimitMiddleware
+
+__all__ = ["BodySizeLimitMiddleware"]

--- a/api/middleware/body_size_limit.py
+++ b/api/middleware/body_size_limit.py
@@ -1,0 +1,23 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests with bodies exceeding the configured limit."""
+
+    def __init__(self, app, max_bytes: int = 50 * 1024 * 1024):
+        super().__init__(app)
+        self.max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next):
+        """Return 413 if the request body is too large."""
+        if request.method in {"POST", "PUT", "PATCH"}:
+            cl = request.headers.get("content-length")
+            if cl is not None:
+                try:
+                    if int(cl) > self.max_bytes:
+                        return PlainTextResponse("Payload too large", status_code=413)
+                except ValueError:
+                    pass
+        return await call_next(request)

--- a/api/tests/test_body_size_limit.py
+++ b/api/tests/test_body_size_limit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware.body_size_limit import BodySizeLimitMiddleware
+
+
+def create_app(limit: int = 10) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=limit)
+
+    @app.post("/")
+    async def root(data: dict | None = None):  # pragma: no cover - simple echo
+        return {"ok": True}
+
+    return app
+
+
+def test_rejects_large_payload():
+    app = create_app(limit=10)
+    client = TestClient(app)
+    headers = {"content-length": "11"}
+    resp = client.post("/", content="x", headers=headers)
+    assert resp.status_code == 413
+
+
+def test_allows_small_payload():
+    app = create_app(limit=10)
+    client = TestClient(app)
+    resp = client.post("/", json={"a": 1})
+    assert resp.status_code == 200

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -21,6 +21,7 @@ from fastapi.responses import FileResponse
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from api.middleware.body_size_limit import BodySizeLimitMiddleware
 from middleware.performance import TimingMiddleware
 from middleware.rate_limit import RateLimitMiddleware, RedisRateLimiter
 from middleware.security_headers import SecurityHeadersMiddleware
@@ -71,6 +72,7 @@ def _configure_app(service: BaseService) -> str:
     service._add_health_routes()
     service.start()
     service.app.add_middleware(TimingMiddleware)
+    service.app.add_middleware(BodySizeLimitMiddleware)
 
     import redis
 


### PR DESCRIPTION
## Summary
- add BodySizeLimitMiddleware to guard against oversized request payloads
- wire middleware into API service configuration
- test that large requests are rejected and small ones succeed

## Testing
- `pre-commit run --files api/middleware/__init__.py api/middleware/body_size_limit.py yosai_intel_dashboard/src/adapters/api/adapter.py api/tests/test_body_size_limit.py`
- `pytest --override-ini="addopts=" api/tests/test_body_size_limit.py api/tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a83f5f57c83209c5c01547a707b98