### PR TITLE
feat: standardize missing value handling

### DIFF
--- a/tests/analytics/test_processor_io.py
+++ b/tests/analytics/test_processor_io.py
@@ -183,3 +183,11 @@ def test_mapping_processor_io(tmp_path):
     result.data.to_parquet(parquet_path)
     loaded = pd.read_parquet(parquet_path)
     assert loaded.equals(result.data)
+
+
+def test_missing_value_standardization():
+    df = pd.DataFrame({"num": [1.0, None], "cat": ["x", None]})
+    proc = DataProcessor()
+    out = proc.clean_data(df)
+    assert out.loc[1, "num"] == 0
+    assert out.loc[1, "cat"] == "missing"


### PR DESCRIPTION
## Summary
- normalize missing values in analytics DataProcessor for numeric and categorical columns
- cover missing-value preprocessing with a unit test

## Testing
- `pytest tests/analytics/test_processor_io.py::test_missing_value_standardization -q` *(fails: metaclass conflict in tests configuration)*
- `python - <<'PY'
import sys, types, importlib.util, pathlib, pandas as pd
protocols_mod = types.ModuleType('services.analytics.protocols')
class DataProcessorProtocol: ...
protocols_mod.DataProcessorProtocol = DataProcessorProtocol
sys.modules['services.analytics.protocols'] = protocols_mod
sys.modules['services.analytics'] = types.ModuleType('services.analytics')
path = pathlib.Path('yosai_intel_dashboard/src/services/analytics/data_processor.py')
spec = importlib.util.spec_from_file_location('services.analytics.data_processor', path)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
DataProcessor = mod.DataProcessor

df = pd.DataFrame({'num': [1.0, None], 'cat': ['x', None]})
proc = DataProcessor()
out = proc.clean_data(df)
print(out)
assert out.loc[1, 'num'] == 0
assert out.loc[1, 'cat'] == 'missing'
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689c0b0ca8b08320a675464610a2b10b