### PR TITLE
feat: instrument analytics service with OpenTelemetry spans

### DIFF
--- a/docs/analytics/observability.md
+++ b/docs/analytics/observability.md
@@ -1,0 +1,10 @@
+# Analytics Service Observability
+
+The analytics service emits OpenTelemetry spans for critical operations such as
+fetching data from the database and running model inference.  These spans are
+exported to the tracing backend configured via `config/telemetry.py`.
+
+To enable tracing, call `configure_tracing()` with the service name and ensure
+the environment variables for the Jaeger or Zipkin endpoint are set.  After
+starting the service, the spans appear in the configured tracing UI where they
+can be inspected for latency and error analysis.

--- a/yosai_intel_dashboard/src/infrastructure/config/telemetry.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/telemetry.py
@@ -1,0 +1,33 @@
+"""Telemetry configuration for analytics services."""
+
+import os
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.zipkin.json import ZipkinExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from tracing.config import (
+    DEFAULT_JAEGER_ENDPOINT,
+    DEFAULT_TRACING_EXPORTER,
+    DEFAULT_ZIPKIN_ENDPOINT,
+    JAEGER_ENDPOINT_ENV,
+    TRACING_EXPORTER_ENV,
+    ZIPKIN_ENDPOINT_ENV,
+)
+
+
+def configure_tracing(service_name: str) -> None:
+    """Configure OpenTelemetry with the repository's tracing backend."""
+    exporter_type = os.getenv(TRACING_EXPORTER_ENV, DEFAULT_TRACING_EXPORTER).lower()
+    if exporter_type == "zipkin":
+        endpoint = os.getenv(ZIPKIN_ENDPOINT_ENV, DEFAULT_ZIPKIN_ENDPOINT)
+        exporter = ZipkinExporter(endpoint=endpoint)
+    else:
+        endpoint = os.getenv(JAEGER_ENDPOINT_ENV, DEFAULT_JAEGER_ENDPOINT)
+        exporter = JaegerExporter(collector_endpoint=endpoint)
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)


### PR DESCRIPTION
## Summary
- instrument analytics model and feature pipeline with OpenTelemetry spans
- add tracing to database analytics fetch and risk score calculation
- configure Jaeger/Zipkin exporter via config/telemetry.py
- document analytics observability and tracing setup

## Testing
- `pre-commit run --files intel_analysis_service/ml/models.py intel_analysis_service/ml/feature_pipeline.py yosai_intel_dashboard/src/services/analytics/analytics_service.py config/telemetry.py docs/analytics/observability.md`
- `pytest intel_analysis_service/tests` *(fails: coverage requirement; rerun with PYTEST_ADDOPTS='' shows 10 passed)*
- `pytest tests/services/analytics/test_analytics_service.py` *(fails: NameError: UTC_SUFFIX is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf75cc1083208fa34c1deabc1b05