### PR TITLE
Add script to verify PostgreSQL and TimescaleDB sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,19 @@ job periodically (for example via `cron` or a Kubernetes CronJob):
 python scripts/replicate_to_timescale.py
 ```
 
+### Data Synchronization Check
+
+Use `scripts/data-sync-check.sh` to ensure tables remain consistent between the
+source PostgreSQL database and TimescaleDB. Provide connection strings via flags
+or the `POSTGRES_DSN` and `TIMESCALE_DSN` environment variables:
+
+```bash
+scripts/data-sync-check.sh --postgres "$POSTGRES_DSN" --timescale "$TIMESCALE_DSN" --tables events,metrics
+```
+
+The script compares row counts for each table (or hashes with `--hash`) and
+exits with a non‑zero status when mismatches are found.
+
 For convenience the repository provides a wrapper script which upgrades all
 databases defined in the configuration:
 

--- a/scripts/data-sync-check.sh
+++ b/scripts/data-sync-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--postgres DSN] [--timescale DSN] [--tables tbl1,tbl2] [--hash]
+
+Compare row counts or hashes for tables in PostgreSQL and TimescaleDB.
+Connection strings may also be provided via POSTGRES_DSN and TIMESCALE_DSN.
+USAGE
+}
+
+PG_DSN="${POSTGRES_DSN:-}"
+TS_DSN="${TIMESCALE_DSN:-}"
+TABLES=(events metrics)
+USE_HASH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --postgres|-p)
+      PG_DSN="$2"
+      shift 2
+      ;;
+    --timescale|-t)
+      TS_DSN="$2"
+      shift 2
+      ;;
+    --tables|-T)
+      IFS=',' read -r -a TABLES <<< "$2"
+      shift 2
+      ;;
+    --hash|-H)
+      USE_HASH=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+
+done
+
+if [[ -z "$PG_DSN" || -z "$TS_DSN" ]]; then
+  echo "POSTGRES_DSN and TIMESCALE_DSN must be set via flags or environment variables" >&2
+  usage >&2
+  exit 1
+fi
+
+mismatch=false
+
+for tbl in "${TABLES[@]}"; do
+  if $USE_HASH; then
+    query="SELECT md5(COALESCE(string_agg(md5(t::text), ''), '')) FROM \"$tbl\" t"
+  else
+    query="SELECT COUNT(*) FROM \"$tbl\""
+  fi
+
+  pg_val=$(psql "$PG_DSN" -Atc "$query" 2>/dev/null) || {
+    echo "Failed to query $tbl in PostgreSQL" >&2
+    mismatch=true
+    continue
+  }
+  ts_val=$(psql "$TS_DSN" -Atc "$query" 2>/dev/null) || {
+    echo "Failed to query $tbl in TimescaleDB" >&2
+    mismatch=true
+    continue
+  }
+
+  if [[ "$pg_val" != "$ts_val" ]]; then
+    echo "Mismatch for table '$tbl': postgres=$pg_val timescale=$ts_val"
+    mismatch=true
+  fi
+done
+
+if $mismatch; then
+  exit 1
+else
+  echo "All tables consistent: ${TABLES[*]}"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/data-sync-check.sh` to compare table counts or hashes between PostgreSQL and TimescaleDB
- document data-sync verification script in README

## Testing
- `pre-commit run --files scripts/data-sync-check.sh README.md`
- `shellcheck scripts/data-sync-check.sh`
- `scripts/data-sync-check.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_689cdf8290bc83208b972df41ce0e076