### PR TITLE
feat: add brew prerequisite to mac deps script

### DIFF
--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+# Fix Mac dependencies and architecture issues for the project.
+# Homebrew is a prerequisite for running this script.
 set -euo pipefail
 IFS=$'\n\t'
+
+command -v brew >/dev/null || { echo "Homebrew is required" >&2; exit 1; }
 
 # Colors for output
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- note Homebrew prerequisite for Mac deps script
- check for Homebrew before running

## Testing
- `pre-commit run --files scripts/fix_mac_deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b058de5208320856610115d5bcec0