### PR TITLE
Introduce low-latency circuit breakers

### DIFF
--- a/gateway/internal/cache/redis_cache_test.go
+++ b/gateway/internal/cache/redis_cache_test.go
@@ -41,7 +41,28 @@ func TestRedisCacheSetGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get after ttl: %v", err)
 	}
-	if expired != nil {
-		t.Fatalf("expected nil after ttl, got %+v", expired)
+	if expired == nil || expired.Decision != defaultDecision {
+		t.Fatalf("expected default decision after ttl, got %+v", expired)
+	}
+}
+
+func TestRedisCacheMissReturnsDefault(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer srv.Close()
+
+	os.Setenv("REDIS_HOST", srv.Host())
+	os.Setenv("REDIS_PORT", srv.Port())
+	os.Setenv("CACHE_TTL_SECONDS", "1")
+
+	c := NewRedisCache()
+	got, err := c.GetDecision(context.Background(), "missing", "door")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.Decision != defaultDecision {
+		t.Fatalf("expected default decision, got %+v", got)
 	}
 }

--- a/gateway/internal/logging/audit.go
+++ b/gateway/internal/logging/audit.go
@@ -6,9 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/sony/gobreaker"
+
+	"github.com/WSG23/resilience"
 )
 
 // AuditLog represents a structured audit entry.
@@ -24,6 +29,7 @@ type AuditLogger struct {
 	endpoint string
 	index    string
 	client   *http.Client
+	breaker  *gobreaker.CircuitBreaker
 }
 
 // NewAuditLogger creates an AuditLogger. The Elasticsearch endpoint can be
@@ -34,10 +40,16 @@ func NewAuditLogger() *AuditLogger {
 	if ep == "" {
 		return &AuditLogger{}
 	}
+	settings := gobreaker.Settings{
+		Name:        "audit-logger",
+		Timeout:     time.Second + time.Duration(rand.Intn(1000))*time.Millisecond,
+		ReadyToTrip: func(c gobreaker.Counts) bool { return c.ConsecutiveFailures >= 3 },
+	}
 	return &AuditLogger{
 		endpoint: ep,
 		index:    "audit", // default index
-		client:   &http.Client{Timeout: 2 * time.Second},
+		client:   &http.Client{},
+		breaker:  resilience.NewGoBreaker("audit-logger", settings),
 	}
 }
 
@@ -52,16 +64,24 @@ func (l *AuditLogger) Log(ctx context.Context, entry AuditLog) error {
 		return err
 	}
 	url := fmt.Sprintf("%s/%s/_doc", l.endpoint, l.index)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := l.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
-	return nil
+	_, err = l.breaker.Execute(func() (interface{}, error) {
+		resp, err := l.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 500 {
+			return nil, fmt.Errorf("status %d", resp.StatusCode)
+		}
+		io.Copy(io.Discard, resp.Body)
+		return nil, nil
+	})
+	return err
 }


### PR DESCRIPTION
## Summary
- switch cache, DB, and audit calls to 20ms timeouts
- guard outbound calls with gobreaker including jittered half-open
- return policy-default decisions on cache miss or downstream failure
- exercise breaker transitions and degraded-mode behavior in tests

## Testing
- `go test ./internal/cache ./internal/engine ./internal/logging` *(fails: missing go.sum entry for google.golang.org/protobuf/reflect/protoreflect)*

------
https://chatgpt.com/codex/tasks/task_e_689d6b9d98408320a232380e54caf9a0