### PR TITLE
Add Hadolint configuration for infra images

### DIFF
--- a/infra/.hadolint.yaml
+++ b/infra/.hadolint.yaml
@@ -1,0 +1,17 @@
+format: tty
+failure-threshold: warning
+trustedRegistries:
+  - docker.io
+  - ghcr.io
+  - gcr.io
+ignored:
+  # Allow /bin/sh in distroless/alpine based images where bash is absent
+  - DL4006
+rules:
+  # Require pinned tags (no :latest)
+  - DL3007
+  # No sudo inside containers
+  - DL3002
+  # Use apk/apt best practices; clean up lists/cache
+  - DL3015
+  - DL3018


### PR DESCRIPTION
## Summary
- configure hadolint for infra to enforce pinned tags and other Docker best practices

## Testing
- `pre-commit run --files infra/.hadolint.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689b035850508320b0e7ed5368c0edfe