### PR TITLE
feat: persist model baselines

### DIFF
--- a/tests/test_model_registry_drift.py
+++ b/tests/test_model_registry_drift.py
@@ -25,11 +25,14 @@ ModelRegistry = mr.ModelRegistry
 
 
 class DummyS3:
-    def upload_file(self, *a, **k):
-        pass
+    def __init__(self):
+        self.storage: dict[tuple[str, str], bytes] = {}
 
-    def download_file(self, *a, **k):
-        pass
+    def upload_file(self, filename: str, bucket: str, key: str) -> None:
+        self.storage[(bucket, key)] = Path(filename).read_bytes()
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        Path(filename).write_bytes(self.storage[(bucket, key)])
 
 
 def test_get_drift_metrics_uses_compute_psi(monkeypatch):
@@ -56,3 +59,20 @@ def test_get_drift_metrics_uses_compute_psi(monkeypatch):
     assert called["baseline"].equals(base)
     assert called["current"].equals(cur)
     assert metrics == {"a": 0.1}
+
+
+def test_get_drift_metrics_loads_baseline_from_s3(tmp_path):
+    s3 = DummyS3()
+    registry = ModelRegistry("sqlite:///:memory:", bucket="b", s3_client=s3)
+    base = pd.DataFrame({"a": [0, 1, 2]})
+    cur = pd.DataFrame({"a": [1, 2, 3]})
+    model_path = tmp_path / "model.bin"
+    model_path.write_text("x")
+    record = registry.register_model("m", str(model_path), {"acc": 1.0}, "hash", baseline=base)
+    registry.set_active_version("m", record.version)
+    registry._baseline_features.clear()
+    registry.log_features("m", cur)
+    metrics = registry.get_drift_metrics("m")
+    assert metrics and "a" in metrics
+    drift = registry.detect_drift("m", cur)
+    assert "a" in drift and "psi" in drift["a"]


### PR DESCRIPTION
## Summary
- persist baseline feature stats and URIs in `ModelRecord`
- load and fetch stored baselines for drift detection and metrics
- add tests around baseline storage and retrieval

## Testing
- `pytest --override-ini addopts='' tests/test_model_registry_drift.py::test_get_drift_metrics_uses_compute_psi -p no:cov -q` (fails: TypeError: object() takes no arguments)
- `pytest --override-ini addopts='' tests/test_model_registry_drift.py::test_get_drift_metrics_loads_baseline_from_s3 -p no:cov -q` (fails: TypeError: object() takes no arguments)


------
https://chatgpt.com/codex/tasks/task_e_689c44b02f94832084f8508b0e08f219