### PR TITLE
test: add health endpoint contract test

### DIFF
--- a/tests/api/contract.spec.ts
+++ b/tests/api/contract.spec.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+test("health returns 200", async () => {
+  const res = await axios.get(process.env.API_URL + "/health");
+  expect(res.status).toBe(200);
+});


### PR DESCRIPTION
## Summary
- add contract test verifying /health endpoint returns 200

## Testing
- `API_URL=http://localhost:3000 npx vitest run tests/api/contract.spec.ts --config vitest.contract.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a848dde288320b9f8f1c941719ba1