### PR TITLE
feat(api): add body size limit middleware

### DIFF
--- a/api/middleware/body_size_limit.py
+++ b/api/middleware/body_size_limit.py
@@ -2,19 +2,15 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-
 class BodySizeLimitMiddleware(BaseHTTPMiddleware):
-    """Reject requests with bodies exceeding the configured limit."""
-
     def __init__(self, app, max_bytes: int = 50 * 1024 * 1024):
         super().__init__(app)
         self.max_bytes = max_bytes
 
     async def dispatch(self, request: Request, call_next):
-        """Return 413 if the request body is too large."""
         if request.method in {"POST", "PUT", "PATCH"}:
             cl = request.headers.get("content-length")
-            if cl is not None:
+            if cl:
                 try:
                     if int(cl) > self.max_bytes:
                         return PlainTextResponse("Payload too large", status_code=413)


### PR DESCRIPTION
## Summary
- add middleware to reject requests with excessive body sizes

## Testing
- `pytest api/tests/test_body_size_limit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a92293f5c83209e75f883c4dbd093