### PR TITLE
Add security contract tests and enforce headers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, JSONResponse, Response
+
+MAX_PAYLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
+class PayloadLimitMiddleware(BaseHTTPMiddleware):
+    """Middleware enforcing a maximum request payload size."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        content_length = request.headers.get("content-length")
+        if content_length is not None and int(content_length) > MAX_PAYLOAD_SIZE:
+            return PlainTextResponse("Payload too large", status_code=413)
+        return await call_next(request)
+
+
+app = Starlette()
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
+app.add_middleware(PayloadLimitMiddleware)
+
+
+@app.route("/health")
+async def health(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+@app.route("/echo", methods=["POST"])
+async def echo(request: Request) -> Response:
+    data = await request.body()
+    return Response(content=data, media_type="application/octet-stream")

--- a/tests/api/test_security_contracts.py
+++ b/tests/api/test_security_contracts.py
@@ -1,0 +1,24 @@
+from starlette.testclient import TestClient
+from api.main import app
+
+
+def test_health_ok():
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+
+
+def test_security_headers_present():
+    c = TestClient(app)
+    r = c.get("/health")
+    h = r.headers
+    assert h.get("X-Content-Type-Options") == "nosniff"
+    assert h.get("X-Frame-Options") == "DENY"
+    assert h.get("Referrer-Policy") == "no-referrer"
+
+
+def test_payload_limit_enforced():
+    c = TestClient(app)
+    big = b"x" * (50 * 1024 * 1024 + 1)
+    r = c.post("/echo", data=big)
+    assert r.status_code in (400, 413)


### PR DESCRIPTION
## Summary
- add a lightweight Starlette app with security headers and payload size limiting
- cover health and payload contract with new tests

## Testing
- `pytest tests/api/test_security_contracts.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689a846827a08320a58483f70a2a8944