### PR TITLE
Add security and body size middlewares

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+from api.middleware.body_size_limit import BodySizeLimitMiddleware
+from api.middleware.security_headers import SecurityHeadersMiddleware
+
+app = FastAPI()
+app.add_middleware(BodySizeLimitMiddleware, max_bytes=50 * 1024 * 1024)
+app.add_middleware(SecurityHeadersMiddleware)

--- a/api/middleware/__init__.py
+++ b/api/middleware/__init__.py
@@ -1,0 +1,6 @@
+"""Middlewares for the API service."""
+
+from .body_size_limit import BodySizeLimitMiddleware
+from .security_headers import SecurityHeadersMiddleware
+
+__all__ = ["BodySizeLimitMiddleware", "SecurityHeadersMiddleware"]

--- a/api/middleware/body_size_limit.py
+++ b/api/middleware/body_size_limit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.status import HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests exceeding a maximum body size."""
+
+    def __init__(self, app, max_bytes: int) -> None:
+        super().__init__(app)
+        self.max_bytes = max_bytes
+
+    async def dispatch(self, request, call_next):
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > self.max_bytes:
+            return Response(status_code=HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
+        body = await request.body()
+        if len(body) > self.max_bytes:
+            return Response(status_code=HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+        request._body = body
+        return await call_next(request)

--- a/api/middleware/security_headers.py
+++ b/api/middleware/security_headers.py
@@ -1,0 +1,3 @@
+from middleware.security_headers import SecurityHeadersMiddleware
+
+__all__ = ["SecurityHeadersMiddleware"]


### PR DESCRIPTION
## Summary
- add BodySizeLimitMiddleware to cap request size
- apply security headers middleware

## Testing
- `pytest api/tests/test_smoke.py --override-ini="addopts="`
- `pytest tests/middleware/test_security_headers.py --override-ini="addopts="` *(fails: '_LazyModule' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689a8434213483208521a9bcad67d2a4