### PR TITLE
Handle serialization errors in logger

### DIFF
--- a/libs/ts/logger.test.ts
+++ b/libs/ts/logger.test.ts
@@ -1,0 +1,20 @@
+import { base } from './logger';
+
+describe('base logger', () => {
+  it('omits extra on circular references', () => {
+    const extra: any = {};
+    extra.self = extra;
+    const output = base('info', 'with circular', extra);
+    const parsed = JSON.parse(output);
+    expect(parsed.message).toContain('serialization error');
+    expect(parsed.self).toBeUndefined();
+  });
+
+  it('omits extra on unserializable values', () => {
+    const extra: any = { value: BigInt(1) };
+    const output = base('info', 'with bigint', extra);
+    const parsed = JSON.parse(output);
+    expect(parsed.message).toContain('serialization error');
+    expect(parsed.value).toBeUndefined();
+  });
+});

--- a/libs/ts/logger.ts
+++ b/libs/ts/logger.ts
@@ -1,0 +1,42 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  [key: string]: unknown;
+}
+
+export function base(
+  level: LogLevel,
+  message: string,
+  extra: Record<string, unknown> = {},
+): string {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...extra,
+  };
+  try {
+    return JSON.stringify(entry);
+  } catch (err) {
+    return JSON.stringify({
+      timestamp: entry.timestamp,
+      level,
+      message: `${message} (serialization error: ${(err as Error).message})`,
+    });
+  }
+}
+
+export function info(message: string, extra?: Record<string, unknown>): string {
+  return base('info', message, extra);
+}
+
+export function warn(message: string, extra?: Record<string, unknown>): string {
+  return base('warn', message, extra);
+}
+
+export function error(message: string, extra?: Record<string, unknown>): string {
+  return base('error', message, extra);
+}


### PR DESCRIPTION
## Summary
- add base logger utility with robust JSON serialization handling
- cover circular and unserializable extras with tests

## Testing
- `npx vitest run -c /tmp/vitest.config.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689b8493cc6c832084ebe5fac6d5fd81