### PR TITLE
Add asyncio mark for retry test

### DIFF
--- a/shared/python/tests/test_retry.py
+++ b/shared/python/tests/test_retry.py
@@ -1,0 +1,17 @@
+import pytest
+
+from shared.python.retry import aretry
+
+
+@pytest.mark.asyncio
+async def test_aretry_eventual_success():
+    attempts = {"count": 0}
+
+    async def flaky():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    result = await aretry(flaky, attempts=3, base_delay=0, exceptions=(ValueError,))
+    assert result == "ok"


### PR DESCRIPTION
## Summary
- add async test for aretry with pytest

## Testing
- `PYTHONPATH=. pytest shared/python/tests/test_retry.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689b848873a08320972da6f4f25726ea