### PR TITLE
test: add retry backoff and error info tests

### DIFF
--- a/shared/python/tests/test_retry.py
+++ b/shared/python/tests/test_retry.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+from shared.python import retry as retry_mod
+
+
+def test_custom_backoff_respected(monkeypatch):
+    delays = []
+
+    def fake_sleep(seconds: float) -> None:
+        delays.append(seconds)
+
+    # Remove jitter for deterministic behavior
+    monkeypatch.setattr(retry_mod, "_ajitter", lambda base, jitter=0.2: base)
+    monkeypatch.setattr(retry_mod, "_sleep", fake_sleep)
+
+    attempts = {"count": 0}
+
+    def flakey():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    assert retry_mod.retry(flakey, attempts=3, base_delay=1) == "ok"
+    assert delays == [1, 2]
+
+
+def test_retryerror_includes_last_exception(monkeypatch):
+    monkeypatch.setattr(retry_mod, "_sleep", lambda s: None)
+    monkeypatch.setattr(retry_mod, "_ajitter", lambda base, jitter=0.2: base)
+
+    def always_fail():
+        raise RuntimeError("kaput")
+
+    with pytest.raises(retry_mod.RetryError) as excinfo:
+        retry_mod.retry(always_fail, attempts=2, base_delay=0)
+
+    assert "kaput" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)


### PR DESCRIPTION
## Summary
- test custom backoff delays and jitter-less behavior for retry
- test that RetryError exposes the last exception message and cause

## Testing
- `pytest shared/python/tests/test_retry.py -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_689b848b6048832092f70daf6bf94ab6