### PR TITLE
chore: add accessibility test automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: npm ci
       - name: Run frontend tests
         run: npm test -- --watchAll=false
+      - name: Run accessibility tests
+        run: npm run test:a11y
 
   lint-test:
     name: Lint

--- a/cypress.a11y.config.ts
+++ b/cypress.a11y.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/e2e/**/*.cy.{js,ts}'
+  }
+})

--- a/cypress/e2e/a11y.cy.ts
+++ b/cypress/e2e/a11y.cy.ts
@@ -1,0 +1,8 @@
+/// <reference types="cypress" />
+
+describe('Static page accessibility', () => {
+  it('has no detectable accessibility violations', () => {
+    cy.visit('cypress/fixtures/a11y.html')
+    cy.injectAxeAndCheck()
+  })
+})

--- a/cypress/fixtures/a11y.html
+++ b/cypress/fixtures/a11y.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Accessibility Test Page</title>
+</head>
+<body>
+  <h1>Accessible Sample Page</h1>
+  <img src="https://via.placeholder.com/150" alt="placeholder" />
+  <button type="button">Click me</button>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test": "vitest",
     "test:ui": "vitest --dir src",
     "test:watch": "vitest --watch",
+    "test:a11y": "cypress run --config-file cypress.a11y.config.ts --spec 'cypress/e2e/a11y.cy.ts'",
     "eject": "react-scripts eject",
     "build-css": "sh scripts/build_css.sh",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Summary
- add Cypress-based accessibility test suite and fixture
- expose `test:a11y` npm script
- run accessibility checks in CI workflow

## Testing
- `npm test -- --run`
- `npm run test:a11y`


------
https://chatgpt.com/codex/tasks/task_e_689c06a9623883208364d8f95cb92518