### PR TITLE
refactor: use pathlib and f-strings in services

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_service.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import threading
 from pathlib import Path
 from typing import (
@@ -185,7 +184,7 @@ class DataSourceRouter:
         """Return analytics data for ``source``."""
         uploaded_data = self.orchestrator.loader.load_uploaded_data()
         if uploaded_data and source in ["uploaded", "sample"]:
-            logger.info("Forcing uploaded data usage (source was: %s)", source)
+            logger.info(f"Forcing uploaded data usage (source was: {source})")
             return self.orchestrator.process_uploaded_data_directly(uploaded_data)
 
         if source == "sample":
@@ -304,7 +303,7 @@ class AnalyticsService(AnalyticsServiceProtocol, AnalyticsProviderProtocol):
             query = AnalyticsQueryV1.model_validate({"source": source})
         except ValidationError:
             sanitized = normalize_text(source).strip().lower()
-            logger.error("Invalid analytics source: %s", sanitized)
+            logger.error(f"Invalid analytics source: {sanitized}")
             raise ValueError(f"Invalid analytics source: {sanitized}")
 
         normalized = normalize_text(query.source)
@@ -577,7 +576,7 @@ class AnalyticsService(AnalyticsServiceProtocol, AnalyticsProviderProtocol):
         dest = Path(destination_dir or str(models_path))
         dest = dest / name / record.version
         dest.mkdir(parents=True, exist_ok=True)
-        local_path = dest / os.path.basename(record.storage_uri)
+        local_path = dest / Path(record.storage_uri).name
         local_version = self.model_registry.get_version_metadata(name)
         if local_version == record.version and local_path.exists():
             return str(local_path)
@@ -595,10 +594,7 @@ class AnalyticsService(AnalyticsServiceProtocol, AnalyticsProviderProtocol):
             ValueError,
         ) as exc:  # pragma: no cover - best effort
             logger.error(
-                "Failed to download model %s (%s): %s",
-                name,
-                type(exc).__name__,
-                exc,
+                f"Failed to download model {name} ({type(exc).__name__}): {exc}"
             )
             return None
 

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -187,7 +187,7 @@ def preload_active_models(service: AnalyticsService) -> None:
             continue
         local_dir = service.model_dir / name / record.version
         local_dir.mkdir(parents=True, exist_ok=True)
-        filename = os.path.basename(record.storage_uri)
+        filename = Path(record.storage_uri).name
         local_path = local_dir / filename
         if not local_path.exists():
             try:
