### PR TITLE
Add optional directory arg to ensure-no-latest script

### DIFF
--- a/scripts/k8s/ensure-no-latest.sh
+++ b/scripts/k8s/ensure-no-latest.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+usage() {
+  cat <<USAGE >&2
+Usage: $(basename "$0") [DIRECTORY]
+
+Ensures no ':latest' image tags are used in Kubernetes manifests under DIRECTORY.
+DIRECTORY defaults to '${root}/deploy'.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+dir="${1:-${root}/deploy}"
+
+if [[ ! -d "$dir" ]]; then
+  echo "Directory '$dir' does not exist." >&2
+  exit 1
+fi
+
+if grep -R --include='*.yaml' --include='*.yml' -n ':latest' "$dir"; then
+  echo "Error: ':latest' tag found in manifests under $dir" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add a script to block ':latest' image tags in k8s manifests
- support optional directory parameter defaulting to repo deploy folder

## Testing
- `pre-commit run --files scripts/k8s/ensure-no-latest.sh`
- `bash -n scripts/k8s/ensure-no-latest.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b05ebb79c8320b7b8ea14e579cf0a