### PR TITLE
feat: add shutdown utilities

### DIFF
--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,0 +1,19 @@
+package shutdown
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// Notify returns a context that is canceled on SIGINT/SIGTERM.
+func Notify(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}
+
+// WithTimeout returns a child context that times out after d.
+func WithTimeout(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, d)
+}


### PR DESCRIPTION
## Summary
- add shutdown package with helpers for signal-aware contexts and timeouts

## Testing
- `go test ./pkg/shutdown` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_689af431043c83208dda7e55aeb4747e