### PR TITLE
feat: use redis-backed rate limiter

### DIFF
--- a/tests/services/test_event_ingestion_app.py
+++ b/tests/services/test_event_ingestion_app.py
@@ -98,13 +98,22 @@ def load_module():
     core_stub = types.ModuleType("core.security")
 
     class DummyLimiter:
-        def is_allowed(self, *a, **k):
+        def __init__(self, *a, **k):
+            pass
+
+        async def is_allowed(self, *a, **k):
             return {
                 "allowed": True,
                 "limit": 100,
                 "remaining": 99,
                 "reset": time.time() + 60,
             }
+
+        def start_cleanup(self):
+            pass
+
+        async def stop_cleanup(self):
+            pass
 
     core_stub.RateLimiter = DummyLimiter
     safe_import("core.security", core_stub)

--- a/tests/test_rate_limit_headers.py
+++ b/tests/test_rate_limit_headers.py
@@ -4,6 +4,47 @@ import sys
 import time
 import types
 
+import asyncio
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.expire_at = {}
+
+    async def incr(self, key: str) -> int:
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    async def expire(self, key: str, seconds: int) -> None:
+        self.expire_at[key] = time.time() + seconds
+
+    async def ttl(self, key: str) -> int:
+        exp = self.expire_at.get(key)
+        if exp is None:
+            return -2
+        remaining = int(exp - time.time())
+        if remaining <= 0:
+            self.store.pop(key, None)
+            self.expire_at.pop(key, None)
+            return -2
+        return remaining
+
+    async def set(self, key: str, value: int, ex: int | None = None) -> None:
+        self.store[key] = value
+        if ex is not None:
+            self.expire_at[key] = time.time() + ex
+
+    async def scan_iter(self, match: str | None = None):
+        prefix = match[:-1] if match and match.endswith("*") else match
+        for key in list(self.expire_at.keys()):
+            if prefix is None or key.startswith(prefix):
+                yield key
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+        self.expire_at.pop(key, None)
+
 # Stub out heavy SecurityValidator dependency before import
 validator_stub = types.ModuleType("validation.security_validator")
 validator_stub.SecurityValidator = object  # type: ignore[attr-defined]
@@ -12,19 +53,21 @@ sys.modules["validation.security_validator"] = validator_stub
 from yosai_intel_dashboard.src.core.security import RateLimiter
 
 
+
 def test_rate_limiter_returns_header_fields():
-    limiter = RateLimiter(max_requests=2, window_minutes=1)
-    result1 = limiter.is_allowed("user")
+    redis_client = FakeRedis()
+    limiter = RateLimiter(redis_client, max_requests=2, window_minutes=1)
+    result1 = asyncio.run(limiter.is_allowed("user"))
     assert result1["allowed"] is True
     assert result1["limit"] == 2
     assert result1["remaining"] == 1
     assert result1["reset"] > time.time()
 
-    result2 = limiter.is_allowed("user")
+    result2 = asyncio.run(limiter.is_allowed("user"))
     assert result2["allowed"] is True
     assert result2["remaining"] == 0
 
-    result3 = limiter.is_allowed("user")
+    result3 = asyncio.run(limiter.is_allowed("user"))
     assert result3["allowed"] is False
     assert result3["retry_after"] > 0
     assert result3["remaining"] == 0

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
@@ -354,7 +354,7 @@ def load_app(jwt_secret: str | None = "secret") -> tuple:
     security_stub = types.ModuleType("core.security")
 
     class DummyRateLimiter:
-        def is_allowed(self, *a, **k):
+        async def is_allowed(self, *a, **k):
             return {"allowed": True}
 
     security_stub.RateLimiter = DummyRateLimiter


### PR DESCRIPTION
## Summary
- move RateLimiter to Redis with TTL-based IP blocking and cleanup
- wire analytics and ingestion services to the async Redis limiter
- adjust tests for async rate limiter interface

## Testing
- `pytest tests/test_rate_limit_headers.py -q --cov-fail-under=0`
- `pytest tests/services/test_event_ingestion_app.py -q --cov-fail-under=0` *(fails: module takes at most 2 arguments)*
- `pytest yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py -q --cov-fail-under=0` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689ba9ef7cc0832089949612295ad695