### PR TITLE
refactor: break up cache warming and AST utilities

### DIFF
--- a/tests/test_find_duplicate_functions_helpers.py
+++ b/tests/test_find_duplicate_functions_helpers.py
@@ -1,0 +1,40 @@
+import ast
+
+from scripts.find_duplicate_functions import _parse_python_file, _extract_functions
+
+
+def test_parse_python_file_valid(tmp_path):
+    file = tmp_path / "mod.py"
+    file.write_text("x = 1\n")
+    tree = _parse_python_file(file)
+    assert isinstance(tree, ast.AST)
+
+
+def test_parse_python_file_invalid(tmp_path):
+    file = tmp_path / "bad.py"
+    file.write_text("def bad(:\n    pass")
+    assert _parse_python_file(file) is None
+
+
+def test_extract_functions(tmp_path):
+    code = """
+from __future__ import annotations
+
+def foo():
+    return 1
+
+class C:
+    def bar(self):
+        return 2
+"""
+    file = tmp_path / "mod.py"
+    file.write_text(code)
+    tree = _parse_python_file(file)
+    assert tree is not None
+    functions = _extract_functions(tree, file)
+    names = {info.name for _, info in functions}
+    assert names == {"foo", "bar"}
+    bar_info = next(info for _, info in functions if info.name == "bar")
+    assert bar_info.is_method
+    foo_info = next(info for _, info in functions if info.name == "foo")
+    assert foo_info.const_value == 1

--- a/tests/test_start_api_helpers.py
+++ b/tests/test_start_api_helpers.py
@@ -1,0 +1,64 @@
+import asyncio
+import types
+
+from start_api import _warm_cache, _ensure_health_endpoint
+
+
+class DummyWarmer:
+    last_instance = None
+
+    def __init__(self, cache_manager, load_fn):
+        type(self).last_instance = self
+        self.cache_manager = cache_manager
+        self.load_fn = load_fn
+        self.path = None
+
+    async def warm_from_file(self, path: str) -> None:  # pragma: no cover - simple stub
+        self.path = path
+
+
+class DummyCacheManager:
+    def __init__(self) -> None:
+        self.warm_args = None
+
+    async def warm(self, keys, loader):
+        self.warm_args = (keys, loader)
+
+    def get(self, key):  # pragma: no cover - unused lookup
+        return None
+
+
+def test_warm_cache_executes(tmp_path):
+    cache_manager = DummyCacheManager()
+    cache_cfg = types.SimpleNamespace(usage_stats_path="usage.txt", warm_keys=["k1"])
+
+    def load_fn(key):
+        return None
+
+    _warm_cache(cache_manager, cache_cfg, DummyWarmer, load_fn)
+    assert cache_manager.warm_args == (["k1"], load_fn)
+    assert DummyWarmer.last_instance.path == "usage.txt"
+
+
+def test_ensure_health_endpoint_adds_route():
+    class Route:
+        def __init__(self, path):
+            self.path = path
+
+    class App:
+        def __init__(self):
+            self.routes = [Route("/other")]
+            self.handler = None
+
+        def get(self, path):
+            def decorator(func):
+                self.routes.append(Route(path))
+                self.handler = func
+                return func
+
+            return decorator
+
+    app = App()
+    _ensure_health_endpoint(app)
+    assert any(r.path == "/health" for r in app.routes)
+    assert asyncio.run(app.handler()) == {"status": "ok"}


### PR DESCRIPTION
## Summary
- extract `_parse_python_file` and `_extract_functions` helpers from `find_duplicate_functions`
- move cache warmup and health route logic into dedicated helpers in `start_api`
- add focused tests for new helpers

## Testing
- `ruff check scripts/find_duplicate_functions.py start_api.py tests/test_find_duplicate_functions_helpers.py tests/test_start_api_helpers.py`
- `pytest -c /dev/null tests/test_find_duplicate_functions_helpers.py tests/test_start_api_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_689c8a5643dc8320b14edf647cd2dc0a