### PR TITLE
feat: add k8s latest tag check script

### DIFF
--- a/scripts/k8s/ensure-no-latest.sh
+++ b/scripts/k8s/ensure-no-latest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPTDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+COMMON_SH="$SCRIPTDIR/../common.sh"
+if [[ -f "$COMMON_SH" ]]; then
+  # shellcheck disable=SC1090
+  source "$COMMON_SH"
+else
+  echo "Warning: common.sh not found at $COMMON_SH" >&2
+fi
+
+TARGET_DIR="${1:-$SCRIPTDIR/../../k8s}"
+if grep -R --line-number --exclude-dir='.git' -e ':latest' "$TARGET_DIR"; then
+  echo "Error: 'latest' tag found in Kubernetes manifests" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add k8s script checking for :latest tag
- load common.sh with warning if missing

## Testing
- `bash scripts/k8s/ensure-no-latest.sh`
- `pytest -q` *(fails: Required test coverage of 80% not reached. Total coverage: 1.88%)*

------
https://chatgpt.com/codex/tasks/task_e_689b05eddc648320a21d26cc5cd74062