### PR TITLE
Refactor analytics microservice test setup

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
@@ -20,9 +20,432 @@ sys.modules.setdefault("services", services_stub)
 
 # Stub hierarchical packages to prevent loading the full application
 yosai_stub = types.ModuleType("yosai_intel_dashboard")
+yosai_stub.__path__ = [str(SERVICES_PATH.parent)]
 src_stub = types.ModuleType("yosai_intel_dashboard.src")
+src_stub.__path__ = [str(SERVICES_PATH.parent)]
 services_pkg_stub = types.ModuleType("yosai_intel_dashboard.src.services")
 services_pkg_stub.__path__ = [str(SERVICES_PATH)]
 sys.modules.setdefault("yosai_intel_dashboard", yosai_stub)
 sys.modules.setdefault("yosai_intel_dashboard.src", src_stub)
 sys.modules.setdefault("yosai_intel_dashboard.src.services", services_pkg_stub)
+
+
+def _register_environment_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub external modules that the analytics microservice depends on."""
+    import builtins
+
+    otel = types.SimpleNamespace(
+        FastAPIInstrumentor=types.SimpleNamespace(instrument_app=lambda *a, **k: None)
+    )
+    prom = types.SimpleNamespace(
+        Instrumentator=lambda: types.SimpleNamespace(
+            instrument=lambda app: None, expose=lambda app: None
+        )
+    )
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.fastapi", otel)
+    monkeypatch.setitem(sys.modules, "prometheus_fastapi_instrumentator", prom)
+    monkeypatch.setattr(
+        builtins, "ErrorHandlingMiddleware", lambda app, *a, **k: app, raising=False
+    )
+    monkeypatch.setattr(
+        builtins, "rate_limit_decorator", lambda *a, **k: (lambda f: f), raising=False
+    )
+
+    db = types.SimpleNamespace(
+        create_pool=AsyncMock(),
+        close_pool=AsyncMock(),
+        get_pool=AsyncMock(return_value=object()),
+    )
+    monkeypatch.setitem(sys.modules, "services.common.async_db", db)
+    cfg = types.SimpleNamespace(
+        type="sqlite",
+        host="localhost",
+        port=5432,
+        name="test",
+        user="user",
+        password="",
+        connection_timeout=1,
+        get_connection_string=lambda: "postgresql://",
+        initial_pool_size=1,
+        max_pool_size=1,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "config",
+        types.SimpleNamespace(DatabaseSettings=lambda: cfg, get_database_config=lambda: cfg),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.infrastructure.config",
+        types.SimpleNamespace(get_database_config=lambda: cfg),
+    )
+    loader_stub = types.SimpleNamespace(
+        ConfigurationLoader=lambda: types.SimpleNamespace(
+            get_service_config=lambda: types.SimpleNamespace(redis_url="redis://test")
+        )
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.infrastructure.config.loader",
+        loader_stub,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.database.utils",
+        types.SimpleNamespace(parse_connection_string=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(sys.modules, "config.dynamic_config", types.SimpleNamespace(dynamic_config={}))
+    monkeypatch.setitem(sys.modules, "config.base", types.SimpleNamespace(CacheConfig=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "config.database_exceptions", types.SimpleNamespace(UnicodeEncodingError=Exception)
+    )
+    monkeypatch.setitem(
+        sys.modules, "config.environment", types.SimpleNamespace(get_environment=lambda: "test")
+    )
+    monkeypatch.setitem(
+        sys.modules, "config.validate", types.SimpleNamespace(validate_required_env=lambda vars: None)
+    )
+
+    class DummyCfg:
+        service_name = "analytics-test"
+        log_level = "INFO"
+        metrics_addr = ""
+        tracing_endpoint = ""
+
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_framework.config",
+        types.SimpleNamespace(ServiceConfig=DummyCfg, load_config=lambda path: DummyCfg()),
+    )
+
+    redis_async = types.SimpleNamespace(Redis=AsyncMock)
+    monkeypatch.setitem(sys.modules, "redis.asyncio", redis_async)
+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(asyncio=redis_async))
+
+    hc = types.SimpleNamespace(
+        register_health_check=lambda *a, **k: None,
+        setup_health_checks=lambda app: None,
+        DependencyHealthMiddleware=lambda app: app,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.infrastructure.discovery.health_check",
+        hc,
+    )
+
+    class DummyService:
+        def __init__(self):
+            self.app = FastAPI()
+            self.app.state.live = True
+            self.app.state.ready = True
+            self.app.state.startup_complete = True
+
+        def stop(self):
+            pass
+
+    class DummyBuilder:
+        def __init__(self, name: str):
+            self.name = name
+
+        def with_logging(self, *a, **k):
+            return self
+
+        def with_metrics(self, *a, **k):
+            return self
+
+        def with_health(self):
+            return self
+
+        def build(self):
+            return DummyService()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_framework.service",
+        types.SimpleNamespace(BaseService=DummyService, ServiceBuilder=DummyBuilder),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_framework",
+        types.SimpleNamespace(ServiceBuilder=DummyBuilder, BaseService=DummyService),
+    )
+    monkeypatch.setitem(
+        sys.modules, "yosai_framework.errors", types.SimpleNamespace(ServiceError=Exception)
+    )
+
+    class DummyRateLimiter:
+        async def is_allowed(self, *a, **k):
+            return {"allowed": True}
+
+    security_config = types.SimpleNamespace(
+        get_secret=lambda key, vault_key=None: os.environ.get(key, "")
+    )
+    sec_mod = types.SimpleNamespace(
+        RateLimiter=DummyRateLimiter, security_config=security_config
+    )
+    unicode_mod = types.SimpleNamespace(sanitize_for_utf8=lambda x: x)
+    handler_mod = types.SimpleNamespace(
+        UnicodeHandler=types.SimpleNamespace(sanitize=lambda obj: obj)
+    )
+    validator_mod = types.SimpleNamespace(
+        UnicodeValidator=lambda: types.SimpleNamespace(validate_dataframe=lambda df: df)
+    )
+    monkeypatch.setitem(sys.modules, "core.security", sec_mod)
+    monkeypatch.setitem(sys.modules, "core.unicode", unicode_mod)
+    monkeypatch.setitem(sys.modules, "utils.unicode_handler", handler_mod)
+    monkeypatch.setitem(sys.modules, "validation.unicode_validator", validator_mod)
+    # mirrored paths used by application modules
+    monkeypatch.setitem(sys.modules, "yosai_intel_dashboard.src.core.security", sec_mod)
+    monkeypatch.setitem(sys.modules, "yosai_intel_dashboard.src.core.unicode", unicode_mod)
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.utils.unicode_handler", handler_mod
+    )
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.validation.unicode_validator", validator_mod
+    )
+    monkeypatch.setitem(sys.modules, "tracing", types.ModuleType("tracing"))
+    monkeypatch.setitem(sys.modules, "hvac", types.ModuleType("hvac"))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "services.common.secrets",
+        types.SimpleNamespace(get_secret=lambda path: "secret"),
+    )
+
+    auth = types.SimpleNamespace(
+        verify_jwt_token=lambda token: jwt.decode(
+            token, os.environ["JWT_SECRET_KEY"], algorithms=["HS256"]
+        )
+    )
+    monkeypatch.setitem(sys.modules, "services.auth", auth)
+
+    def _read_csv(buffer):
+        import csv, io
+
+        text = buffer.read().decode()
+        reader = csv.reader(io.StringIO(text))
+        headers = next(reader, None)
+        return [list(map(int, row)) for row in reader]
+
+    pandas_stub = types.SimpleNamespace(DataFrame=lambda data: data, read_csv=_read_csv)
+    monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
+
+    # Simple in-memory model registry used by the microservice
+    @dataclass
+    class DummyRecord:
+        name: str
+        version: str
+        storage_uri: str
+        is_active: bool = False
+
+    class DummyRegistry:
+        def __init__(self):
+            self.models: dict[str, dict[str, DummyRecord]] = {}
+
+        def register_model(
+            self,
+            name: str,
+            model_path: str,
+            metrics: dict,
+            dataset_hash: str,
+            *,
+            version: str | None = None,
+            training_date: object | None = None,
+        ) -> DummyRecord:
+            rec = DummyRecord(name, version or "1", model_path)
+            self.models.setdefault(name, {})[rec.version] = rec
+            return rec
+
+        def set_active_version(self, name: str, version: str) -> None:
+            for r in self.models.get(name, {}).values():
+                r.is_active = r.version == version
+
+        def get_model(
+            self,
+            name: str,
+            version: str | None = None,
+            *,
+            active_only: bool = False,
+        ) -> DummyRecord | None:
+            if active_only:
+                for r in self.models.get(name, {}).values():
+                    if r.is_active:
+                        return r
+                return None
+            if version:
+                return self.models.get(name, {}).get(version)
+            return None
+
+        def list_models(self, name: str | None = None):
+            if name:
+                return list(self.models.get(name, {}).values())
+            res: list[DummyRecord] = []
+            for d in self.models.values():
+                res.extend(d.values())
+            return res
+
+        def download_artifact(self, src: str, dest: str) -> None:
+            Path(dest).write_bytes(Path(src).read_bytes())
+
+    registry_mod = types.ModuleType("models.ml.model_registry")
+    registry_mod.ModelRegistry = DummyRegistry
+    registry_mod.ModelRecord = DummyRecord
+    ml_module = types.ModuleType("yosai_intel_dashboard.models.ml")
+    ml_module.ModelRegistry = DummyRegistry
+    ml_module.ModelRecord = DummyRecord
+    monkeypatch.setitem(sys.modules, "yosai_intel_dashboard.models.ml", ml_module)
+    monkeypatch.setitem(sys.modules, "models.ml", ml_module)
+    registry_mod = types.ModuleType("models.ml.model_registry")
+    registry_mod.ModelRegistry = DummyRegistry
+    registry_mod.ModelRecord = DummyRecord
+    monkeypatch.setitem(sys.modules, "models.ml.model_registry", registry_mod)
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.models.ml.model_registry", registry_mod
+    )
+    models_pkg = types.ModuleType("models")
+    models_pkg.ml = ml_module
+    models_pkg.__path__ = []
+    yd_models_pkg = types.ModuleType("yosai_intel_dashboard.models")
+    yd_models_pkg.ml = ml_module
+    yd_models_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "models", models_pkg)
+    monkeypatch.setitem(sys.modules, "yosai_intel_dashboard.models", yd_models_pkg)
+
+    # Minimal analytics and pipeline modules used during model loading
+    analytics_pkg = types.ModuleType("analytics")
+    analytics_pkg.feature_extraction = types.SimpleNamespace(
+        extract_event_features=lambda df, logger=None: df
+    )
+    analytics_pkg.anomaly_detection = types.SimpleNamespace(
+        AnomalyDetector=lambda: types.SimpleNamespace(
+            analyze_anomalies=lambda df: types.SimpleNamespace(
+                severity_distribution={},
+                detection_summary={},
+                risk_assessment={"risk_score": 0},
+                recommendations=[],
+                processing_metadata={},
+            )
+        )
+    )
+    analytics_pkg.security_patterns = types.SimpleNamespace(
+        SecurityPatternsAnalyzer=lambda: types.SimpleNamespace(
+            analyze_security_patterns=lambda df: types.SimpleNamespace(
+                overall_score=0,
+                risk_level="low",
+                confidence_interval=(0.0, 0.0),
+                threat_indicators=[],
+                pattern_analysis={},
+                recommendations=[],
+            )
+        )
+    )
+    monkeypatch.setitem(sys.modules, "analytics", analytics_pkg)
+    for name in ["feature_extraction", "anomaly_detection", "security_patterns"]:
+        monkeypatch.setitem(sys.modules, f"analytics.{name}", getattr(analytics_pkg, name))
+
+    pipeline_stub = types.ModuleType(
+        "yosai_intel_dashboard.models.ml.pipeline_contract"
+    )
+    pipeline_stub.preprocess_events = lambda df: df
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.models.ml.pipeline_contract", pipeline_stub
+    )
+
+    # Error handling modules without Flask dependency
+    from fastapi import HTTPException
+
+    error_mod = types.ModuleType("yosai_intel_dashboard.src.error_handling")
+    error_mod.http_error = lambda code, message, status_code: HTTPException(
+        status_code, {"code": code, "message": message}
+    )
+    monkeypatch.setitem(
+        sys.modules, "yosai_intel_dashboard.src.error_handling", error_mod
+    )
+    middleware_mod = types.ModuleType(
+        "yosai_intel_dashboard.src.error_handling.middleware"
+    )
+    middleware_mod.ErrorHandlingMiddleware = lambda app, *a, **k: app
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.error_handling.middleware",
+        middleware_mod,
+    )
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    _register_environment_stubs(monkeypatch)
+
+
+@pytest.fixture
+def mock_services(monkeypatch):
+    queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+    queries_stub.fetch_dashboard_summary = AsyncMock(return_value={"status": "ok"})
+    queries_stub.fetch_access_patterns = AsyncMock(return_value={"days": 7})
+    monkeypatch.setitem(
+        sys.modules, "services.analytics_microservice.async_queries", queries_stub
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.services.analytics_microservice.async_queries",
+        queries_stub,
+    )
+
+    class DummyAnalyticsService:
+        def __init__(self, *a, **k):
+            self.redis = types.SimpleNamespace(get=AsyncMock(), set=AsyncMock())
+            self.pool = object()
+            self.model_registry = None
+            self.cache_ttl = 300
+            self.model_dir = Path("/tmp")
+            self.models = {}
+
+        async def close(self):
+            pass
+
+    dummy_service = DummyAnalyticsService()
+    analytics_stub = types.ModuleType(
+        "services.analytics_microservice.analytics_service"
+    )
+    analytics_stub.AnalyticsService = DummyAnalyticsService
+    analytics_stub.get_analytics_service = lambda *a, **k: dummy_service
+    monkeypatch.setitem(
+        sys.modules, "services.analytics_microservice.analytics_service", analytics_stub
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "yosai_intel_dashboard.src.services.analytics_microservice.analytics_service",
+        analytics_stub,
+    )
+
+    return queries_stub, dummy_service
+
+
+def _load_app(dummy_service, secret: str | None):
+    if secret is not None:
+        os.environ["JWT_SECRET_KEY"] = secret
+    else:
+        os.environ.pop("JWT_SECRET_KEY", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "services.analytics_microservice.app",
+        SERVICES_PATH / "analytics_microservice" / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+
+    module.app.state.ready = True
+    module.app.state.startup_complete = True
+    module.app.state.analytics_service = dummy_service
+    return module
+
+
+@pytest.fixture
+def app_factory(mock_services):
+    queries_stub, dummy_service = mock_services
+
+    def factory(secret: str | None = "secret"):
+        module = _load_app(dummy_service, secret)
+        return module, queries_stub, dummy_service
+
+    return factory

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py
@@ -1,414 +1,18 @@
 from __future__ import annotations
 
 import time
-import types
-from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import httpx
 import joblib
 import pytest
 from jose import jwt
-from yosai_intel_dashboard.src.services.analytics_microservice.model_loader import (
-    preload_active_models,
-)
 
 
 class Dummy:
     def predict(self, data):
         return [len(data)]
 
-# stub out the heavy 'services' package before pytest imports it
-services_stub = types.ModuleType("services")
-services_stub.__path__ = [str(SERVICES_PATH)]
-sys.modules["services"] = services_stub
-
-
-def load_app(jwt_secret: str | None = "secret") -> tuple:
-
-    otel_stub = types.ModuleType("opentelemetry.instrumentation.fastapi")
-    otel_stub.FastAPIInstrumentor = types.SimpleNamespace(
-        instrument_app=lambda *a, **k: None
-    )
-    sys.modules.setdefault("opentelemetry.instrumentation.fastapi", otel_stub)
-
-    prom_stub = types.ModuleType("prometheus_fastapi_instrumentator")
-
-    class DummyInstr:
-        def instrument(self, app):
-            return self
-
-        def expose(self, app):
-            return self
-
-    prom_stub.Instrumentator = lambda: DummyInstr()
-    sys.modules.setdefault("prometheus_fastapi_instrumentator", prom_stub)
-
-    import builtins
-
-    builtins.ErrorHandlingMiddleware = lambda app, *a, **k: app
-    builtins.rate_limit_decorator = lambda *a, **k: (lambda func: func)
-
-    db_stub = types.ModuleType("services.common.async_db")
-    db_stub.create_pool = AsyncMock()
-    db_stub.close_pool = AsyncMock()
-    db_stub.get_pool = AsyncMock(return_value=object())
-    sys.modules["services.common.async_db"] = db_stub
-    common_pkg = types.ModuleType("services.common")
-    common_pkg.async_db = db_stub
-    sys.modules["services.common"] = common_pkg
-
-    config_stub = types.ModuleType("config")
-
-    class _Cfg:
-        def __init__(self):
-            self.type = "sqlite"
-            self.host = "localhost"
-            self.port = 5432
-            self.name = "test"
-            self.user = "user"
-            self.password = ""
-            self.connection_timeout = 1
-
-        def get_connection_string(self):
-            return "postgresql://"
-
-        initial_pool_size = 1
-        max_pool_size = 1
-
-    config_stub.DatabaseSettings = _Cfg
-    config_stub.get_database_config = lambda: _Cfg()
-    dynamic_module = types.ModuleType("config.dynamic_config")
-    dynamic_module.dynamic_config = {}
-    sys.modules["config.dynamic_config"] = dynamic_module
-    base_module = types.ModuleType("config.base")
-    base_module.CacheConfig = lambda *a, **k: None
-    sys.modules["config.base"] = base_module
-    db_exc_module = types.ModuleType("config.database_exceptions")
-
-    class _UnicodeErr(Exception):
-        def __init__(self, *a, **k):
-            pass
-
-    db_exc_module.UnicodeEncodingError = _UnicodeErr
-    sys.modules["config.database_exceptions"] = db_exc_module
-    sys.modules["config"] = config_stub
-
-    env_stub = types.ModuleType("config.environment")
-    env_stub.get_environment = lambda: "test"
-    sys.modules["config.environment"] = env_stub
-
-    validate_stub = types.ModuleType("config.validate")
-    validate_stub.validate_required_env = lambda vars: None
-    sys.modules["config.validate"] = validate_stub
-
-    yf_config_stub = types.ModuleType("yosai_framework.config")
-
-    class DummyCfg:
-        service_name = "analytics-test"
-        log_level = "INFO"
-        metrics_addr = ""
-        tracing_endpoint = ""
-
-    yf_config_stub.ServiceConfig = DummyCfg
-    yf_config_stub.load_config = lambda path: DummyCfg()
-    sys.modules["yosai_framework.config"] = yf_config_stub
-
-    redis_stub = types.ModuleType("redis")
-    redis_async = types.ModuleType("redis.asyncio")
-    redis_async.Redis = AsyncMock
-    redis_stub.asyncio = redis_async
-    sys.modules.setdefault("redis", redis_stub)
-    sys.modules.setdefault("redis.asyncio", redis_async)
-
-    analytics_stub = types.ModuleType(
-        "services.analytics_microservice.analytics_service"
-    )
-
-    class DummyAnalyticsService:
-        def __init__(self, *a, **k):
-            self.redis = types.SimpleNamespace(get=AsyncMock(), set=AsyncMock())
-            self.pool = object()
-            self.model_registry = None
-            self.cache_ttl = 300
-            self.model_dir = pathlib.Path("/tmp")
-            self.models = {}
-
-        async def close(self):
-            pass
-
-    dummy_service = DummyAnalyticsService()
-
-    analytics_stub.AnalyticsService = DummyAnalyticsService
-    analytics_stub.get_analytics_service = lambda *a, **k: dummy_service
-    sys.modules["services.analytics_microservice.analytics_service"] = analytics_stub
-
-    queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
-    queries_stub.fetch_dashboard_summary = AsyncMock(return_value={"status": "ok"})
-    queries_stub.fetch_access_patterns = AsyncMock(return_value={"days": 7})
-    sys.modules["services.analytics_microservice.async_queries"] = queries_stub
-
-    health_stub = types.ModuleType(
-        "yosai_intel_dashboard.src.infrastructure.discovery.health_check"
-    )
-    health_stub.register_health_check = lambda *a, **k: None
-    health_stub.setup_health_checks = lambda app: None
-    health_stub.DependencyHealthMiddleware = lambda app: app
-    sys.modules["yosai_intel_dashboard.src.infrastructure.discovery.health_check"] = (
-        health_stub
-    )
-
-    service_stub = types.ModuleType("yosai_framework.service")
-
-    class DummyService:
-        def __init__(self):
-            self.app = FastAPI()
-            self.app.state.live = True
-            self.app.state.ready = True
-            self.app.state.startup_complete = True
-
-        def stop(self):
-            pass
-
-    class DummyBuilder:
-        def __init__(self, name: str):
-            self
-
-        def with_logging(self, *a, **k):
-            return self
-
-        def with_metrics(self, *a, **k):
-            return self
-
-        def with_health(self):
-            return self
-
-        def build(self):
-            return DummyService()
-
-    service_stub.BaseService = DummyService
-    service_stub.ServiceBuilder = DummyBuilder
-    sys.modules["yosai_framework.service"] = service_stub
-    yf_pkg = types.ModuleType("yosai_framework")
-    yf_pkg.ServiceBuilder = DummyBuilder
-    yf_pkg.BaseService = DummyService
-    errors_stub = types.ModuleType("yosai_framework.errors")
-
-    class ServiceError(Exception):
-        pass
-
-    errors_stub.ServiceError = ServiceError
-    sys.modules["yosai_framework"] = yf_pkg
-    sys.modules["yosai_framework.errors"] = errors_stub
-
-    secrets_stub = types.ModuleType("services.common.secrets")
-    secrets_stub.get_secret = lambda path: "secret"
-    sys.modules["services.common.secrets"] = secrets_stub
-
-    auth_stub = types.ModuleType("services.auth")
-    auth_stub.verify_jwt_token = lambda token: jwt.decode(
-        token, jwt_secret, algorithms=["HS256"]
-    )
-    sys.modules["services.auth"] = auth_stub
-
-    # Stub ModelRegistry used by the microservice
-    registry_mod = types.ModuleType("models.ml.model_registry")
-
-    @dataclass
-    class DummyRecord:
-        name: str
-        version: str
-        storage_uri: str
-        is_active: bool = False
-
-    class DummyRegistry:
-        def __init__(self, *a, **k):
-            self.models: dict[str, dict[str, DummyRecord]] = {}
-
-        def register_model(
-            self,
-            name: str,
-            model_path: str,
-            metrics: dict,
-            dataset_hash: str,
-            *,
-            version: str | None = None,
-            training_date: None | object = None,
-        ) -> DummyRecord:
-            rec = DummyRecord(name, version or "1", model_path)
-            self.models.setdefault(name, {})[rec.version] = rec
-            return rec
-
-        def set_active_version(self, name: str, version: str) -> None:
-            for r in self.models.get(name, {}).values():
-                r.is_active = r.version == version
-
-        def get_model(
-            self,
-            name: str,
-            version: str | None = None,
-            *,
-            active_only: bool = False,
-        ) -> DummyRecord | None:
-            if active_only:
-                for r in self.models.get(name, {}).values():
-                    if r.is_active:
-                        return r
-                return None
-            if version:
-                return self.models.get(name, {}).get(version)
-            return None
-
-        def list_models(self, name: str | None = None):
-            if name:
-                return list(self.models.get(name, {}).values())
-            res = []
-            for d in self.models.values():
-                res.extend(d.values())
-            return res
-
-        def download_artifact(self, src: str, dest: str) -> None:
-            Path(dest).write_bytes(Path(src).read_bytes())
-
-    registry_mod.ModelRegistry = DummyRegistry
-    registry_mod.ModelRecord = DummyRecord
-    sys.modules["models.ml.model_registry"] = registry_mod
-    sys.modules["yosai_intel_dashboard.models.ml.model_registry"] = registry_mod
-    ml_pkg = types.ModuleType("models.ml")
-    ml_pkg.ModelRegistry = DummyRegistry
-    ml_pkg.ModelRecord = DummyRecord
-    sys.modules["models.ml"] = ml_pkg
-    sys.modules["yosai_intel_dashboard.models.ml"] = ml_pkg
-    models_stub = types.ModuleType("models")
-    models_stub.ml = ml_pkg
-    sys.modules["models"] = models_stub
-    sys.modules["yosai_intel_dashboard.models"] = models_stub
-
-    # Stub analytics modules used by threat_assessment endpoint
-    fe_stub = types.ModuleType("analytics.feature_extraction")
-    fe_stub.extract_event_features = lambda df, logger=None: df
-
-    ad_stub = types.ModuleType("analytics.anomaly_detection")
-
-    @dataclass
-    class DummyResult:
-        total_anomalies: int = 0
-        severity_distribution: dict = None
-        detection_summary: dict = None
-        risk_assessment: dict = None
-        recommendations: list = None
-        processing_metadata: dict = None
-
-    class DummyDetector:
-        def analyze_anomalies(self, df):
-            return DummyResult(
-                severity_distribution={},
-                detection_summary={},
-                risk_assessment={"risk_score": 0},
-                recommendations=[],
-                processing_metadata={},
-            )
-
-    ad_stub.AnomalyDetector = DummyDetector
-
-    sp_stub = types.ModuleType("analytics.security_patterns")
-
-    @dataclass
-    class DummyAssessment:
-        overall_score: int = 0
-        risk_level: str = "low"
-        confidence_interval: tuple = (0.0, 0.0)
-        threat_indicators: list = None
-        pattern_analysis: dict = None
-        recommendations: list = None
-
-    class DummyAnalyzer:
-        def analyze_security_patterns(self, df):
-            return DummyAssessment(
-                threat_indicators=[],
-                pattern_analysis={},
-                recommendations=[],
-            )
-
-    sp_stub.SecurityPatternsAnalyzer = DummyAnalyzer
-
-    analytics_pkg = types.ModuleType("analytics")
-    analytics_pkg.feature_extraction = fe_stub
-    analytics_pkg.anomaly_detection = ad_stub
-    analytics_pkg.security_patterns = sp_stub
-    sys.modules["analytics"] = analytics_pkg
-    sys.modules["analytics.feature_extraction"] = fe_stub
-    sys.modules["analytics.anomaly_detection"] = ad_stub
-    sys.modules["analytics.security_patterns"] = sp_stub
-
-    pipeline_stub = types.ModuleType(
-        "yosai_intel_dashboard.models.ml.pipeline_contract"
-    )
-    pipeline_stub.preprocess_events = lambda df: df
-    ml_pkg.pipeline_contract = pipeline_stub
-    sys.modules["yosai_intel_dashboard.models.ml.pipeline_contract"] = pipeline_stub
-    sys.modules["models.ml.pipeline_contract"] = pipeline_stub
-
-    # Minimal stubs for unicode and validation utilities
-    core_unicode = types.ModuleType("core.unicode")
-    core_unicode.sanitize_for_utf8 = lambda x: x
-    core_pkg = types.ModuleType("core")
-    core_pkg.unicode = core_unicode
-    security_stub = types.ModuleType("core.security")
-
-    class DummyRateLimiter:
-        async def is_allowed(self, *a, **k):
-            return {"allowed": True}
-
-    security_stub.RateLimiter = DummyRateLimiter
-    core_pkg.security = security_stub
-    sys.modules["core"] = core_pkg
-    sys.modules["core.unicode"] = core_unicode
-    sys.modules["core.security"] = security_stub
-
-    unicode_stub = types.ModuleType("utils.unicode_handler")
-
-    class DummyHandler:
-        @staticmethod
-        def sanitize(obj):
-            return obj
-
-    unicode_stub.UnicodeHandler = DummyHandler
-    sys.modules["utils.unicode_handler"] = unicode_stub
-
-    val_stub = types.ModuleType("validation.unicode_validator")
-
-    class DummyValidator:
-        def validate_dataframe(self, df):
-            return df
-
-    val_stub.UnicodeValidator = DummyValidator
-    sys.modules["validation.unicode_validator"] = val_stub
-
-    sys.modules.setdefault("tracing", types.ModuleType("tracing"))
-    sys.modules.setdefault("hvac", types.ModuleType("hvac"))
-
-    if jwt_secret is not None:
-        os.environ["JWT_SECRET_KEY"] = jwt_secret
-    else:
-        os.environ.pop("JWT_SECRET_KEY", None)
-
-    spec = importlib.util.spec_from_file_location(
-        "services.analytics_microservice.app",
-        SERVICES_PATH / "analytics_microservice" / "app.py",
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore[arg-type]
-
-    # Mark application as ready without running full startup
-    module.app.state.ready = True
-    module.app.state.startup_complete = True
-    module.app.state.analytics_service = dummy_service
-
-    # base service already registers health routes
-
-    return module, queries_stub, dummy_service
 
 @pytest.mark.asyncio
 async def test_health_endpoints(app_factory):
@@ -433,8 +37,8 @@ async def test_health_endpoints(app_factory):
 
 
 @pytest.mark.asyncio
-async def test_dashboard_summary_endpoint():
-    module, queries_stub, dummy_service = load_app()
+async def test_dashboard_summary_endpoint(app_factory):
+    module, queries_stub, _ = app_factory()
     from services.auth import verify_jwt_token
 
     token = jwt.encode(
@@ -442,15 +46,12 @@ async def test_dashboard_summary_endpoint():
         "secret",
         algorithm="HS256",
     )
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-
     assert verify_jwt_token(token)["iss"] == "gateway"
     headers = {"Authorization": f"Bearer {token}"}
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/v1/analytics/dashboard-summary", headers=headers)
-
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
@@ -470,10 +71,9 @@ async def test_unauthorized_request(app_factory):
 
 
 @pytest.mark.asyncio
-async def test_internal_error_response():
-    module, queries_stub, _ = load_app()
+async def test_internal_error_response(app_factory):
+    module, queries_stub, _ = app_factory()
     from services.auth import verify_jwt_token
-
 
     queries_stub.fetch_dashboard_summary.side_effect = RuntimeError("boom")
     token = jwt.encode(
@@ -486,17 +86,14 @@ async def test_internal_error_response():
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get(
-            "/api/v1/analytics/dashboard-summary",
-            headers=headers,
-        )
+        resp = await client.get("/api/v1/analytics/dashboard-summary", headers=headers)
         assert resp.status_code == 500
         assert resp.json() == {"code": "internal", "message": "boom"}
 
 
 @pytest.mark.asyncio
-async def test_model_registry_endpoints(tmp_path):
-    module, _, svc = load_app()
+async def test_model_registry_endpoints(app_factory, tmp_path):
+    module, _, svc = app_factory()
     from services.auth import verify_jwt_token
 
     svc.model_dir = tmp_path
@@ -509,8 +106,6 @@ async def test_model_registry_endpoints(tmp_path):
         "secret",
         algorithm="HS256",
     )
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-
     assert verify_jwt_token(token)["iss"] == "gateway"
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -538,8 +133,8 @@ async def test_model_registry_endpoints(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_predict_endpoint(tmp_path):
-    module, _, svc = load_app()
+async def test_predict_endpoint(app_factory, tmp_path):
+    module, _, svc = app_factory()
     from services.auth import verify_jwt_token
 
     svc.model_dir = tmp_path
@@ -554,6 +149,10 @@ async def test_predict_endpoint(tmp_path):
     registry.register_model("demo", str(path), {}, "", version="1")
     registry.set_active_version("demo", "1")
     svc.model_registry = registry
+    from yosai_intel_dashboard.src.services.analytics_microservice.model_loader import (
+        preload_active_models,
+    )
+
     preload_active_models(svc)
 
     token = jwt.encode(
@@ -561,8 +160,6 @@ async def test_predict_endpoint(tmp_path):
         "secret",
         algorithm="HS256",
     )
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-
     assert verify_jwt_token(token)["iss"] == "gateway"
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -578,8 +175,8 @@ async def test_predict_endpoint(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_batch_predict_endpoint(tmp_path):
-    module, _, svc = load_app()
+async def test_batch_predict_endpoint(app_factory, tmp_path):
+    module, _, svc = app_factory()
     from services.auth import verify_jwt_token
 
     svc.model_dir = tmp_path
@@ -592,8 +189,6 @@ async def test_batch_predict_endpoint(tmp_path):
         "secret",
         algorithm="HS256",
     )
-    from yosai_intel_dashboard.src.services.auth import verify_jwt_token
-
     assert verify_jwt_token(token)["iss"] == "gateway"
     headers = {"Authorization": f"Bearer {token}"}
 


### PR DESCRIPTION
## Summary
- streamline analytics microservice tests by using fixtures for environment stubs and app creation
- expose app_factory fixture with mocked services for reuse across tests
- simplify async endpoint tests to rely on shared fixtures

## Testing
- `pytest -c /dev/null yosai_intel_dashboard/src/services/analytics_microservice/tests/test_endpoints_async.py::test_health_endpoints -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689c3fb7915c832088fd249a3c777516