### PR TITLE
Fix auto rollback script error handling

### DIFF
--- a/scripts/rollback/auto_rollback.sh
+++ b/scripts/rollback/auto_rollback.sh
@@ -8,12 +8,14 @@ DEPLOYMENT="${2:-yosai-dashboard}"
 
 error_rate=$(curl -sf "$METRIC_URL" || echo 0)
 
-if python - <<PY 2>/dev/null; then
+# Compare the current error rate with the threshold using a tiny Python
+# snippet. If the threshold is breached we trigger a rollback of the
+# deployment in the target namespace.
+if python - "$error_rate" "$THRESHOLD" 2>/dev/null <<'PY' | grep -q breach; then
 import sys
 err=float(sys.argv[1]); thr=float(sys.argv[2])
 print("breach" if err>thr else "ok")
 PY
-"$error_rate" "$THRESHOLD" | grep -q breach; then
   echo "SLO breach detected (error rate $error_rate > $THRESHOLD). Triggering rollback."
   "$(dirname "$0")/restore_images.sh" "$DEPLOYMENT" "$NAMESPACE"
 else


### PR DESCRIPTION
## Summary
- fix Python threshold comparison pipeline in `auto_rollback.sh`

## Testing
- `shellcheck scripts/rollback/auto_rollback.sh`
- `bash -n scripts/rollback/auto_rollback.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d5eafc068832090be4905309346fc