### PR TITLE
Add shared preprocessing contract for ML pipelines

### DIFF
--- a/analytics/risk_scoring.py
+++ b/analytics/risk_scoring.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
-from . import feature_extraction
+from yosai_intel_dashboard.models.ml.pipeline_contract import preprocess_events
 
 
 @dataclass
@@ -122,7 +122,7 @@ def score_events(
 ) -> RiskScoreResult:
     """Score raw event data using simple heuristics and context."""
 
-    features = feature_extraction.extract_event_features(df)
+    features = preprocess_events(df)
     total = len(features)
     denied = int(features["access_denied"].sum())
     anomaly_score = (denied / total) * 100 if total else 0

--- a/docs/feature_pipeline.md
+++ b/docs/feature_pipeline.md
@@ -5,6 +5,15 @@
 `FeaturePipeline` orchestrates feature extraction and transformation using the
 existing `FeastFeatureStore` and `ModelRegistry` utilities.
 
+## Transformation Flow
+
+Raw event records are first normalised through the shared
+`preprocess_events` contract. This function applies the project-wide
+feature engineering steps and returns a dataframe enriched with
+temporal, access, user and security attributes. The resulting features
+are then passed into `FeaturePipeline` for any additional per-model
+transformations before training or inference.
+
 ## Loading Definitions
 
 ```python

--- a/yosai_intel_dashboard/src/models/ml/__init__.py
+++ b/yosai_intel_dashboard/src/models/ml/__init__.py
@@ -2,6 +2,7 @@
 
 from .base_model import BaseModel, ModelMetadata
 from .model_registry import ModelRecord, ModelRegistry
+from .pipeline_contract import preprocess_events
 from .security_models import (
     TrainResult,
     train_access_anomaly_iforest,
@@ -16,6 +17,7 @@ __all__ = [
     "ModelRecord",
     "BaseModel",
     "ModelMetadata",
+    "preprocess_events",
     "TrainResult",
     "train_access_anomaly_iforest",
     "train_risk_scoring_xgboost",

--- a/yosai_intel_dashboard/src/models/ml/feature_pipeline.py
+++ b/yosai_intel_dashboard/src/models/ml/feature_pipeline.py
@@ -12,7 +12,7 @@ from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.inspection import permutation_importance
 
-from analytics.feature_extraction import extract_event_features
+from .pipeline_contract import preprocess_events
 from yosai_intel_dashboard.models.ml.feature_store import FeastFeatureStore
 from yosai_intel_dashboard.models.ml.model_registry import ModelRegistry
 
@@ -65,7 +65,7 @@ class FeaturePipeline(BaseEstimator, TransformerMixin):
 
     # ------------------------------------------------------------------
     def fit(self, X: pd.DataFrame, y: Any | None = None) -> "FeaturePipeline":
-        df = extract_event_features(X)
+        df = preprocess_events(X)
         if not self.feature_list:
             self.feature_list = df.columns.tolist()
         Parallel(n_jobs=self.n_jobs)(
@@ -76,7 +76,7 @@ class FeaturePipeline(BaseEstimator, TransformerMixin):
 
     # ------------------------------------------------------------------
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
-        df = extract_event_features(X)
+        df = preprocess_events(X)
         for entry in self.transformers.values():
             transformed = entry.transformer.transform(df[entry.columns])
             if isinstance(transformed, pd.DataFrame):

--- a/yosai_intel_dashboard/src/models/ml/pipeline_contract.py
+++ b/yosai_intel_dashboard/src/models/ml/pipeline_contract.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Shared preprocessing contract for event-based models.
+
+This module exposes a single helper :func:`preprocess_events` which applies
+all agreed upon feature engineering steps.  Both training code and inference
+services should rely on this function to ensure the same transformations are
+used across the project.
+"""
+
+from typing import Any
+import pandas as pd
+
+from analytics import feature_extraction
+
+
+def preprocess_events(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the canonical feature set for raw event data.
+
+    Parameters
+    ----------
+    df:
+        Raw event dataframe containing columns such as ``timestamp`` and
+        ``access_result``.
+
+    Returns
+    -------
+    DataFrame
+        The input dataframe augmented with engineered feature columns.
+    """
+
+    return feature_extraction.extract_event_features(df)
+
+
+__all__ = ["preprocess_events"]

--- a/yosai_intel_dashboard/src/models/ml/security_models.py
+++ b/yosai_intel_dashboard/src/models/ml/security_models.py
@@ -11,7 +11,7 @@ import joblib
 import numpy as np
 import pandas as pd
 
-from yosai_intel_dashboard.src.services.analytics.feature_extraction import extract_event_features
+from .pipeline_contract import preprocess_events
 from yosai_intel_dashboard.src.infrastructure.monitoring.model_performance_monitor import (
     ModelMetrics,
     get_model_performance_monitor,
@@ -99,7 +99,7 @@ def train_access_anomaly_iforest(
     model_name: str = "access-anomaly-iso",
 ) -> TrainResult:
     """Train an Isolation Forest anomaly detector for access patterns."""
-    features = extract_event_features(df)
+    features = preprocess_events(df)
     data_cols = [
         "hour",
         "day_of_week",
@@ -132,7 +132,7 @@ def train_risk_scoring_xgboost(
         raise ImportError("xgboost is not available")
     if target_column not in df:
         raise ValueError(f"target column '{target_column}' missing")
-    features = extract_event_features(df.drop(columns=[target_column]))
+    features = preprocess_events(df.drop(columns=[target_column]))
     numeric = features.select_dtypes(include=["number", "bool"]).fillna(0)
     scaler = StandardScaler()
     X = scaler.fit_transform(numeric)
@@ -201,7 +201,7 @@ def train_user_clustering_dbscan(
     model_name: str = "user-cluster-dbscan",
 ) -> TrainResult:
     """Train a DBSCAN model for user behavior clustering."""
-    features = extract_event_features(df)
+    features = preprocess_events(df)
     scaler = StandardScaler()
     X = scaler.fit_transform(
         features[["hour", "day_of_week", "user_event_count", "door_event_count"]]
@@ -231,7 +231,7 @@ def train_online_threat_detector(
             raise ValueError("df must contain 'label' column for training")
         classes = sorted(df["label"].unique())
 
-    features = extract_event_features(df.drop(columns=["label"]))
+    features = preprocess_events(df.drop(columns=["label"]))
     numeric = features.select_dtypes(include=["number", "bool"]).fillna(0)
     scaler = StandardScaler()
     X = scaler.fit_transform(numeric)

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -29,7 +29,8 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, ConfigDict
 
-from analytics import anomaly_detection, feature_extraction, security_patterns
+from analytics import anomaly_detection, security_patterns
+from yosai_intel_dashboard.models.ml.pipeline_contract import preprocess_events
 from shared.errors.types import ErrorCode, ErrorResponse
 from jose import jwt
 from yosai_framework import ServiceBuilder
@@ -374,7 +375,7 @@ async def threat_assessment(
     else:
         df = pd.DataFrame(payload)
 
-    features = feature_extraction.extract_event_features(df)
+    features = preprocess_events(df)
     anomaly = anomaly_detection.AnomalyDetector().analyze_anomalies(features)
     patterns = security_patterns.SecurityPatternsAnalyzer().analyze_security_patterns(
         features


### PR DESCRIPTION
## Summary
- add `preprocess_events` contract for consistent event feature engineering
- update training utilities and analytics services to use the contract
- document transformation flow in feature pipeline docs

## Testing
- `pytest -o addopts='' tests/test_feature_extraction.py tests/test_feature_pipeline.py` *(fails: NameError `_SECURITYCONFIG_SESSIONTIMEOUTBYROLEENTRY`)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9e9b97c83208b03f8c368394920