### PR TITLE
feat: add model rollback with drift thresholds

### DIFF
--- a/docs/model_registry.md
+++ b/docs/model_registry.md
@@ -1,0 +1,22 @@
+# Model Registry Policy
+
+The model registry tracks every trained model version and manages which
+version is currently active. When a new model version is proposed for
+activation, its metrics are compared against those of the active model.
+
+## Drift thresholds
+
+`ModelRegistry` accepts a `drift_thresholds` mapping that defines the
+maximum allowed absolute difference for each metric. During activation
+(`set_active_version`), the registry verifies that the difference between
+the new version's metrics and the active version's metrics does not exceed
+the configured thresholds. If any metric drifts beyond its threshold, the
+activation is rejected.
+
+## Rollback
+
+Every time a new model is activated, the previous active version is stored
+in an internal history. The `rollback_model(name)` API restores the most
+recently active version for the given model, enabling quick reversions if
+an activation causes issues.
+

--- a/scripts/model_registry_cli.py
+++ b/scripts/model_registry_cli.py
@@ -53,12 +53,16 @@ def main(argv: List[str] | None = None) -> int:
         return 0
 
     if args.command == "activate":
-        registry.set_active_version(args.name, args.version)
-        print(f"Activated {args.name} version {args.version}")
+        try:
+            registry.set_active_version(args.name, args.version)
+            print(f"Activated {args.name} version {args.version}")
+        except ValueError as exc:
+            LOG.error(str(exc))
+            return 1
         return 0
 
     if args.command == "rollback":
-        rec = registry.rollback_to_previous(args.name)
+        rec = registry.rollback_model(args.name)
         if rec is None:
             print(f"No previous version found for {args.name}")
         else:

--- a/tests/ml/test_model_registry_policy.py
+++ b/tests/ml/test_model_registry_policy.py
@@ -1,0 +1,88 @@
+import importlib.util
+from pathlib import Path
+import types
+
+import pytest
+
+
+class DummyS3:
+    def upload_file(self, *a, **k):
+        pass
+
+    def download_file(self, *a, **k):
+        pass
+
+
+class DummyRun:
+    def __init__(self):
+        self.info = types.SimpleNamespace(run_id="run")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyMlflow:
+    def start_run(self):
+        return DummyRun()
+
+    def log_metric(self, *a, **k):
+        pass
+
+    def log_artifact(self, *a, **k):
+        pass
+
+    def set_tracking_uri(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def registry(monkeypatch, tmp_path):
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "yosai_intel_dashboard"
+        / "src"
+        / "models"
+        / "ml"
+        / "model_registry.py"
+    )
+    spec = importlib.util.spec_from_file_location("model_registry", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "mlflow", DummyMlflow())
+    return module.ModelRegistry(
+        "sqlite:///:memory:",
+        bucket="bucket",
+        s3_client=DummyS3(),
+        drift_thresholds={"accuracy": 0.05},
+    )
+
+
+def test_activation_respects_drift_threshold(tmp_path, registry):
+    p1 = tmp_path / "m1.bin"
+    p1.write_text("a")
+    registry.register_model("m", str(p1), {"accuracy": 0.9}, "h1", version="0.1.0")
+    registry.set_active_version("m", "0.1.0")
+    p2 = tmp_path / "m2.bin"
+    p2.write_text("b")
+    registry.register_model("m", str(p2), {"accuracy": 0.7}, "h2", version="0.1.1")
+    with pytest.raises(ValueError):
+        registry.set_active_version("m", "0.1.1")
+
+
+def test_rollback_model_restores_previous(tmp_path, registry):
+    p1 = tmp_path / "p1.bin"
+    p1.write_text("1")
+    registry.register_model("m2", str(p1), {"accuracy": 0.9}, "h1", version="0.1.0")
+    registry.set_active_version("m2", "0.1.0")
+    p2 = tmp_path / "p2.bin"
+    p2.write_text("2")
+    registry.register_model("m2", str(p2), {"accuracy": 0.92}, "h2", version="0.1.1")
+    registry.set_active_version("m2", "0.1.1")
+    registry.rollback_model("m2")
+    active = registry.get_model("m2", active_only=True)
+    assert active.version == "0.1.0"
+

