### PR TITLE
Use SecureQueryBuilder to guard dynamic SQL identifiers

### DIFF
--- a/yosai_intel_dashboard/src/services/migration/framework.py
+++ b/yosai_intel_dashboard/src/services/migration/framework.py
@@ -49,8 +49,9 @@ class MigrationStrategy(ABC):
             return
         async with self.target_pool.acquire() as conn:
             builder = SecureQueryBuilder(allowed_tables=APPROVED_TABLES)
-            table = builder.table(self.name)
-            sql, _ = builder.build(f"TRUNCATE TABLE {table} CASCADE", logger=LOG)
+            sql, _ = builder.build(
+                "TRUNCATE TABLE %s CASCADE", self.name, logger=LOG
+            )
             await conn.execute(sql)
 
 

--- a/yosai_intel_dashboard/src/services/query_optimizer.py
+++ b/yosai_intel_dashboard/src/services/query_optimizer.py
@@ -51,7 +51,16 @@ class QueryOptimizer:
         statements: List[str] = []
         for col in columns:
             if self._needs_index(table, col, plan):
-                statements.append(f"CREATE INDEX idx_{table}_{col} ON {table} ({col})")
+                builder = SecureQueryBuilder(
+                    allowed_tables={table}, allowed_columns={col}
+                )
+                table_q = builder.table(table)
+                col_q = builder.column(col)
+                index_name = f"idx_{table_q}_{col_q}"
+                stmt, _ = builder.build(
+                    f"CREATE INDEX {index_name} ON {table_q} ({col_q})"
+                )
+                statements.append(stmt)
         return statements
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate table and column names in IndexOptimizer using SecureQueryBuilder
- build CREATE INDEX statements and migration rollbacks through placeholder-based SecureQueryBuilder APIs
- test IndexOptimizer against SQL injection attempts

## Testing
- `pytest -o addopts='' tests/database/test_index_optimizer.py::test_recommend_new_indexes_rejects_malicious_identifiers -vv`
- `pytest tests/database/test_index_optimizer.py tests/database/test_baseline_metrics_sql_injection.py tests/database/test_sql_injection.py` *(fails: NameError: _SECURITYCONFIG_SESSIONTIMEOUTBYROLEENTRY not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9ea6c2c832088887d6df84d1792