### PR TITLE
Add probes, canary pipeline, online migrations, and deployment runbook

### DIFF
--- a/deployment/pipeline.yaml
+++ b/deployment/pipeline.yaml
@@ -1,0 +1,25 @@
+stages:
+  - build
+  - canary
+  - promote
+
+build:
+  stage: build
+  script:
+    - docker build -t yosai-dashboard:$CI_COMMIT_SHA .
+
+canary:
+  stage: canary
+  script:
+    - kubectl apply -f k8s/canary
+  when: manual
+  needs:
+    - build
+
+promote_blue_green:
+  stage: promote
+  script:
+    - kubectl apply -f k8s/bluegreen
+  when: manual
+  needs:
+    - canary

--- a/k8s/base/pgbouncer.yaml
+++ b/k8s/base/pgbouncer.yaml
@@ -29,6 +29,16 @@ spec:
               value: session
           ports:
             - containerPort: 6432
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/production/pgbouncer.yaml
+++ b/k8s/production/pgbouncer.yaml
@@ -32,6 +32,16 @@ spec:
               value: session
           ports:
             - containerPort: 6432
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/services/bluegreen-template.yaml
+++ b/k8s/services/bluegreen-template.yaml
@@ -28,6 +28,18 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -58,6 +70,18 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/services/canary-template.yaml
+++ b/k8s/services/canary-template.yaml
@@ -28,6 +28,18 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -58,6 +70,18 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -22,10 +22,10 @@ ALTER TABLE access_events
   );
 
 -- Common indexes for query patterns
-CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
-CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
-CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
-CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_time ON access_events(time);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
 
 -- Continuous aggregate for fast summaries
 CREATE MATERIALIZED VIEW IF NOT EXISTS access_events_5min
@@ -66,8 +66,8 @@ CREATE TABLE IF NOT EXISTS access_permissions (
     valid_from TIMESTAMPTZ,
     valid_to TIMESTAMPTZ
 );
