### PR TITLE
Add graceful shutdown server example

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"yourmodule/pkg/shutdown"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	srv := &http.Server{Addr: ":8080", Handler: mux}
+
+	root := context.Background()
+	ctx, stop := shutdown.Notify(root)
+	defer stop()
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	// Run server
+	eg.Go(func() error {
+		fmt.Println("listening on :8080")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+
+	// Wait for signal/cancel then shutdown gracefully
+	eg.Go(func() error {
+		<-ctx.Done()
+		shctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shctx)
+	})
+
+	if err := eg.Wait(); err != nil {
+		fmt.Println("server exit:", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module yourmodule
+
+go 1.23.0
+
+toolchain go1.23.8
+
+require golang.org/x/sync v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,0 +1,14 @@
+package shutdown
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+)
+
+// Notify returns a context that is cancelled when the process receives an interrupt or SIGTERM signal.
+// It also returns a stop function to cancel the context manually.
+func Notify(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+	return ctx, cancel
+}


### PR DESCRIPTION
## Summary
- add minimal HTTP server and graceful shutdown logic
- provide shutdown utility wrapping signal.NotifyContext

## Testing
- `go test ./cmd/app`
- `go test ./pkg/shutdown`


------
https://chatgpt.com/codex/tasks/task_e_689af43c4b40832099b2187a87996c11