### PR TITLE
refactor: add structured logging and typed exceptions

### DIFF
--- a/dashboard/wsgi.py
+++ b/dashboard/wsgi.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 from yosai_intel_dashboard.src.core.env_validation import validate_required_env
 from yosai_intel_dashboard.src.core.app_factory import create_app
+
+logger = logging.getLogger(__name__)
 
 validate_required_env()
 
@@ -16,7 +20,7 @@ if __name__ == "__main__":
     if dev_mode:
         app.run()
     else:
-        print(
+        logger.error(
             "Refusing to start the development server without --dev or YOSAI_DEV=1. "
             "Use 'gunicorn wsgi:server' or an equivalent WSGI server in production."
         )

--- a/unit_tests/cli/test_feature_flags_cli.py
+++ b/unit_tests/cli/test_feature_flags_cli.py
@@ -1,0 +1,34 @@
+import logging
+import pytest
+import requests
+
+from cli.feature_flags import create_flag, list_flags
+from yosai_intel_dashboard.src.exceptions import ExternalServiceError
+from yosai_intel_dashboard.src.logging_config import configure_logging
+
+
+configure_logging()
+
+
+def test_list_flags_timeout(monkeypatch, caplog):
+    def fake_get(*args, **kwargs):
+        raise requests.Timeout("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ExternalServiceError):
+            list_flags("http://example.com", token="secret", roles=None)
+    assert "secret" not in caplog.text
+
+
+def test_create_flag_request_error(monkeypatch, caplog):
+    def fake_post(*args, **kwargs):
+        raise requests.ConnectionError("down")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ExternalServiceError):
+            create_flag(
+                "http://example.com", "new_flag", True, token=None, roles=None
+            )
+

--- a/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
+++ b/yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py
@@ -291,9 +291,10 @@ class ComplianceCSVProcessor:
             # Check for timestamp patterns
             try:
                 pd.to_datetime(sample_values.iloc[0])
-                detected_types.add("access_logs")
-            except:
+            except (ValueError, TypeError, pd.errors.ParserError):
                 pass
+            else:
+                detected_types.add("access_logs")
 
         return {"detected_types": detected_types}
 

--- a/yosai_intel_dashboard/src/exceptions.py
+++ b/yosai_intel_dashboard/src/exceptions.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+class YosaiError(Exception):
+    """Base exception for Yosai Intel Dashboard."""
+
+class ExternalServiceError(YosaiError):
+    """Raised when calls to external services fail."""
+
+class InvalidResponseError(YosaiError):
+    """Raised when external services return an unexpected response."""

--- a/yosai_intel_dashboard/src/logging_config.py
+++ b/yosai_intel_dashboard/src/logging_config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from logging.config import dictConfig
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+        }
+    },
+    "root": {"handlers": ["console"], "level": "INFO"},
+}
+
+
+def configure_logging(level: int | str = "INFO") -> None:
+    """Apply default logging configuration.
+
+    Parameters
+    ----------
+    level:
+        Logging level for the root logger.
+    """
+    config = dict(LOGGING_CONFIG)
+    config["root"] = dict(config["root"], level=level)
+    dictConfig(config)


### PR DESCRIPTION
## Summary
- add central logging configuration and exception taxonomy
- replace prints and bare excepts with structured logging and typed errors
- wrap feature flag CLI network calls with timeouts and add error-path tests

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/exceptions.py yosai_intel_dashboard/src/logging_config.py cli/feature_flags.py dashboard/wsgi.py yosai_intel_dashboard/src/adapters/api/plugins/compliance_plugin/services/compliance_csv_processor.py unit_tests/cli/test_feature_flags_cli.py`
- `pytest unit_tests/cli/test_feature_flags_cli.py -q` *(fails: KeyboardInterrupt / coverage threshold)*

------
https://chatgpt.com/codex/tasks/task_e_689c7db264f483208be6b11eb6af9354