### PR TITLE
feat: add logger interface

### DIFF
--- a/libs/ts/logger.ts
+++ b/libs/ts/logger.ts
@@ -1,12 +1,19 @@
 const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
-export type LogLevel = typeof LEVELS[number];
+export type LogLevel = (typeof LEVELS)[number];
+
+export interface Logger {
+  debug: (...args: any[]) => void;
+  info: (...args: any[]) => void;
+  warn: (...args: any[]) => void;
+  error: (...args: any[]) => void;
+}
 
 function resolveLevel(raw?: string): LogLevel {
   const lvl = raw?.toLowerCase();
   return LEVELS.includes(lvl as LogLevel) ? (lvl as LogLevel) : 'info';
 }
 
-export function createLogger(name: string, level?: string) {
+export function createLogger(name: string, level?: string): Logger {
   // @ts-ignore process may be undefined in some runtimes
   const env = level ?? (typeof process !== 'undefined' ? process?.env?.LOG_LEVEL : undefined);
   const resolved = resolveLevel(env);
@@ -23,6 +30,6 @@ export function createLogger(name: string, level?: string) {
     info: log('info'),
     warn: log('warn'),
     error: log('error'),
-  };
+  } satisfies Logger;
 }
 

--- a/libs/ts/logger.vitest.test.ts
+++ b/libs/ts/logger.vitest.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createLogger } from './logger';
+import { describe, it, expect, vi, afterEach, expectTypeOf } from 'vitest';
+import { createLogger, type Logger } from './logger';
 
 const ORIGINAL = process.env.LOG_LEVEL;
 
@@ -12,7 +12,7 @@ afterEach(() => {
 describe('createLogger LOG_LEVEL handling', () => {
   it('honors valid LOG_LEVEL', () => {
     process.env.LOG_LEVEL = 'warn';
-    const logger = createLogger('test');
+    const logger: Logger = createLogger('test');
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -29,7 +29,7 @@ describe('createLogger LOG_LEVEL handling', () => {
 
   it('falls back to info on invalid LOG_LEVEL', () => {
     process.env.LOG_LEVEL = 'verbose';
-    const logger = createLogger('test');
+    const logger: Logger = createLogger('test');
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     logger.debug('debug');
@@ -40,7 +40,7 @@ describe('createLogger LOG_LEVEL handling', () => {
 
   it('defaults to info when LOG_LEVEL unset', () => {
     delete process.env.LOG_LEVEL;
-    const logger = createLogger('test');
+    const logger: Logger = createLogger('test');
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     logger.debug('debug');
@@ -48,4 +48,13 @@ describe('createLogger LOG_LEVEL handling', () => {
     expect(debugSpy).not.toHaveBeenCalled();
     expect(infoSpy).toHaveBeenCalledOnce();
   });
+});
+
+it('returns object satisfying Logger interface', () => {
+  const logger = createLogger('test');
+  expectTypeOf(logger).toMatchTypeOf<Logger>();
+  expect(typeof logger.debug).toBe('function');
+  expect(typeof logger.info).toBe('function');
+  expect(typeof logger.warn).toBe('function');
+  expect(typeof logger.error).toBe('function');
 });


### PR DESCRIPTION
## Summary
- define `Logger` interface with debug/info/warn/error methods
- return typed `Logger` from `createLogger`
- test logger object conforms to `Logger` interface

## Testing
- `npx vitest run libs/ts/logger.vitest.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b849961e88320a73593d501e7f8b9