### PR TITLE
chore: remove deprecated deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# DEPRECATED: This script is not used. Deployment is handled by CI/CD (see docs/ci-cd.md).
-
-echo "Deployment is handled by the CI/CD pipeline. See docs/ci-cd.md."
-exit 1


### PR DESCRIPTION
## Summary
- remove unused deploy.sh; deployment handled by CI/CD docs

## Testing
- `pytest unit_tests/test_environment_config.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689b05fa59f083208c8e5a88d1bca083