### PR TITLE
feat(api): add middleware for body size and security

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,44 +1,22 @@
 from __future__ import annotations
 
-from starlette.applications import Starlette
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse, JSONResponse, Response
+from fastapi import FastAPI, Request, Response
 
-MAX_PAYLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
+from api.middleware.body_size_limit import BodySizeLimitMiddleware
+from api.middleware.security_headers import SecurityHeadersMiddleware
 
 
-class PayloadLimitMiddleware(BaseHTTPMiddleware):
-    """Middleware enforcing a maximum request payload size."""
-
-    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
-        content_length = request.headers.get("content-length")
-        if content_length is not None and int(content_length) > MAX_PAYLOAD_SIZE:
-            return PlainTextResponse("Payload too large", status_code=413)
-        return await call_next(request)
+app = FastAPI()
+app.add_middleware(BodySizeLimitMiddleware, max_bytes=50 * 1024 * 1024)
+app.add_middleware(SecurityHeadersMiddleware)
 
 
-app = Starlette()
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
 
 
-@app.middleware("http")
-async def add_security_headers(request: Request, call_next):
-    response = await call_next(request)
-    response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Referrer-Policy"] = "no-referrer"
-    return response
-
-
-app.add_middleware(PayloadLimitMiddleware)
-
-
-@app.route("/health")
-async def health(request: Request) -> JSONResponse:
-    return JSONResponse({"status": "ok"})
-
-
-@app.route("/echo", methods=["POST"])
+@app.post("/echo")
 async def echo(request: Request) -> Response:
     data = await request.body()
     return Response(content=data, media_type="application/octet-stream")


### PR DESCRIPTION
## Summary
- use shared body size and security header middleware in API main

## Testing
- `pre-commit run --files api/main.py api/middleware/body_size_limit.py api/middleware/security_headers.py`
- `pytest api/tests/test_body_size_limit.py`
- `pytest tests/middleware/test_security_headers.py tests/api/test_security_contracts.py` *(fails: `_LazyModule` object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689af6c0cdb48320a673fb2e86b6a965