### PR TITLE
Remove direct dependency on InMemoryMetricsRepository

### DIFF
--- a/src/repository/__init__.py
+++ b/src/repository/__init__.py
@@ -1,5 +1,5 @@
 """Repository interfaces and implementations."""
 
-from .metrics import InMemoryMetricsRepository, CachedMetricsRepository
+from .metrics import CachedMetricsRepository
 
-__all__ = ["InMemoryMetricsRepository", "CachedMetricsRepository"]
+__all__ = ["CachedMetricsRepository"]

--- a/src/repository/metrics.py
+++ b/src/repository/metrics.py
@@ -119,4 +119,4 @@ class CachedMetricsRepository(BaseComponent):
         )
 
 
-__all__ = ["InMemoryMetricsRepository", "CachedMetricsRepository"]
+__all__ = ["CachedMetricsRepository"]

--- a/tests/api/test_metrics_endpoints.py
+++ b/tests/api/test_metrics_endpoints.py
@@ -1,10 +1,32 @@
 from flask import Flask
+from typing import Any, Dict
 
 from src.api.metrics import metrics_bp, set_metrics_repository
-from src.repository import InMemoryMetricsRepository
+from yosai_intel_dashboard.src.core.protocols.metrics import MetricsRepositoryProtocol
 
 
-def create_app(repo: InMemoryMetricsRepository) -> Flask:
+class StubMetricsRepository(MetricsRepositoryProtocol):
+    def __init__(
+        self,
+        performance: Dict[str, Any] | None = None,
+        drift: Dict[str, Any] | None = None,
+        feature_importances: Dict[str, Any] | None = None,
+    ) -> None:
+        self._performance = performance or {}
+        self._drift = drift or {}
+        self._feature_importances = feature_importances or {}
+
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        return self._performance
+
+    def get_drift_data(self) -> Dict[str, Any]:
+        return self._drift
+
+    def get_feature_importances(self) -> Dict[str, Any]:
+        return self._feature_importances
+
+
+def create_app(repo: MetricsRepositoryProtocol) -> Flask:
     app = Flask(__name__)
     set_metrics_repository(repo)
     app.register_blueprint(metrics_bp)
@@ -12,7 +34,7 @@ def create_app(repo: InMemoryMetricsRepository) -> Flask:
 
 
 def test_performance_endpoint() -> None:
-    repo = InMemoryMetricsRepository(performance={"t": 1})
+    repo = StubMetricsRepository(performance={"t": 1})
     app = create_app(repo)
     client = app.test_client()
     resp = client.get("/v1/metrics/performance")
@@ -21,7 +43,7 @@ def test_performance_endpoint() -> None:
 
 
 def test_drift_endpoint() -> None:
-    repo = InMemoryMetricsRepository(drift={"prediction_drift": 0.3})
+    repo = StubMetricsRepository(drift={"prediction_drift": 0.3})
     app = create_app(repo)
     client = app.test_client()
     resp = client.get("/v1/metrics/drift")
@@ -30,7 +52,7 @@ def test_drift_endpoint() -> None:
 
 
 def test_feature_importance_endpoint() -> None:
-    repo = InMemoryMetricsRepository(feature_importances={"a": 0.1})
+    repo = StubMetricsRepository(feature_importances={"a": 0.1})
     app = create_app(repo)
     client = app.test_client()
     resp = client.get("/v1/metrics/feature-importance")


### PR DESCRIPTION
## Summary
- remove InMemoryMetricsRepository from repository package exports
- update metrics endpoint tests to use a stub that implements MetricsRepositoryProtocol

## Testing
- `pre-commit run --files src/repository/__init__.py src/repository/metrics.py tests/api/test_metrics_endpoints.py`
- `pytest tests/api/test_metrics_endpoints.py` *(fails: TypeError: metaclass conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689bfffac6e483209dcf9f327bc99891