### PR TITLE
Add concurrency control to integration tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enforce concurrency for integration tests workflow to cancel in-progress runs on the same ref

## Testing
- `pre-commit run --files .github/workflows/integration-tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_689d73029130832099e645dcf8a120c4