--- a/tests/models/test_model_registry.py
+++ b/tests/models/test_model_registry.py
@@ -122,7 +122,7 @@ def test_set_active_version_closes_session(tmp_path, registry, track_session_clo
     assert len(track_session_closes) >= 1
 
 
-def test_rollback_to_previous_closes_session(tmp_path, registry, track_session_closes):
+def test_rollback_model_closes_session(tmp_path, registry, track_session_closes):
     p1 = tmp_path / "m1.bin"
     p1.write_text("a")
     registry.register_model("m5", str(p1), {"acc": 1.0}, "h1", version="0.1.0")
@@ -132,7 +132,7 @@ def test_rollback_to_previous_closes_session(tmp_path, registry, track_session_c
     registry.register_model("m5", str(p2), {"acc": 0.9}, "h2", version="0.1.1")
     registry.set_active_version("m5", "0.1.1")
     track_session_closes.clear()
-    registry.rollback_to_previous("m5")
+    registry.rollback_model("m5")
     calls = len(track_session_closes)
     active = registry.get_model("m5", active_only=True)
     assert calls >= 1

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_monitor.py
@@ -129,7 +129,7 @@ class ModelMonitor:
                 or metrics.precision < self.performance_threshold
                 or metrics.recall < self.performance_threshold
             ):
-                self.registry.rollback_to_previous(rec.name)
+                self.registry.rollback_model(rec.name)
                 continue
             drift = self.monitor.detect_drift(metrics)
             status = "drift" if drift else "ok"

--- a/yosai_intel_dashboard/src/models/ml/model_registry.py
+++ b/yosai_intel_dashboard/src/models/ml/model_registry.py
@@ -73,6 +73,7 @@ class ModelRegistry:
         s3_client: Any | None = None,
         mlflow_uri: str | None = None,
         metric_thresholds: Dict[str, float] | None = None,
+        drift_thresholds: Dict[str, float] | None = None,
     ) -> None:
         self.engine = create_engine(database_url)
         Base.metadata.create_all(self.engine)
@@ -89,8 +90,10 @@ class ModelRegistry:
         elif mlflow_uri:
             raise RuntimeError("mlflow is required for tracking")
         self.metric_thresholds = metric_thresholds or {}
+        self.drift_thresholds = drift_thresholds or {}
         self._baseline_features: Dict[str, pd.DataFrame] = {}
         self._latest_features: Dict[str, pd.DataFrame] = {}
+        self._previous_active: Dict[str, List[str]] = {}
 
     # --------------------------------------------------------------
     def _metrics_improved(self, new: Dict[str, float], old: Dict[str, float]) -> bool:
@@ -225,6 +228,29 @@ class ModelRegistry:
     def set_active_version(self, name: str, version: str) -> None:
         session = self._session()
         try:
+            new_rec = session.execute(
+                select(ModelRecord)
+                .where(ModelRecord.name == name, ModelRecord.version == version)
+            ).scalar_one_or_none()
+            if new_rec is None:
+                raise ValueError(f"Model {name} version {version} not found")
+            current = session.execute(
+                select(ModelRecord)
+                .where(ModelRecord.name == name, ModelRecord.is_active.is_(True))
+            ).scalar_one_or_none()
+            if current:
+                for m, threshold in self.drift_thresholds.items():
+                    old_val = (current.metrics or {}).get(m)
+                    new_val = (new_rec.metrics or {}).get(m)
+                    if (
+                        old_val is not None
+                        and new_val is not None
+                        and abs(new_val - old_val) > threshold
+                    ):
+                        raise ValueError(
+                            f"Metric {m} drift {abs(new_val - old_val):.4f} exceeds {threshold}"
+                        )
+                self._previous_active.setdefault(name, []).append(current.version)
             session.execute(
                 update(ModelRecord)
                 .where(ModelRecord.name == name)
@@ -239,18 +265,19 @@ class ModelRegistry:
         finally:
             session.close()
 
-    def rollback_to_previous(self, name: str) -> ModelRecord | None:
+    def rollback_model(self, name: str) -> ModelRecord | None:
         session = self._session()
         try:
-            stmt = (
-                select(ModelRecord)
-                .where(ModelRecord.name == name)
-                .order_by(ModelRecord.version.desc())
-            )
-            records = session.execute(stmt).scalars().all()
-            target = next((r for r in records if not r.is_active), None)
-            if target is None:
+            history = self._previous_active.get(name)
+            if not history:
                 return None
+            target_version = history.pop()
+            current = session.execute(
+                select(ModelRecord)
+                .where(ModelRecord.name == name, ModelRecord.is_active.is_(True))
+            ).scalar_one_or_none()
+            if current:
+                self._previous_active.setdefault(name, []).append(current.version)
             session.execute(
                 update(ModelRecord)
                 .where(ModelRecord.name == name)
@@ -258,14 +285,21 @@ class ModelRegistry:
             )
             session.execute(
                 update(ModelRecord)
-                .where(ModelRecord.id == target.id)
+                .where(ModelRecord.name == name, ModelRecord.version == target_version)
                 .values(is_active=True)
             )
             session.commit()
-            session.refresh(target)
-            return target
+            rec = session.execute(
+                select(ModelRecord)
+                .where(ModelRecord.name == name, ModelRecord.version == target_version)
+            ).scalar_one_or_none()
+            return rec
         finally:
             session.close()
+
+    # Backwards compatibility alias
+    def rollback_to_previous(self, name: str) -> ModelRecord | None:
+        return self.rollback_model(name)
 
     # --------------------------------------------------------------
     def download_artifact(self, storage_uri: str, destination: str) -> None:


### PR DESCRIPTION
## Summary
- prevent large metric drift before activating a new model version
- track previously active model versions and add `rollback_model`
- document model registry policy and add tests

## Testing
- `pytest --no-cov tests/ml/test_model_registry_policy.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba9e8e8fc83208cc7d0277bbe9a3c