### PR TITLE
fix: ensure appuser group created before user in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,12 @@ COPY --from=builder /opt/venv /opt/venv
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      useradd -l -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY --chown=appuser:appuser . /app

--- a/Dockerfile.fixed
+++ b/Dockerfile.fixed
@@ -43,12 +43,12 @@ COPY --from=builder /opt/venv /opt/venv
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      useradd -l -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY --chown=appuser:appuser . /app

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,14 +28,12 @@ COPY --from=builder /opt/venv /opt/venv
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      useradd -l -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY . /app

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -28,14 +28,12 @@ COPY --from=builder /opt/venv /opt/venv
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      # hadolint ignore=DL3046
-      useradd -l -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY . /app

--- a/yosai_intel_dashboard/src/adapters/api/Dockerfile
+++ b/yosai_intel_dashboard/src/adapters/api/Dockerfile
@@ -25,12 +25,12 @@ COPY --from=builder /opt/venv /opt/venv
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      useradd -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY . /app

--- a/yosai_intel_dashboard/src/services/event-ingestion/Dockerfile
+++ b/yosai_intel_dashboard/src/services/event-ingestion/Dockerfile
@@ -10,12 +10,12 @@ RUN pip install --no-cache-dir fastapi uvicorn kafka-python prometheus-fastapi-i
 ARG UID=1000
 ARG GID=1000
 RUN set -eux; \
-    if command -v addgroup >/dev/null 2>&1; then \
-      addgroup -g "${GID}" appuser || true; \
-      adduser -D -u "${UID}" -G appuser appuser 2>/dev/null || adduser --uid "${UID}" --gid "${GID}" --disabled-password --gecos "" appuser; \
+    if addgroup --help 2>&1 | grep -q BusyBox; then \
+        addgroup -g "${GID}" appuser; \
+        adduser -D -u "${UID}" -G appuser appuser; \
     else \
-      groupadd -g "${GID}" appuser || true; \
-      useradd -m -u "${UID}" -g "${GID}" appuser || true; \
+        groupadd --gid "${GID}" appuser; \
+        useradd --no-create-home --uid "${UID}" --gid "${GID}" appuser; \
     fi
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
## Summary
- ensure appuser group exists before user creation across Dockerfiles
- use BusyBox-aware user/group creation snippet

## Testing
- `docker build -t app-test -f Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fedde348320ba43c309f9121990