### PR TITLE
refactor metrics repository protocol

### DIFF
--- a/src/api/metrics.py
+++ b/src/api/metrics.py
@@ -1,50 +1,44 @@
-from flask import Blueprint, jsonify
+from __future__ import annotations
 
-from src.repository import (
-    CachedMetricsRepository,
-    InMemoryMetricsRepository,
-    MetricsRepository,
-)
+from flask import Blueprint, jsonify
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from yosai_intel_dashboard.src.core.protocols.metrics import MetricsRepositoryProtocol
 
 metrics_bp = Blueprint("metrics", __name__, url_prefix="/v1/metrics")
 
-_metrics_repo: MetricsRepository = CachedMetricsRepository(InMemoryMetricsRepository())
+_metrics_repo: MetricsRepositoryProtocol | None = None
 
 
-def set_metrics_repository(
-    repo: MetricsRepository, *, use_cache: bool = True, ttl: int = 60
-) -> None:
-    """Inject a metrics repository implementation.
-
-    Parameters
-    ----------
-    repo:
-        The underlying metrics repository.
-    use_cache:
-        If ``True`` (default), wrap ``repo`` in :class:`CachedMetricsRepository`.
-    ttl:
-        Cache expiration in seconds when ``use_cache`` is enabled.
-    """
+def set_metrics_repository(repo: MetricsRepositoryProtocol) -> None:
+    """Inject a metrics repository implementation."""
     global _metrics_repo
-    _metrics_repo = CachedMetricsRepository(repo, ttl=ttl) if use_cache else repo
+    _metrics_repo = repo
+
+
+def _get_repo() -> MetricsRepositoryProtocol:
+    if _metrics_repo is None:  # pragma: no cover - safety check
+        raise RuntimeError("Metrics repository not configured")
+    return _metrics_repo
 
 
 @metrics_bp.get("/performance")
 def get_performance_metrics():
     """Return performance metrics from the repository."""
-    return jsonify(_metrics_repo.get_performance_metrics())
+    return jsonify(_get_repo().get_performance_metrics())
 
 
 @metrics_bp.get("/drift")
 def get_drift_data():
     """Return drift statistics from the repository."""
-    return jsonify(_metrics_repo.get_drift_data())
+    return jsonify(_get_repo().get_drift_data())
 
 
 @metrics_bp.get("/feature-importance")
 def get_feature_importances():
     """Return feature importances from the repository."""
-    return jsonify(_metrics_repo.get_feature_importances())
+    return jsonify(_get_repo().get_feature_importances())
 
 
 __all__ = ["metrics_bp", "set_metrics_repository"]

--- a/src/repository/__init__.py
+++ b/src/repository/__init__.py
@@ -1,5 +1,5 @@
 """Repository interfaces and implementations."""
 
-from .metrics import MetricsRepository, InMemoryMetricsRepository, CachedMetricsRepository
+from .metrics import InMemoryMetricsRepository, CachedMetricsRepository
 
-__all__ = ["MetricsRepository", "InMemoryMetricsRepository", "CachedMetricsRepository"]
+__all__ = ["InMemoryMetricsRepository", "CachedMetricsRepository"]

--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from src.common.base import BaseComponent
 from src.common.events import EventBus, EventPublisher
 from src.common.mixins import LoggingMixin, SerializationMixin
-from src.repository import InMemoryMetricsRepository, MetricsRepository
+from src.repository import InMemoryMetricsRepository
 
 
 def generate_sample_metrics() -> Dict[str, Any]:
@@ -24,7 +24,7 @@ class MetricsProvider(EventPublisher, LoggingMixin, SerializationMixin, BaseComp
     def __init__(
         self,
         event_bus: EventBus,
-        repo: MetricsRepository | None = None,
+        repo: Any | None = None,
         interval: float = 1.0,
     ) -> None:
         BaseComponent.__init__(

--- a/tests/test_metrics_cache.py
+++ b/tests/test_metrics_cache.py
@@ -1,9 +1,9 @@
 import time
 
-from src.repository import CachedMetricsRepository, MetricsRepository
+from src.repository import CachedMetricsRepository
 
 
-class DummyRepo(MetricsRepository):
+class DummyRepo:
     def __init__(self) -> None:
         self.calls = 0
 

--- a/yosai_intel_dashboard/src/core/protocols/metrics.py
+++ b/yosai_intel_dashboard/src/core/protocols/metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MetricsRepositoryProtocol(Protocol):
+    """Persistence operations for metric data."""
+
+    def get_performance_metrics(self) -> Dict[str, Any]: ...
+
+    def get_drift_data(self) -> Dict[str, Any]: ...
+
+    def get_feature_importances(self) -> Dict[str, Any]: ...
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a combined metric snapshot."""
+        return {
+            "performance": self.get_performance_metrics(),
+            "drift": self.get_drift_data(),
+            "feature_importance": self.get_feature_importances(),
+        }
+
+
+__all__ = ["MetricsRepositoryProtocol"]


### PR DESCRIPTION
## Summary
- add MetricsRepositoryProtocol to core protocols
- refactor metrics repository implementations to use the protocol
- simplify metrics API to depend on injected repository

## Testing
- `pytest -c /dev/null tests/api/test_metrics_endpoints.py tests/test_metrics_cache.py tests/websocket/test_metrics_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_689ba9e03468832087418a3c0174934f