### PR TITLE
refactor(ui): type navigation icons and unify test router

### DIFF
--- a/yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
-jest.mock('react-router-dom', () => ({
-  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
-  useLocation: () => ({ pathname: '/' }),
-  useNavigate: () => jest.fn(),
-  MemoryRouter: ({ children }: any) => <div>{children}</div>,
-}), { virtual: true });
+import {
+  MockLink,
+  MockMemoryRouter as MemoryRouter,
+} from '../test-utils/router';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: MockLink,
+    useLocation: () => ({ pathname: '/' }),
+    useNavigate: () => jest.fn(),
+    MemoryRouter,
+  }),
+  { virtual: true },
+);
 import Navigation, { Header, Sidebar } from './Navigation';
 import { boundStore } from '../state/store';
-
-const MemoryRouter: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div>{children}</div>
-);
 
 beforeEach(() => {
   act(() => {
@@ -23,7 +28,7 @@ test('renders navigation links', () => {
   render(
     <MemoryRouter>
       <Navigation />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.getByText('Upload')).toBeInTheDocument();
   expect(screen.getByText('Analytics')).toBeInTheDocument();
@@ -34,7 +39,7 @@ test('hides advanced navigation for beginners', () => {
   render(
     <MemoryRouter>
       <Navigation />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
 });
@@ -46,7 +51,7 @@ test('shows advanced navigation for experts', () => {
   render(
     <MemoryRouter>
       <Navigation />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.getByText('Experimental')).toBeInTheDocument();
 });
@@ -55,7 +60,7 @@ test('header shows title', () => {
   render(
     <MemoryRouter>
       <Header />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.getByText('Yosai Intel Dashboard')).toBeInTheDocument();
 });
@@ -64,7 +69,7 @@ test('sidebar renders when open', () => {
   render(
     <MemoryRouter>
       <Sidebar isOpen={true} />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.getByText('Analytics Ready')).toBeInTheDocument();
 });

--- a/yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx
@@ -10,14 +10,14 @@ import {
   Database,
   Shield,
   Activity,
-  LayoutDashboard
+  LayoutDashboard,
 } from 'lucide-react';
 import { useProficiencyStore } from '../state/store';
 
 interface NavItem {
   name: string;
   href?: string;
-  icon?: any;
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   description?: string;
   level: number;
   children?: NavItem[];
@@ -90,7 +90,10 @@ interface NavigationProps {
   orientation?: 'horizontal' | 'vertical';
 }
 
-const Navigation: React.FC<NavigationProps> = ({ className = '', orientation = 'horizontal' }) => {
+const Navigation: React.FC<NavigationProps> = ({
+  className = '',
+  orientation = 'horizontal',
+}) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { level: userLevel, logFeatureUsage } = useProficiencyStore();
@@ -103,7 +106,7 @@ const Navigation: React.FC<NavigationProps> = ({ className = '', orientation = '
         orientation === 'horizontal' && depth === 0
           ? 'flex items-center space-x-1'
           : 'flex flex-col space-y-2',
-        depth > 0 ? 'ml-4' : ''
+        depth > 0 ? 'ml-4' : '',
       )}
     >
       {items
@@ -123,7 +126,7 @@ const Navigation: React.FC<NavigationProps> = ({ className = '', orientation = '
                 'flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors',
                 active
                   ? 'bg-blue-100 text-blue-700'
-                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
               )}
               title={item.description}
               aria-current={active ? 'page' : undefined}
@@ -131,20 +134,26 @@ const Navigation: React.FC<NavigationProps> = ({ className = '', orientation = '
               {Icon && (
                 <Icon
                   className={
-                    orientation === 'horizontal' && depth === 0 ? 'h-4 w-4' : 'h-5 w-5'
+                    orientation === 'horizontal' && depth === 0
+                      ? 'h-4 w-4'
+                      : 'h-5 w-5'
                   }
                 />
               )}
               <span
                 className={
-                  orientation === 'horizontal' && depth === 0 ? 'hidden sm:inline' : undefined
+                  orientation === 'horizontal' && depth === 0
+                    ? 'hidden sm:inline'
+                    : undefined
                 }
               >
                 {item.name}
               </span>
             </Link>
           ) : (
-            <span className="px-3 py-2 text-sm font-medium text-gray-500">{item.name}</span>
+            <span className="px-3 py-2 text-sm font-medium text-gray-500">
+              {item.name}
+            </span>
           );
 
           return (
@@ -200,7 +209,7 @@ export const Sidebar: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
     <aside
       className={cn(
         'fixed inset-y-0 left-0 z-50 w-64 bg-white shadow-lg transform transition-transform duration-200 ease-in-out',
-        isOpen ? 'translate-x-0' : '-translate-x-full'
+        isOpen ? 'translate-x-0' : '-translate-x-full',
       )}
     >
       <div className="flex flex-col h-full">

--- a/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-jest.mock('react-router-dom', () => ({
-  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
-  useLocation: () => ({ pathname: '/' }),
-  useNavigate: () => jest.fn(),
-  MemoryRouter: ({ children }: any) => <div>{children}</div>,
-}), { virtual: true });
+import {
+  MockLink,
+  MockMemoryRouter as MemoryRouter,
+} from '../../test-utils/router';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: MockLink,
+    useLocation: () => ({ pathname: '/' }),
+    useNavigate: () => jest.fn(),
+    MemoryRouter,
+  }),
+  { virtual: true },
+);
 import Navbar from './Navbar';
 import { NavbarTitleProvider } from './NavbarTitleContext';
-
-const MemoryRouter: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div>{children}</div>
-);
 
 test('shows brand text and toggles menu', () => {
   (window as any).innerWidth = 500;
@@ -20,7 +25,7 @@ test('shows brand text and toggles menu', () => {
       <NavbarTitleProvider>
         <Navbar />
       </NavbarTitleProvider>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
   expect(screen.getByText('YOSAI Intelligence')).toBeInTheDocument();
   const toggle = screen.getByLabelText('Toggle menu');

--- a/yosai_intel_dashboard/src/adapters/ui/test-utils/router.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/test-utils/router.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const MockLink: React.FC<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>
+> = ({ children, ...props }) => <a {...props}>{children}</a>;
+
+export const MockMemoryRouter: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <div>{children}</div>;


### PR DESCRIPTION
## Summary
- type `NavItem.icon` with `React.ComponentType` to avoid `any`
- extract reusable `MockLink` and `MockMemoryRouter` for tests
- adjust navigation and navbar tests to leverage shared mocks

## Testing
- `npx ts-prune -p tsconfig.json`
- `npx -y depcheck`
- `npx prettier -w yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx yosai_intel_dashboard/src/adapters/ui/test-utils/router.tsx`
- `npx eslint yosai_intel_dashboard/src/adapters/ui/components/Navigation.tsx yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx yosai_intel_dashboard/src/adapters/ui/test-utils/router.tsx` *(fails: Cannot find package 'eslint-plugin-prettier')*
- `npx -y vitest run yosai_intel_dashboard/src/adapters/ui/components/Navigation.test.tsx yosai_intel_dashboard/src/adapters/ui/components/layout/Navbar.test.tsx` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_689c7eb1818c8320a64de45678509eaa