### PR TITLE
chore: update flink for py311

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ RapidFuzz==3.13.0
 pymemcache==4.0.0
 
 # Kafka integration
-apache-flink==1.18.0
+apache-flink>=1.20.0
 confluent-kafka==2.11.0
 fastavro==1.11.1
 


### PR DESCRIPTION
## Summary
- bump apache-flink to >=1.20.0 for Python 3.11 compatibility

## Testing
- `pip install -r requirements.txt` *(fails: Cannot install -r requirements.txt (line 72) and pandas==2.0.3 because these package versions have conflicting dependencies)*
- `pip install 'apache-flink>=1.20.0'`
- `pre-commit run --files requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689bd5b66f388320ab8612e9f2caa44a