### PR TITLE
chore: externalize creds and add key rotation job

### DIFF
--- a/k8s/cron/key-rotation.yaml
+++ b/k8s/cron/key-rotation.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vault-key-rotation
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: rotate-vault-keys
+              image: curlimages/curl:8.6.0
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  curl -sSf -X POST -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/rotate"
+              env:
+                - name: VAULT_ADDR
+                  valueFrom:
+                    configMapKeyRef:
+                      name: vault-config
+                      key: VAULT_ADDR
+                - name: VAULT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-secret
+                      key: VAULT_TOKEN

--- a/k8s/microservices/analytics-service.yaml
+++ b/k8s/microservices/analytics-service.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: analytics-service
-          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          image: yosai-intel-dashboard:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/k8s/microservices/api-gateway.yaml
+++ b/k8s/microservices/api-gateway.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: api-gateway
-          image: yosai-gateway:${IMAGE_TAG:-v0.1.0}
+          image: yosai-gateway:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/k8s/microservices/event-ingestion.yaml
+++ b/k8s/microservices/event-ingestion.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: event-ingestion
-          image: event-ingestion:${IMAGE_TAG:-v0.1.0}
+          image: event-ingestion:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/k8s/microservices/secret-rotation-cronjob.yaml
+++ b/k8s/microservices/secret-rotation-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: rotate-secrets
-              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              image: yosai-intel-dashboard:${IMAGE_TAG}
               imagePullPolicy: IfNotPresent
               command: ["python", "scripts/vault_rotate.py"]
               envFrom:

--- a/k8s/microservices/timescale-replication-cronjob.yaml
+++ b/k8s/microservices/timescale-replication-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: replicate-to-timescale
-              image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+              image: yosai-intel-dashboard:${IMAGE_TAG}
               imagePullPolicy: IfNotPresent
               command: ["python", "scripts/replicate_to_timescale.py"]
               envFrom:

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -32,12 +32,12 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: setup-symlinks
-          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          image: yosai-intel-dashboard:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command: ["python", "scripts/create_symlinks.py"]
       containers:
         - name: yosai-dashboard
-          image: yosai-intel-dashboard:${IMAGE_TAG:-v0.1.0}
+          image: yosai-intel-dashboard:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8050
@@ -53,7 +53,10 @@ spec:
             - name: DB_NAME
               value: "yosai_intel"
             - name: DB_USER
-              value: "postgres"
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: username
             - name: VAULT_ADDR
               valueFrom:
                 configMapKeyRef:

--- a/k8s/production/pgbouncer.yaml
+++ b/k8s/production/pgbouncer.yaml
@@ -22,7 +22,10 @@ spec:
             - name: DB_PORT
               value: "5432"
             - name: DB_USER
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/runbooks/key-rotation.md
+++ b/runbooks/key-rotation.md
@@ -1,0 +1,26 @@
+# Vault Key Rotation Runbook
+
+## Scheduled Rotation
+1. A Kubernetes CronJob (`vault-key-rotation`) runs nightly and calls the Vault rotation API.
+2. The job posts to `$VAULT_ADDR/v1/sys/rotate` with the cluster's `VAULT_TOKEN`.
+3. On success the API returns `204` and rotates the underlying encryption keys.
+
+## Manual Rotation
+1. Ensure `VAULT_ADDR` and `VAULT_TOKEN` environment variables are set.
+2. Trigger the CronJob manually:
+   ```bash
+   kubectl create job --from=cronjob/vault-key-rotation vault-key-rotation-manual
+   ```
+3. Check the job status until completion:
+   ```bash
+   kubectl get jobs | grep vault-key-rotation-manual
+   ```
+4. Confirm Vault reports the new key version:
+   ```bash
+   curl -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_ADDR/v1/sys/rotations" | jq
+   ```
+
+## Validation
+- Ensure the CronJob logs show a `204` response from the rotation API.
+- Verify dependent services continue to authenticate and decrypt data after rotation.
+- Investigate and rollback if any service fails to access Vault post-rotation.

--- a/yosai_intel_dashboard/src/infrastructure/config/settings.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/settings.py
@@ -7,15 +7,22 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 
+def _env_required(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"{name} environment variable must be set")
+    return value
+
+
 @dataclass
 class DatabaseSettings:
     """Database connection configuration."""
 
-    host: str = field(default_factory=lambda: os.getenv("DB_HOST", "localhost"))
-    port: int = field(default_factory=lambda: int(os.getenv("DB_PORT", "5432")))
-    user: str = field(default_factory=lambda: os.getenv("DB_USER", "postgres"))
-    password: str = field(default_factory=lambda: os.getenv("DB_PASSWORD", ""))
-    name: str = field(default_factory=lambda: os.getenv("DB_NAME", "app"))
+    host: str = field(default_factory=lambda: _env_required("DB_HOST"))
+    port: int = field(default_factory=lambda: int(_env_required("DB_PORT")))
+    user: str = field(default_factory=lambda: _env_required("DB_USER"))
+    password: str = field(default_factory=lambda: _env_required("DB_PASSWORD"))
+    name: str = field(default_factory=lambda: _env_required("DB_NAME"))
     min_connections: int = field(
         default_factory=lambda: int(os.getenv("DB_MIN_CONNECTIONS", "1"))
     )
@@ -59,7 +66,7 @@ class SecuritySettings:
 class AnalyticsSettings:
     """Analytics service configuration."""
 
-    api_key: str = field(default_factory=lambda: os.getenv("ANALYTICS_API_KEY", ""))
+    api_key: str = field(default_factory=lambda: _env_required("ANALYTICS_API_KEY"))
     endpoint: str = field(default_factory=lambda: os.getenv("ANALYTICS_ENDPOINT", ""))
     enabled: bool = field(
         default_factory=lambda: os.getenv("ENABLE_ANALYTICS", "false").lower() == "true"


### PR DESCRIPTION
## Summary
- use Vault secrets for database user in deployments
- remove plaintext fallbacks in manifests and config
- add Vault key rotation CronJob and runbook

## Testing
- `pre-commit run --files k8s/microservices/analytics-service.yaml k8s/microservices/api-gateway.yaml k8s/microservices/event-ingestion.yaml k8s/microservices/secret-rotation-cronjob.yaml k8s/microservices/timescale-replication-cronjob.yaml k8s/production/deployment.yaml k8s/production/pgbouncer.yaml k8s/cron/key-rotation.yaml runbooks/key-rotation.md yosai_intel_dashboard/src/infrastructure/config/settings.py`
- `pytest tests/test_config_production_secrets.py::test_invalid_secrets_raise -q` *(fails: SyntaxError in existing monitoring module)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ba392608320b11dc4728f9b2145