### PR TITLE
fix pytest file discovery pattern

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths =
     tests
     tests/cli
     services/analytics_microservice/tests
-python_files = test_.py
+python_files = test_*.py
 python_classes = Test
 python_functions = test_*
 norecursedirs = scripts/manual_tests


### PR DESCRIPTION
## Summary
- ensure pytest discovers test modules by adjusting `python_files` pattern

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/yosai_intel_dashboard_fresh/models/ml/model_registry.py')*

------
https://chatgpt.com/codex/tasks/task_e_689c5dff0eec832089e25c35b2b3b78f