### PR TITLE
Use parameterized intervals for analytics queries

### DIFF
--- a/docs/database/parameterized_intervals.md
+++ b/docs/database/parameterized_intervals.md
@@ -1,0 +1,17 @@
+# Parameterized time intervals
+
+To avoid SQL injection, construct dynamic time ranges using PostgreSQL's
+`make_interval` with parameter placeholders rather than string concatenation.
+
+```python
+rows = await pool.fetch(
+    """
+    SELECT ...
+    WHERE time > NOW() - make_interval(days => $1)
+    """,
+    days,
+)
+```
+
+This pattern ensures the `days` value is treated as an integer parameter
+rather than raw SQL.

--- a/tests/services/analytics/test_queries_security.py
+++ b/tests/services/analytics/test_queries_security.py
@@ -1,0 +1,46 @@
+import asyncio
+from yosai_intel_dashboard.src.services.analytics_microservice import queries
+
+
+class FakePool:
+    def __init__(self):
+        self.query = None
+        self.args = None
+
+    async def fetch(self, query, *args):
+        self.query = query
+        self.args = args
+        return []
+
+
+def test_hourly_event_counts_uses_make_interval():
+    pool = FakePool()
+    asyncio.run(queries.hourly_event_counts(pool, 3))
+    assert "make_interval" in pool.query
+    assert "$1" in pool.query
+    assert pool.args == (3,)
+
+
+def test_hourly_event_counts_rejects_injection():
+    pool = FakePool()
+    malicious = "1; DROP TABLE access_events;--"
+    asyncio.run(queries.hourly_event_counts(pool, malicious))  # type: ignore[arg-type]
+    assert malicious not in pool.query
+    assert pool.args == (malicious,)
+
+
+def test_top_doors_uses_make_interval_and_limit():
+    pool = FakePool()
+    asyncio.run(queries.top_doors(pool, 7, limit=10))
+    assert "make_interval" in pool.query
+    assert "$1" in pool.query and "$2" in pool.query
+    assert pool.args == (7, 10)
+
+
+def test_top_doors_rejects_injection():
+    pool = FakePool()
+    malicious = "1; DROP TABLE access_events;--"
+    asyncio.run(queries.top_doors(pool, malicious, limit=5))  # type: ignore[arg-type]
+    assert malicious not in pool.query
+    assert pool.args == (malicious, 5)
+

--- a/yosai_intel_dashboard/src/core/registry.py
+++ b/yosai_intel_dashboard/src/core/registry.py
@@ -31,4 +31,8 @@ class ServiceRegistry:
         cls._services.pop(name, None)
 
 
-__all__ = ["ServiceRegistry"]
+# Shared registry instance used across the application.
+registry = ServiceRegistry()
+
+
+__all__ = ["ServiceRegistry", "registry"]

--- a/yosai_intel_dashboard/src/services/analytics_microservice/queries.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/queries.py
@@ -15,11 +15,11 @@ async def hourly_event_counts(pool: asyncpg.Pool, days: int) -> List[Dict[str, A
                facility_id,
                COUNT(*) AS event_count
         FROM access_events
-        WHERE time > NOW() - $1::interval
+        WHERE time > NOW() - make_interval(days => $1)
         GROUP BY bucket, facility_id
         ORDER BY bucket
         """,
-        f"{days} days",
+        days,
     )
     return [dict(r) for r in rows]
 
@@ -32,12 +32,12 @@ async def top_doors(
         """
         SELECT door_id, COUNT(*) AS event_count
         FROM access_events
-        WHERE time > NOW() - $1::interval
+        WHERE time > NOW() - make_interval(days => $1)
         GROUP BY door_id
         ORDER BY event_count DESC
         LIMIT $2
         """,
-        f"{days} days",
+        days,
         limit,
     )
     return [dict(r) for r in rows]


### PR DESCRIPTION
## Summary
- build time windows with `make_interval(days => $1)` to avoid interpolated intervals
- document parameterized interval pattern for safe SQL
- add tests ensuring analytics queries resist injection

## Testing
- `pytest tests/services/analytics/test_queries_security.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689bb7f9facc8320b7409edecb9d2cf1