### PR TITLE
fix: remove unused path variable from reload secrets

### DIFF
--- a/deployment/reload-secrets.sh
+++ b/deployment/reload-secrets.sh
@@ -7,7 +7,7 @@ SECRET_DIR=${SECRET_DIR:-/etc/secrets}
 PID_FILE=${PID_FILE:-/var/run/service.pid}
 
 inotifywait -m "$SECRET_DIR" -e modify,create,delete |
-while read -r path _ file; do
+while read -r _ _ file; do
   if [ -f "$PID_FILE" ]; then
     kill -HUP "$(cat "$PID_FILE")"
   fi


### PR DESCRIPTION
## Summary
- avoid storing unused path variable when monitoring secrets

## Testing
- `shellcheck deployment/reload-secrets.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d5fc5efe88320af40192defe5bab9