### PR TITLE
Add shutdown context helper with timeout

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,4 @@
+module github.com/WSG23/yosai_intel_dashboard_fresh/pkg
+
+go 1.23.8
+

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,0 +1,30 @@
+package shutdown
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// WithTimeout returns a context that is cancelled when the timeout expires or
+// when an interrupt or termination signal is received. It returns the derived
+// context and a cancel function to release resources.
+func WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+		signal.Stop(sigCh)
+		close(sigCh)
+	}()
+
+	return ctx, cancel
+}

--- a/pkg/shutdown/shutdown_test.go
+++ b/pkg/shutdown/shutdown_test.go
@@ -1,0 +1,18 @@
+package shutdown
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWithTimeout(t *testing.T) {
+	ctx, cancel := WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		// ok
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("expected timeout to fire")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `shutdown.WithTimeout` to cancel contexts on timeout or interrupt signals
- cover timeout behavior with unit test

## Testing
- `cd pkg && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689af46719408320bfd9ae609d2f58e5