### PR TITLE
Add Unicode surrogate sanitization helper

### DIFF
--- a/shared/python/unicode_sanitize.py
+++ b/shared/python/unicode_sanitize.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import re
+
+_SURROGATES = re.compile(r"[\uD800-\uDFFF]")
+
+
+def clean_surrogates(s: str) -> str:
+    """
+    Replace isolated surrogate code points with U+FFFD.
+    Safe for logging, JSON, CSV, and HTML contexts.
+    """
+    return _SURROGATES.sub("\uFFFD", s)

--- a/tests/shared/test_unicode_sanitize.py
+++ b/tests/shared/test_unicode_sanitize.py
@@ -1,0 +1,11 @@
+from shared.python.unicode_sanitize import clean_surrogates
+
+
+def test_clean_surrogates_replaces():
+    text = "\ud800A\udfff"
+    assert clean_surrogates(text) == "\uFFFDA\uFFFD"
+
+
+def test_clean_surrogates_no_change():
+    text = "regular"
+    assert clean_surrogates(text) == text


### PR DESCRIPTION
## Summary
- add `clean_surrogates` utility to sanitize isolated Unicode surrogates
- cover utility with tests

## Testing
- `pytest tests/shared/test_unicode_sanitize.py -q -o python_files='test_*.py' -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_689b09f9f9348320b48abc69d668984c