### PR TITLE
refactor: break circular import

### DIFF
--- a/A.py
+++ b/A.py
@@ -1,0 +1,16 @@
+from core.types import BProtocol
+
+
+class A:
+    """Component depending on a BProtocol implementation.
+
+    The dependency is injected through the constructor to avoid a
+    compile‑time import of :mod:`B` which would create a circular import.
+    """
+
+    def __init__(self, b: BProtocol) -> None:
+        self._b = b
+
+    def do_a(self) -> str:
+        """Delegate to the injected ``B`` implementation."""
+        return f"A -> {self._b.do_b()}"

--- a/B.py
+++ b/B.py
@@ -1,0 +1,21 @@
+from core.types import BProtocol
+
+
+class B(BProtocol):
+    """Simple implementation of :class:`BProtocol`."""
+
+    def do_b(self) -> str:
+        return "B"
+
+
+def create_a() -> "A":
+    """Create an :class:`A` instance without top-level imports.
+
+    Importing :mod:`A` locally keeps this module importable on its own and
+    breaks the circular dependency that would otherwise exist between the
+    two modules.
+    """
+
+    from A import A  # Local import to avoid circular dependency
+
+    return A(B())

--- a/core/types.py
+++ b/core/types.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class BProtocol(Protocol):
+    """Protocol representing the behaviour expected by :mod:`A`."""
+
+    def do_b(self) -> str:
+        """Return a string representation."""
+        ...

--- a/unit_tests/test_circular_import.py
+++ b/unit_tests/test_circular_import.py
@@ -1,0 +1,13 @@
+from A import A
+from B import B, create_a
+
+
+def test_import_and_usage() -> None:
+    """Modules should import without circular dependencies."""
+
+    b = B()
+    a = A(b)
+    assert a.do_a() == "A -> B"
+
+    a2 = create_a()
+    assert a2.do_a() == "A -> B"


### PR DESCRIPTION
## Summary
- add `BProtocol` interface in `core/types`
- refactor `A` to inject `BProtocol` implementation via constructor
- implement `B` with local import helper `create_a`
- add unit test ensuring modules import without circular dependency

## Testing
- `pytest unit_tests/test_circular_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c71daf8748320b251c49792fa1013