### PR TITLE
feat: unify logging with correlation IDs and fluent bit config

### DIFF
--- a/deploy/logging/README.md
+++ b/deploy/logging/README.md
@@ -1,0 +1,12 @@
+# Logging Deployment
+
+This directory contains a sample Fluent Bit configuration used to forward
+container logs to both Elasticsearch (for ELK) and Datadog. Deploy the Fluent
+Bit sidecar alongside services like `gateway` to enable centralised log
+collection.
+
+1. Set `ELASTICSEARCH_HOST` and `DATADOG_API_KEY` environment variables.
+2. Mount `fluent-bit-config.yaml` into the Fluent Bit container at
+   `/fluent-bit/etc/fluent-bit.conf`.
+3. Confirm in staging that logs appear in both Kibana and the Datadog Log
+   Explorer using the correlation ID field.

--- a/deploy/logging/fluent-bit-config.yaml
+++ b/deploy/logging/fluent-bit-config.yaml
@@ -1,0 +1,27 @@
+# Fluent Bit configuration to ship logs to Elasticsearch and Datadog
+service:
+  daemon: "Off"
+  flush: 1
+
+inputs:
+  - name: tail
+    path: /var/log/app/*.log
+    parser: json
+
+filters:
+  - name: modify
+    match: "*"
+    add:
+      service: "gateway"
+
+outputs:
+  - name: es
+    match: "*"
+    host: ${ELASTICSEARCH_HOST}
+    port: 9200
+    logstash_format: On
+  - name: datadog
+    match: "*"
+    apikey: ${DATADOG_API_KEY}
+    dd_service: "gateway"
+    dd_source: "fluentbit"

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,6 +7,7 @@ This directory contains standard operating procedures for the Yosai Intel Dashbo
 - **Restart services** using `docker-compose restart <service>` or `kubectl rollout restart deployment/<service>`.
 - **Check health** endpoints at `/v1/health` and review Prometheus targets for scrape status.
 - **View metrics** in Grafana dashboards under the `gateway`, `event-processor` and `database` folders.
+- **Validate logs** in staging by searching for recent correlation IDs in Kibana and the Datadog Log Explorer.
 
 ## Incident Response
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -22,9 +22,8 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rabbitmq/amqp091-go v1.8.1
 	github.com/redis/go-redis/v9 v9.11.0
-	github.com/riferrei/srclient v0.7.3
-	github.com/sirupsen/logrus v1.9.3
-	github.com/sony/gobreaker v1.0.0
+       github.com/riferrei/srclient v0.7.3
+       github.com/sony/gobreaker v1.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0

--- a/gateway/internal/tracing/tracing.go
+++ b/gateway/internal/tracing/tracing.go
@@ -1,107 +1,93 @@
 package tracing
 
 import (
-        "context"
-        "os"
-        "strings"
+	"context"
+	"os"
+	"strings"
 
-        "go.opentelemetry.io/otel"
-        "go.opentelemetry.io/otel/exporters/jaeger"
-        zipkin "go.opentelemetry.io/otel/exporters/zipkin"
-        "go.opentelemetry.io/otel/propagation"
-        "go.opentelemetry.io/otel/trace"
-        sdkresource "go.opentelemetry.io/otel/sdk/resource"
-        sdktrace "go.opentelemetry.io/otel/sdk/trace"
-        semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-
-        "github.com/sirupsen/logrus"
+	"github.com/WSG23/yosai-framework/logging"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	zipkin "go.opentelemetry.io/otel/exporters/zipkin"
+	"go.opentelemetry.io/otel/propagation"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.uber.org/zap"
 )
 
 const (
-        ExporterEnv           = "TRACING_EXPORTER"
-        JaegerEndpointEnv     = "JAEGER_ENDPOINT"
-        ZipkinEndpointEnv     = "ZIPKIN_ENDPOINT"
-        DefaultJaegerEndpoint = "http://localhost:14268/api/traces"
-        DefaultZipkinEndpoint = "http://localhost:9411/api/v2/spans"
-        ServiceVersionEnv     = "SERVICE_VERSION"
-        EnvironmentEnv        = "APP_ENV"
+	ExporterEnv           = "TRACING_EXPORTER"
+	JaegerEndpointEnv     = "JAEGER_ENDPOINT"
+	ZipkinEndpointEnv     = "ZIPKIN_ENDPOINT"
+	DefaultJaegerEndpoint = "http://localhost:14268/api/traces"
+	DefaultZipkinEndpoint = "http://localhost:9411/api/v2/spans"
+	ServiceVersionEnv     = "SERVICE_VERSION"
+	EnvironmentEnv        = "APP_ENV"
 )
 
 // Logger is the structured logger used across gateway services.
 var (
-        Logger              = logrus.New()
-        serviceVersion      string
-        serviceEnvironment  string
-        serviceName         string
+	Logger             *logging.ZapLogger
+	serviceVersion     string
+	serviceEnvironment string
+	serviceName        string
 )
-
-type traceFormatter struct{
-        logrus.JSONFormatter
-}
-
-func (f *traceFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-        if entry.Context != nil {
-                span := trace.SpanFromContext(entry.Context)
-                sc := span.SpanContext()
-                if sc.IsValid() {
-                        entry.Data["trace_id"] = sc.TraceID().String()
-                        entry.Data["span_id"] = sc.SpanID().String()
-                }
-        }
-        if entry.Data["service"] == nil {
-                entry.Data["service"] = serviceName
-        }
-        entry.Data["service_version"] = serviceVersion
-        entry.Data["environment"] = serviceEnvironment
-        return f.JSONFormatter.Format(entry)
-}
 
 // InitTracing configures OpenTelemetry with a Jaeger or Zipkin exporter and returns
 // a shutdown function to flush spans.
 func InitTracing(name string) (func(context.Context) error, error) {
-        serviceName = name
-        exporter := strings.ToLower(os.Getenv(ExporterEnv))
-        var (
-                endpoint string
-                err error
-                exp sdktrace.SpanExporter
-        )
-        if exporter == "zipkin" {
-                endpoint = os.Getenv(ZipkinEndpointEnv)
-                if endpoint == "" {
-                        endpoint = DefaultZipkinEndpoint
-                }
-                exp, err = zipkin.New(endpoint)
-        } else {
-                endpoint = os.Getenv(JaegerEndpointEnv)
-                if endpoint == "" {
-                        endpoint = DefaultJaegerEndpoint
-                }
-                exp, err = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
-        }
-        if err != nil {
-                return nil, err
-        }
-        serviceVersion = os.Getenv(ServiceVersionEnv)
-        if serviceVersion == "" {
-                serviceVersion = "0.0.0"
-        }
-        serviceEnvironment = os.Getenv(EnvironmentEnv)
-        if serviceEnvironment == "" {
-                serviceEnvironment = "development"
-        }
-        tp := sdktrace.NewTracerProvider(
-                sdktrace.WithBatcher(exp),
-                sdktrace.WithResource(sdkresource.NewWithAttributes(
-                        semconv.SchemaURL,
-                        semconv.ServiceName(serviceName),
-                )),
-        )
+	serviceName = name
+	exporter := strings.ToLower(os.Getenv(ExporterEnv))
+	var (
+		endpoint string
+		err      error
+		exp      sdktrace.SpanExporter
+	)
+	if exporter == "zipkin" {
+		endpoint = os.Getenv(ZipkinEndpointEnv)
+		if endpoint == "" {
+			endpoint = DefaultZipkinEndpoint
+		}
+		exp, err = zipkin.New(endpoint)
+	} else {
+		endpoint = os.Getenv(JaegerEndpointEnv)
+		if endpoint == "" {
+			endpoint = DefaultJaegerEndpoint
+		}
+		exp, err = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
+	}
+	if err != nil {
+		return nil, err
+	}
+	serviceVersion = os.Getenv(ServiceVersionEnv)
+	if serviceVersion == "" {
+		serviceVersion = "0.0.0"
+	}
+	serviceEnvironment = os.Getenv(EnvironmentEnv)
+	if serviceEnvironment == "" {
+		serviceEnvironment = "development"
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(sdkresource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName),
+		)),
+	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
-        Logger.SetFormatter(&traceFormatter{})
-        Logger.SetOutput(os.Stdout)
+	lg, err := logging.NewZapLogger(serviceName, "INFO")
+	if err != nil {
+		return nil, err
+	}
+	lg.Logger = lg.Logger.With(
+		zap.String("service", serviceName),
+		zap.String("service_version", serviceVersion),
+		zap.String("environment", serviceEnvironment),
+	)
+	Logger = lg
 
 	return tp.Shutdown, nil
 }

--- a/go/framework/logging/logger.go
+++ b/go/framework/logging/logger.go
@@ -1,8 +1,10 @@
 package logging
 
 import (
+	"context"
 	"strings"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -35,3 +37,46 @@ func NewZapLogger(name, level string) (*ZapLogger, error) {
 
 func (l *ZapLogger) Info(msg string, fields ...zap.Field)  { l.Logger.Info(msg, fields...) }
 func (l *ZapLogger) Error(msg string, fields ...zap.Field) { l.Logger.Error(msg, fields...) }
+
+// Debug writes a debug level log entry.
+func (l *ZapLogger) Debug(msg string, fields ...zap.Field) { l.Logger.Debug(msg, fields...) }
+
+const correlationIDKey = "correlation_id"
+
+func contextFields(ctx context.Context) []zap.Field {
+	if ctx == nil {
+		return nil
+	}
+	var fields []zap.Field
+	if v, ok := ctx.Value(correlationIDKey).(string); ok && v != "" {
+		fields = append(fields, zap.String(correlationIDKey, v))
+	}
+	if span := trace.SpanFromContext(ctx); span != nil {
+		sc := span.SpanContext()
+		if sc.IsValid() {
+			fields = append(fields,
+				zap.String("trace_id", sc.TraceID().String()),
+				zap.String("span_id", sc.SpanID().String()),
+			)
+		}
+	}
+	return fields
+}
+
+// InfoContext logs an info message including correlation and tracing data from context.
+func (l *ZapLogger) InfoContext(ctx context.Context, msg string, fields ...zap.Field) {
+	fields = append(fields, contextFields(ctx)...)
+	l.Logger.Info(msg, fields...)
+}
+
+// ErrorContext logs an error message including correlation and tracing data from context.
+func (l *ZapLogger) ErrorContext(ctx context.Context, msg string, fields ...zap.Field) {
+	fields = append(fields, contextFields(ctx)...)
+	l.Logger.Error(msg, fields...)
+}
+
+// DebugContext logs a debug message including correlation and tracing data from context.
+func (l *ZapLogger) DebugContext(ctx context.Context, msg string, fields ...zap.Field) {
+	fields = append(fields, contextFields(ctx)...)
+	l.Logger.Debug(msg, fields...)
+}

--- a/pkg/httpx/go.mod
+++ b/pkg/httpx/go.mod
@@ -2,3 +2,4 @@ module github.com/WSG23/httpx
 
 go 1.23
 
+require github.com/google/uuid v1.6.0

--- a/pkg/httpx/go.sum
+++ b/pkg/httpx/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // HTTPDoer is the subset of http.Client used by this package. It enables
@@ -26,11 +28,39 @@ func New(c HTTPDoer) *Client { return &Client{httpClient: c} }
 // timeout to avoid hanging requests.
 var Default = New(&http.Client{Timeout: 10 * time.Second})
 
+// CorrelationIDKey is the context key used to store the correlation ID.
+const CorrelationIDKey = "correlation_id"
+
+// CorrelationIDHeader is the HTTP header carrying the correlation ID.
+const CorrelationIDHeader = "X-Correlation-ID"
+
+// WithCorrelationID returns a context containing a correlation ID. If the
+// provided context already has one, it is reused.
+func WithCorrelationID(ctx context.Context) (context.Context, string) {
+	if v, ok := ctx.Value(CorrelationIDKey).(string); ok && v != "" {
+		return ctx, v
+	}
+	id := uuid.NewString()
+	return context.WithValue(ctx, CorrelationIDKey, id), id
+}
+
+// CorrelationIDFromContext extracts the correlation ID from context.
+func CorrelationIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(CorrelationIDKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
 // DoJSON executes the HTTP request using the client's HTTPDoer and decodes
 // the JSON response body into dst. The provided context controls the request
 // and will cancel the call if it is done.
 func (c *Client) DoJSON(ctx context.Context, req *http.Request, dst any) (err error) {
+	ctx, cid := WithCorrelationID(ctx)
 	req = req.WithContext(ctx)
+	if cid != "" {
+		req.Header.Set(CorrelationIDHeader, cid)
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("do request: %w", err)


### PR DESCRIPTION
## Summary
- use `pkg/httpx` correlation IDs in zap-based logger
- switch gateway logging from logrus to shared zap logger
- add fluent bit config and runbook instructions for shipping logs to ELK/Datadog

## Testing
- `go test ./pkg/httpx`
- `go test ./go/framework/logging`
- `cd gateway && go test ./internal/engine -run Test -count=1`
- `cd gateway && go mod tidy` *(fails: ambiguous import for google.golang.org/genproto)*


------
https://chatgpt.com/codex/tasks/task_e_689d2fe144908320b90b5b2cf0722ec3