### PR TITLE
fix: handle install failures on Apple Silicon

### DIFF
--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -137,15 +137,18 @@ install_compatible_packages() {
     print_info "Installing scikit-learn..."
     pip3 install "scikit-learn>=1.0.0"
     
-    # For Apple Silicon, ensure we get the right wheels
-    if [ "$IS_APPLE_SILICON" = true ]; then
-        print_info "Installing Apple Silicon optimized packages..."
-        
+        # For Apple Silicon, ensure we get the right wheels
+        if [ "$IS_APPLE_SILICON" = true ]; then
+            print_info "Installing Apple Silicon optimized packages..."
+
         # Force reinstall with platform-specific wheels
-        pip3 install --force-reinstall --no-deps \
+        if ! pip3 install --force-reinstall --no-deps \
             --platform macosx_11_0_arm64 \
             --target ./temp_packages \
-            numpy scipy scikit-learn 2>/dev/null || true
+            numpy scipy scikit-learn 2>/dev/null; then
+            print_error "Failed to install Apple Silicon optimized packages"
+            exit 1
+        fi
             
         # Clean up temp
         rm -rf ./temp_packages 2>/dev/null || true


### PR DESCRIPTION
## Summary
- fail the fix_mac_deps script when Apple Silicon package installation fails

## Testing
- `pre-commit run --files scripts/fix_mac_deps.sh`
- `pytest -q` (failed: Module already imported so cannot be rewritten; tests.config)

------
https://chatgpt.com/codex/tasks/task_e_689b058a626c832082857d4694c67407