### PR TITLE
Refactor access event model to iterable interface

### DIFF
--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 """
 Complete Integration Tests for Analytics System
 """
-import pandas as pd
 import pytest
 
-from yosai_intel_dashboard.src.core.domain.entities import ModelFactory
-from yosai_intel_dashboard.src.services import (
-    create_analytics_service,
-    get_analytics_service,
-)
+from yosai_intel_dashboard.src.adapters.access_event_dataframe import dataframe_to_events
+from yosai_intel_dashboard.src.core.domain.entities.base import AccessEventModel, ModelFactory
 
 
 def test_analytics_service_creation():
     """Test analytics service can be created"""
+    from yosai_intel_dashboard.src.services import (
+        create_analytics_service,
+        get_analytics_service,
+    )
+
     service = get_analytics_service(create_analytics_service())
     assert service is not None
     assert hasattr(service, "health_check")
@@ -23,6 +24,11 @@ def test_analytics_service_creation():
 
 def test_analytics_with_sample_data():
     """Test analytics generation with sample data"""
+    from yosai_intel_dashboard.src.services import (
+        create_analytics_service,
+        get_analytics_service,
+    )
+
     service = get_analytics_service(create_analytics_service())
     result = service.get_analytics_by_source("sample")
 
@@ -33,19 +39,34 @@ def test_analytics_with_sample_data():
 
 def test_model_factory():
     """Test model factory creates models correctly"""
