### PR TITLE
chore: upgrade Feast for pandas 2 compatibility

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,8 +10,8 @@ Flask-Caching==2.0.2
 cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
-pandas==2.0.3  # feast 0.30.2 compatible
-numpy>=1.23,<2.0  # Python 3.11 compatible
+pandas==2.2.3  # Feast >=0.47 supports pandas >=2
+numpy>=1.26,<2.0  # required for pandas 2.2.3
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0
@@ -63,10 +63,10 @@ opentelemetry-exporter-jaeger==1.21.0
 opentelemetry-exporter-zipkin==1.21.0
 pika==1.3.2
 boto3==1.34.103
-protobuf==3.20.3
+protobuf==4.25.3  # required by Feast 0.47.0
 
 strawberry-graphql[fastapi]
-feast==0.30.2
+feast==0.47.0  # supports pandas >=2 and pydantic >=2
 tenacity==8.2.3
 shap==0.44.1
 lime==0.2.0.1

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -10,8 +10,8 @@ Flask-Caching==2.0.2
 cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
-pandas==2.0.3  # feast 0.30.2 compatible
-numpy>=1.23,<2.0  # Python 3.11 compatible
+pandas==2.2.3  # Feast >=0.47 supports pandas >=2
+numpy>=1.26,<2.0  # required for pandas 2.2.3
 Authlib==1.6.1
 python-jose==3.5.0
 argon2-cffi==23.1.0
@@ -63,10 +63,10 @@ opentelemetry-exporter-jaeger==1.21.0
 opentelemetry-exporter-zipkin==1.21.0
 pika==1.3.2
 boto3==1.34.103
-protobuf==3.20.3
+protobuf==4.25.3  # required by Feast 0.47.0
 
 strawberry-graphql[fastapi]
-feast==0.30.2
+feast==0.47.0  # supports pandas >=2 and pydantic >=2
 tenacity==8.2.3
 shap==0.44.1
 lime==0.2.0.1


### PR DESCRIPTION
## Summary
- upgrade Feast to 0.47.0 to support pandas 2.x
- align pandas, numpy, and protobuf versions with Feast 0.47.0 requirements

## Testing
- `pytest tests/integration/test_model_drift.py -q` *(fails: TypeError: 'module' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689c6b4eacec8320a1f5d1802527461b