-CREATE INDEX IF NOT EXISTS idx_access_permissions_person_id ON access_permissions(person_id);
-CREATE INDEX IF NOT EXISTS idx_access_permissions_door_id ON access_permissions(door_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_permissions_person_id ON access_permissions(person_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_permissions_door_id ON access_permissions(door_id);
 
 CREATE TABLE IF NOT EXISTS access_blocklist (
     person_id VARCHAR(50) PRIMARY KEY,
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS time_restrictions (
     end_time TIME NOT NULL,
     days_of_week INT[]
 );
-CREATE INDEX IF NOT EXISTS idx_time_restrictions_door_id ON time_restrictions(door_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_time_restrictions_door_id ON time_restrictions(door_id);
 
 CREATE TABLE IF NOT EXISTS anti_passback_state (
     person_id VARCHAR(50) PRIMARY KEY,
@@ -112,8 +112,8 @@ CREATE TABLE IF NOT EXISTS anomaly_detections (
     verified_at TIMESTAMPTZ
 );
 SELECT create_hypertable('anomaly_detections', 'detected_at', if_not_exists => TRUE);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
 ALTER TABLE anomaly_detections
   SET (
        timescaledb.compress,

--- a/migrations/004_add_missing_indexes.sql
+++ b/migrations/004_add_missing_indexes.sql
@@ -1,7 +1,7 @@
 -- Add indexes identified from query logs
-CREATE INDEX IF NOT EXISTS idx_access_events_timestamp ON access_events(timestamp);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
-CREATE INDEX IF NOT EXISTS idx_incident_tickets_status ON incident_tickets(status);
-CREATE INDEX IF NOT EXISTS idx_doors_facility_id ON doors(facility_id);
-CREATE INDEX IF NOT EXISTS idx_doors_is_critical ON doors(is_critical);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_timestamp ON access_events(timestamp);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_incident_tickets_status ON incident_tickets(status);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_doors_facility_id ON doors(facility_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_doors_is_critical ON doors(is_critical);

--- a/migrations/005_add_experiment_id.sql
+++ b/migrations/005_add_experiment_id.sql
@@ -1,2 +1,2 @@
 ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS experiment_id VARCHAR(64) NOT NULL DEFAULT 'default';
-CREATE INDEX IF NOT EXISTS idx_model_registry_name_experiment ON model_registry (name, experiment_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_model_registry_name_experiment ON model_registry (name, experiment_id);

--- a/migrations/timescale/001_create_hypertables.sql
+++ b/migrations/timescale/001_create_hypertables.sql
@@ -14,10 +14,10 @@ CREATE TABLE IF NOT EXISTS access_events (
 SELECT create_hypertable('access_events', 'time', chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
 
 -- Indexes for common query patterns
-CREATE INDEX IF NOT EXISTS idx_access_events_time ON access_events(time);
-CREATE INDEX IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
-CREATE INDEX IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
-CREATE INDEX IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_time ON access_events(time);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_person_id ON access_events(person_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_door_id ON access_events(door_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_facility_id ON access_events(facility_id);
 
 -- Anomaly detections hypertable
 CREATE TABLE IF NOT EXISTS anomaly_detections (
@@ -35,5 +35,5 @@ CREATE TABLE IF NOT EXISTS anomaly_detections (
     verified_at TIMESTAMPTZ
 );
 SELECT create_hypertable('anomaly_detections', 'detected_at', if_not_exists => TRUE);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
-CREATE INDEX IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_detected_at ON anomaly_detections(detected_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anomaly_detections_type ON anomaly_detections(anomaly_type);

--- a/migrations/timescale/versions/0001_initial.py
+++ b/migrations/timescale/versions/0001_initial.py
@@ -15,13 +15,14 @@ depends_on = None
 
 def upgrade() -> None:
     base = Path(__file__).resolve().parents[1]
-    for fname in [
-        "001_create_hypertables.sql",
-        "002_create_continuous_aggregates.sql",
-        "003_setup_compression.sql",
-        "004_retention_policies.sql",
-    ]:
-        op.execute((base / fname).read_text())
+    with op.get_context().autocommit_block():
+        for fname in [
+            "001_create_hypertables.sql",
+            "002_create_continuous_aggregates.sql",
+            "003_setup_compression.sql",
+            "004_retention_policies.sql",
+        ]:
+            op.execute((base / fname).read_text())
 
 
 def downgrade() -> None:

--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -15,7 +15,8 @@ depends_on = None
 
 def upgrade() -> None:
     sql_path = Path(__file__).resolve().parents[1] / "001_init.sql"
-    op.execute(sql_path.read_text())
+    with op.get_context().autocommit_block():
+        op.execute(sql_path.read_text())
 
 
 def downgrade() -> None:

--- a/migrations/versions/0004_add_missing_indexes.py
+++ b/migrations/versions/0004_add_missing_indexes.py
@@ -15,7 +15,8 @@ depends_on = None
 
 def upgrade() -> None:
     sql_path = Path(__file__).resolve().parents[1] / "004_add_missing_indexes.sql"
-    op.execute(sql_path.read_text())
+    with op.get_context().autocommit_block():
+        op.execute(sql_path.read_text())
 
 
 def downgrade() -> None:

--- a/migrations/versions/0005_add_experiment_id.py
+++ b/migrations/versions/0005_add_experiment_id.py
@@ -15,7 +15,8 @@ depends_on = None
 
 def upgrade() -> None:
     sql_path = Path(__file__).resolve().parents[1] / "005_add_experiment_id.sql"
-    op.execute(sql_path.read_text())
+    with op.get_context().autocommit_block():
+        op.execute(sql_path.read_text())
 
 
 def downgrade() -> None:

--- a/runbooks/deployment.md
+++ b/runbooks/deployment.md
@@ -1,0 +1,13 @@
+# Deployment Runbook
+
+## Rollout Procedure
+1. Build and push container images.
+2. Deploy the canary release using `k8s/canary` manifests.
+3. Verify metrics and logs for the canary pods.
+4. Promote traffic with the blue/green deployment in `k8s/bluegreen`.
+5. Remove the old color once the new version is healthy.
+
+## Rollback Procedure
+1. Re-route traffic back to the previous color or disable the canary.
+2. Redeploy the last known good image.
+3. Monitor until service health is restored.


### PR DESCRIPTION
## Summary
- add readiness and liveness probes to pgbouncer and deployment templates
- introduce canary and blue/green steps in deployment pipeline
- run database migrations using concurrent index creation and autocommit blocks
- document rollout and rollback procedures in runbook

## Testing
- `pre-commit run --files k8s/base/pgbouncer.yaml k8s/production/pgbouncer.yaml k8s/services/bluegreen-template.yaml k8s/services/canary-template.yaml migrations/001_init.sql migrations/004_add_missing_indexes.sql migrations/005_add_experiment_id.sql migrations/timescale/001_create_hypertables.sql migrations/versions/0001_initial.py migrations/versions/0004_add_missing_indexes.py migrations/versions/0005_add_experiment_id.py migrations/timescale/versions/0001_initial.py deployment/pipeline.yaml runbooks/deployment.md`
- `pytest -q` (fails: unrecognized arguments --cov=. --cov-report=html --cov-report=term-missing --cov-fail-under=80 --randomly-seed=1234 --disable-socket --allow-hosts=127.0.0.1,localhost)


------
https://chatgpt.com/codex/tasks/task_e_689d2fdce7648320b1b9091ece94bee9