### PR TITLE
Add Docker healthcheck and ensure API exposes /health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,4 @@ USER appuser
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["start_api.py"]
+HEALTHCHECK --interval=30s --timeout=10s CMD curl --fail http://localhost:8000/health || exit 1

--- a/api/start_api.py
+++ b/api/start_api.py
@@ -58,6 +58,12 @@ def main() -> None:
     app = create_api_app()
     app.state.container = container
 
+    # Ensure a /health endpoint is available for container checks
+    if not any(getattr(r, "path", "") == "/health" for r in app.routes):
+        @app.get("/health")
+        async def _health() -> dict[str, str]:
+            return {"status": "ok"}
+
     logger.info("\n🚀 Starting Yosai Intel Dashboard API...")
     logger.info(f"   Available at: http://localhost:{API_PORT}")
     logger.info(f"   Health check: http://localhost:{API_PORT}/health")

--- a/start_api.py
+++ b/start_api.py
@@ -66,6 +66,12 @@ def main() -> None:
     app = create_api_app()
     app.state.container = container
 
+    # Ensure a /health endpoint is available for container checks
+    if not any(getattr(r, "path", "") == "/health" for r in app.routes):
+        @app.get("/health")
+        async def _health() -> dict[str, str]:
+            return {"status": "ok"}
+
     logger.info("\n🚀 Starting Yosai Intel Dashboard API...")
     logger.info(f"   Available at: http://localhost:{API_PORT}")
     logger.info(f"   Health check: http://localhost:{API_PORT}/health")


### PR DESCRIPTION
## Summary
- append health check command to Dockerfile for container monitoring
- guarantee `/health` endpoint exists in API startup scripts

## Testing
- `pytest tests/test_health_endpoint.py -q` *(fails: metaclass conflict import error)*
- `python - <<'PY'
from yosai_intel_dashboard.src.adapters.api.adapter import create_api_app
app = create_api_app()
print('/health' in [getattr(r, 'path', '') for r in app.routes])
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689bc9e368dc83209a12203b7e55e166