### PR TITLE
Add unit tests for rate limiter behaviors

### DIFF
--- a/tests/security/test_rate_limiter.py
+++ b/tests/security/test_rate_limiter.py
@@ -1,0 +1,46 @@
+import time
+import pytest
+
+from yosai_intel_dashboard.src.core.rate_limiter import RateLimiter
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_blocking_behavior():
+    limiter = RateLimiter(window=60, limit=1)
+    first = await limiter.is_allowed("user", "1.1.1.1")
+    assert first["allowed"] is True
+
+    second = await limiter.is_allowed("user", "1.1.1.1")
+    assert second["allowed"] is False
+    assert second["retry_after"] > 0
+
+
+@pytest.mark.asyncio
+async def test_reset_allows_requests(monkeypatch):
+    limiter = RateLimiter(window=10, limit=1)
+
+    current = [1000.0]
+    monkeypatch.setattr(time, "time", lambda: current[0])
+
+    assert (await limiter.is_allowed("user", "1.1.1.1"))["allowed"] is True
+
+    current[0] += 1
+    blocked = await limiter.is_allowed("user", "1.1.1.1")
+    assert blocked["allowed"] is False
+    assert blocked["retry_after"] > 0
+
+    current[0] += 10
+    reset = await limiter.is_allowed("user", "1.1.1.1")
+    assert reset["allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_spoofed_ip_does_not_bypass(monkeypatch):
+    limiter = RateLimiter(window=60, limit=1)
+
+    assert (await limiter.is_allowed("user", "1.1.1.1"))["allowed"] is True
+
+    spoofed = await limiter.is_allowed("user", "9.9.9.9")
+    assert spoofed["allowed"] is False


### PR DESCRIPTION
## Summary
- add unit tests covering rate limiter blocking, reset window, and spoofed IP scenarios

## Testing
- `pytest tests/security/test_rate_limiter.py -q` *(fails: Required test coverage of 80% not reached. Total coverage: 1.98%)*
- `pytest tests/security/test_rate_limiter.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_689ba9ee79588320a258f9a441df935f