### PR TITLE
chore(ci): add image scan step

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -66,3 +66,40 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.repository }}
+
+  scan:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      matrix:
+        image: [backend, gateway, jobs]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Scan image
+        id: trivy
+        uses: aquasecurity/trivy-action@0.14.0
+        continue-on-error: true
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.sha }}
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          severity: CRITICAL
+          exit-code: 1
+      - name: Upload scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+      - name: Fail on critical vulnerabilities
+        if: steps.trivy.outcome == 'failure'
+        run: exit 1

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -10,6 +10,10 @@ This guide describes how to install ArgoCD, apply Helm charts, and verify deploy
 - [Helm](https://helm.sh/) installed locally
 - Access to the Git repository containing the Helm charts
 
+## Image Vulnerability Scan
+
+The CI pipeline scans every published container image with `trivy image` and uploads a SARIF report. Deployments should proceed only after the scan job succeeds without critical findings in the workflow.
+
 ## Install ArgoCD
 
 1. Create the ArgoCD namespace:


### PR DESCRIPTION
## Summary
- add Trivy image scan job that uploads SARIF results and fails on critical issues
- document image vulnerability scan in deployment guide

## Testing
- `pre-commit run --files .github/workflows/docker-build-push.yml docs/deployment_guide.md`

------
https://chatgpt.com/codex/tasks/task_e_689bb803ddd08320892b09ed6227c8a2