### PR TITLE
Add concurrency to k6 smoke workflow

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure k6 smoke workflow cancels in-progress runs via concurrency group

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install --legacy-peer-deps` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d73061df88320ac1b85151ffb3151