### PR TITLE
Use ServiceRegistry for metrics repository lookup

### DIFF
--- a/src/websocket/metrics_provider.py
+++ b/src/websocket/metrics_provider.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import threading
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict
 
 
 from src.common.base import BaseComponent
 from shared.events.bus import EventBus, EventPublisher
 from src.common.mixins import LoggingMixin, SerializationMixin
-from src.repository import InMemoryMetricsRepository
 from shared.events.names import EventName
+from yosai_intel_dashboard.src.core.registry import ServiceRegistry
+from yosai_intel_dashboard.src.core.protocols.metrics import MetricsRepositoryProtocol
 
 def generate_sample_metrics() -> Dict[str, Any]:
     """Return static metric payload for demonstration."""
@@ -27,7 +28,7 @@ class MetricsProvider(EventPublisher, LoggingMixin, SerializationMixin, BaseComp
     def __init__(
         self,
         event_bus: EventBus,
-        repo: "MetricsRepositoryProtocol" | None = None,
+        repo: MetricsRepositoryProtocol | None = None,
         interval: float = 1.0,
     ) -> None:
         repo = repo or ServiceRegistry.get("metrics_repository")

--- a/tests/websocket/test_metrics_provider.py
+++ b/tests/websocket/test_metrics_provider.py
@@ -1,7 +1,17 @@
-from src.repository import InMemoryMetricsRepository
+from __future__ import annotations
+
 from src.websocket.metrics_provider import MetricsProvider
-from src.common.config import ConfigService
 from shared.events.names import EventName
+from yosai_intel_dashboard.src.core.registry import ServiceRegistry
+
+
+class DummyRepo:
+    def __init__(self, data):
+        self._data = data
+
+    def snapshot(self):
+        return self._data
+
 
 class DummyBus:
     def __init__(self) -> None:
@@ -11,12 +21,25 @@ class DummyBus:
         self.events.append((event_type, data))
 
 
-def test_metrics_provider_publishes_snapshot() -> None:
-    repo = InMemoryMetricsRepository(performance={"throughput": 1})
-    ServiceRegistry.register("metrics_repository", repo)
+def test_metrics_provider_injected_repo() -> None:
+    repo = DummyRepo({"throughput": 1})
     bus = DummyBus()
-    provider = MetricsProvider(bus, interval=0.01)
+    provider = MetricsProvider(bus, repo=repo, interval=0.01)
     import time
     time.sleep(0.02)
     provider.stop()
     assert (EventName.METRICS_UPDATE, repo.snapshot()) in bus.events
+
+
+def test_metrics_provider_registry_lookup() -> None:
+    repo = DummyRepo({"throughput": 2})
+    ServiceRegistry.register("metrics_repository", repo)
+    try:
+        bus = DummyBus()
+        provider = MetricsProvider(bus, interval=0.01)
+        import time
+        time.sleep(0.02)
+        provider.stop()
+        assert (EventName.METRICS_UPDATE, repo.snapshot()) in bus.events
+    finally:
+        ServiceRegistry.remove("metrics_repository")


### PR DESCRIPTION
## Summary
- refactor websocket metrics provider to retrieve metrics repository via ServiceRegistry
- verify repository injection and registry lookup in websocket metrics provider tests

## Testing
- `pytest tests/websocket/test_metrics_provider.py -q` *(fails: TypeError: metaclass conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd79b1708320bff6af42b1d4df83