### PR TITLE
feat: track feature def versions in model registry

### DIFF
--- a/scripts/train_anomaly_models.py
+++ b/scripts/train_anomaly_models.py
@@ -162,6 +162,7 @@ def main(argv: list[str] | None = None) -> int:
             f"{name}.joblib",
             metrics,
             dataset_hash,
+            feature_defs_version=None,
         )
         LOG.info("Registered %s version %s", record.name, record.version)
     return 0

--- a/yosai_intel_dashboard/src/models/ml/model_registry.py
+++ b/yosai_intel_dashboard/src/models/ml/model_registry.py
@@ -152,6 +152,7 @@ class ModelRegistry:
         dataset_hash: str,
         training_date: datetime | None,
         experiment_id: str,
+        feature_defs_version: str | None,
     ) -> ModelRecord:
         """Upload the model artifact, log metrics and persist the registry record."""
         key = f"{name}/{version}/{Path(model_path).name}"
@@ -277,6 +278,7 @@ class ModelRegistry:
         version: str | None = None,
         training_date: datetime | None = None,
         experiment_id: str = "default",
+        feature_defs_version: str | None = None,
 
     ) -> ModelRecord:
         session = self._session()
@@ -308,7 +310,7 @@ class ModelRegistry:
                     metrics=metrics,
                     accuracy=metrics.get("accuracy"),
                     dataset_hash=dataset_hash,
-                    feature_defs_version=None,
+                    feature_defs_version=feature_defs_version,
                     storage_uri=storage_uri,
                     mlflow_run_id=run_id,
                     experiment_id=experiment_id,

--- a/yosai_intel_dashboard/src/models/ml/security_models.py
+++ b/yosai_intel_dashboard/src/models/ml/security_models.py
@@ -270,7 +270,13 @@ def _register_model(
     with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as fh:
         joblib.dump(model_obj, fh)
         tmp_path = Path(fh.name)
-    record = registry.register_model(name, str(tmp_path), metrics, dataset_hash)
+    record = registry.register_model(
+        name,
+        str(tmp_path),
+        metrics,
+        dataset_hash,
+        feature_defs_version=None,
+    )
     dest_dir = Path("models") / name / record.version
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_path = dest_dir / f"{name}.joblib"

--- a/yosai_intel_dashboard/src/models/ml/training/pipeline.py
+++ b/yosai_intel_dashboard/src/models/ml/training/pipeline.py
@@ -217,6 +217,7 @@ class TrainingPipeline:
             str(best_res.model_path),
             best_res.metrics,
             dataset_hash,
+            feature_defs_version=None,
         )
         if improved:
             self.registry.set_active_version(best_res.name, record.version)

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -123,6 +123,7 @@ async def register_model(
             {},
             "",
             version=version,
+            feature_defs_version=None,
         )
         svc.model_registry.set_active_version(name, record.version)
         try:


### PR DESCRIPTION
## Summary
- allow ModelRegistry.register_model to accept and store feature definition versions
- propagate feature_defs_version through training helpers and microservice registration

## Testing
- `pytest tests/models/test_model_registry.py tests/models/test_model_registry_versioning.py tests/ml/test_model_registry_policy.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689c44ac774883208b9cb83cce6f529b