### PR TITLE
chore: update pandas and feast compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ pytest-asyncio>=0.23
 pytest-dotenv==0.5.2
 memory-profiler>=0.61.0
 selenium>=4.20.0
-pydantic==2.10.6
+pydantic==2.9.2
 dask[distributed]==2024.4.1
 tqdm>=4.0
 aiohttp>=3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
 dash-bootstrap-components==1.6.0
-pandas==2.0.3  # feast 0.30.2 compatible
-numpy>=1.23,<2.0  # Python 3.11 compatible
+pandas==2.2.3  # Feast >=0.47 supports pandas >=2
+numpy>=1.26,<2.0  # required for pandas 2.2.3
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0
@@ -21,7 +21,7 @@ cssutils==2.8.0
 scipy==1.11.3
 scikit-learn==1.7.1
 joblib==1.3.2
-psutil==7.0.0
+psutil==6.1.0  # safety 3.6.0 requires psutil~=6.1
 psycopg2-binary==2.9.7
 asyncpg==0.30.0
 redis==6.4.0
@@ -63,13 +63,13 @@ fastapi==0.116.1
 opentelemetry-api==1.35.0
 opentelemetry-sdk==1.35.0
 opentelemetry-exporter-jaeger==1.21.0
-opentelemetry-exporter-zipkin==1.21.0
+opentelemetry-exporter-zipkin-json==1.21.0
 pika==1.3.2
 boto3==1.34.103
-protobuf==3.20.3
+protobuf==4.25.3  # required by Feast 0.47.0
 
 strawberry-graphql[fastapi]==0.278.1
-feast==0.30.2
+feast==0.47.0  # supports pandas >=2 and pydantic >=2
 tenacity==8.2.3
 shap==0.44.1
 lime==0.2.0.1


### PR DESCRIPTION
## Summary
- upgrade Feast for pandas>=2 and pydantic>=2 support
- bump pandas and numpy versions
- align protobuf, psutil, and opentelemetry exporter with new Feast
- adjust dev dependency on pydantic

## Testing
- `pip install -r requirements-dev.txt` *(fails: building dependencies cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_689c5dfdc6d8832094b390d1cafc9867