### PR TITLE
Remove unused pandas import and add timezone

### DIFF
--- a/yosai_intel_dashboard/src/core/domain/entities/base.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/base.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 """Base classes for data models used throughout the application."""
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Protocol, runtime_checkable
 
-import pandas as pd
 from yosai_intel_dashboard.src.infrastructure.config import constants
 
 from ..value_objects.enums import AccessResult


### PR DESCRIPTION
## Summary
- import timezone for UTC-aware defaults
- drop unused pandas import

## Testing
- `pre-commit run --files ./yosai_intel_dashboard/src/core/domain/entities/base.py`
- `pytest tests/test_analytics_integration.py::test_model_factory -q` *(fails: metaclass conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9d4f2488320bbf61f008cb06a1f