### PR TITLE
Add cleanup to useUpload hook and test

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import useUpload from './useUpload';
+import { api } from '../api/client';
+
+vi.useFakeTimers();
+
+describe('useUpload cleanup', () => {
+  it('stops polling after unmount', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({ job_id: 'job1' });
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ progress: 0, done: false });
+
+    const { result, unmount } = renderHook(() => useUpload());
+
+    const file = new File(['content'], 'test.csv', { type: 'text/csv' });
+
+    act(() => {
+      result.current.onDrop([file]);
+    });
+
+    await act(async () => {
+      await result.current.uploadAllFiles();
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(getSpy).not.toHaveBeenCalled();
+
+    postSpy.mockRestore();
+    getSpy.mockRestore();
+  });
+});

--- a/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { api } from '../api/client';
 import {
@@ -19,6 +19,15 @@ export const useUpload = () => {
 
   const controllers = useRef<Map<string, AbortController>>(new Map());
   const polls = useRef<Record<string, NodeJS.Timeout>>({});
+
+  useEffect(() => {
+    return () => {
+      controllers.current.forEach((controller) => controller.abort());
+      controllers.current.clear();
+      Object.values(polls.current).forEach((poll) => clearInterval(poll));
+      polls.current = {};
+    };
+  }, []);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const newFiles: UploadedFile[] = acceptedFiles.map((file) => ({


### PR DESCRIPTION
## Summary
- abort active uploads and clear polling intervals when useUpload unmounts
- add unit test ensuring polling stops after unmount

## Testing
- `npx vitest run --config vitest.temp.config.ts yosai_intel_dashboard/src/adapters/ui/hooks/useUpload.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689c06153164832088f24f38a2426ace