### PR TITLE
Pin dependency versions for consistent installs

### DIFF
--- a/docs/dependency-versions.md
+++ b/docs/dependency-versions.md
@@ -1,0 +1,13 @@
+# Dependency Version Pins
+
+The following key dependencies are pinned to known-compatible versions to avoid resolver conflicts:
+
+| Package | Version |
+|---------|---------|
+| Flask | 3.1.1 |
+| flasgger | 0.9.7.1 |
+| pandas | 2.2.3 |
+| psycopg2-binary | 2.9.10 |
+| uvicorn | 0.34.0 |
+
+Ensure these versions are kept in sync across `requirements.txt` and development tooling to prevent installation issues.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,4 +36,4 @@ testcontainers[postgresql,redis]==3.7.1
 prometheus_client==0.22.1
 jsonschema>=4.21.1
 hypothesis>=6.99
-uvicorn==0.30.1
+uvicorn==0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cachetools==6.1.0
 websockets==11.0.3
 plotly==5.15.0
 dash-bootstrap-components==1.6.0
-pandas==2.0.3
+pandas==2.2.3
 numpy>=2.0,<3.0
 Authlib==1.6.1
 PyJWT==2.10.1
@@ -22,7 +22,7 @@ scipy==1.16.1
 scikit-learn==1.7.1
 joblib==1.3.2
 psutil==6.1.0  # safety 3.6.0 requires psutil~=6.1
-psycopg2-binary==2.9.7
+psycopg2-binary==2.9.10
 asyncpg==0.30.0
 redis==6.4.0
 requests==2.32.4


### PR DESCRIPTION
## Summary
- Align uvicorn development pin with application requirement
- Bump pandas and psycopg2-binary for Python 3.12 wheels
- Document Flask, Flasgger, pandas, psycopg2-binary and uvicorn versions to avoid resolver conflicts

## Testing
- `pip install --dry-run -r requirements-dev.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_689d58e1440083208f161570febe8e59