### PR TITLE
Add tests and coverage thresholds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run unit tests
+        run: |
+          pytest tests/unit tests/integration --cov=repositories --cov=yosai_intel_dashboard/src/services/kafka_consumer.py --cov-fail-under=80
+      - name: Go handler tests
+        run: |
+          cd gateway && go test ./internal/handlers -coverprofile=coverage.out
+          cov=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3,1,length($3)-1)}')
+          echo "Go coverage: $cov%"
+          awk -v cov="$cov" 'BEGIN { if (cov+0 < 80) exit 1 }'

--- a/gateway/internal/handlers/breaker_test.go
+++ b/gateway/internal/handlers/breaker_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+        "encoding/json"
+        "errors"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+
+        "github.com/prometheus/client_golang/prometheus"
+        dto "github.com/prometheus/client_model/go"
+)
+
+type errorGatherer struct{}
+
+func (errorGatherer) Gather() ([]*dto.MetricFamily, error) {
+        return nil, errors.New("boom")
+}
+
+func TestBreakerMetricsSuccess(t *testing.T) {
+        reg := prometheus.NewRegistry()
+        ctr := prometheus.NewCounterVec(prometheus.CounterOpts{
+                Name: "circuit_breaker_state_transitions_total",
+                Help: "test",
+        }, []string{"name", "state"})
+        reg.MustRegister(ctr)
+        ctr.WithLabelValues("svc", "open").Inc()
+
+        old := prometheus.DefaultGatherer
+        prometheus.DefaultGatherer = reg
+        defer func() { prometheus.DefaultGatherer = old }()
+
+        req := httptest.NewRequest(http.MethodGet, "/breaker", nil)
+        resp := httptest.NewRecorder()
+        BreakerMetrics(resp, req)
+
+        if resp.Code != http.StatusOK {
+                t.Fatalf("expected 200, got %d", resp.Code)
+        }
+        var out map[string]map[string]float64
+        if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+                t.Fatalf("invalid json: %v", err)
+        }
+        if out["svc"]["open"] != 1 {
+                t.Fatalf("expected metric, got %v", out)
+        }
+}
+
+func TestBreakerMetricsError(t *testing.T) {
+        old := prometheus.DefaultGatherer
+        prometheus.DefaultGatherer = errorGatherer{}
+        defer func() { prometheus.DefaultGatherer = old }()
+
+        req := httptest.NewRequest(http.MethodGet, "/breaker", nil)
+        resp := httptest.NewRecorder()
+        BreakerMetrics(resp, req)
+
+        if resp.Code != http.StatusInternalServerError {
+                t.Fatalf("expected 500, got %d", resp.Code)
+        }
+}
+

--- a/tests/integration/test_person_repository.py
+++ b/tests/integration/test_person_repository.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from repositories.person_repository import InMemoryPersonRepository, Person
+
+
+def test_find_by_id_missing_returns_none() -> None:
+    repo = InMemoryPersonRepository()
+    result = repo.find_by_id("missing")
+    assert result.is_success() and result.value is None
+
+
+def test_find_by_id_failure_on_exception(monkeypatch) -> None:
+    repo = InMemoryPersonRepository()
+
+    class Broken(dict):
+        def get(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    repo._people = Broken()
+    result = repo.find_by_id("1")
+    assert result.is_failure() and "boom" in result.error
+
+
+def test_find_by_department_failure(monkeypatch) -> None:
+    repo = InMemoryPersonRepository()
+
+    class Broken(dict):
+        def values(self):  # type: ignore[override]
+            raise RuntimeError("fail")
+
+    repo._people = Broken()
+    result = repo.find_by_department("eng")
+    assert result.is_failure() and "fail" in result.error
+
+
+def test_save_failure_on_storage_error(monkeypatch) -> None:
+    repo = InMemoryPersonRepository()
+    p = Person(person_id="1")
+
+    class Broken(dict):
+        def __setitem__(self, key, value):  # type: ignore[override]
+            raise RuntimeError("storage")
+
+    repo._people = Broken()
+    result = repo.save(p)
+    assert result.is_failure() and "storage" in result.error
+

--- a/tests/unit/test_kafka_consumer.py
+++ b/tests/unit/test_kafka_consumer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub confluent_kafka.avro before importing the module under test
+avro_module = types.ModuleType("confluent_kafka.avro")
+avro_module.AvroConsumer = MagicMock()
+sys.modules.setdefault("confluent_kafka", types.ModuleType("confluent_kafka"))
+sys.modules["confluent_kafka.avro"] = avro_module
+
+from yosai_intel_dashboard.src.services.kafka_consumer import KafkaConsumer
+
+
+def test_poll_returns_message() -> None:
+    msg = MagicMock()
+    msg.error.return_value = None
+    avro_module.AvroConsumer.return_value.poll.return_value = msg
+
+    consumer = KafkaConsumer(["topic"], brokers="b", schema_registry="s")
+    assert consumer.poll() is msg
+
+
+def test_poll_logs_error_and_returns_none(caplog) -> None:
+    err_msg = MagicMock()
+    err_msg.error.return_value = Exception("bad")
+    avro_module.AvroConsumer.return_value.poll.return_value = err_msg
+
+    consumer = KafkaConsumer(["topic"])
+    with caplog.at_level(logging.ERROR):
+        assert consumer.poll() is None
+        assert "Consumer error" in caplog.text
+
+
+def test_close_swallows_exceptions() -> None:
+    instance = avro_module.AvroConsumer.return_value
+    instance.commit.side_effect = Exception("fail")
+    instance.close.side_effect = Exception("fail")
+
+    consumer = KafkaConsumer(["topic"])
+    consumer.close()  # should not raise
+


### PR DESCRIPTION
## Summary
- add unit tests for gateway breaker handler
- test Kafka consumer edge cases
- cover person repository error paths
- enforce test coverage in CI

## Testing
- `pytest tests/unit/test_kafka_consumer.py tests/integration/test_person_repository.py -q -o addopts=""`
- `go test ./internal/handlers -run TestBreakerMetricsSuccess -count=1 -cover` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689d2fde14d08320bcb631d0f2f10fe0