-    df = pd.DataFrame(
-        {
-            "user_id": ["user1", "user2"],
-            "door_id": ["door1", "door2"],
-            "access_result": ["Granted", "Denied"],
-        }
+    class FakeDataFrame:
+        def __init__(self, records):
+            self._records = records
+            self.empty = not records
+
+        def to_dict(self, orient: str):
+            assert orient == "records"
+            return self._records
+
+    df = FakeDataFrame(
+        [
+            {"user_id": "user1", "door_id": "door1", "access_result": "Granted"},
+            {"user_id": "user2", "door_id": "door2", "access_result": "Denied"},
+        ]
     )
+
+    events = dataframe_to_events(df)
+    direct_model = AccessEventModel()
+    assert direct_model.load(events)
+    assert isinstance(direct_model.events, list)
+    assert direct_model.get_user_activity() == {"user1": 1, "user2": 1}
+    assert direct_model.get_door_activity() == {"door1": 1, "door2": 1}
 
     models = ModelFactory.create_models_from_dataframe(df)
     assert "access" in models
     assert "anomaly" in models
     access_model = models["access"]
-    assert isinstance(access_model.events, pd.DataFrame)
+    assert isinstance(access_model.events, list)
     assert access_model.get_user_activity() == {"user1": 1, "user2": 1}
     assert access_model.get_door_activity() == {"door1": 1, "door2": 1}
 
@@ -78,6 +99,11 @@ def test_model_factory_absent(monkeypatch):
 
 def test_health_check():
     """Test service health check"""
+    from yosai_intel_dashboard.src.services import (
+        create_analytics_service,
+        get_analytics_service,
+    )
+
     service = get_analytics_service(create_analytics_service())
     health = service.health_check()
 

--- a/yosai_intel_dashboard/src/adapters/access_event_dataframe.py
+++ b/yosai_intel_dashboard/src/adapters/access_event_dataframe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Utilities for converting tabular records into access event collections."""
+
+import logging
+from datetime import datetime
+from typing import Any, List
+
+try:  # optional pandas dependency
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - fallback when pandas unavailable
+    pd = None  # type: ignore
+
+from yosai_intel_dashboard.src.core.domain.entities.events import AccessEvent
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import AccessResult, BadgeStatus
+
+logger = logging.getLogger(__name__)
+
+
+def dataframe_to_events(df: Any) -> List[AccessEvent]:
+    """Convert a table-like object to ``AccessEvent`` instances.
+
+    The adapter expects ``df`` to provide a ``to_dict('records')`` method and an
+    ``empty`` attribute similar to :class:`pandas.DataFrame`.  Pandas is only
+    required if timestamp values are provided as ``pd.Timestamp`` objects.
+    """
+
+    events: List[AccessEvent] = []
+    if df is None or getattr(df, "empty", True):
+        logger.warning("Empty DataFrame provided to AccessEvent adapter")
+        return events
+
+    try:
+        records = df.to_dict("records")  # type: ignore[call-arg]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error accessing DataFrame records: %s", exc)
+        return events
+
+    for row in records:
+        try:
+            ts = row.get("timestamp")
+            if (
+                pd is not None
+                and hasattr(pd, "Timestamp")
+                and isinstance(ts, pd.Timestamp)  # type: ignore[attr-defined]
+            ):
+                timestamp = ts.to_pydatetime()
+            else:
+                try:
+                    timestamp = datetime.fromisoformat(str(ts))
+                except Exception:
+                    timestamp = datetime.now()
+
+            event = AccessEvent(
+                event_id=str(row.get("event_id", "")),
+                timestamp=timestamp,
+                person_id=str(row.get("person_id") or row.get("user_id", "")),
+                door_id=str(row.get("door_id") or row.get("location", "")),
+                badge_id=row.get("badge_id"),
+                access_result=AccessResult(row.get("access_result", AccessResult.DENIED.value)),
+                badge_status=BadgeStatus(row.get("badge_status", BadgeStatus.INVALID.value)),
+                door_held_open_time=float(row.get("door_held_open_time", 0.0)),
+                entry_without_badge=bool(row.get("entry_without_badge", False)),
+                device_status=row.get("device_status", "normal"),
+                raw_data=row,
+            )
+            events.append(event)
+        except Exception as exc:  # pragma: no cover - best effort per row
+            logger.error("Error parsing access event row: %s", exc)
+
+    return events
+
+
+__all__ = ["dataframe_to_events"]

--- a/yosai_intel_dashboard/src/core/domain/entities/base.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/base.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Protocol, runtime_checkable
 
 import pandas as pd
+
+from ..value_objects.enums import AccessResult
+from .events import AccessEvent
 
 logger = logging.getLogger(__name__)
 
@@ -31,62 +34,55 @@ class BaseModel:
         return True
 
 
+@runtime_checkable
+class AccessEventCollection(Protocol):
+    """Iterable collection of :class:`AccessEvent` instances."""
+
+    def __iter__(self) -> Iterable[AccessEvent]:
+        ...
+
+
 @dataclass(slots=True)
 class AccessEventModel(BaseModel):
     """Model for access control events"""
 
-    events: pd.DataFrame = field(default_factory=pd.DataFrame)
+    events: List[AccessEvent] = field(default_factory=list)
 
-    def load_from_dataframe(self, df: pd.DataFrame) -> bool:
-        """Load events from pandas DataFrame"""
+    def load(self, events: AccessEventCollection) -> bool:
+        """Load access events from an iterable collection."""
         try:
-            if df is None or df.empty:
-                logger.warning("Empty DataFrame provided to AccessEventModel")
+            event_list = list(events)
+            if not event_list:
+                logger.warning("Empty events provided to AccessEventModel")
                 return False
-
-            self.events = df.copy()
+            self.events = event_list
             logger.info(f"Loaded {len(self.events)} access events")
             return True
-
-        except Exception as e:
-            logger.error(f"Error loading DataFrame into AccessEventModel: {e}")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Error loading events into AccessEventModel: {exc}")
             return False
 
     def get_user_activity(self) -> Dict[str, int]:
         """Get user activity summary"""
-        if self.events.empty:
+        if not self.events:
             return {}
-
-        try:
-            user_col = None
-            for col in ["user_id", "person_id"]:
-                if col in self.events.columns:
-                    user_col = col
-                    break
-            if user_col is None:
-                return {}
-            return self.events[user_col].value_counts().to_dict()
-        except Exception as e:
-            logger.error(f"Error calculating user activity: {e}")
-            return {}
+        counts: Dict[str, int] = {}
+        for event in self.events:
+            user_id = getattr(event, "person_id", None) or getattr(event, "user_id", None)
+            if user_id:
+                counts[user_id] = counts.get(user_id, 0) + 1
+        return counts
 
     def get_door_activity(self) -> Dict[str, int]:
         """Get door activity summary"""
-        if self.events.empty:
+        if not self.events:
             return {}
-
-        try:
-            door_col = None
-            for col in ["door_id", "location"]:
-                if col in self.events.columns:
-                    door_col = col
-                    break
-            if door_col is None:
-                return {}
-            return self.events[door_col].value_counts().to_dict()
-        except Exception as e:
-            logger.error(f"Error calculating door activity: {e}")
-            return {}
+        counts: Dict[str, int] = {}
+        for event in self.events:
+            door_id = getattr(event, "door_id", None) or getattr(event, "location", None)
+            if door_id:
+                counts[door_id] = counts.get(door_id, 0) + 1
+        return counts
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary with analytics"""
@@ -103,36 +99,32 @@ class AccessEventModel(BaseModel):
 
     def _get_access_patterns(self) -> Dict[str, Any]:
         """Analyze access patterns"""
-        if self.events.empty:
+        if not self.events:
             return {}
 
-        try:
-            df = self.events
-            patterns: Dict[str, Any] = {
-                "total_access_attempts": len(df),
-                "successful_attempts": 0,
-                "failed_attempts": 0,
-                "hourly_distribution": {},
-            }
+        patterns: Dict[str, Any] = {
+            "total_access_attempts": len(self.events),
+            "successful_attempts": 0,
+            "failed_attempts": 0,
+            "hourly_distribution": {},
+        }
 
-            if "access_result" in df.columns:
-                results = df["access_result"].astype(str).str.lower()
-                patterns["successful_attempts"] = results.str.contains(
-                    "grant|success", regex=True
-                ).sum()
-                patterns["failed_attempts"] = results.str.contains(
-                    "den|fail", regex=True
-                ).sum()
+        for event in self.events:
+            result = getattr(event, "access_result", None)
+            result_val = result.value if isinstance(result, AccessResult) else str(result)
+            result_val = str(result_val).lower()
+            if "grant" in result_val or "success" in result_val:
+                patterns["successful_attempts"] += 1
+            elif "den" in result_val or "fail" in result_val:
+                patterns["failed_attempts"] += 1
 
-            if "timestamp" in df.columns:
-                times = pd.to_datetime(df["timestamp"], errors="coerce")
-                hourly = times.dropna().dt.hour.value_counts().sort_index()
-                patterns["hourly_distribution"] = hourly.to_dict()
+            ts = getattr(event, "timestamp", None)
+            if isinstance(ts, datetime):
+                hour = ts.hour
+                hourly = patterns["hourly_distribution"]
+                hourly[hour] = hourly.get(hour, 0) + 1
 
-            return patterns
-        except Exception as e:
-            logger.error(f"Error analyzing access patterns: {e}")
-            return {}
+        return patterns
 
 
 @dataclass(slots=True)
@@ -237,24 +229,27 @@ class ModelFactory:
         models = {}
 
         try:
-            if df is None or df.empty:
+            from ....adapters.access_event_dataframe import dataframe_to_events
+
+            events = dataframe_to_events(df)
+            if not events:
                 logger.warning("Empty DataFrame provided to ModelFactory")
                 return {}
+
             # Create access model
-            access_model = ModelFactory.create_access_model(df)
-            if access_model.load_from_dataframe(df):
+            access_model = ModelFactory.create_access_model()
+            if access_model.load(events):
                 models["access"] = access_model
 
             # Create anomaly model
-            anomaly_model = ModelFactory.create_anomaly_model(df)
-            events = df.to_dict("records") if not df.empty else []
-            anomaly_model.detect_anomalies(events)
+            anomaly_model = ModelFactory.create_anomaly_model()
+            anomaly_model.detect_anomalies([e.to_dict() for e in events])
             models["anomaly"] = anomaly_model
 
             logger.info(f"Created {len(models)} models from DataFrame")
             return models
 
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive
             logger.error(f"Error creating models from DataFrame: {e}")
             return {}
 
@@ -311,4 +306,10 @@ class ModelFactory:
             return {}
 
 
-__all__ = ["BaseModel", "AccessEventModel", "AnomalyDetectionModel", "ModelFactory"]
+__all__ = [
+    "BaseModel",
+    "AccessEventCollection",
+    "AccessEventModel",
+    "AnomalyDetectionModel",
+    "ModelFactory",
+]

--- a/yosai_intel_dashboard/src/core/domain/entities/events.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/events.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict
 
-from .enums import AccessResult, AnomalyType, BadgeStatus, SeverityLevel, TicketStatus
+from ..value_objects.enums import (
+    AccessResult,
+    AnomalyType,
+    BadgeStatus,
+    SeverityLevel,
+    TicketStatus,
+)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- Introduce `AccessEventCollection` protocol and refactor `AccessEventModel` to work with generic iterables of events
- Add `dataframe_to_events` adapter for converting tabular records into `AccessEvent` objects
- Update tests to exercise new adapter with a lightweight DataFrame stand‑in

## Testing
- `pytest tests/test_analytics_integration.py::test_model_factory -q -c /tmp/pytest.ini`


------
https://chatgpt.com/codex/tasks/task_e_689ba9a0b0648320ba0774ee4624f72b