### PR TITLE
Add bias detection utilities to training pipeline

### DIFF
--- a/ml_tests/test_bias_detection.py
+++ b/ml_tests/test_bias_detection.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+from yosai_intel_dashboard.src.models.ml.training.bias import detect_bias
+from yosai_intel_dashboard.src.models.ml.training import pipeline as train_pipeline
+
+
+class DummyRegistry:
+    def get_model(self, *args, **kwargs):
+        return None
+
+    def _metrics_improved(self, *args, **kwargs):
+        return True
+
+    class _Rec:
+        def __init__(self):
+            self.version = "0.1.0"
+            self.metrics = {}
+
+    def register_model(self, *args, **kwargs):
+        return self._Rec()
+
+    def set_active_version(self, *args, **kwargs):
+        pass
+
+
+def test_detect_bias_returns_metrics():
+    y_true = [0, 1, 0, 1]
+    y_pred = [0, 1, 1, 0]
+    sensitive = ["A", "A", "B", "B"]
+    metrics = detect_bias(y_true, y_pred, sensitive)
+    assert "overall" in metrics and "by_group" in metrics
+
+
+def test_pipeline_bias_reporting(tmp_path, monkeypatch):
+    monkeypatch.setattr(train_pipeline, "preprocess_events", lambda df: df)
+    df = pd.DataFrame(
+        {
+            "feat": [0, 1, 0, 1],
+            "sensitive": ["A", "A", "B", "B"],
+            "target": [0, 1, 0, 1],
+        }
+    )
+    models = {"lr": (LogisticRegression(max_iter=100), {})}
+    registry = DummyRegistry()
+    tp = train_pipeline.TrainingPipeline(registry=registry, cv_splits=2)
+    report = tmp_path / "bias.json"
+    res = tp.run(
+        df,
+        target_column="target",
+        models=models,
+        bias_column="sensitive",
+        bias_report=report,
+    )
+    assert res.bias_metrics and "overall" in res.bias_metrics
+    assert report.exists() and json.loads(report.read_text()) == res.bias_metrics

--- a/yosai_intel_dashboard/src/models/ml/training/__init__.py
+++ b/yosai_intel_dashboard/src/models/ml/training/__init__.py
@@ -1,1 +1,4 @@
+from .bias import detect_bias  # noqa: F401
 from . import pipeline  # noqa: F401
+
+__all__ = ["detect_bias", "pipeline"]

--- a/yosai_intel_dashboard/src/models/ml/training/bias.py
+++ b/yosai_intel_dashboard/src/models/ml/training/bias.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Bias detection utilities using fairness metrics."""
+
+import logging
+from typing import Any, Dict, Iterable
+
+from optional_dependencies import import_optional
+
+MetricFrame = import_optional("fairlearn.metrics.MetricFrame")
+selection_rate = import_optional("fairlearn.metrics.selection_rate")
+accuracy_score = import_optional("sklearn.metrics.accuracy_score")
+
+logger = logging.getLogger(__name__)
+
+
+def detect_bias(
+    y_true: Iterable[Any],
+    y_pred: Iterable[Any],
+    sensitive_features: Iterable[Any],
+) -> Dict[str, Any]:
+    """Compute basic fairness metrics.
+
+    Parameters
+    ----------
+    y_true, y_pred:
+        Ground truth and predicted labels.
+    sensitive_features:
+        Iterable identifying the sensitive group for each sample.
+
+    Returns
+    -------
+    dict
+        Dictionary with overall metrics, per-group metrics and metric
+        differences. Returns an empty dict if required dependencies are
+        missing.
+    """
+
+    if not (MetricFrame and selection_rate and accuracy_score):
+        logger.warning("fairlearn and scikit-learn are required for bias detection")
+        return {}
+
+    frame = MetricFrame(
+        metrics={"accuracy": accuracy_score, "selection_rate": selection_rate},
+        y_true=list(y_true),
+        y_pred=list(y_pred),
+        sensitive_features=list(sensitive_features),
+    )
+    result: Dict[str, Any] = {
+        "overall": frame.overall.to_dict(),
+        "by_group": frame.by_group.to_dict(),
+    }
+    try:  # pragma: no cover - depends on fairlearn implementation
+        result["difference"] = frame.difference().to_dict()
+    except Exception:  # pragma: no cover
+        logger.debug("difference metric not available", exc_info=True)
+    return result
+
+
+__all__ = ["detect_bias"]


### PR DESCRIPTION
## Summary
- add fairness-based `detect_bias` utility using optional fairlearn metrics
- integrate optional bias reporting into training pipeline
- cover bias detection with basic tests

## Testing
- `pip install fairlearn` (successful)
- `pytest -c /tmp/pytest_min.ini ml_tests/test_bias_detection.py -q` *(fails: ImportError: cannot import name '__version__' from 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c0b6d06dc83208cb00b6fd602ea68