### PR TITLE
Pin flasgger to supported release and downgrade Flask

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,8 +1,8 @@
 # Core dashboard requirements
 # These packages must be installed before running the application.
 # The Dockerfiles and scripts/setup.sh handle this automatically.
-Flask==3.1.1
-Werkzeug==3.1.3
+Flask==2.3.3
+Werkzeug==2.3.8
 flask-babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
@@ -28,7 +28,7 @@ requests==2.32.4
 sqlparse==0.5.3
 bleach==6.1.0
 PyYAML==6.0.1
-flasgger==0.9.7.1
+flasgger==0.9.5
 python-dotenv==1.0.0
 pytest==7.4.0
 polars==1.31.0

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,8 +1,8 @@
 # Core dashboard requirements
 # These packages must be installed before running the application.
 # The Dockerfiles and scripts/setup.sh handle this automatically.
-Flask==3.1.1
-Werkzeug==3.1.3
+Flask==2.3.3
+Werkzeug==2.3.8
 flask-babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
@@ -28,7 +28,7 @@ requests==2.32.4
 sqlparse==0.5.3
 bleach==6.1.0
 PyYAML==6.0.1
-flasgger==0.9.7.1
+flasgger==0.9.5
 python-dotenv==1.0.0
 pytest==7.4.0
 polars==1.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Core dashboard requirements
 # These packages must be installed before running the application.
 # The Dockerfiles and scripts/setup.sh handle this automatically.
-Flask==3.1.1
-Werkzeug==3.1.3
+Flask==2.3.3
+Werkzeug==2.3.8
 flask-babel==4.0.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
@@ -29,7 +29,7 @@ requests==2.32.4
 sqlparse==0.5.3
 bleach==6.1.0
 PyYAML==6.0.1
-flasgger==0.9.7.1
+flasgger==0.9.5
 python-dotenv==1.0.0
 pytest==7.4.0
 polars==1.31.0


### PR DESCRIPTION
## Summary
- use flasgger 0.9.5 across requirements files
- downgrade Flask to 2.3.3 and Werkzeug to 2.3.8

## Testing
- `pip install Flask==2.3.3 flasgger==0.9.5 Werkzeug==2.3.8`
- `pip install -r requirements.txt` *(fails: operation canceled during heavy build)*
- `pre-commit run --files requirements.txt api/requirements.txt dashboard/requirements.txt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d58dcca608320af2f221224a96d3d