### PR TITLE
Add HTTP client helper with JSON response support

### DIFF
--- a/pkg/httpx/go.mod
+++ b/pkg/httpx/go.mod
@@ -1,0 +1,4 @@
+module github.com/WSG23/httpx
+
+go 1.23
+

--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -1,0 +1,26 @@
+package httpx
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "time"
+)
+
+// DefaultClient is the client used by DoJSON. It has a
+// non-zero timeout to avoid hanging requests.
+var DefaultClient = &http.Client{Timeout: 10 * time.Second}
+
+// DoJSON executes the HTTP request using DefaultClient and decodes
+// the JSON response body into dst. The provided context controls the
+// request and will cancel the call if it is done.
+func DoJSON(ctx context.Context, req *http.Request, dst any) error {
+    req = req.WithContext(ctx)
+    resp, err := DefaultClient.Do(req)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+    return json.NewDecoder(resp.Body).Decode(dst)
+}
+

--- a/pkg/httpx/httpx_test.go
+++ b/pkg/httpx/httpx_test.go
@@ -1,0 +1,25 @@
+package httpx
+
+import (
+    "context"
+    "net/http"
+    "testing"
+    "time"
+)
+
+func TestDefaultClientTimeout(t *testing.T) {
+    if DefaultClient.Timeout == 0 {
+        t.Fatal("expected non-zero client timeout")
+    }
+}
+
+func TestDoJSON_ContextCancel(t *testing.T) {
+    req, _ := http.NewRequest("GET", "http://127.0.0.1:0/never", nil) // invalid port ⇒ fast fail
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+    defer cancel()
+    var dst map[string]any
+    if err := DoJSON(ctx, req, &dst); err == nil {
+        t.Fatal("expected error for unreachable host or timeout")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add httpx utility with default HTTP client timeout
- add DoJSON helper and tests for timeout and context cancellation

## Testing
- `go test -run Test -v`

------
https://chatgpt.com/codex/tasks/task_e_689af4530584832081ceee8fdbdd92da