### PR TITLE
docs: describe publish_event usage

### DIFF
--- a/docs/callback_architecture.md
+++ b/docs/callback_architecture.md
@@ -59,6 +59,10 @@ def on_complete(info: dict) -> None:
 events.register_callback(CallbackEvent.ANALYSIS_COMPLETE, on_complete)
 ```
 
+When a component needs to broadcast an update without directly invoking callbacks,
+use the :func:`~yosai_intel_dashboard.src.services.event_publisher.publish_event` helper.
+It relays payloads to listeners through the shared :class:`~src.common.events.EventBus`.
+
 ## Grouped Operations
 
 `TrulyUnifiedCallbacks` can execute a series of operations sequentially. This is

--- a/yosai_intel_dashboard/src/services/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/event_publisher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +9,14 @@ def publish_event(
     payload: Dict[str, Any],
     event: str = "analytics_update",
 ) -> None:
-    """Trigger a callback for ``event`` if registered."""
+    """Publish ``payload`` via the centralized :mod:`yosai_intel_dashboard.src.core.callbacks.event_bus`."""
+
+    if event_bus:
+        try:
+            event_bus.emit(event, payload)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.debug("Event bus publish failed: %s", exc)
+
     try:
         from yosai_intel_dashboard.src.infrastructure.callbacks import (
             CallbackType,


### PR DESCRIPTION
## Summary
- document purpose of `publish_event` and tie it to the central event bus
- note publisher helper in callback architecture docs

## Testing
- `pytest tests/test_event_publisher.py::test_publish_event_success -q` *(fails: Required test coverage of 80% not reached. Total coverage: 3.51%)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9f4fbf48320b14116e5cbe91a76