### PR TITLE
chore: prune unused exports and deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@heroicons/react": "^2.2.0",
         "@tanstack/react-query": "^5.83.0",
         "axios": "^1.10.0",
-        "bootstrap": "^5.3.7",
         "d3": "^7.9.0",
         "dataloader": "^2.2.2",
         "echarts": "^6.0.0",
@@ -4698,17 +4697,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -6669,7 +6657,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/q": {
@@ -6694,7 +6682,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6891,7 +6879,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
       "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
@@ -7062,7 +7050,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
       "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.0",
@@ -7087,7 +7075,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
       "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.39.0",
@@ -7109,7 +7097,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
       "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.39.0",
@@ -7127,7 +7115,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
       "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7144,7 +7132,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
       "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.39.0",
@@ -7169,7 +7157,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
       "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7183,7 +7171,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
       "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.39.0",
@@ -7212,7 +7200,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
       "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
@@ -7236,7 +7224,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
       "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.39.0",
@@ -7254,7 +7242,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9080,25 +9068,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/bootstrap": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
-      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -15761,7 +15730,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -25482,7 +25451,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -25596,20 +25565,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -25741,6 +25696,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@heroicons/react": "^2.2.0",
     "@tanstack/react-query": "^5.83.0",
     "axios": "^1.10.0",
-    "bootstrap": "^5.3.7",
     "d3": "^7.9.0",
     "dataloader": "^2.2.2",
     "echarts": "^6.0.0",
@@ -44,11 +43,11 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
     "@capacitor/android": "^7.4.2",
     "@capacitor/ios": "^7.4.2",
     "@fullhuman/postcss-purgecss": "^7.0.2",
     "@playwright/test": "^1.46.0",
-    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/yosai_intel_dashboard/src/adapters/ui/components/Timeline.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/Timeline.tsx
@@ -12,7 +12,7 @@ import {
 import { usePreferencesStore } from '../state';
 import { useNetworkStatus } from '../lib/network';
 
-export interface TimelineDatum {
+interface TimelineDatum {
   time: string | number;
   value: number;
 }
@@ -26,13 +26,20 @@ const Timeline: React.FC<TimelineProps> = ({ data, onRangeChange }) => {
   const { saveData } = usePreferencesStore();
   const network = useNetworkStatus();
   const dataSaver =
-    saveData || network.saveData || ['slow-2g', '2g'].includes(network.effectiveType ?? '');
+    saveData ||
+    network.saveData ||
+    ['slow-2g', '2g'].includes(network.effectiveType ?? '');
   const [range, setRange] = useState<{ startIndex: number; endIndex: number }>({
     startIndex: 0,
     endIndex: data.length - 1,
   });
 
-  const handleBrushChange = (r: any) => {
+  interface BrushRange {
+    startIndex?: number;
+    endIndex?: number;
+  }
+
+  const handleBrushChange = (r?: BrushRange) => {
     if (!r) return;
     const { startIndex, endIndex } = r;
     setRange({ startIndex, endIndex });

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Spinner from './Spinner';
+import Spinner, { SpinnerProps } from './Spinner';
 
-interface Props {
-  sizeClass?: string;
-  className?: string;
-}
+type CenteredSpinnerProps = SpinnerProps;
 
-export const CenteredSpinner: React.FC<Props> = ({ sizeClass, className = '' }) => (
+const CenteredSpinner: React.FC<CenteredSpinnerProps> = ({
+  sizeClass,
+  className = '',
+}) => (
   <div className={`flex items-center justify-center ${className}`}>
     <Spinner sizeClass={sizeClass} />
   </div>

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.vitest.test.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.vitest.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import CenteredSpinner from './CenteredSpinner';
+
+test('centers the spinner and forwards size', () => {
+  const { container } = render(<CenteredSpinner sizeClass="h-4 w-4" />);
+  expect(container.firstChild).toHaveClass('flex items-center justify-center');
+  const spinner = container.querySelector('div > div > div');
+  expect(spinner).toHaveClass('h-4 w-4');
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/shared/Spinner.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/shared/Spinner.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
-interface SpinnerProps {
+export interface SpinnerProps {
   /** CSS size classes like 'h-6 w-6' */
   sizeClass?: string;
   className?: string;
 }
 
-export const Spinner: React.FC<SpinnerProps> = ({ sizeClass = 'h-6 w-6', className = '' }) => (
+const Spinner: React.FC<SpinnerProps> = ({
+  sizeClass = 'h-6 w-6',
+  className = '',
+}) => (
   <div
     className={`animate-spin rounded-full border-2 border-b-transparent border-current ${sizeClass} ${className}`}
     role="status"


### PR DESCRIPTION
## Summary
- drop unused `bootstrap` dependency
- remove dead named exports and share `SpinnerProps`
- tighten Timeline brush typing and add CenteredSpinner test

## Testing
- `npx eslint yosai_intel_dashboard/src/adapters/ui/components/shared/Spinner.tsx yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.tsx yosai_intel_dashboard/src/adapters/ui/components/Timeline.tsx yosai_intel_dashboard/src/adapters/ui/components/shared/CenteredSpinner.vitest.test.tsx`
- `npx depcheck`
- `npx ts-prune -p tsconfig.json`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689c7ec8d03083209bef319e90273c70