### PR TITLE
Fix auto rollback ShellCheck warning

### DIFF
--- a/scripts/rollback/auto_rollback.sh
+++ b/scripts/rollback/auto_rollback.sh
@@ -11,7 +11,7 @@ error_rate=$(curl -sf "$METRIC_URL" || echo 0)
 # Compare the current error rate with the threshold using a tiny Python
 # snippet. If the threshold is breached we trigger a rollback of the
 # deployment in the target namespace.
-if python - "$error_rate" "$THRESHOLD" 2>/dev/null <<'PY' | grep -q breach; then
+if python - "$error_rate" "$THRESHOLD" <<'PY' 2>/dev/null | grep -q breach; then
 import sys
 err=float(sys.argv[1]); thr=float(sys.argv[2])
 print("breach" if err>thr else "ok")


### PR DESCRIPTION
## Summary
- pipe python here-doc to grep to avoid ShellCheck warning

## Testing
- `shellcheck scripts/rollback/auto_rollback.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d5fc4a6948320a890f548029f6ab9