### PR TITLE
test: verify websocket metrics provider DI and registry

### DIFF
--- a/tests/websocket/test_metrics_provider.py
+++ b/tests/websocket/test_metrics_provider.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from src.websocket.metrics_provider import MetricsProvider
+from src.websocket.metrics_provider import MetricsProvider, generate_sample_metrics
 from shared.events.names import EventName
 from yosai_intel_dashboard.src.core.registry import ServiceRegistry
 
@@ -17,18 +17,22 @@ class DummyBus:
     def __init__(self) -> None:
         self.events = []
 
-    def publish(self, event_type: str, data, source=None) -> None:
+    def publish(self, event_type: str, data, source=None) -> None:  # pragma: no cover - simple bus
         self.events.append((event_type, data))
+
+
+def _wait_provider(provider) -> None:
+    import time
+    time.sleep(0.02)
+    provider.stop()
 
 
 def test_metrics_provider_injected_repo() -> None:
     repo = DummyRepo({"throughput": 1})
     bus = DummyBus()
     provider = MetricsProvider(bus, repo=repo, interval=0.01)
-    import time
-    time.sleep(0.02)
-    provider.stop()
-    assert (EventName.METRICS_UPDATE, repo.snapshot()) in bus.events
+    _wait_provider(provider)
+    assert bus.events == [(EventName.METRICS_UPDATE, repo.snapshot())]
 
 
 def test_metrics_provider_registry_lookup() -> None:
@@ -37,9 +41,16 @@ def test_metrics_provider_registry_lookup() -> None:
     try:
         bus = DummyBus()
         provider = MetricsProvider(bus, interval=0.01)
-        import time
-        time.sleep(0.02)
-        provider.stop()
-        assert (EventName.METRICS_UPDATE, repo.snapshot()) in bus.events
+        _wait_provider(provider)
+        assert bus.events == [(EventName.METRICS_UPDATE, repo.snapshot())]
+    finally:
+        ServiceRegistry.remove("metrics_repository")
+
+
+def test_generate_sample_metrics_registry_lookup() -> None:
+    repo = DummyRepo({"throughput": 3})
+    ServiceRegistry.register("metrics_repository", repo)
+    try:
+        assert generate_sample_metrics() == repo.snapshot()
     finally:
         ServiceRegistry.remove("metrics_repository")


### PR DESCRIPTION
## Summary
- add helper and additional tests in websocket suite
- cover dependency injection and ServiceRegistry lookup for MetricsProvider
- ensure metrics generation pulls repository from registry

## Testing
- `pytest tests/websocket/test_metrics_provider.py tests/websocket/test_metrics.py -q` *(fails: TypeError: metaclass conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689c002692cc8320be74e9adbddb97ee