### PR TITLE
shared: document and harden env config loader (#0)

### DIFF
--- a/shared/python/config_loader.py
+++ b/shared/python/config_loader.py
@@ -1,21 +1,53 @@
+"""Typed access to environment variables with validation."""
+
 from __future__ import annotations
+
 import os
 from typing import Callable, Optional, TypeVar
 
 T = TypeVar("T")
 
+
 class ConfigError(RuntimeError):
-    pass
+    """Raised when an environment variable is missing or invalid."""
 
 
 def _coerce(value: str, caster: Callable[[str], T], name: str) -> T:
+    """Coerce ``value`` using ``caster`` and wrap errors with ``ConfigError``.
+
+    Args:
+        value: Raw string value retrieved from the environment.
+        caster: Callable used to convert ``value`` to the desired type.
+        name: Name of the environment variable for error reporting.
+
+    Returns:
+        The converted value returned by ``caster``.
+
+    Raises:
+        ConfigError: If ``caster`` fails to convert the value.
+    """
+
     try:
         return caster(value)
-    except Exception as e:
-        raise ConfigError(f"Invalid value for {name!r}: {value!r}") from e
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(f"Invalid value for {name!r}: {value!r}") from exc
 
 
 def get_str(name: str, default: Optional[str] = None, required: bool = False) -> str:
+    """Retrieve a string environment variable.
+
+    Args:
+        name: Name of the environment variable.
+        default: Value to return if the variable is not set.
+        required: Whether to raise ``ConfigError`` if the variable is missing.
+
+    Returns:
+        The environment variable value or ``default`` if unset.
+
+    Raises:
+        ConfigError: If ``required`` is ``True`` and the variable is missing.
+    """
+
     v = os.getenv(name, default)
     if required and v is None:
         raise ConfigError(f"Missing required env: {name}")
@@ -23,6 +55,20 @@ def get_str(name: str, default: Optional[str] = None, required: bool = False) ->
 
 
 def get_int(name: str, default: Optional[int] = None, required: bool = False) -> int:
+    """Retrieve an integer environment variable.
+
+    Args:
+        name: Name of the environment variable.
+        default: Value to return if the variable is not set.
+        required: Whether to raise ``ConfigError`` if the variable is missing.
+
+    Returns:
+        The integer value of the environment variable or ``default`` if unset.
+
+    Raises:
+        ConfigError: If the variable is required but missing or cannot be cast.
+    """
+
     v = os.getenv(name)
     if v is None:
         if required and default is None:
@@ -32,6 +78,16 @@ def get_int(name: str, default: Optional[int] = None, required: bool = False) ->
 
 
 def get_bool(name: str, default: Optional[bool] = None) -> bool:
+    """Retrieve a boolean environment variable.
+
+    Args:
+        name: Name of the environment variable.
+        default: Value to return if the variable is not set.
+
+    Returns:
+        ``True`` if the variable is a truthy string, ``False`` otherwise.
+    """
+
     v = os.getenv(name)
     if v is None:
         return False if default is None else default

--- a/unit_tests/test_config_loader.py
+++ b/unit_tests/test_config_loader.py
@@ -1,0 +1,24 @@
+import pytest
+
+from shared.python.config_loader import ConfigError, get_bool, get_int, get_str
+
+
+def test_get_str_required_missing(monkeypatch):
+    with pytest.raises(ConfigError):
+        get_str("MISSING_VAR", required=True)
+
+
+def test_get_int_conversion_error(monkeypatch):
+    monkeypatch.setenv("MY_INT", "notint")
+    with pytest.raises(ConfigError):
+        get_int("MY_INT", required=True)
+
+
+def test_get_bool_true(monkeypatch):
+    monkeypatch.setenv("FLAG", "yes")
+    assert get_bool("FLAG") is True
+
+
+def test_get_bool_default(monkeypatch):
+    monkeypatch.delenv("FLAG", raising=False)
+    assert get_bool("FLAG", default=True) is True


### PR DESCRIPTION
## Summary
- document configuration loader helpers
- restrict casting errors to value/type errors and expose dedicated tests

## Testing
- `ruff check shared/python/config_loader.py unit_tests/test_config_loader.py --fix`
- `black --line-length 88 shared/python/config_loader.py unit_tests/test_config_loader.py`
- `pytest --override-ini addopts='' unit_tests/test_config_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c71c3d29483209a5d6515f5f1721d