### PR TITLE
feat: enable automated secret rotation

### DIFF
--- a/deployment/reload-secrets.sh
+++ b/deployment/reload-secrets.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# Watches the mounted secret directory and sends HUP to the service process
+# when any secret is updated. Requires inotify-tools in the image.
+
+set -eu
+SECRET_DIR=${SECRET_DIR:-/etc/secrets}
+PID_FILE=${PID_FILE:-/var/run/service.pid}
+
+inotifywait -m "$SECRET_DIR" -e modify,create,delete |
+while read -r path _ file; do
+  if [ -f "$PID_FILE" ]; then
+    kill -HUP "$(cat "$PID_FILE")"
+  fi
+  echo "reloaded secret $file" >&2
+done

--- a/docs/security.md
+++ b/docs/security.md
@@ -47,3 +47,16 @@ To reduce the risk of SQL injection vulnerabilities:
 - Validate user-supplied data types before executing a query.
 
 Following these practices ensures that user input is passed separately from the SQL statement, preventing malicious injections.
+
+## Secret Rotation
+
+Secrets are rotated automatically. The `k8s/cron/secret-rotate.yaml` CronJob
+invokes a Vault script to generate fresh credentials and update Kubernetes
+secrets. Services load credentials from mounted files and rely on the
+`pkg/config` `SecretWatcher` to reload values when the files change.
+
+To trigger a rotation manually, run:
+
+```bash
+kubectl create job --from=cronjob/secret-rotate secret-rotate-manual
+```

--- a/k8s/cron/secret-rotate.yaml
+++ b/k8s/cron/secret-rotate.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: secret-rotate
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          restartPolicy: OnFailure
+          containers:
+            - name: rotate-secrets
+              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              imagePullPolicy: IfNotPresent
+              command: ["python", "scripts/vault_rotate.py"]
+              envFrom:
+                - configMapRef:
+                    name: vault-config
+                - secretRef:
+                    name: vault-secret

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// SecretWatcher watches a file and reloads its contents when updated.
+type SecretWatcher struct {
+	Path  string
+	mu    sync.RWMutex
+	value string
+}
+
+// NewSecretWatcher creates a watcher for the given file path.
+func NewSecretWatcher(path string) (*SecretWatcher, error) {
+	w := &SecretWatcher{Path: path}
+	if err := w.reload(); err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := watcher.Add(path); err != nil {
+		watcher.Close()
+		return nil, err
+	}
+
+	go func() {
+		for range watcher.Events {
+			w.reload()
+		}
+	}()
+
+	return w, nil
+}
+
+// Value returns the latest secret value.
+func (w *SecretWatcher) Value() string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.value
+}
+
+func (w *SecretWatcher) reload() error {
+	data, err := ioutil.ReadFile(w.Path)
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.value = string(data)
+	w.mu.Unlock()
+	return nil
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,3 +1,7 @@
 module pkg
 
 go 1.23.8
+
+require github.com/fsnotify/fsnotify v1.7.0
+
+require golang.org/x/sys v0.4.0 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1,0 +1,4 @@
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vault/policies/secret-rotation.hcl
+++ b/vault/policies/secret-rotation.hcl
@@ -1,0 +1,3 @@
+path "secret/data/*" {
+  capabilities = ["create", "update", "read"]
+}


### PR DESCRIPTION
## Summary
- add Vault policy for rotating secrets
- watch mounted credentials and reload on change
- schedule secret rotation via CronJob
- document secret rotation procedure

## Testing
- `pre-commit run --files vault/policies/secret-rotation.hcl deployment/reload-secrets.sh pkg/config/secret.go pkg/go.mod pkg/go.sum k8s/cron/secret-rotate.yaml docs/security.md`
- `cd pkg && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d2fe0adcc8320be7ec07ced3bacc2