### PR TITLE
fix: clean imports and test helpers

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -34,8 +34,6 @@ from yosai_intel_dashboard.models.ml.pipeline_contract import preprocess_events
 from shared.errors.types import ErrorCode, ErrorResponse
 from jose import jwt
 from yosai_framework import ServiceBuilder
-from yosai_framework.errors import ServiceError
-from yosai_framework.service import BaseService
 from yosai_intel_dashboard.models.ml import ModelRegistry
 from yosai_intel_dashboard.src.core.security import RateLimiter, security_config
 from yosai_intel_dashboard.src.database.utils import parse_connection_string
@@ -57,8 +55,7 @@ from yosai_intel_dashboard.src.services.analytics_microservice.analytics_service
 from yosai_intel_dashboard.src.services.analytics_microservice.unicode_middleware import (
     UnicodeSanitizationMiddleware,
 )
-from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-from yosai_intel_dashboard.src.services.common.async_db import close_pool, create_pool
+from yosai_intel_dashboard.src.services.common.async_db import create_pool
 from yosai_intel_dashboard.src.services.explainability_service import (
     ExplainabilityService,
 )
@@ -123,6 +120,15 @@ async def rate_limit(request: Request, call_next):
     for key, value in headers.items():
         response.headers[key] = value
     return response
+
+
+def rate_limit_decorator(*_: Any, **__: Any):
+    """Placeholder rate limit decorator."""
+
+    def decorator(func):
+        return func
+
+    return decorator
 
 
 async def _external_api_check(_: FastAPI) -> Dict[str, Any]:

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
@@ -8,3 +8,12 @@ SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2]
 services_stub = types.ModuleType("services")
 services_stub.__path__ = [str(SERVICES_PATH)]
 sys.modules.setdefault("services", services_stub)
+
+# Stub hierarchical packages to prevent loading the full application
+yosai_stub = types.ModuleType("yosai_intel_dashboard")
+src_stub = types.ModuleType("yosai_intel_dashboard.src")
+services_pkg_stub = types.ModuleType("yosai_intel_dashboard.src.services")
+services_pkg_stub.__path__ = [str(SERVICES_PATH)]
+sys.modules.setdefault("yosai_intel_dashboard", yosai_stub)
+sys.modules.setdefault("yosai_intel_dashboard.src", src_stub)
+sys.modules.setdefault("yosai_intel_dashboard.src.services", services_pkg_stub)

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
@@ -7,6 +7,7 @@ import sys
 import time
 import types
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import httpx
@@ -443,6 +444,7 @@ async def test_health_endpoints():
 @pytest.mark.asyncio
 async def test_dashboard_summary_endpoint():
     module, queries_stub, dummy_service = load_app()
+    from services.auth import verify_jwt_token
 
     token = jwt.encode(
         {"sub": "svc", "iss": "gateway", "exp": int(time.time()) + 60},
@@ -477,7 +479,7 @@ async def test_unauthorized_request():
 @pytest.mark.asyncio
 async def test_internal_error_response():
     module, queries_stub, _ = load_app()
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
+    from services.auth import verify_jwt_token
 
     queries_stub.fetch_dashboard_summary.side_effect = RuntimeError("boom")
     token = jwt.encode(
@@ -501,6 +503,7 @@ async def test_internal_error_response():
 @pytest.mark.asyncio
 async def test_model_registry_endpoints(tmp_path):
     module, _, svc = load_app()
+    from services.auth import verify_jwt_token
     svc.model_dir = tmp_path
     from yosai_intel_dashboard.models.ml import ModelRegistry
 
@@ -540,6 +543,7 @@ async def test_model_registry_endpoints(tmp_path):
 @pytest.mark.asyncio
 async def test_predict_endpoint(tmp_path):
     module, _, svc = load_app()
+    from services.auth import verify_jwt_token
     svc.model_dir = tmp_path
 
     model = Dummy()
@@ -575,9 +579,8 @@ async def test_predict_endpoint(tmp_path):
 
 @pytest.mark.asyncio
 async def test_batch_predict_endpoint(tmp_path):
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-
     module, _, svc = load_app()
+    from services.auth import verify_jwt_token
     svc.model_dir = tmp_path
 
     model = Dummy()


### PR DESCRIPTION
## Summary
- remove unused imports in analytics microservice
- add placeholder rate_limit_decorator
- fix test imports for verify_jwt_token and Path

## Testing
- `SECRET_KEY=test pytest yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py` *(fails: No module named 'bleach')*


------
https://chatgpt.com/codex/tasks/task_e_689c14b89b0083208bcb74a3ec95fc69