### PR TITLE
refactor: centralize event names

### DIFF
--- a/shared/events/names.py
+++ b/shared/events/names.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class EventName(str, Enum):
+    """Canonical event names used across the application."""
+
+    METRICS_UPDATE = "metrics_update"
+    ANALYTICS_UPDATE = "analytics_update"
+
+__all__ = ["EventName"]

--- a/src/websocket/metrics.py
+++ b/src/websocket/metrics.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Dict
 
 from shared.events.bus import EventBus
+from shared.events.names import EventName
 
 try:
     from prometheus_client import REGISTRY, Counter, start_http_server
@@ -84,7 +85,7 @@ def _publish_snapshot() -> None:
     if _event_bus is None:
         return
     payload = _snapshot()
-    _event_bus.publish("metrics_update", payload)
+    _event_bus.publish(EventName.METRICS_UPDATE, payload)
 
 
 def set_event_bus(bus: EventBus) -> None:

--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -10,6 +10,7 @@ from src.common.base import BaseComponent
 from shared.events.bus import EventBus, EventPublisher
 from src.common.mixins import LoggingMixin, SerializationMixin
 from src.repository import InMemoryMetricsRepository
+from shared.events.names import EventName
 
 
 def generate_sample_metrics() -> Dict[str, Any]:
@@ -44,7 +45,7 @@ class MetricsProvider(EventPublisher, LoggingMixin, SerializationMixin, BaseComp
     def _run(self) -> None:
         while not self._stop.is_set():
             payload = self.repo.snapshot()
-            self.publish_event("metrics_update", payload)
+            self.publish_event(EventName.METRICS_UPDATE, payload)
 
             self.log("Published metrics update")
 

--- a/tests/common/test_event_name_constants.py
+++ b/tests/common/test_event_name_constants.py
@@ -1,0 +1,17 @@
+from shared.events.bus import EventBus
+from shared.events.names import EventName
+
+
+def test_callbacks_use_standard_event_names() -> None:
+    bus = EventBus()
+    metrics: list[dict] = []
+    analytics: list[dict] = []
+
+    bus.subscribe(EventName.METRICS_UPDATE, lambda payload: metrics.append(payload))
+    bus.subscribe(EventName.ANALYTICS_UPDATE, lambda payload: analytics.append(payload))
+
+    bus.publish(EventName.METRICS_UPDATE, {"a": 1})
+    bus.publish(EventName.ANALYTICS_UPDATE, {"b": 2})
+
+    assert metrics == [{"a": 1}]
+    assert analytics == [{"b": 2}]

--- a/tests/integration/test_sample_plugin_upload.py
+++ b/tests/integration/test_sample_plugin_upload.py
@@ -34,6 +34,7 @@ sys.modules["scipy"].stats = sys.modules["scipy.stats"]
 
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from yosai_intel_dashboard.src.core.events import EventBus
+from shared.events.names import EventName
 from yosai_intel_dashboard.src.core.plugins.auto_config import setup_plugins
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
     TrulyUnifiedCallbacks,
@@ -95,7 +96,7 @@ class SamplePlugin:
         def handle_upload(filename, contents):
             if not contents:
                 raise PreventUpdate
-            event_bus.emit("analytics_update", {"file": filename})
+            event_bus.emit(EventName.ANALYTICS_UPDATE, {"file": filename})
             self.called = True
             return f"plugin:{filename}"
         return True
@@ -187,7 +188,7 @@ def test_plugin_upload_event_sse_ws(
     t.join(timeout=5)
 
     assert logs and logs > 3
-    events = event_bus.get_event_history("analytics_update")
+    events = event_bus.get_event_history(EventName.ANALYTICS_UPDATE)
     assert events and events[-1]["data"]["file"] == "sample.csv"
     assert messages and json.loads(messages[0])["file"] == "sample.csv"
 

--- a/tests/integration/test_websocket_event_flow.py
+++ b/tests/integration/test_websocket_event_flow.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 import websockets
 from src.common.config import ConfigService
+from shared.events.names import EventName
 
 
 def _load_server():
@@ -92,6 +93,6 @@ async def test_websocket_event_flow(websocket_server):
     async with websockets.connect("ws://127.0.0.1:8770") as ws:
         await asyncio.sleep(0.05)
         payload = {"value": 42}
-        websocket_server.emit("analytics_update", payload)
+        websocket_server.emit(EventName.ANALYTICS_UPDATE, payload)
         message = await asyncio.wait_for(ws.recv(), timeout=5)
         assert json.loads(message) == payload

--- a/tests/integration/test_websocket_events.py
+++ b/tests/integration/test_websocket_events.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 import websockets
 from src.common.config import ConfigService
+from shared.events.names import EventName
 
 
 def _load_server():
@@ -85,7 +86,7 @@ def test_websocket_events_broadcast():
 
             task = asyncio.create_task(client())
             await asyncio.sleep(0.1)
-            event_bus.emit("analytics_update", {"value": 42})
+            event_bus.emit(EventName.ANALYTICS_UPDATE, {"value": 42})
             return await asyncio.wait_for(task, timeout=5)
 
         data = asyncio.run(runner())

--- a/tests/integration/test_websocket_updates.py
+++ b/tests/integration/test_websocket_updates.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 from src.common.config import ConfigService
+from shared.events.names import EventName
 
 
 def _load_provider():
@@ -73,4 +74,4 @@ def test_websocket_data_provider_integration():
     provider = Provider(bus, config=cfg)
     time.sleep(0.05)
     provider.stop()
-    assert any(e[0] == "analytics_update" for e in bus.events)
+    assert any(e[0] == EventName.ANALYTICS_UPDATE for e in bus.events)

--- a/tests/unit/test_websocket_server.py
+++ b/tests/unit/test_websocket_server.py
@@ -9,6 +9,7 @@ import types
 from pathlib import Path
 
 from src.common.config import ConfigService
+from shared.events.names import EventName
 
 
 
@@ -108,12 +109,12 @@ def test_buffered_events_flushed_on_client_connect() -> None:
     time.sleep(0.1)
 
     for i in range(3):
-        event_bus.emit("analytics_update", {"idx": i})
+        event_bus.emit(EventName.ANALYTICS_UPDATE, {"idx": i})
 
     messages = _run_client(8766, 3)
     assert [m["idx"] for m in messages] == [0, 1, 2]
 
-    history = event_bus.get_event_history("analytics_update")
+    history = event_bus.get_event_history(EventName.ANALYTICS_UPDATE)
     assert len(history) == 6  # original 3 + republished 3
 
     server.stop()
@@ -129,12 +130,12 @@ def test_queue_bound() -> None:
     time.sleep(0.1)
 
     for i in range(3):
-        event_bus.emit("analytics_update", {"idx": i})
+        event_bus.emit(EventName.ANALYTICS_UPDATE, {"idx": i})
 
     messages = _run_client(8767, 2)
     assert [m["idx"] for m in messages] == [1, 2]
 
-    history = event_bus.get_event_history("analytics_update")
+    history = event_bus.get_event_history(EventName.ANALYTICS_UPDATE)
     assert len(history) == 5  # initial 3 + republished 2
 
     server.stop()
@@ -154,7 +155,7 @@ def test_compressed_broadcast() -> None:
     time.sleep(0.1)
 
     payload = {"data": "x" * 100}
-    event_bus.emit("analytics_update", payload)
+    event_bus.emit(EventName.ANALYTICS_UPDATE, payload)
 
     messages = _run_client(8768, 1)
     assert messages[0] == payload

--- a/tests/websocket/test_metrics.py
+++ b/tests/websocket/test_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.websocket import metrics
+from shared.events.names import EventName
 
 
 class DummyBus:
@@ -24,7 +25,7 @@ def test_websocket_metrics_publish_updates():
     metrics.record_reconnect_attempt()
     metrics.record_ping_failure()
 
-    assert bus.events[0][0] == "metrics_update"
+    assert bus.events[0][0] == EventName.METRICS_UPDATE
     assert bus.events[0][1]["websocket_connections_total"] == 1
     assert bus.events[0][1]["websocket_reconnect_attempts_total"] == 0
     assert bus.events[1][1]["websocket_reconnect_attempts_total"] == 1

--- a/tests/websocket/test_metrics_provider.py
+++ b/tests/websocket/test_metrics_provider.py
@@ -1,6 +1,7 @@
 from src.repository import InMemoryMetricsRepository
 from src.websocket.metrics_provider import MetricsProvider
 from src.common.config import ConfigService
+from shared.events.names import EventName
 
 
 class DummyBus:
@@ -18,4 +19,4 @@ def test_metrics_provider_publishes_snapshot() -> None:
     import time
     time.sleep(0.02)
     provider.stop()
-    assert ("metrics_update", repo.snapshot()) in bus.events
+    assert (EventName.METRICS_UPDATE, repo.snapshot()) in bus.events

--- a/yosai_intel_dashboard/src/services/analytics/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_service.py
@@ -28,6 +28,7 @@ from typing import (
 )
 
 import requests
+from shared.events.names import EventName
 
 from yosai_intel_dashboard.src.core.error_handling import (
     ErrorCategory,
@@ -405,7 +406,7 @@ class AnalyticsService(AnalyticsServiceProtocol, AnalyticsProviderProtocol):
             return {"status": "error", "message": str(e)}
 
     def _publish_event(
-        self, payload: Dict[str, Any], event: str = "analytics_update"
+        self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE
     ) -> None:
         """Publish ``payload`` to the event bus if available."""
         self.publisher.publish(payload, event)

--- a/yosai_intel_dashboard/src/services/analytics/core/interfaces.py
+++ b/yosai_intel_dashboard/src/services/analytics/core/interfaces.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Protocol
 
+from shared.events.names import EventName
+
 import pandas as pd
 
 
@@ -95,7 +97,7 @@ class EventPublisherProtocol(Protocol):
     """Publish analytics events."""
 
     def publish(
-        self, payload: Dict[str, Any], event: str = "analytics_update"
+        self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE
     ) -> None: ...
 
 

--- a/yosai_intel_dashboard/src/services/analytics/events/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/events/publisher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from shared.events.bus import EventBus
+from shared.events.names import EventName
 from yosai_intel_dashboard.src.services.event_publisher import publish_event
 
 
@@ -12,7 +13,9 @@ class Publisher:
     def __init__(self, event_bus: EventBus | None) -> None:
         self.event_bus = event_bus
 
-    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+    def publish(
+        self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE
+    ) -> None:
         publish_event(self.event_bus, payload, event)
 
 

--- a/yosai_intel_dashboard/src/services/analytics/protocols.py
+++ b/yosai_intel_dashboard/src/services/analytics/protocols.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 import pandas as pd
+from shared.events.names import EventName
 
 
 @runtime_checkable
@@ -196,6 +197,8 @@ class PublishingProtocol(Protocol):
     """Publish analytics events."""
 
     @abstractmethod
-    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+    def publish(
+        self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE
+    ) -> None:
         """Publish ``payload`` to the event bus."""
         ...

--- a/yosai_intel_dashboard/src/services/analytics/publisher.py
+++ b/yosai_intel_dashboard/src/services/analytics/publisher.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from yosai_intel_dashboard.src.services.event_publisher import publish_event
 from yosai_intel_dashboard.src.services.analytics.core.interfaces import EventBusProtocol
+from shared.events.names import EventName
 
 
 class Publisher:
@@ -12,7 +13,9 @@ class Publisher:
     def __init__(self, event_bus: Any | None = None) -> None:
         self.event_bus = event_bus
 
-    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+    def publish(
+        self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE
+    ) -> None:
         publish_event(self.event_bus, payload, event)
 
 

--- a/yosai_intel_dashboard/src/services/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/event_publisher.py
@@ -1,13 +1,15 @@
 import logging
 from typing import Any, Dict
 
+from shared.events.names import EventName
+
 logger = logging.getLogger(__name__)
 
 
 def publish_event(
     event_bus: Any | None,
     payload: Dict[str, Any],
-    event: str = "analytics_update",
+    event: str = EventName.ANALYTICS_UPDATE,
 ) -> None:
     """Publish ``payload`` via the centralized :mod:`yosai_intel_dashboard.src.core.callbacks.event_bus`."""
 

--- a/yosai_intel_dashboard/src/services/publishing_service.py
+++ b/yosai_intel_dashboard/src/services/publishing_service.py
@@ -6,6 +6,7 @@ from src.common import BaseComponent, EventDispatchMixin, handle_deprecated
 from yosai_intel_dashboard.src.core.interfaces.protocols import EventBusProtocol
 from yosai_intel_dashboard.src.services.analytics.protocols import PublishingProtocol
 from yosai_intel_dashboard.src.services.analytics.publisher import Publisher
+from shared.events.names import EventName
 
 
 class PublishingService(EventDispatchMixin, BaseComponent, PublishingProtocol):
@@ -16,7 +17,7 @@ class PublishingService(EventDispatchMixin, BaseComponent, PublishingProtocol):
         super().__init__(event_bus=event_bus)
         self._publisher = Publisher(event_bus)
 
-    def publish(self, payload: Dict[str, Any], event: str = "analytics_update") -> None:
+    def publish(self, payload: Dict[str, Any], event: str = EventName.ANALYTICS_UPDATE) -> None:
         self._publisher.publish(payload, event)
 
 

--- a/yosai_intel_dashboard/src/services/utils/event_publisher.py
+++ b/yosai_intel_dashboard/src/services/utils/event_publisher.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict
 
 from shared.events.bus import EventBus
+from shared.events.names import EventName
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 def publish_event(
     event_bus: EventBus | None,
     payload: Dict[str, Any],
-    event: str = "analytics_update",
+    event: str = EventName.ANALYTICS_UPDATE,
 ) -> None:
     """Safely publish ``payload`` to ``event_bus`` if available."""
     if event_bus:

--- a/yosai_intel_dashboard/src/services/websocket_data_provider.py
+++ b/yosai_intel_dashboard/src/services/websocket_data_provider.py
@@ -23,6 +23,7 @@ from yosai_intel_dashboard.src.infrastructure.callbacks.dispatcher import (
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import (
     CallbackEvent as CallbackType,
 )
+from shared.events.names import EventName
 
 
 class WebSocketDataProvider(LoggingMixin, SerializationMixin, BaseComponent):
@@ -49,7 +50,7 @@ class WebSocketDataProvider(LoggingMixin, SerializationMixin, BaseComponent):
             payload: Dict[str, Any] = generate_sample_analytics()
             trigger_callback(CallbackType.ANALYTICS_UPDATE, payload)
 
-            self.log("analytics_update dispatched", logging.DEBUG)
+            self.log(f"{EventName.ANALYTICS_UPDATE} dispatched", logging.DEBUG)
             self._stop.wait(self.interval)
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- add `EventName` enum listing metrics and analytics events
- replace string event literals in metrics utilities and analytics publishers with `EventName`
- add test verifying callbacks publish with standardized event names

## Testing
- `pre-commit run --files src/websocket/metrics.py src/websocket/metrics_provider.py tests/integration/test_sample_plugin_upload.py tests/integration/test_websocket_event_flow.py tests/integration/test_websocket_events.py tests/integration/test_websocket_updates.py tests/unit/test_websocket_server.py tests/websocket/test_metrics.py tests/websocket/test_metrics_provider.py yosai_intel_dashboard/src/services/analytics/analytics_service.py yosai_intel_dashboard/src/services/analytics/core/interfaces.py yosai_intel_dashboard/src/services/analytics/events/publisher.py yosai_intel_dashboard/src/services/analytics/protocols.py yosai_intel_dashboard/src/services/analytics/publisher.py yosai_intel_dashboard/src/services/event_publisher.py yosai_intel_dashboard/src/services/publishing_service.py yosai_intel_dashboard/src/services/utils/event_publisher.py yosai_intel_dashboard/src/services/websocket_data_provider.py shared/events/names.py tests/common/test_event_name_constants.py` (fails: no files to check)
- `pytest tests/websocket/test_metrics.py tests/websocket/test_metrics_provider.py tests/common/test_event_name_constants.py tests/unit/test_websocket_server.py tests/integration/test_websocket_events.py tests/integration/test_sample_plugin_upload.py tests/integration/test_websocket_updates.py tests/integration/test_websocket_event_flow.py -q` (fails: ImportError: cannot import name 'registry')

------
https://chatgpt.com/codex/tasks/task_e_689bb806f21083209b0e4e5d6f585b19