### PR TITLE
Add API contract regression tests

### DIFF
--- a/api/tests/test_contracts.py
+++ b/api/tests/test_contracts.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+
+def test_health_ok():
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+
+
+def test_security_headers_present():
+    c = TestClient(app)
+    r = c.get("/health")
+    h = r.headers
+    assert h.get("X-Content-Type-Options") == "nosniff"
+    assert h.get("X-Frame-Options") == "DENY"
+    assert h.get("Referrer-Policy") == "no-referrer"
+
+
+def test_payload_limit_enforced():
+    c = TestClient(app)
+    big = b"x" * (50 * 1024 * 1024 + 1)
+    r = c.post("/echo", data=big)
+    assert r.status_code in (400, 413)


### PR DESCRIPTION
## Summary
- add tests for /health endpoint, security headers, and 50MB payload limit

## Testing
- `PYTHONPATH=. pytest api/tests/test_contracts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a92abc7008320b020a347fe8aa6f3