### PR TITLE
Quote variables in Go SDK git_push script

### DIFF
--- a/sdks/go/git_push.sh
+++ b/sdks/go/git_push.sh
@@ -43,9 +43,9 @@ if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
         echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
+        git remote add origin "$(printf 'https://%s/%s/%s.git' "$git_host" "$git_user_id" "$git_repo_id")"
     else
-        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
+        git remote add origin "$(printf 'https://%s:%s@%s/%s/%s.git' "$git_user_id" "$GIT_TOKEN" "$git_host" "$git_user_id" "$git_repo_id")"
     fi
 
 fi


### PR DESCRIPTION
## Summary
- Quote variables when constructing git remote URLs in `sdks/go/git_push.sh`

## Testing
- `shellcheck sdks/go/git_push.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d5fc48664832097a9dffcfffc00dc