### PR TITLE
Add security headers middleware for API

### DIFF
--- a/api/middleware/security_headers.py
+++ b/api/middleware/security_headers.py
@@ -1,0 +1,16 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from typing import Callable
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next: Callable):
+        resp: Response = await call_next(request)
+        resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+        resp.headers.setdefault("X-Frame-Options", "DENY")
+        resp.headers.setdefault("Referrer-Policy", "no-referrer")
+        resp.headers.setdefault(
+            "Permissions-Policy",
+            "geolocation=(), camera=(), microphone=(), fullscreen=()",
+        )
+        return resp


### PR DESCRIPTION
## Summary
- add simple SecurityHeadersMiddleware under api/middleware

## Testing
- `pre-commit run --files api/middleware/security_headers.py`
- `pytest api/tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_689a841337b08320915cd931dace3a7e