### PR TITLE
Validate LOG_LEVEL before creating logger

### DIFF
--- a/libs/ts/logger.ts
+++ b/libs/ts/logger.ts
@@ -1,0 +1,28 @@
+const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+export type LogLevel = typeof LEVELS[number];
+
+function resolveLevel(raw?: string): LogLevel {
+  const lvl = raw?.toLowerCase();
+  return LEVELS.includes(lvl as LogLevel) ? (lvl as LogLevel) : 'info';
+}
+
+export function createLogger(name: string, level?: string) {
+  // @ts-ignore process may be undefined in some runtimes
+  const env = level ?? (typeof process !== 'undefined' ? process?.env?.LOG_LEVEL : undefined);
+  const resolved = resolveLevel(env);
+  const threshold = LEVELS.indexOf(resolved);
+
+  const log = (lvl: LogLevel) => (...args: any[]) => {
+    if (LEVELS.indexOf(lvl) < threshold) return;
+    const message = args.length === 1 ? args[0] : args;
+    console[lvl](JSON.stringify({ name, level: lvl, message }));
+  };
+
+  return {
+    debug: log('debug'),
+    info: log('info'),
+    warn: log('warn'),
+    error: log('error'),
+  };
+}
+

--- a/libs/ts/logger.vitest.test.ts
+++ b/libs/ts/logger.vitest.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createLogger } from './logger';
+
+const ORIGINAL = process.env.LOG_LEVEL;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.LOG_LEVEL;
+  else process.env.LOG_LEVEL = ORIGINAL;
+  vi.restoreAllMocks();
+});
+
+describe('createLogger LOG_LEVEL handling', () => {
+  it('honors valid LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'warn';
+    const logger = createLogger('test');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logger.debug('debug');
+    logger.info('info');
+    logger.warn('warn');
+    logger.error('error');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to info on invalid LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'verbose';
+    const logger = createLogger('test');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    logger.debug('debug');
+    logger.info('info');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledOnce();
+  });
+
+  it('defaults to info when LOG_LEVEL unset', () => {
+    delete process.env.LOG_LEVEL;
+    const logger = createLogger('test');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    logger.debug('debug');
+    logger.info('info');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     include: [
       'components/**/*.vitest.test.{ts,tsx}',
       'pages/**/*.vitest.test.{ts,tsx}',
+      'libs/**/*.vitest.test.{ts,tsx}',
     ],
     exclude: ['yosai_intel_dashboard/**'],
   },


### PR DESCRIPTION
## Summary
- add simple logger with log level guard and JSON output
- default to `info` when LOG_LEVEL is unset or invalid
- test logger behavior for valid, invalid, and missing LOG_LEVEL

## Testing
- `npx vitest run libs/ts/logger.vitest.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b8492cc84832083c983f8239477dd