### PR TITLE
harden docker artifacts

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS builder
+ARG PYTHON_IMAGE=python:3.11-slim
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE} AS builder
 WORKDIR /app
 
 # Install system packages
@@ -11,12 +13,14 @@ RUN apt-get update \
 
 # Install Python dependencies
 COPY requirements.txt ./
+# hadolint ignore=SC1091
 RUN python -m venv /opt/venv \
     && . /opt/venv/bin/activate \
     && grep -v '^apache-flink' requirements.txt > requirements.filtered \
     && pip install --no-cache-dir -r requirements.filtered
 
-FROM python:3.11-slim
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE}
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
@@ -39,7 +43,10 @@ WORKDIR /app
 COPY . /app
 COPY ../yosai_intel_dashboard /app/yosai_intel_dashboard
 COPY ../core /app/core
-RUN chmod +x docker-entrypoint.sh && chown -R appuser:appuser /app
+RUN chmod 0755 docker-entrypoint.sh \
+    && find /app -type f -name '*.sh' -exec chmod 0755 {} \; \
+    && find /app -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.conf' \) -exec chmod 0644 {} \; \
+    && chown -R appuser:appuser /app
 USER appuser
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 log() {
-  echo "[docker-entrypoint] $*"
+  printf '[docker-entrypoint] %s\n' "$*"
 }
 
 start_fallback() {

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS builder
+ARG PYTHON_IMAGE=python:3.11-slim
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE} AS builder
 WORKDIR /app
 
 # Install system packages
@@ -11,13 +13,14 @@ RUN apt-get update \
 
 # Install Python dependencies
 COPY ../requirements.txt ./
-
+# hadolint ignore=SC1091
 RUN python -m venv /opt/venv \
     && . /opt/venv/bin/activate \
     && grep -v '^apache-flink' requirements.txt > requirements.filtered \
     && pip install --no-cache-dir -r requirements.filtered
 
-FROM python:3.11-slim
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE}
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONPATH=/app:/app/yosai_intel_dashboard/src
 
@@ -40,7 +43,9 @@ WORKDIR /app
 COPY . /app
 COPY ../core /app/core
 COPY ../docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x docker-entrypoint.sh \
+RUN chmod 0755 docker-entrypoint.sh \
+    && find /app -type f -name '*.sh' -exec chmod 0755 {} \; \
+    && find /app -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.conf' \) -exec chmod 0644 {} \; \
     && rm -rf /app/yosai_intel_dashboard/tests \
     && chown -R appuser:appuser /app
 USER appuser

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 log() {
-  echo "[docker-entrypoint] $*"
+  printf '[docker-entrypoint] %s\n' "$*"
 }
 
 start_fallback() {

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
       - infra
 
   kafka:
-    image: redpandadata/redpanda:latest
+    image: redpandadata/redpanda:${REDPANDA_TAG:-24.1.2}
     command:
       - redpanda
       - start

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -108,7 +108,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   kafka-ui:
-    image: provectuslabs/kafka-ui:latest
+    image: provectuslabs/kafka-ui:${KAFKA_UI_TAG:-0.7.2}
     container_name: yosai-kafka-ui
     depends_on:
       - kafka1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 log() {
-  echo "[docker-entrypoint] $*"
+  printf '[docker-entrypoint] %s\n' "$*"
 }
 
 start_fallback() {

--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: vault-auth
       containers:
         - name: api
-          image: registry.example.com/yosai:latest
+          image: registry.example.com/yosai:1.0.0
           env:
             - name: JWT_SECRET_KEY
               valueFrom:


### PR DESCRIPTION
## Summary
- parameterize Python base images and enforce permission checks in API and dashboard Dockerfiles
- log via printf in entrypoint scripts for safer variable handling
- remove `latest` tags in docker-compose files and documentation

## Testing
- `shellcheck docker-entrypoint.sh api/docker-entrypoint.sh dashboard/docker-entrypoint.sh`
- `hadolint api/Dockerfile dashboard/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_689c7ff9f9748320a34fcc727e91bdd1