### PR TITLE
feat: versioned model artifact handling

### DIFF
--- a/tests/models/test_model_registry.py
+++ b/tests/models/test_model_registry.py
@@ -196,6 +196,12 @@ def test_download_artifact_invalid_scheme(tmp_path, registry):
         registry.download_artifact("ftp://host/file.bin", str(tmp_path / "x"))
 
 
+def test_version_metadata(tmp_path, registry, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    registry.store_version_metadata("demo", "1.2.3")
+    assert registry.get_version_metadata("demo") == "1.2.3"
+
+
 @pytest.mark.skip(reason="requires full analytics stack")
 def test_log_features_and_drift(monkeypatch, stub_services_registry):
     # Provide minimal stubs so mlflow import succeeds

--- a/yosai_intel_dashboard/src/models/ml/model_registry.py
+++ b/yosai_intel_dashboard/src/models/ml/model_registry.py
@@ -268,6 +268,20 @@ class ModelRegistry:
             session.close()
 
     # --------------------------------------------------------------
+    def store_version_metadata(self, name: str, version: str) -> None:
+        """Persist the active version for *name* to the local models directory."""
+        path = Path("models") / name
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "VERSION").write_text(version)
+
+    def get_version_metadata(self, name: str) -> str | None:
+        """Return the stored local version for *name*, if available."""
+        path = Path("models") / name / "VERSION"
+        if path.exists():
+            return path.read_text().strip()
+        return None
+
+    # --------------------------------------------------------------
     def download_artifact(self, storage_uri: str, destination: str) -> None:
         parsed = urlparse(storage_uri)
         scheme = parsed.scheme

--- a/yosai_intel_dashboard/src/services/analytics/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_service.py
@@ -577,11 +577,15 @@ class AnalyticsService(AnalyticsServiceProtocol, AnalyticsProviderProtocol):
         dest = dest / name / record.version
         dest.mkdir(parents=True, exist_ok=True)
         local_path = dest / os.path.basename(record.storage_uri)
+        local_version = self.model_registry.get_version_metadata(name)
+        if local_version == record.version and local_path.exists():
+            return str(local_path)
         try:
             self.model_registry.download_artifact(
                 record.storage_uri,
                 str(local_path),
             )
+            self.model_registry.store_version_metadata(name, record.version)
             return str(local_path)
         except (
             OSError,


### PR DESCRIPTION
## Summary
- store trained models under versioned directories
- track active version metadata in model registry
- reuse local artifacts when loading models

## Testing
- `pytest -o addopts='' tests/models/test_model_registry.py tests/models/test_model_registry_versioning.py tests/test_feature_pipeline.py tests/test_analytics_service.py tests/services/analytics/test_analytics_service.py` *(fails: fixture 'stub_services_registry' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9ac68cc8320ac673951d6c60e18