### PR TITLE
feat: add API healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,13 @@ RUN python -m venv /opt/venv \
     && pip install --no-cache-dir -r requirements.filtered
 
 FROM python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee
+
+# Install runtime packages
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
@@ -45,3 +52,4 @@ USER appuser
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["start_api.py"]
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl --fail http://localhost:5001/health || exit 1

--- a/api/start_api.py
+++ b/api/start_api.py
@@ -58,6 +58,12 @@ def main() -> None:
     app = create_api_app()
     app.state.container = container
 
+    # Ensure a basic health endpoint is available
+    if not any(getattr(route, "path", None) == "/health" for route in app.router.routes):
+        @app.get("/health")
+        async def _health() -> dict[str, str]:
+            return {"status": "ok"}
+
     logger.info("\n🚀 Starting Yosai Intel Dashboard API...")
     logger.info(f"   Available at: http://localhost:{API_PORT}")
     logger.info(f"   Health check: http://localhost:{API_PORT}/health")

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -62,4 +62,8 @@ The CI pipeline scans every published container image with `trivy image` and upl
    argocd app get yosai-dashboard
    ```
 3. Verify services respond as expected by inspecting logs or accessing exposed endpoints.
+4. Confirm the API health endpoint responds:
+   ```bash
+   curl -f http://<service-host>:5001/health
+   ```
 

--- a/start_api.py
+++ b/start_api.py
@@ -66,6 +66,12 @@ def main() -> None:
     app = create_api_app()
     app.state.container = container
 
+    # Ensure a basic health endpoint is available
+    if not any(getattr(route, "path", None) == "/health" for route in app.router.routes):
+        @app.get("/health")
+        async def _health() -> dict[str, str]:
+            return {"status": "ok"}
+
     logger.info("\n🚀 Starting Yosai Intel Dashboard API...")
     logger.info(f"   Available at: http://localhost:{API_PORT}")
     logger.info(f"   Health check: http://localhost:{API_PORT}/health")


### PR DESCRIPTION
## Summary
- install curl and add Docker `HEALTHCHECK` probing `/health`
- ensure start scripts register a default `/health` route
- document health endpoint verification in deployment guide

## Testing
- `pytest tests/test_health_endpoint.py -q` *(fails: metaclass conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9ce0760832095d6f6aa6a591575