### PR TITLE
docs: add event schema guidelines and DLQ docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
             ruff-report.txt
             mypy-report.txt
 
+  schema-version:
+    name: Schema Version Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Validate schema version bumps
+        run: python scripts/check_schema_versions.py
+
   backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest

--- a/docs/events/dlq.md
+++ b/docs/events/dlq.md
@@ -1,0 +1,18 @@
+# Kafka Dead Letter Queue
+
+Kafka consumers publish records that cannot be processed to a dedicated
+`dead-letter` topic. Messages remain there until they are inspected and
+replayed.
+
+## Processing
+
+Use the `scripts/kafka-replay.sh` helper to replay messages from the dead-letter
+queue back to a primary topic once the underlying issue is fixed:
+
+```bash
+# Replay all messages from dead-letter to access-events
+scripts/kafka-replay.sh dead-letter access-events
+```
+
+The script relies on the Kafka command line tools (`kafka-console-consumer` and
+`kafka-console-producer`) being available in your `PATH`.

--- a/docs/events/schema-evolution.md
+++ b/docs/events/schema-evolution.md
@@ -1,0 +1,16 @@
+# Event Schema Versioning
+
+Event schemas under `schemas/avro/` follow semantic versioning. Each schema file
+name includes a suffix like `_v1.avsc` that denotes the major version. When a
+schema changes, create a new file with an incremented version and keep the
+previous files intact.
+
+Existing schema files **must not** be modified in place. Instead:
+
+- Copy the latest version to a new file with the next version number.
+- Apply schema changes to that new file only.
+- Register the new version with the schema registry.
+- Update producers and consumers to handle the new version.
+
+The `scripts/check_schema_versions.py` helper runs in CI and fails if any schema
+is modified without adding a new versioned file.

--- a/scripts/check_schema_versions.py
+++ b/scripts/check_schema_versions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Check that Avro schema changes include a version bump.
+
+The script inspects files under ``schemas/avro`` that changed compared to the
+main branch. Any modified or deleted schema files will cause a failure because
+new versions must be added as separate files.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_DIR = Path("schemas/avro")
+VERSION_RE = re.compile(r"_v(\d+)\.avsc$")
+
+
+def _git_diff() -> list[tuple[str, str]]:
+    """Return (status, path) tuples for schema files changed from main."""
+    try:
+        base = (
+            subprocess.check_output(
+                ["git", "merge-base", "HEAD", "origin/main"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            or "HEAD~1"
+        )
+    except Exception:
+        base = "HEAD~1"
+    out = subprocess.check_output(
+        ["git", "diff", "--name-status", base, "--", str(SCHEMA_DIR)],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+    results: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line:
+            continue
+        status, path = line.split("\t", 1)
+        results.append((status, path))
+    return results
+
+
+def main() -> int:
+    issues: list[str] = []
+    for status, path in _git_diff():
+        rel = Path(path)
+        match = VERSION_RE.search(rel.name)
+        if status != "A":
+            issues.append(
+                f"{rel} was {status} - schemas must be added with a new version file"
+            )
+            continue
+        if not match:
+            issues.append(f"{rel} does not include version suffix _vN.avsc")
+            continue
+        base_name = rel.name[: match.start()]
+        existing = sorted(SCHEMA_DIR.glob(f"{base_name}*_v*.avsc"))
+        if len(existing) > 1:
+            latest = max(
+                int(VERSION_RE.search(p.name).group(1))  # type: ignore[union-attr]
+                for p in existing
+                if p.name != rel.name
+            )
+            new_version = int(match.group(1))
+            if new_version <= latest:
+                issues.append(
+                    f"{rel} version {new_version} not greater than existing {latest}"
+                )
+    if issues:
+        print("Schema version check failed:")
+        for msg in issues:
+            print(" -", msg)
+        return 1
+    print("Schema version check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kafka-replay.sh
+++ b/scripts/kafka-replay.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Replay messages from a source Kafka topic to a target topic.
+# Usage: scripts/kafka-replay.sh <source-topic> <target-topic> [broker-list]
+# Example: scripts/kafka-replay.sh dead-letter access-events localhost:9092
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SOURCE="${1:-}"
+TARGET="${2:-}"
+BROKERS="${3:-localhost:9092}"
+
+if [[ -z "${SOURCE}" || -z "${TARGET}" ]]; then
+  echo "Usage: $0 <source-topic> <target-topic> [broker-list]" >&2
+  exit 1
+fi
+
+kafka-console-consumer \
+  --bootstrap-server "${BROKERS}" \
+  --topic "${SOURCE}" \
+  --from-beginning \
+  --timeout-ms 1000 |
+  kafka-console-producer \
+  --bootstrap-server "${BROKERS}" \
+  --topic "${TARGET}"
+
+echo "Replayed messages from ${SOURCE} to ${TARGET}"


### PR DESCRIPTION
## Summary
- document event schema versioning policy
- document Kafka dead-letter queue usage and replay script
- add CI check enforcing schema version bumps
- provide Kafka topic replay helper script

## Testing
- `ruff check scripts/check_schema_versions.py`
- `black --check scripts/check_schema_versions.py`
- `mypy scripts/check_schema_versions.py`
- `shellcheck scripts/kafka-replay.sh`
- `pytest -q` *(fails: FileNotFoundError: models/ml/model_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf6f9a588320aaa50f79d4cb139c