### PR TITLE
chore: add dependency policy and k6 smoke test

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -1,0 +1,17 @@
+name: k6 smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install k6
+        uses: grafana/setup-k6@v1
+      - name: Run unlock path smoke test
+        run: k6 run load-tests/k6/scenarios/unlock-path-smoke.js

--- a/deps-policy.yml
+++ b/deps-policy.yml
@@ -1,0 +1,7 @@
+critical_path:
+  charting:
+    allow:
+      - recharts
+  mapping:
+    allow:
+      - mapbox-gl

--- a/load-tests/k6/scenarios/unlock-path-smoke.js
+++ b/load-tests/k6/scenarios/unlock-path-smoke.js
@@ -1,0 +1,16 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '2m',
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<100'],
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:8080/unlock');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", "schedule:weekly"],
   "github-actions": {
     "enabled": true
   },
@@ -16,6 +16,11 @@
     {
       "matchManagers": ["npm"],
       "groupName": "npm-packages"
+    },
+    {
+      "matchPackageNames": ["left-pad", "request"],
+      "enabled": false,
+      "description": "blocklist for abandoned packages"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- document critical charting and mapping dependencies
- run k6 unlock-path smoke test in CI
- configure Renovate for weekly cadence and block abandoned packages

## Testing
- `pre-commit run --files renovate.json .github/workflows/k6-smoke.yml deps-policy.yml load-tests/k6/scenarios/unlock-path-smoke.js`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d677609e883208ccbbad42291d1cd