### PR TITLE
Refactor analytics service for async connection pool and caching tests

### DIFF
--- a/src/services/database/analytics_service.py
+++ b/src/services/database/analytics_service.py
@@ -1,10 +1,9 @@
 """Database-backed analytics service with in-memory caching.
 
-This module provides a small façade around a :class:`DatabaseManager`.  The
-service validates connectivity before executing any analytics queries and keeps
-results in a simple in-memory cache with an expiration TTL.  Individual queries
-are executed via private asynchronous helpers which each handle their own
-exceptions, returning fallback values instead of bubbling up errors.
+The service validates connectivity before executing any analytics queries and
+keeps results in a simple in-memory cache with an expiration TTL.  Individual
+queries are executed via private asynchronous helpers which each handle their
+own exceptions, returning fallback values instead of bubbling up errors.
 """
 
 from __future__ import annotations
@@ -12,20 +11,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Mapping
-from typing import Any, Dict, List, Protocol
-
-
-class DatabaseManagerProtocol(Protocol):
-    """Protocol describing the minimal database manager interface used."""
-
-    def health_check(self) -> bool:
-        """Return ``True`` when the database connection is healthy."""  # pragma: no cover - simple protocol
-
-    def get_connection(self) -> Any:
-        """Retrieve a database connection object."""  # pragma: no cover - simple protocol
-
-    def release_connection(self, connection: Any) -> None:
-        """Release a previously acquired connection."""  # pragma: no cover - simple protocol
+from typing import Any, Dict, List
 
 from yosai_intel_dashboard.src.infrastructure.config.connection_pool import (
     DatabaseConnectionPool,
@@ -47,11 +33,18 @@ class AnalyticsService:
         ``DEFAULT_POOL_ACQUIRE_TIMEOUT``.
     """
 
-    def __init__(self, db_manager: DatabaseManagerProtocol, ttl: int = 60) -> None:
-        self._db_manager: DatabaseManagerProtocol = db_manager
+    def __init__(
+        self,
+        pool: DatabaseConnectionPool,
+        ttl: int = 60,
+        acquire_timeout: float | None = None,
+    ) -> None:
+        self._pool = pool
         self._ttl = ttl
         self._timeout = (
-            acquire_timeout if acquire_timeout is not None else DEFAULT_POOL_ACQUIRE_TIMEOUT
+            acquire_timeout
+            if acquire_timeout is not None
+            else DEFAULT_POOL_ACQUIRE_TIMEOUT
         )
         self._cache: Dict[str, Any] | None = None
         self._expiry: float = 0.0
@@ -119,37 +112,29 @@ class AnalyticsService:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    async def aget_analytics(self) -> Dict[str, Any]:
-        """Asynchronously return analytics data, using the cache when possible."""
+    async def get_analytics(self) -> Dict[str, Any]:
+        """Return analytics data, using the cache when possible."""
 
         cached = self._get_cached()
         if cached is not None:
             return cached
 
+        if not self._pool.health_check():
+            return {
+                "status": "error",
+                "message": "database health check failed",
+                "error_code": "health_check_failed",
+            }
+
         try:
-            if not self._pool.health_check():
-                return {
-                    "status": "error",
-                    "message": "database health check failed",
-                    "error_code": "health_check_failed",
-                }
-            with self._pool.acquire(timeout=self._timeout) as connection:
-                data = asyncio.run(self._gather_analytics(connection))
-            result = {"status": "success", "data": data}
-            self._set_cache(result)
-            return result
+            async with self._pool.acquire_async(timeout=self._timeout) as connection:
+                data = await self._gather_analytics(connection)
         except TimeoutError as exc:
             return {
                 "status": "error",
                 "message": str(exc),
                 "error_code": "pool_timeout",
             }
-
-        try:
-            data = await self._gather_analytics(connection)
-            result = {"status": "success", "data": data}
-            self._set_cache(result)
-            return result
         except Exception as exc:  # pragma: no cover - best effort
             return {
                 "status": "error",
@@ -157,10 +142,9 @@ class AnalyticsService:
                 "error_code": "query_failed",
             }
 
-    def get_analytics(self) -> Dict[str, Any]:
-        """Synchronous wrapper for :meth:`aget_analytics`."""
-
-        return asyncio.run(self.aget_analytics())
+        result = {"status": "success", "data": data}
+        self._set_cache(result)
+        return result
 
 
 __all__ = ["AnalyticsService"]

--- a/tests/integration/test_analytics_pool_exhaustion.py
+++ b/tests/integration/test_analytics_pool_exhaustion.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from yosai_intel_dashboard.src.infrastructure.config.connection_pool import (
     DatabaseConnectionPool,
 )
@@ -24,7 +26,7 @@ def test_pool_exhaustion_returns_error():
     service = AnalyticsService(pool, acquire_timeout=0.1)
 
     with pool.acquire():
-        result = service.get_analytics()
+        result = asyncio.run(service.get_analytics())
 
     assert result["status"] == "error"
     assert result["error_code"] == "pool_timeout"

--- a/tests/test_db_async_service.py
+++ b/tests/test_db_async_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 
 from src.services.database.analytics_service import AnalyticsService
 
@@ -7,24 +8,20 @@ class Conn:
     def execute_query(self, query):
         if "COUNT" in query:
             return [{"count": 1}]
-        return [
-            {"event_type": "login", "status": "success", "timestamp": "2024-01-01"}
-        ]
+        return [{"event_type": "login", "status": "success", "timestamp": "2024-01-01"}]
 
 
-class Manager:
+class Pool:
     def health_check(self):
         return True
 
-    def get_connection(self):
-        return Conn()
-
-    def release_connection(self, conn):
-        pass
+    @asynccontextmanager
+    async def acquire_async(self, *, timeout=None):
+        yield Conn()
 
 
 def test_get_analytics_async():
-    service = AnalyticsService(Manager())
+    service = AnalyticsService(Pool())
     result = asyncio.run(service.get_analytics())
     assert result["status"] == "success"
     assert result["data"]["user_count"] == 1


### PR DESCRIPTION
## Summary
- accept DatabaseConnectionPool directly in AnalyticsService
- remove asyncio.run usage and streamline query error handling
- add unit tests for cache hit and miss scenarios

## Testing
- `pre-commit run --files src/services/database/analytics_service.py tests/services/database/test_analytics_service_cache.py tests/test_db_async_service.py tests/integration/test_analytics_pool_exhaustion.py`
- `pytest tests/services/database/test_analytics_service_cache.py tests/test_db_async_service.py tests/integration/test_analytics_pool_exhaustion.py` *(fails: ImportError: cannot import name 'registry')*


------
https://chatgpt.com/codex/tasks/task_e_689bb7ef66dc8320b71ea75912202a7e