### PR TITLE
feat: add strict mode library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ data/learned_mappings.json
 !public/manifest.json
 !yosai_intel_dashboard/src/adapters/ui/lib/
 !yosai_intel_dashboard/src/adapters/ui/lib/gestures.ts
+!scripts/lib/
+!scripts/lib/**
 !dashboards/grafana/*.json
 !dashboards/performance/*.json
 !monitoring/grafana/*.json

--- a/scripts/fix_mac_deps.sh
+++ b/scripts/fix_mac_deps.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
+
+SCRIPTDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/strict_mode.sh
+. "${SCRIPTDIR}/lib/strict_mode.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -289,6 +291,7 @@ EOF
 
 main() {
     print_header
+    require brew
     
     # Navigate to project directory if not already there
     if [ ! -f "app.py" ]; then

--- a/scripts/lib/strict_mode.sh
+++ b/scripts/lib/strict_mode.sh
@@ -1,12 +1,15 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
+# Provides common strict-mode settings and a `require` helper.
 set -euo pipefail
 IFS=$'\n\t'
 
 require() {
+  local cmd
   for cmd in "$@"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
-      echo "Command '$cmd' is required but not installed" >&2
-      exit 1
+      printf "Command '%s' is required but not installed\n" "$cmd" >&2
+      return 1
     fi
   done
 }
+

--- a/scripts/lib/strict_mode.sh
+++ b/scripts/lib/strict_mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+require() {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "Command '$cmd' is required but not installed" >&2
+      exit 1
+    fi
+  done
+}


### PR DESCRIPTION
## Summary
- add strict-mode helper with `require` command checker
- use strict-mode library in fix_mac_deps and verify `brew` is present
- allow tracking scripts/lib in gitignore

## Testing
- `pre-commit run --files scripts/lib/strict_mode.sh scripts/fix_mac_deps.sh .gitignore`
- `shellcheck -x scripts/lib/strict_mode.sh scripts/fix_mac_deps.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b058fb1cc8320b1c1b544ceeecc8f