### PR TITLE
feat: make after-hours configurable

### DIFF
--- a/docs/models_guide.md
+++ b/docs/models_guide.md
@@ -295,3 +295,11 @@ def get_active_threats(db_connection, events):
     ]
     return high_severity
 ```
+
+#### Configuring after-hours detection
+
+The hours that trigger an `after_hours_access` anomaly are defined by
+the `AFTER_HOURS` list in
+`yosai_intel_dashboard.src.infrastructure.config.constants`.  Each entry
+is an hour prefix such as `"22:"` or `"05:"`.  Projects can override this
+list to match their own business hours.

--- a/tests/test_anomaly_after_hours.py
+++ b/tests/test_anomaly_after_hours.py
@@ -1,0 +1,26 @@
+"""Tests for configurable after-hours anomaly detection."""
+
+from __future__ import annotations
+
+from yosai_intel_dashboard.src.core.domain.entities.base import AnomalyDetectionModel
+from yosai_intel_dashboard.src.infrastructure.config import constants
+
+
+def test_detects_after_hours_by_default() -> None:
+    model = AnomalyDetectionModel(None)
+    events = [{"timestamp": "2024-04-22 23:00", "access_result": "Granted"}]
+
+    anomalies = model.detect_anomalies(events)
+
+    assert any(a["type"] == "after_hours_access" for a in anomalies)
+
+
+def test_custom_after_hours(monkeypatch) -> None:
+    model = AnomalyDetectionModel(None)
+    events = [{"timestamp": "2024-04-22 09:00", "access_result": "Granted"}]
+
+    monkeypatch.setattr(constants, "AFTER_HOURS", ["09:"])
+    anomalies = model.detect_anomalies(events)
+
+    assert any(a["type"] == "after_hours_access" for a in anomalies)
+

--- a/yosai_intel_dashboard/src/core/domain/entities/base.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/base.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 import pandas as pd
+from yosai_intel_dashboard.src.infrastructure.config import constants
 
 logger = logging.getLogger(__name__)
 
@@ -152,10 +153,7 @@ class AnomalyDetectionModel(BaseModel):
             for event in events:
                 # After hours access (simple check)
                 timestamp = str(event.get("timestamp", ""))
-                if any(
-                    hour in timestamp
-                    for hour in ["22:", "23:", "00:", "01:", "02:", "03:", "04:", "05:"]
-                ):
+                if any(hour in timestamp for hour in constants.AFTER_HOURS):
                     anomalies.append(
                         {
                             "type": "after_hours_access",

--- a/yosai_intel_dashboard/src/infrastructure/config/constants.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/constants.py
@@ -13,6 +13,9 @@ MIGRATION_CHUNK_SIZE: int = 1_000
 # File extensions supported across upload services
 UPLOAD_ALLOWED_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls"}
 
+# Hour prefixes considered outside normal working hours for anomaly detection
+AFTER_HOURS = ["22:", "23:", "00:", "01:", "02:", "03:", "04:", "05:"]
+
 
 class SecurityLimits:
     """Security-related validation limits."""


### PR DESCRIPTION
## Summary
- centralize after-hours window as `AFTER_HOURS` constant
- detect anomalies using configurable after-hours list
- document and test custom after-hours behavior

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/infrastructure/config/constants.py yosai_intel_dashboard/src/core/domain/entities/base.py docs/models_guide.md tests/test_anomaly_after_hours.py`
- `pytest tests/test_anomaly_after_hours.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_689ba9a7c9a88320b324889aaeb91e52