### PR TITLE
Add Permissions-Policy header to SecurityHeadersMiddleware

### DIFF
--- a/middleware/security_headers.py
+++ b/middleware/security_headers.py
@@ -13,6 +13,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         self.frame_options = "DENY"
         self.content_type_options = "nosniff"
         self.referrer_policy = "no-referrer"
+        self.permissions_policy = (
+            "geolocation=(), camera=(), microphone=(), fullscreen=()"
+        )
 
     async def dispatch(self, request, call_next):
         response = await call_next(request)
@@ -21,4 +24,5 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("X-Frame-Options", self.frame_options)
         response.headers.setdefault("X-Content-Type-Options", self.content_type_options)
         response.headers.setdefault("Referrer-Policy", self.referrer_policy)
+        response.headers.setdefault("Permissions-Policy", self.permissions_policy)
         return response

--- a/tests/middleware/test_security_headers.py
+++ b/tests/middleware/test_security_headers.py
@@ -36,3 +36,7 @@ async def test_security_headers_present():
     assert resp.headers["X-Frame-Options"] == "DENY"
     assert resp.headers["X-Content-Type-Options"] == "nosniff"
     assert resp.headers["Referrer-Policy"] == "no-referrer"
+    assert (
+        resp.headers["Permissions-Policy"]
+        == "geolocation=(), camera=(), microphone=(), fullscreen=()"
+    )


### PR DESCRIPTION
## Summary
- include Permissions-Policy header in SecurityHeadersMiddleware
- test security middleware sets Permissions-Policy header

## Testing
- `pre-commit run --files middleware/security_headers.py tests/middleware/test_security_headers.py`
- `pytest tests/middleware/test_security_headers.py::test_security_headers_present -vv -s --maxfail=1 --tb=short` *(fails: '_LazyModule' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689a9246483083208fe631f8e38d0ee2