### PR TITLE
feat(cache): add max item limit and LRU eviction

### DIFF
--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -283,7 +283,9 @@ Cached results are stored in memory and optionally in Redis if available. Cache
 entries expire automatically after the TTL, ensuring that repeated dashboard
 requests do not trigger heavy calculations unnecessarily. The TTL values for
 analytics results and JWKS lookups are defined in `CacheConfig` (see
-`config/base.py`).
+`config/base.py`). In-memory caches keep at most 1,024 entries by default
+(`CacheConfig.max_items`) and evict the least recently used item when this limit
+is exceeded.
 
 ### L1/L2/L3 Cache Levels
 
@@ -291,7 +293,8 @@ The caching subsystem is organised into three tiers managed by
 `HierarchicalCacheManager`:
 
 * **L1** – in‑process memory for the fastest access. The maximum number of
-  entries is controlled by `CACHE_L1_SIZE`.
+  entries is controlled by `CACHE_L1_SIZE` (default 1,024) and entries are
+  discarded using an LRU policy once the limit is reached.
 * **L2** – a shared Redis cache enabled when `CACHE_TYPE=redis` and configured
   with `CACHE_HOST`, `CACHE_PORT` and `CACHE_DATABASE`.
 * **L3** – an optional file‑based cache activated via `CACHE_L3_PATH`. Use

--- a/tests/test_cache_lru.py
+++ b/tests/test_cache_lru.py
@@ -1,0 +1,36 @@
+import sys
+import types
+
+import pytest
+
+perf_stub = types.ModuleType("yosai_intel_dashboard.src.core.performance")
+perf_stub.cache_monitor = types.SimpleNamespace(
+    record_cache_hit=lambda *a, **k: None,
+    record_cache_miss=lambda *a, **k: None,
+)
+sys.modules["yosai_intel_dashboard.src.core.performance"] = perf_stub
+
+from yosai_intel_dashboard.src.infrastructure.cache.cache_manager import (
+    CacheConfig,
+    InMemoryCacheManager,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.performance
+async def test_lru_eviction() -> None:
+    cfg = CacheConfig(timeout_seconds=10, max_items=2)
+    manager = InMemoryCacheManager(cfg)
+    await manager.start()
+
+    await manager.set("a", 1)
+    await manager.set("b", 2)
+    assert await manager.get("a") == 1
+
+    await manager.set("c", 3)  # should evict key 'b'
+
+    assert await manager.get("b") is None
+    assert await manager.get("a") == 1
+    assert await manager.get("c") == 3
+
+    await manager.stop()


### PR DESCRIPTION
## Summary
- add `max_items` to CacheConfig
- evict least-recently-used entries when the limit is exceeded
- document default cache size
- add regression test for LRU behavior

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/cache/cache_manager.py docs/performance_monitoring.md tests/test_cache_lru.py`
- `pytest tests/test_cache_lru.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689ba9ba55e08320aa86cb274a6c64a0