### PR TITLE
feat: lazy load heavy visualizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "postcss-cli": "^11.0.1",
         "postcss-import": "^16.1.1",
         "prettier": "^3.6.2",
+        "rollup-plugin-visualizer": "^6.0.3",
         "tailwindcss": "^4.1.11",
         "tailwindcss-react-native": "^1.7.10",
         "typescript": "^5.9.2",
@@ -23382,6 +23383,60 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.3.tgz",
+      "integrity": "sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "postcss-cli": "^11.0.1",
     "postcss-import": "^16.1.1",
     "prettier": "^3.6.2",
+    "rollup-plugin-visualizer": "^6.0.3",
     "tailwindcss": "^4.1.11",
     "tailwindcss-react-native": "^1.7.10",
     "typescript": "^5.9.2",
@@ -87,7 +88,7 @@
   },
   "scripts": {
     "start": "cd yosai_intel_dashboard/src/adapters/ui && vite --config ../../../../vite.config.ts",
-    "build": "cd yosai_intel_dashboard/src/adapters/ui && vite build --config ../../../../vite.config.ts",
+    "build": "cd yosai_intel_dashboard/src/adapters/ui && ANALYZE=true vite build --config ../../../../vite.config.ts",
     "build:android": "cd yosai_intel_dashboard/src/adapters/ui && vite build --config ../../../../vite.config.ts && npx cap sync android",
     "build:ios": "cd yosai_intel_dashboard/src/adapters/ui && vite build --config ../../../../vite.config.ts && npx cap sync ios",
     "test": "vitest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
+  plugins: process.env.ANALYZE
+    ? [visualizer({ filename: 'bundle-stats.html', open: true })]
+    : [],
   build: {
     rollupOptions: {
       output: {

--- a/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/pages/Graphs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { LineChart as LineChartIcon } from 'lucide-react';
 import { ChunkGroup } from '../components/layout';
@@ -13,8 +13,12 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { AccessibleVisualization } from '../components/accessibility';
-import { NetworkGraph, FacilityLayout } from './visualizations';
 import useGraphsData from '../hooks/useGraphsData';
+
+const NetworkGraph = React.lazy(() => import('./visualizations/NetworkGraph'));
+const FacilityLayout = React.lazy(
+  () => import('./visualizations/FacilityLayout'),
+);
 
 interface ChartData {
   hourly_distribution?: Record<string, number | string>;
@@ -71,7 +75,11 @@ const Graphs: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (selectedChart === 'network' || selectedChart === 'facility' || !selectedChart) {
+    if (
+      selectedChart === 'network' ||
+      selectedChart === 'facility' ||
+      !selectedChart
+    ) {
       return;
     }
     const fetchData = async () => {
@@ -106,7 +114,9 @@ const Graphs: React.FC = () => {
             rows: links.map((l) => [l.source, l.target]),
           }}
         >
-          <NetworkGraph />
+          <Suspense fallback={<div>Loading visualization...</div>}>
+            <NetworkGraph />
+          </Suspense>
         </AccessibleVisualization>
       );
     }
@@ -119,7 +129,9 @@ const Graphs: React.FC = () => {
           summary="Rotating 3D model of facility layout."
           tableData={{ headers: ['Room'], rows: rooms.map((r) => [r]) }}
         >
-          <FacilityLayout />
+          <Suspense fallback={<div>Loading visualization...</div>}>
+            <FacilityLayout />
+          </Suspense>
         </AccessibleVisualization>
       );
     }
@@ -233,9 +245,7 @@ const Graphs: React.FC = () => {
           Failed to load graphs.
         </div>
       )}
-      {!isLoading && !isError && (
-        <div role="presentation">{renderChart()}</div>
-      )}
+      {!isLoading && !isError && <div role="presentation">{renderChart()}</div>}
       {!isLoading && !isError && showDetails && chartData && (
         <pre
           aria-label="chart-details"


### PR DESCRIPTION
## Summary
- lazy-load heavy visualization components with React.lazy
- generate bundle analysis via rollup-plugin-visualizer

## Testing
- `npm test`
- `npm run lint` *(fails: Prettier formatting errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c065708688320b364db2b4f42ed1f