### PR TITLE
feat: introduce service registry

### DIFF
--- a/yosai_intel_dashboard/src/core/__init__.py
+++ b/yosai_intel_dashboard/src/core/__init__.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from .registry import ServiceRegistry, registry
+
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .async_utils import (
         AsyncContextManager,
@@ -100,6 +102,8 @@ __all__ = [
     "CircuitBreakerOpen",
     "circuit_breaker",
     "async_batch",
+    "ServiceRegistry",
+    "registry",
 ]
 
 _ASYNC_EXPORTS = {

--- a/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
+++ b/yosai_intel_dashboard/src/core/interfaces/service_protocols.py
@@ -12,6 +12,7 @@ from yosai_intel_dashboard.src.mapping.core.interfaces import (
     StorageInterface,
 )
 from yosai_intel_dashboard.src.mapping.core.models import MappingData
+from yosai_intel_dashboard.src.core import registry
 
 
 @runtime_checkable
@@ -118,11 +119,10 @@ def get_door_mapping_service(
     c = _get_container(container)
     if c and c.has("door_mapping_service"):
         return c.get("door_mapping_service")
-    from yosai_intel_dashboard.src.services.door_mapping_service import (
-        door_mapping_service,
-    )
+    # Ensure registration side effects
+    import yosai_intel_dashboard.src.services.door_mapping_service  # noqa: F401
 
-    return door_mapping_service
+    return registry.get("door_mapping_service")
 
 
 def get_device_learning_service(

--- a/yosai_intel_dashboard/src/core/registry.py
+++ b/yosai_intel_dashboard/src/core/registry.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Lightweight service registry used for global lookups."""
+
+from typing import Any, Dict
+
+
+class ServiceRegistry:
+    """Very small service registry.
+
+    Services are stored by a string key and can be retrieved or removed later.
+    The implementation is intentionally minimal for ease of use in tests and
+    runtime modules.
+    """
+
+    def __init__(self) -> None:
+        self._services: Dict[str, Any] = {}
+
+    def register(self, name: str, service: Any) -> None:
+        """Register *service* under *name*."""
+
+        self._services[name] = service
+
+    def get(self, name: str) -> Any:
+        """Return the service registered under *name*.
+
+        Raises ``KeyError`` if the service has not been registered.
+        """
+
+        return self._services[name]
+
+    def remove(self, name: str) -> None:
+        """Remove the service registered under *name* if present."""
+
+        self._services.pop(name, None)
+
+
+# Global registry instance used across the application
+registry = ServiceRegistry()
+
+__all__ = ["ServiceRegistry", "registry"]

--- a/yosai_intel_dashboard/src/core/utils/config_helpers.py
+++ b/yosai_intel_dashboard/src/core/utils/config_helpers.py
@@ -11,25 +11,34 @@ is not provided.
 from typing import Any
 
 from src.common.config import ConfigService, ConfigurationMixin
+from yosai_intel_dashboard.src.core import registry
 
 
-_default_cfg = ConfigService()
 _mixin = ConfigurationMixin()
+
+
+def _resolve_cfg(cfg: Any | None) -> Any:
+    if cfg is not None:
+        return cfg
+    try:
+        return registry.get("config_service")
+    except KeyError:
+        return ConfigService()
 
 
 def get_ai_confidence_threshold(cfg: Any | None = None) -> float:
     """Return the AI confidence threshold from ``cfg`` or defaults."""
-    return _mixin.get_ai_confidence_threshold(cfg or _default_cfg)
+    return _mixin.get_ai_confidence_threshold(_resolve_cfg(cfg))
 
 
 def get_max_upload_size_mb(cfg: Any | None = None) -> int:
     """Return the maximum upload size in megabytes from ``cfg`` or defaults."""
-    return _mixin.get_max_upload_size_mb(cfg or _default_cfg)
+    return _mixin.get_max_upload_size_mb(_resolve_cfg(cfg))
 
 
 def get_upload_chunk_size(cfg: Any | None = None) -> int:
     """Return the upload chunk size from ``cfg`` or defaults."""
-    return _mixin.get_upload_chunk_size(cfg or _default_cfg)
+    return _mixin.get_upload_chunk_size(_resolve_cfg(cfg))
 
 
 __all__ = [

--- a/yosai_intel_dashboard/src/services/analytics/async_api.py
+++ b/yosai_intel_dashboard/src/services/analytics/async_api.py
@@ -24,6 +24,7 @@ from yosai_intel_dashboard.src.core.cache_manager import CacheConfig, InMemoryCa
 from yosai_intel_dashboard.src.error_handling import http_error
 from yosai_intel_dashboard.src.services.analytics.analytics_service import get_analytics_service
 from yosai_intel_dashboard.src.services.cached_analytics import CachedAnalyticsService
+from yosai_intel_dashboard.src.core import registry
 from yosai_intel_dashboard.src.services.common.async_db import get_pool
 from yosai_intel_dashboard.src.services.security import require_permission
 from yosai_intel_dashboard.src.services.summary_report_generator import SummaryReportGenerator
@@ -57,7 +58,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 cache_manager = InMemoryCacheManager(CacheConfig(timeout_seconds=300))
-analytics_service = CachedAnalyticsService(cache_manager)
+registry.register("cached_analytics_service", CachedAnalyticsService(cache_manager))
 ws_server: AnalyticsWebSocketServer | None = None
 
 app = FastAPI(dependencies=[Depends(require_permission("analytics.read"))])
@@ -96,7 +97,7 @@ ERROR_RESPONSES = {
 
 async def get_service() -> CachedAnalyticsService:
     """Return the analytics service instance."""
-    return analytics_service
+    return registry.get("cached_analytics_service")
 
 
 @app.on_event("startup")

--- a/yosai_intel_dashboard/src/services/door_mapping_service.py
+++ b/yosai_intel_dashboard/src/services/door_mapping_service.py
@@ -17,6 +17,7 @@ from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGener
 from yosai_intel_dashboard.src.services.common import ModelRegistry
 from yosai_intel_dashboard.src.services.common.config_utils import common_init, create_config_methods
 from yosai_intel_dashboard.src.services.learning.src.api.consolidated_service import get_learning_service
+from yosai_intel_dashboard.src.core import registry
 
 logger = logging.getLogger(__name__)
 
@@ -456,7 +457,17 @@ class DoorMappingService:
             return ""
 
 
-# Service instance
-door_mapping_service = DoorMappingService(DynamicConfigurationService())
+def get_door_mapping_service() -> DoorMappingService:
+    try:
+        return registry.get("door_mapping_service")
+    except KeyError:
+        from yosai_intel_dashboard.src.services.configuration_service import (
+            DynamicConfigurationService,
+        )
 
-__all__ = ["DoorMappingService", "DeviceAttributeData", "door_mapping_service"]
+        service = DoorMappingService(DynamicConfigurationService())
+        registry.register("door_mapping_service", service)
+        return service
+
+
+__all__ = ["DoorMappingService", "DeviceAttributeData", "get_door_mapping_service"]

--- a/yosai_intel_dashboard/src/services/upload/ai.py
+++ b/yosai_intel_dashboard/src/services/upload/ai.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List
 
 from dash.dash import no_update
 
+from yosai_intel_dashboard.src.core import registry
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,13 +78,14 @@ class AISuggestionService:
         return [suggested_values]
 
 
-# Shared instance for module level helpers
-_DEFAULT_AI_SERVICE = AISuggestionService()
+# Register service for global lookups
+registry.register("ai_suggestion_service", AISuggestionService())
 
 
 def analyze_device_name_with_ai(device_name: str) -> Dict[str, Any]:
     """Convenience wrapper calling :class:`AISuggestionService`."""
-    return _DEFAULT_AI_SERVICE.analyze_device_name_with_ai(device_name)
+    service: AISuggestionService = registry.get("ai_suggestion_service")
+    return service.analyze_device_name_with_ai(device_name)
 
 
 __all__ = ["AISuggestionService", "analyze_device_name_with_ai"]


### PR DESCRIPTION
## Summary
- add minimal ServiceRegistry with register/get/remove and global instance
- expose registry via core package
- replace module-level service singletons with registry lookups

## Testing
- `python -m py_compile yosai_intel_dashboard/src/core/registry.py yosai_intel_dashboard/src/core/__init__.py yosai_intel_dashboard/src/core/utils/config_helpers.py yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/model_metrics.py yosai_intel_dashboard/src/services/analytics/async_api.py yosai_intel_dashboard/src/services/door_mapping_service.py yosai_intel_dashboard/src/services/upload/ai.py yosai_intel_dashboard/src/adapters/api/analytics_router.py yosai_intel_dashboard/src/core/interfaces/service_protocols.py`
- `pytest tests/test_door_mapping_service.py -q` *(fails: ImportError: cannot import name 'DatabaseManager')*

------
https://chatgpt.com/codex/tasks/task_e_689ba9e236c08320b350e33a78afe88f