### PR TITLE
feat: guard upload with error boundary

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/App.errorBoundary.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.errorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+  useLocation: () => ({ pathname: '/' }),
+  useNavigate: () => vi.fn(),
+}), { virtual: true });
+
+vi.mock('lucide-react', () => ({
+  Shield: () => <div />, Menu: () => <div />, Sun: () => <div />, Moon: () => <div />,
+  Upload: () => <div />, BarChart3: () => <div />, TrendingUp: () => <div />,
+  Download: () => <div />, Settings: () => <div />, Database: () => <div />,
+  Activity: () => <div />, LayoutDashboard: () => <div />,
+}), { virtual: true });
+
+vi.mock('./state/store', () => ({
+  useProficiencyStore: () => ({ level: 0, logFeatureUsage: vi.fn() }),
+}), { virtual: true });
+
+vi.mock('./components/upload', () => ({
+  Upload: () => {
+    throw new Error('load failure');
+  },
+}));
+
+import App from './App';
+
+describe('App error boundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue({ ok: true }) as any;
+  });
+
+  afterEach(() => {
+    (console.error as any).mockRestore();
+    (global.fetch as any).mockClear();
+  });
+
+  it('displays fallback when upload fails', async () => {
+    render(<App />);
+    expect(await screen.findByText('Something went wrong.')).toBeInTheDocument();
+    expect(screen.getByText('Report Issue')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/api/error-report', expect.any(Object));
+  });
+});

--- a/yosai_intel_dashboard/src/adapters/ui/App.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.tsx
@@ -4,6 +4,7 @@ import Navigation from './components/Navigation';
 import { Shield, Menu, Sun, Moon } from 'lucide-react';
 import useDarkMode from './hooks/useDarkMode';
 import CenteredSpinner from './components/shared/CenteredSpinner';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const Upload = React.lazy(() =>
   import('./components/upload').then((m) => ({ default: m.Upload })),
@@ -50,9 +51,11 @@ function App() {
         )}
       </header>
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Suspense fallback={<CenteredSpinner className="py-10" />}>
-          <Upload />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={<CenteredSpinner className="py-10" />}>
+            <Upload />
+          </Suspense>
+        </ErrorBoundary>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap Upload's lazy loading in ErrorBoundary for graceful failure handling
- test that ErrorBoundary shows fallback when Upload throws

## Testing
- `npx vitest run --config vitest.temp.config.ts yosai_intel_dashboard/src/adapters/ui/App.errorBoundary.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689bb800f65c83209c49f5cb15963d3b