@@ -543,7 +543,7 @@ async def predict(
     local_dir = app.state.model_dir / name / record.version
 
     local_dir.mkdir(parents=True, exist_ok=True)
-    local_path = local_dir / os.path.basename(record.storage_uri)
+    local_path = local_dir / Path(record.storage_uri).name
     if not local_path.exists():
         try:
             svc.model_registry.download_artifact(record.storage_uri, str(local_path))

--- a/yosai_intel_dashboard/src/services/resilience/recovery.py
+++ b/yosai_intel_dashboard/src/services/resilience/recovery.py
@@ -69,6 +69,6 @@ async def monitor_dependency(
             await _reset(circuit)
             if on_recover is not None:
                 await on_recover()
-            log.info("%s recovered", name)
+            log.info(f"{name} recovered")
         else:
-            log.warning("Recovery attempt for %s failed", name)
+            log.warning(f"Recovery attempt for {name} failed")

--- a/yosai_intel_dashboard/src/services/result_formatting.py
+++ b/yosai_intel_dashboard/src/services/result_formatting.py
@@ -24,11 +24,11 @@ def ensure_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
         ):
             if df[col].dtype == "object":
                 try:
-                    logger.info("Converting column '%s' to datetime", col)
+                    logger.info(f"Converting column '{col}' to datetime")
                     df[col] = pd.to_datetime(df[col], errors="coerce")
-                    logger.info("✅ Successfully converted '%s' to datetime", col)
+                    logger.info(f"✅ Successfully converted '{col}' to datetime")
                 except Exception as exc:  # pragma: no cover - best effort
-                    logger.warning("⚠️ Could not convert '%s' to datetime: %s", col, exc)
+                    logger.warning(f"⚠️ Could not convert '{col}' to datetime: {exc}")
     return df
 
 
@@ -36,11 +36,11 @@ def safe_datetime_operation(df: pd.DataFrame, column: str, operation: str) -> An
     """Safely perform a datetime ``operation`` on ``df[column]``."""
 
     if column not in df.columns:
-        logger.warning("Column '%s' not found in DataFrame", column)
+        logger.warning(f"Column '{column}' not found in DataFrame")
         return None
 
     if df[column].dtype == "object":
-        logger.info("Converting '%s' to datetime for operation '%s'", column, operation)
+        logger.info(f"Converting '{column}' to datetime for operation '{operation}'")
         df[column] = pd.to_datetime(df[column], errors="coerce")
 
     try:
@@ -58,14 +58,11 @@ def safe_datetime_operation(df: pd.DataFrame, column: str, operation: str) -> An
             return df[column].dt.dayofweek
         if operation == "weekday":
             return df[column].dt.day_name()
-        logger.warning("Unknown datetime operation: %s", operation)
+        logger.warning(f"Unknown datetime operation: {operation}")
     except Exception as exc:  # pragma: no cover - best effort
-        logger.error(
-            "Error performing datetime operation '%s' on column '%s': %s",
-            operation,
-            column,
-            exc,
-        )
+            logger.error(
+                f"Error performing datetime operation '{operation}' on column '{column}': {exc}"
+            )
     return None
 
 

--- a/yosai_intel_dashboard/src/services/upload/ai.py
+++ b/yosai_intel_dashboard/src/services/upload/ai.py
@@ -20,12 +20,12 @@ class AISuggestionService:
             if mapping:
                 src = mapping.get("source", "cached")
                 if src == "user_confirmed":
-                    logger.info("🔐 Using USER CONFIRMED mapping for '%s'", device_name)
+                    logger.info(f"🔐 Using USER CONFIRMED mapping for '{device_name}'")
                 else:
-                    logger.info("📦 Using cached mapping for '%s'", device_name)
+                    logger.info(f"📦 Using cached mapping for '{device_name}'")
                 return mapping
 
-            logger.info("🤖 Generating AI analysis for '%s'", device_name)
+            logger.info(f"🤖 Generating AI analysis for '{device_name}'")
             from yosai_intel_dashboard.src.services.ai_device_generator import AIDeviceGenerator
 
             ai_generator = AIDeviceGenerator()
@@ -44,7 +44,7 @@ class AISuggestionService:
             ai_mapping_store.set(device_name, mapping)
             return mapping
         except Exception as exc:
-            logger.info("❌ Error in device analysis: %s", exc)
+            logger.info(f"❌ Error in device analysis: {exc}")
             return {
                 "floor_number": 1,
                 "security_level": 5,
@@ -59,7 +59,7 @@ class AISuggestionService:
         ai_suggestions = file_info.get("ai_suggestions", {})
         columns: List[str] = file_info.get("columns", [])
 
-        logger.info("🤖 Applying AI suggestions for %s columns", len(columns))
+        logger.info(f"🤖 Applying AI suggestions for {len(columns)} columns")
         suggested_values: List[Any] = []
         for column in columns:
             suggestion = ai_suggestions.get(column, {})
@@ -67,13 +67,13 @@ class AISuggestionService:
             field = suggestion.get("field", "")
             if confidence > 0.3 and field:
                 suggested_values.append(field)
-                logger.info("   ✅ %s -> %s (%.0f%%)", column, field, confidence * 100)
+                logger.info(
+                    f"   ✅ {column} -> {field} ({confidence * 100:.0f}%)"
+                )
             else:
                 suggested_values.append(None)
                 logger.info(
-                    "   ❓ %s -> No confident suggestion (%.0f%%)",
-                    column,
-                    confidence * 100,
+                    f"   ❓ {column} -> No confident suggestion ({confidence * 100:.0f}%)"
                 )
         return [suggested_values]
 


### PR DESCRIPTION
## Summary
- replace os.path usage with pathlib.Path in analytics microservice and analytics service
- convert percent-format logging to f-strings across several service modules

## Testing
- `pytest -q` *(fails: metaclass conflict in tests)*
- `python -m py_compile yosai_intel_dashboard/src/services/analytics/analytics_service.py yosai_intel_dashboard/src/services/analytics_microservice/app.py yosai_intel_dashboard/src/services/resilience/recovery.py yosai_intel_dashboard/src/services/result_formatting.py yosai_intel_dashboard/src/services/upload/ai.py`


------
https://chatgpt.com/codex/tasks/task_e_689c14e3b2c48320977e1996888d2e2e