### PR TITLE
fix: remove unused core copy from Dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -40,7 +40,6 @@ RUN set -eux; \
 WORKDIR /app
 COPY . /app
 COPY ../yosai_intel_dashboard /app/yosai_intel_dashboard
-COPY ../core /app/core
 RUN chmod 0755 docker-entrypoint.sh \
     && find /app -type f -name '*.sh' -exec chmod 0755 {} \; \
     && find /app -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.conf' \) -exec chmod 0644 {} \; \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -39,7 +39,6 @@ RUN set -eux; \
     fi
 WORKDIR /app
 COPY . /app
-COPY ../core /app/core
 COPY ../docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod 0755 docker-entrypoint.sh \
     && find /app -type f -name '*.sh' -exec chmod 0755 {} \; \


### PR DESCRIPTION
## Summary
- remove references to non-existent `core` directory in API and dashboard Dockerfiles

## Testing
- `pre-commit run --files api/Dockerfile dashboard/Dockerfile`
- `docker build api -t test-api:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689d58dbce14832089128c769c75348e