### PR TITLE
feat: add zustand theme store and route splitting

### DIFF
--- a/docs/frontend/performance.md
+++ b/docs/frontend/performance.md
@@ -1,0 +1,11 @@
+# Frontend Performance
+
+## Bundle Size
+
+`npm run build` currently fails with:
+
+```
+Could not resolve entry module "index.html".
+```
+
+After adding the required entry file, run `npm run build` and inspect the `dist/` directory to measure bundle size.

--- a/yosai_intel_dashboard/src/adapters/ui/App.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/App.tsx
@@ -1,9 +1,9 @@
-import React, { Suspense, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import Navigation from './components/Navigation';
 import { Shield, Menu, Sun, Moon } from 'lucide-react';
-import useDarkMode from './hooks/useDarkMode';
 import CenteredSpinner from './components/shared/CenteredSpinner';
 import ErrorBoundary from './components/ErrorBoundary';
+import { useThemeStore } from './store';
 
 const Upload = React.lazy(() =>
   import('./components/upload').then((m) => ({ default: m.Upload })),
@@ -11,7 +11,26 @@ const Upload = React.lazy(() =>
 
 function App() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { isDark, toggle } = useDarkMode();
+  const { isDark, toggle } = useThemeStore((state) => ({
+    isDark: state.isDark,
+    toggle: state.toggle,
+  }));
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (isDark) {
+      root.classList.add('dark');
+      window.localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      window.localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  const themeIcon = useMemo(
+    () => (isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />),
+    [isDark],
+  );
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -39,7 +58,7 @@ function App() {
               onClick={toggle}
               aria-label="Toggle dark mode"
             >
-              {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+              {themeIcon}
             </button>
           </div>
         </div>

--- a/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/navigation/BottomNav.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, memo } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Plus } from 'lucide-react';
 import { useSwipe } from '../../lib/gestures';
 import { navItems } from './navItems';
 
-const BottomNav: React.FC = () => {
+const BottomNavComponent: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [activeIndex, setActiveIndex] = useState(
@@ -61,5 +61,5 @@ const BottomNav: React.FC = () => {
   );
 };
 
-export default BottomNav;
+export default memo(BottomNavComponent);
 

--- a/yosai_intel_dashboard/src/adapters/ui/index.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/index.tsx
@@ -61,6 +61,13 @@ DashboardBuilder.preload = () => {
   import('./pages/DashboardBuilder');
 };
 
+const LearnMore: PreloadableComponent = React.lazy(
+  () => import('./pages/LearnMore'),
+);
+LearnMore.preload = () => {
+  import('./pages/LearnMore');
+};
+
 import './index.css';
 
 const rootEl = document.getElementById('root');
@@ -123,6 +130,14 @@ if (rootEl) {
                   </Suspense>
                 }
               />
+              <Route
+                path="/learn"
+                element={
+                  <Suspense fallback={<CenteredSpinner />}>
+                    <LearnMore />
+                  </Suspense>
+                }
+              />
             </Routes>
             {isMobile && <BottomNav />}
           </BrowserRouter>
@@ -139,7 +154,15 @@ if (rootEl) {
     </React.StrictMode>,
   );
 
-  const pages = [Upload, Analytics, Graphs, Export, Settings, DashboardBuilder];
+  const pages = [
+    Upload,
+    Analytics,
+    Graphs,
+    Export,
+    Settings,
+    DashboardBuilder,
+    LearnMore,
+  ];
   if ('requestIdleCallback' in window) {
     (window as any).requestIdleCallback(() =>
       pages.forEach((p) => p.preload?.()),
@@ -181,4 +204,5 @@ export {
   Export,
   Settings,
   DashboardBuilder,
+  LearnMore,
 };

--- a/yosai_intel_dashboard/src/adapters/ui/store/index.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/store/index.ts
@@ -1,0 +1,1 @@
+export { useThemeStore } from './theme';

--- a/yosai_intel_dashboard/src/adapters/ui/store/theme.ts
+++ b/yosai_intel_dashboard/src/adapters/ui/store/theme.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ThemeState {
+  isDark: boolean;
+  toggle: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  isDark: false,
+  toggle: () => set((state) => ({ isDark: !state.isDark })),
+}));


### PR DESCRIPTION
## Summary
- integrate zustand theme store and replace dark mode state
- memoize navigation components with store selectors
- lazy-load LearnMore page for route-based code splitting
- document bundle-size build step

## Testing
- `npm test` *(fails: [AsyncFunction logTipInteraction] is not a spy or a call to a spy)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_689ccf6ccfc88320b1bfbb5406745d36