### PR TITLE
Add integration and performance test scaffolding with CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,34 @@ jobs:
           name: integration-report
           path: integration-report.txt
 
+  performance:
+    name: Performance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt locust
+      - name: Run performance tests
+        run: |
+          set -o pipefail
+          pytest tests/performance --override-ini="addopts=" -W error | tee performance-report.txt
+      - name: Upload performance report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: performance-report
+          path: performance-report.txt
+
   audits:
     name: Audits
     needs:
@@ -233,6 +261,7 @@ jobs:
       - hadolint
       - build-test
       - integration
+      - performance
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/tests/integration/test_compose_postgres.py
+++ b/tests/integration/test_compose_postgres.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import psycopg2
+import pytest
+from testcontainers.compose import DockerCompose
+
+
+def _docker_compose_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "compose", "version"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return bool(shutil.which("docker-compose"))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _docker_compose_available(), reason="docker compose not available")
+def test_postgres_service(tmp_path_factory):
+    compose_dir = tmp_path_factory.mktemp("compose")
+    compose_file = compose_dir / "docker-compose.yml"
+    compose_file.write_text(
+        """
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: testdb
+    ports:
+      - '5432'
+"""
+    )
+    with DockerCompose(str(compose_dir), compose_file_name="docker-compose.yml") as dc:
+        host = dc.get_service_host("db", 5432)
+        port = int(dc.get_service_port("db", 5432))
+        conn = psycopg2.connect(host=host, port=port, user="postgres", password="pass", dbname="testdb")
+        cur = conn.cursor()
+        cur.execute("SELECT 1")
+        assert cur.fetchone()[0] == 1
+        conn.close()

--- a/tests/performance/locust/upload_load.py
+++ b/tests/performance/locust/upload_load.py
@@ -1,0 +1,12 @@
+from locust import HttpUser, task, between
+
+
+class UploadUser(HttpUser):
+    """Minimal load test hitting the upload endpoint."""
+
+    wait_time = between(1, 3)
+
+    @task
+    def upload_file(self):
+        data = {"file": ("data.csv", "a,b\n1,2\n")}
+        self.client.post("/upload", files=data)

--- a/tests/performance/test_locust_scripts.py
+++ b/tests/performance/test_locust_scripts.py
@@ -1,0 +1,10 @@
+import pathlib
+import py_compile
+
+
+def test_locust_scripts_compile():
+    locust_dir = pathlib.Path(__file__).parent / "locust"
+    for path in locust_dir.glob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        py_compile.compile(str(path), doraise=True)

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -85,3 +85,16 @@ def test_import_optional_logs_internal_error(monkeypatch, caplog):
         for record in caplog.records
     )
 
+
+def test_is_available(monkeypatch):
+    """``is_available`` reports module importability correctly."""
+
+    def fake_import(name):
+        if name == "existing":
+            return object()
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert optional_dependencies.is_available("existing")
+    assert not optional_dependencies.is_available("missing")
+


### PR DESCRIPTION
## Summary
- test optional dependency availability
- run minimal Postgres integration test via docker-compose
- add upload load-test scenario and compile check
- run performance suite in CI

## Testing
- `pytest tests/test_optional_dependencies.py::test_is_available -q --override-ini=addopts=`
- `pytest tests/integration/test_compose_postgres.py -q --override-ini=addopts=`
- `pytest tests/performance/test_locust_scripts.py -q --override-ini=addopts=`
- `pre-commit run --files .github/workflows/ci.yml tests/test_optional_dependencies.py tests/integration/test_compose_postgres.py tests/performance/locust/upload_load.py tests/performance/test_locust_scripts.py`

------
https://chatgpt.com/codex/tasks/task_e_689ccf6128888320ba65d6fc531709ec