### PR TITLE
docs: document EventBus utilities

### DIFF
--- a/shared/events/bus.py
+++ b/shared/events/bus.py
@@ -1,3 +1,11 @@
+"""Event bus utilities.
+
+Provides :class:`EventBus` and :class:`EventPublisher` for simple
+publish/subscribe communication with optional async support. Callbacks can be
+throttled and per-event metrics are collected. See
+``docs/callback_architecture.md`` for an architectural overview.
+"""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary
- add module docstring summarizing EventBus and EventPublisher
- link to docs/callback_architecture.md

## Testing
- `pre-commit run --files shared/events/bus.py`
- `pytest tests/common/test_event_bus.py tests/callbacks/test_event_bus.py -q` *(fails: ImportError: cannot import name 'registry' from 'yosai_intel_dashboard.src.core.registry')*

------
https://chatgpt.com/codex/tasks/task_e_689bb807129c8320bc98bab7379fd74c