### PR TITLE
chore: harden coverage script and docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee AS builder
+ARG PYTHON_IMAGE="python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee"
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE} AS builder
 WORKDIR /app
 
 # Install system packages
@@ -15,7 +17,8 @@ RUN python -m venv /opt/venv \
     && grep -v '^apache-flink' requirements.txt > requirements.filtered \
     && /opt/venv/bin/pip install --no-cache-dir -r requirements.filtered
 
-FROM python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE}
 
 # Install runtime packages
 # hadolint ignore=DL3008

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -8,7 +8,8 @@ cd "$ROOT_DIR/gateway"
 # Ensure gocovmerge is available
 if ! command -v gocovmerge > /dev/null 2>&1; then
     echo "Installing gocovmerge..."
-    go install github.com/wadey/gocovmerge@latest
+    GOCOVMERGE_VERSION="${GOCOVMERGE_VERSION:-b5bfa59ec0adc420475f97f89b58045c721d761c}"
+    go install "github.com/wadey/gocovmerge@${GOCOVMERGE_VERSION}"
 fi
 
 TMP_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary
- pin gocovmerge install to a specific commit and allow version override
- parameterize python base image in Dockerfile and silence hadolint DL3006

## Testing
- `shellcheck scripts/test-coverage.sh`
- `hadolint Dockerfile`
- `stat -c "%a %n" scripts/test-coverage.sh docker-entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c8ac10ba0832097bd2fb1a0a71b43