### PR TITLE
Ensure JSON decoder consumes entire body

### DIFF
--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -1,0 +1,25 @@
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+// DecodeJSON decodes JSON from r into dst and ensures the entire
+// input is consumed. If additional tokens remain after the JSON value,
+// an error is returned.
+func DecodeJSON(r io.Reader, dst any) error {
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	// Ensure the decoder has reached EOF to avoid accepting trailing data.
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			err = errors.New("unexpected data after JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/pkg/httpx/httpx_test.go
+++ b/pkg/httpx/httpx_test.go
@@ -1,0 +1,34 @@
+package httpx
+
+import (
+	"strings"
+	"testing"
+)
+
+type testStruct struct {
+	A int `json:"a"`
+}
+
+func TestDecodeJSON(t *testing.T) {
+	var dst testStruct
+	if err := DecodeJSON(strings.NewReader(`{"a":1}`), &dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst.A != 1 {
+		t.Fatalf("unexpected value: %v", dst.A)
+	}
+}
+
+func TestDecodeJSONExtraTokens(t *testing.T) {
+	var dst testStruct
+	if err := DecodeJSON(strings.NewReader(`{"a":1}{"b":2}`), &dst); err == nil {
+		t.Fatalf("expected error for extra tokens, got nil")
+	}
+}
+
+func TestDecodeJSONWhitespace(t *testing.T) {
+	var dst testStruct
+	if err := DecodeJSON(strings.NewReader("{\"a\":1}\n"), &dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add httpx.DecodeJSON to consume the entire JSON payload and error on leftover tokens
- include unit tests covering normal decoding, trailing tokens, and trailing whitespace

## Testing
- `go test ./...`
- `cd go/framework && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689afa3a5c7c832082066e26c341c52d