### PR TITLE
Add async healthcheck utilities

### DIFF
--- a/services/common/healthcheck.py
+++ b/services/common/healthcheck.py
@@ -1,0 +1,17 @@
+import asyncio
+from typing import Callable, Dict
+
+async def check_with_timeout(name: str, probe: Callable, timeout_s: float = 1.5) -> Dict[str, str]:
+    try:
+        await asyncio.wait_for(probe(), timeout=timeout_s)
+        return {name: "ok"}
+    except Exception as e:
+        return {name: f"fail:{type(e).__name__}"}
+
+async def aggregate(*entries):
+    status = {"status": "ok", "checks": {}}
+    for name, probe in entries:
+        status["checks"].update(await check_with_timeout(name, probe))
+        if not list(status["checks"].values())[-1] == "ok":
+            status["status"] = "fail"
+    return status

--- a/services/tests/test_healthcheck.py
+++ b/services/tests/test_healthcheck.py
@@ -1,0 +1,36 @@
+"""Tests for the healthcheck utilities."""
+
+import pytest
+
+from services.common.healthcheck import check_with_timeout, aggregate
+
+
+async def ok_probe():
+    """A probe that succeeds."""
+    return None
+
+
+async def failing_probe():
+    """A probe that raises an error."""
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_check_with_timeout_ok():
+    result = await check_with_timeout("ok", ok_probe)
+    assert result == {"ok": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_check_with_timeout_failure():
+    result = await check_with_timeout("bad", failing_probe)
+    assert result == {"bad": "fail:RuntimeError"}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_status():
+    status = await aggregate(("ok", ok_probe), ("bad", failing_probe))
+    assert status == {
+        "status": "fail",
+        "checks": {"ok": "ok", "bad": "fail:RuntimeError"},
+    }


### PR DESCRIPTION
## Summary
- add async healthcheck helpers with timeout and aggregation
- cover healthcheck module with basic async tests

## Testing
- `pytest services/tests -q --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_e_689a844d6260832099cb9b687ed19964