### PR TITLE
Add metrics adapters and autoscaling manifests

### DIFF
--- a/deploy/k8s/analytics-service-hpa.yaml
+++ b/deploy/k8s/analytics-service-hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: analytics-service-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: analytics-service
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Pods
+      pods:
+        metric:
+          name: kafka_lag
+        target:
+          type: AverageValue
+          averageValue: "100"

--- a/deploy/k8s/api-gateway-hpa.yaml
+++ b/deploy/k8s/api-gateway-hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-gateway-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Pods
+      pods:
+        metric:
+          name: kafka_lag
+        target:
+          type: AverageValue
+          averageValue: "100"

--- a/deploy/k8s/event-ingestion-hpa.yaml
+++ b/deploy/k8s/event-ingestion-hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: event-ingestion-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: event-ingestion
+  minReplicas: 1
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Pods
+      pods:
+        metric:
+          name: kafka_lag
+        target:
+          type: AverageValue
+          averageValue: "200"

--- a/deploy/metrics/cpu-metrics-adapter.yaml
+++ b/deploy/metrics/cpu-metrics-adapter.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cpu-metrics-adapter
+  namespace: monitoring
+data:
+  config.yaml: |
+    rules:
+      - seriesQuery: 'container_cpu_usage_seconds_total{container!="",pod!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: namespace
+            pod:
+              resource: pod
+        name:
+          matches: "^(.*)_total$"
+          as: "${1}_usage"
+        metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[2m])) by (<<.GroupBy>>)'

--- a/deploy/metrics/kafka-lag-metrics-adapter.yaml
+++ b/deploy/metrics/kafka-lag-metrics-adapter.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-lag-metrics-adapter
+  namespace: monitoring
+data:
+  config.yaml: |
+    rules:
+      - seriesQuery: 'kafka_consumergroup_lag{topic!="",partition!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: namespace
+        name:
+          matches: "kafka_consumergroup_lag"
+          as: "kafka_lag"
+        metricsQuery: 'sum(kafka_consumergroup_lag{<<.LabelMatchers>>}) by (consumergroup)'

--- a/deploy/metrics/memory-metrics-adapter.yaml
+++ b/deploy/metrics/memory-metrics-adapter.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: memory-metrics-adapter
+  namespace: monitoring
+data:
+  config.yaml: |
+    rules:
+      - seriesQuery: 'container_memory_working_set_bytes{container!="",pod!=""}'
+        resources:
+          overrides:
+            namespace:
+              resource: namespace
+            pod:
+              resource: pod
+        name:
+          matches: "^(.*)_bytes$"
+          as: "${1}"
+        metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -1,0 +1,29 @@
+# Scaling Guidelines
+
+This document describes resource requests, limits, and scaling thresholds for key services.
+
+## Analytics Service
+- **Resource Requests:** `200m` CPU, `256Mi` memory
+- **Limits:** `1` CPU, `512Mi` memory
+- **Scaling Thresholds:**
+  - CPU utilization > 70%
+  - Memory utilization > 75%
+  - Kafka consumer lag > 100 messages per pod
+
+## API Gateway
+- **Resource Requests:** `300m` CPU, `512Mi` memory
+- **Limits:** `2` CPU, `1Gi` memory
+- **Scaling Thresholds:**
+  - CPU utilization > 65%
+  - Memory utilization > 70%
+  - Kafka consumer lag > 100 messages per pod
+
+## Event Ingestion
+- **Resource Requests:** `250m` CPU, `256Mi` memory
+- **Limits:** `1` CPU, `512Mi` memory
+- **Scaling Thresholds:**
+  - CPU utilization > 70%
+  - Memory utilization > 75%
+  - Kafka consumer lag > 200 messages per pod
+
+These values are used by the HorizontalPodAutoscaler manifests in `deploy/k8s`.


### PR DESCRIPTION
## Summary
- add Prometheus adapter configs for CPU, memory, and Kafka lag metrics
- define HPAs for analytics-service, api-gateway, and event-ingestion
- document resource requests, limits, and scaling thresholds

## Testing
- `pytest -c /dev/null` in `services/` (fails: ModuleNotFoundError, missing async plugin)
- `pytest -c /dev/null` in `api/` (fails: ModuleNotFoundError: No module named 'fastapi')
- `python3 tools/load_test.py --brokers localhost:9092 --prom-url http://localhost:9090 --rate 50 --duration 60` (fails: No module named 'requests')

------
https://chatgpt.com/codex/tasks/task_e_689ccf644c008320a3fcb53ac8c84344