### PR TITLE
refactor: update SecureQueryBuilder import paths

### DIFF
--- a/scripts/migrate_to_timescale.py
+++ b/scripts/migrate_to_timescale.py
@@ -29,7 +29,7 @@ from psycopg2.extensions import connection, cursor
 from psycopg2.extras import DictCursor, execute_batch
 from tqdm import tqdm
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.secure_exec import (
     execute_command,
     execute_query,

--- a/scripts/replicate_to_timescale.py
+++ b/scripts/replicate_to_timescale.py
@@ -12,7 +12,7 @@ import psycopg2
 from prometheus_client import Gauge, start_http_server
 from psycopg2.extras import DictCursor, execute_values
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.secure_exec import (
     execute_command,
     execute_query,

--- a/tests/analytics/test_timescale_queries.py
+++ b/tests/analytics/test_timescale_queries.py
@@ -25,11 +25,11 @@ sys.modules.setdefault("infrastructure", infrastructure_pkg)
 sys.modules.setdefault("infrastructure.security", security_pkg)
 
 spec_sq = importlib.util.spec_from_file_location(
-    "infrastructure.security.query_builder",
+    "yosai_intel_dashboard.src.infrastructure.security.query_builder",
     ROOT / "infrastructure/security/query_builder.py",
 )
 secure_module = importlib.util.module_from_spec(spec_sq)
-sys.modules.setdefault("infrastructure.security.query_builder", secure_module)
+sys.modules.setdefault("yosai_intel_dashboard.src.infrastructure.security.query_builder", secure_module)
 assert spec_sq.loader is not None
 spec_sq.loader.exec_module(secure_module)
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -254,7 +254,7 @@ def register_dependency_stubs() -> None:
         execute_command=lambda *a, **k: None,
     )
     query_builder_stub = _simple_module(
-        "infrastructure.security.query_builder",
+        "yosai_intel_dashboard.src.infrastructure.security.query_builder",
         SecureQueryBuilder=lambda *a, **k: types.SimpleNamespace(
             table=lambda x: x, column=lambda x: x, build=lambda q, logger=None: (q, [])
         ),
@@ -262,11 +262,11 @@ def register_dependency_stubs() -> None:
     register_fallback("database", database_pkg)
     register_fallback("database.connection", connection_stub)
     register_fallback("database.secure_exec", secure_exec_stub)
-    register_fallback("infrastructure.security.query_builder", query_builder_stub)
+    register_fallback("yosai_intel_dashboard.src.infrastructure.security.query_builder", query_builder_stub)
     sys.modules.setdefault("database", database_pkg)
     sys.modules.setdefault("database.connection", connection_stub)
     sys.modules.setdefault("database.secure_exec", secure_exec_stub)
-    sys.modules.setdefault("infrastructure.security.query_builder", query_builder_stub)
+    sys.modules.setdefault("yosai_intel_dashboard.src.infrastructure.security.query_builder", query_builder_stub)
 
     config_manager_stub = _simple_module(
         "yosai_intel_dashboard.src.infrastructure.config.config_manager",

--- a/tests/database/test_baseline_metrics_sql_injection.py
+++ b/tests/database/test_baseline_metrics_sql_injection.py
@@ -23,7 +23,7 @@ def test_baseline_metrics_uses_parameters(monkeypatch):
     monkeypatch.setitem(sys.modules, "security", types.ModuleType("security"))
     monkeypatch.setitem(sys.modules, "security.secure_query_wrapper", fake_sec)
     monkeypatch.setitem(
-        sys.modules, "infrastructure.security.query_builder", fake_secure_query
+        sys.modules, "yosai_intel_dashboard.src.infrastructure.security.query_builder", fake_secure_query
     )
     bm = importlib.import_module("yosai_intel_dashboard.src.database.baseline_metrics")
     importlib.reload(bm)

--- a/tests/plugins/test_dsar_service_rectification.py
+++ b/tests/plugins/test_dsar_service_rectification.py
@@ -53,14 +53,14 @@ secure_exec_mod.execute_command = execute_command
 secure_exec_mod.execute_query = execute_query
 sys.modules["database.secure_exec"] = secure_exec_mod
 
-# Stub infrastructure.security.query_builder with minimal builder
+# Stub yosai_intel_dashboard.src.infrastructure.security.query_builder with minimal builder
 infrastructure_pkg = types.ModuleType("infrastructure")
 infrastructure_pkg.__path__ = []  # type: ignore[attr-defined]
 sys.modules["infrastructure"] = infrastructure_pkg
 infrastructure_sec_pkg = types.ModuleType("infrastructure.security")
 infrastructure_sec_pkg.__path__ = []  # type: ignore[attr-defined]
 sys.modules["infrastructure.security"] = infrastructure_sec_pkg
-secure_query_mod = types.ModuleType("infrastructure.security.query_builder")
+secure_query_mod = types.ModuleType("yosai_intel_dashboard.src.infrastructure.security.query_builder")
 
 
 class SecureQueryBuilder:
@@ -83,7 +83,7 @@ class SecureQueryBuilder:
 
 
 secure_query_mod.SecureQueryBuilder = SecureQueryBuilder
-sys.modules["infrastructure.security.query_builder"] = secure_query_mod
+sys.modules["yosai_intel_dashboard.src.infrastructure.security.query_builder"] = secure_query_mod
 
 # Stub models.compliance to avoid SQLAlchemy dependency
 models_mod = types.ModuleType("yosai_intel_dashboard.models.compliance")

--- a/tests/security/test_secure_query_builder.py
+++ b/tests/security/test_secure_query_builder.py
@@ -9,10 +9,10 @@ import pytest
 SRC_PATH = pathlib.Path(__file__).resolve().parents[2] / "yosai_intel_dashboard" / "src"
 SECURE_QUERY_FILE = SRC_PATH / "infrastructure" / "security" / "query_builder.py"
 spec = importlib.util.spec_from_file_location(
-    "infrastructure.security.query_builder", SECURE_QUERY_FILE
+    "yosai_intel_dashboard.src.infrastructure.security.query_builder", SECURE_QUERY_FILE
 )
 secure_query = importlib.util.module_from_spec(spec)
-sys.modules["infrastructure.security.query_builder"] = secure_query
+sys.modules["yosai_intel_dashboard.src.infrastructure.security.query_builder"] = secure_query
 spec.loader.exec_module(secure_query)
 SecureQueryBuilder = secure_query.SecureQueryBuilder
 

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/database.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/database.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.secure_exec import (
     execute_command,
     execute_query,

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py
@@ -12,7 +12,7 @@ from flask import request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.models.compliance import (
     ConsentLog,
     ConsentType,

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Protocol
 from uuid import uuid4
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.models.compliance import (
     DSARRequest,
     DSARRequestType,

--- a/yosai_intel_dashboard/src/database/baseline_metrics.py
+++ b/yosai_intel_dashboard/src/database/baseline_metrics.py
@@ -11,7 +11,7 @@ historical performance metrics.
 import logging
 from typing import Dict
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.connection import create_database_connection
 from yosai_intel_dashboard.src.database.types import DBRows
 from yosai_intel_dashboard.src.infrastructure.security.secure_query_wrapper import (

--- a/yosai_intel_dashboard/src/database/index_optimizer.py
+++ b/yosai_intel_dashboard/src/database/index_optimizer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterable, List, Sequence
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.types import DBRows
 
 # Importing create_database_connection at module level pulls in heavy

--- a/yosai_intel_dashboard/src/infrastructure/database/secure_query.py
+++ b/yosai_intel_dashboard/src/infrastructure/database/secure_query.py
@@ -22,7 +22,7 @@ def _validate_identifier(name: str, allowed: Set[str]) -> str:
 
 
 # The SecureQueryBuilder implementation has moved to
-# ``infrastructure.security.query_builder``. Importing from this module is
+# ``yosai_intel_dashboard.src.infrastructure.security.query_builder``. Importing from this module is
 # deprecated and will be removed in a future release.
 
 

--- a/yosai_intel_dashboard/src/services/analytics/timescale_queries.py
+++ b/yosai_intel_dashboard/src/services/analytics/timescale_queries.py
@@ -11,7 +11,7 @@ from cachetools import LRUCache
 from sqlalchemy import text
 from sqlalchemy.sql import TextClause
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.core.query_optimizer import monitor_query_performance
 
 LOG = logging.getLogger(__name__)

--- a/yosai_intel_dashboard/src/services/migration/framework.py
+++ b/yosai_intel_dashboard/src/services/migration/framework.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Sequence
 
 import asyncpg
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 
 from .validators.integrity_checker import IntegrityChecker
 

--- a/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py
@@ -5,7 +5,7 @@ from typing import AsyncIterator, Awaitable, Callable, List
 
 import asyncpg
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.infrastructure.config.constants import (
     MIGRATION_CHUNK_SIZE,
 )

--- a/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/events_migration.py
@@ -5,7 +5,7 @@ from typing import AsyncIterator, Awaitable, Callable, List
 
 import asyncpg
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.infrastructure.config.constants import (
     DataProcessingLimits,
 )

--- a/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
+++ b/yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py
@@ -5,7 +5,7 @@ from typing import AsyncIterator, Awaitable, Callable, List
 
 import asyncpg
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.infrastructure.config.constants import (
     MIGRATION_CHUNK_SIZE,
 )

--- a/yosai_intel_dashboard/src/services/migration/validators/integrity_checker.py
+++ b/yosai_intel_dashboard/src/services/migration/validators/integrity_checker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncpg
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 
 
 class IntegrityChecker:

--- a/yosai_intel_dashboard/src/services/optimized_queries.py
+++ b/yosai_intel_dashboard/src/services/optimized_queries.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Sequence
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.secure_exec import (
     execute_query,
     execute_secure_query,

--- a/yosai_intel_dashboard/src/services/query_optimizer.py
+++ b/yosai_intel_dashboard/src/services/query_optimizer.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Any, Dict, Iterable, List, Sequence
 
-from infrastructure.security.query_builder import SecureQueryBuilder
+from yosai_intel_dashboard.src.infrastructure.security.query_builder import SecureQueryBuilder
 from yosai_intel_dashboard.src.database.secure_exec import execute_query
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- update SecureQueryBuilder imports to use `yosai_intel_dashboard.src.infrastructure.security.query_builder`
- adjust tests and utilities to reference new module path

## Testing
- `pre-commit run --files scripts/migrate_to_timescale.py scripts/replicate_to_timescale.py tests/analytics/test_timescale_queries.py tests/config.py tests/database/test_baseline_metrics_sql_injection.py tests/plugins/test_dsar_service_rectification.py tests/security/test_secure_query_builder.py yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/database.py yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/consent_service.py yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/dsar_service.py yosai_intel_dashboard/src/database/baseline_metrics.py yosai_intel_dashboard/src/database/index_optimizer.py yosai_intel_dashboard/src/infrastructure/database/secure_query.py yosai_intel_dashboard/src/services/analytics/timescale_queries.py yosai_intel_dashboard/src/services/migration/framework.py yosai_intel_dashboard/src/services/migration/strategies/analytics_migration.py yosai_intel_dashboard/src/services/migration/strategies/events_migration.py yosai_intel_dashboard/src/services/migration/strategies/gateway_migration.py yosai_intel_dashboard/src/services/migration/validators/integrity_checker.py yosai_intel_dashboard/src/services/optimized_queries.py yosai_intel_dashboard/src/services/query_optimizer.py`
- `rg "infrastructure\.security\.query_builder" -n`

------
https://chatgpt.com/codex/tasks/task_e_689c5df0636c8320b7790967fbd56981