### PR TITLE
Add integration test harness with docker compose

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,22 @@
+name: Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run integration tests
+        run: |
+          bash scripts/run_integration_tests.sh

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,73 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: dashboard
+    ports:
+      - '5432:5432'
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - '2181:2181'
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  analytics-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ['python', '-m', 'uvicorn', 'services.analytics_microservice.app:app', '--host', '0.0.0.0', '--port', '8001']
+    environment:
+      YOSAI_ENV: test
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: dashboard
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      KAFKA_BROKERS: kafka:9092
+    depends_on:
+      - postgres
+      - redis
+      - kafka
+    ports:
+      - '8001:8001'
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
+    environment:
+      YOSAI_ENV: test
+      APP_HOST: analytics-service
+      APP_PORT: 8001
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_GATEWAY_NAME: dashboard
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      - analytics-service
+    ports:
+      - '8081:8080'

--- a/integration_tests/test_workflow.py
+++ b/integration_tests/test_workflow.py
@@ -1,0 +1,39 @@
+import base64
+import time
+import requests
+
+
+def wait_for_service(url: str, timeout: int = 60) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code < 500:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"service {url} not ready")
+
+
+def test_upload_and_analytics():
+    gateway_url = "http://localhost:8081"
+    wait_for_service(f"{gateway_url}/metrics")
+
+    content = b"a,b\n1,2\n"
+    b64 = base64.b64encode(content).decode()
+    data_url = f"data:text/csv;base64,{b64}"
+
+    resp = requests.post(
+        f"{gateway_url}/v1/upload",
+        json={"contents": [data_url], "filenames": ["test.csv"]},
+        timeout=30,
+    )
+    assert resp.status_code == 200
+
+    resp = requests.get(
+        f"{gateway_url}/v1/analytics/dashboard-summary", timeout=30
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("status") == "success"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.integration.yml}
+
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down
+}
+trap cleanup EXIT
+
+pytest integration_tests


### PR DESCRIPTION
## Summary
- add Docker Compose stack for integration tests (gateway, analytics, Postgres, Redis, Kafka)
- add end-to-end upload and analytics test
- add script and GitHub Action to run integration tests

## Testing
- `pre-commit run --files docker-compose.integration.yml scripts/run_integration_tests.sh integration_tests/test_workflow.py .github/workflows/integration-tests.yml`
- `bash scripts/run_integration_tests.sh` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689d4e900c748320aebb45709318aead