### PR TITLE
feat: lazily load upload component

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/App.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.test.tsx
@@ -9,15 +9,17 @@ jest.mock('react-router-dom', () => ({
 }), { virtual: true });
 
 describe('App responsive behavior', () => {
-  it('opens mobile menu', () => {
+  it('opens mobile menu', async () => {
     render(<App />);
+    await screen.findByText(/Upload Files/i);
     const toggle = screen.getByLabelText(/toggle menu/i);
     fireEvent.click(toggle);
     expect(screen.getByText('Upload')).toBeInTheDocument();
   });
 
-  it('toggles dark mode', () => {
+  it('toggles dark mode', async () => {
     render(<App />);
+    await screen.findByText(/Upload Files/i);
     const darkToggle = screen.getByLabelText(/toggle dark mode/i);
     fireEvent.click(darkToggle);
     expect(document.documentElement.classList.contains('dark')).toBe(true);

--- a/yosai_intel_dashboard/src/adapters/ui/App.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import './styles/upload.css';
-import { Upload } from './components/upload';
 import Navigation from './components/Navigation';
 import { Shield, Menu, Sun, Moon } from 'lucide-react';
 import useDarkMode from './hooks/useDarkMode';
+import CenteredSpinner from './components/shared/CenteredSpinner';
+
+const Upload = React.lazy(() => import('./components/upload'));
 
 function App() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -46,7 +48,9 @@ function App() {
         )}
       </header>
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Upload />
+        <Suspense fallback={<CenteredSpinner />}>
+          <Upload />
+        </Suspense>
       </main>
     </div>
   );

--- a/yosai_intel_dashboard/src/adapters/ui/components/upload/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/components/upload/index.ts
@@ -1,4 +1,5 @@
 export { default as Upload } from './Upload';
+export { default } from './Upload';
 export * from './types';
 export { default as ColumnMappingModal } from './ColumnMappingModal';
 export { default as DeviceMappingModal } from './DeviceMappingModal';


### PR DESCRIPTION
## Summary
- lazily import Upload component with React.lazy and Suspense fallback spinner
- default export Upload module to support lazy loading
- wait for lazy content in App tests

## Testing
- `npx vitest run --dir yosai_intel_dashboard/src/adapters/ui App.test.tsx` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9bbf5048320853183f488d22d97