### PR TITLE
Annotate analytics service helpers

### DIFF
--- a/yosai_intel_dashboard/src/services/analytics/analytics_summary.py
+++ b/yosai_intel_dashboard/src/services/analytics/analytics_summary.py
@@ -1,32 +1,42 @@
 """Public API wrappers for analytics generation."""
 
-from typing import Any, Dict
+from typing import Any, cast
 
 import pandas as pd
 
-from .analytics.generator import AnalyticsGenerator
+from .generator import AnalyticsGenerator
 
-_generator = AnalyticsGenerator()
+_generator: AnalyticsGenerator = AnalyticsGenerator()
 
 
-def summarize_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
-    return _generator.summarize_dataframe(df)
+def summarize_dataframe(df: pd.DataFrame) -> dict[str, Any]:
+    """Return summary statistics for the provided dataframe."""
+
+    return cast(dict[str, Any], _generator.summarize_dataframe(df))
 
 
 def create_sample_data(n_events: int = 1000) -> pd.DataFrame:
-    return _generator.create_sample_data(n_events)
+    """Generate a sample dataframe with a default size of 1000 rows."""
+
+    return cast(pd.DataFrame, _generator.create_sample_data(n_events))
 
 
-def analyze_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
-    return _generator.analyze_dataframe(df)
+def analyze_dataframe(df: pd.DataFrame) -> dict[str, Any]:
+    """Run detailed analysis on the dataframe and return metrics."""
+
+    return cast(dict[str, Any], _generator.analyze_dataframe(df))
 
 
-def generate_basic_analytics(df: pd.DataFrame) -> Dict[str, Any]:
-    return _generator.generate_basic_analytics(df)
+def generate_basic_analytics(df: pd.DataFrame) -> dict[str, Any]:
+    """Return fundamental analytics for the dataframe."""
+
+    return cast(dict[str, Any], _generator.generate_basic_analytics(df))
 
 
-def generate_sample_analytics() -> Dict[str, Any]:
-    return _generator.generate_sample_analytics()
+def generate_sample_analytics() -> dict[str, Any]:
+    """Generate a sample dataframe and return its analytics."""
+
+    return cast(dict[str, Any], _generator.generate_sample_analytics())
 
 
 __all__ = [

--- a/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import asyncpg
 import redis.asyncio as aioredis
@@ -41,5 +41,7 @@ class AnalyticsService:
         _preload_models(self)
 
 
-async def get_analytics_service(request) -> AnalyticsService:
-    return request.app.state.analytics_service
+async def get_analytics_service(request: Any) -> AnalyticsService:
+    """Fetch the :class:`AnalyticsService` instance from a request object."""
+
+    return cast(AnalyticsService, request.app.state.analytics_service)


### PR DESCRIPTION
## Summary
- add typed request accessor for analytics microservice service
- tighten analytics summary API with casts and import fix

## Testing
- `mypy --follow-imports=skip --ignore-missing-imports yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py yosai_intel_dashboard/src/services/analytics/analytics_summary.py`
- `flake8 yosai_intel_dashboard/src/services/analytics_microservice/analytics_service.py yosai_intel_dashboard/src/services/analytics/analytics_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_689c572f6c00832093815012404a89f9