### PR TITLE
Fix docker compose overrides for local dashboard & api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+SHELL := /bin/bash
+DC := docker compose
+
+.PHONY: up down logs ps
+up:       ; @$(DC) up -d --build
+down:     ; @$(DC) down -v
+logs:     ; @$(DC) logs -f --tail=200
+ps:       ; @$(DC) ps
+
 BROKERS ?= localhost:9092
 PROM_URL ?= http://localhost:9090
 RATE ?= 50
@@ -9,7 +18,7 @@ DOCKER_COMPOSE := $(shell command -v docker-compose >/dev/null 2>&1 && echo dock
 ENV_VARS = $(shell [ -f .env ] && grep -v '^#' .env | xargs)
 
 .PHONY: load-test load-tests validate build test deploy format lint security clean \
-build-all test-all deploy-all logs deprecation-docs \
+build-all test-all deploy-all cli-logs deprecation-docs \
 proto-python proto-go proto-all docs test-quick test-cov \
 infra-up infra-down infra-logs
 
@@ -40,8 +49,8 @@ test-all:
 deploy-all:
 	$(CLI) deploy-all
 
-logs:
-	$(CLI) logs $(service)
+cli-logs:
+        $(CLI) logs $(service)
 
 format:
 	$(CLI) format

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 services:
   dashboard:
-    build:
-      dockerfile: Dockerfile.fixed
-  api:
-    build:
-      dockerfile: Dockerfile.fixed
+    command: >
+      bash -lc "python - <<'PY'
+      from yosai_intel_dashboard.src.app import app
+      app.run_server(host='0.0.0.0', port=8050, debug=True)
+      PY"

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,4 @@ networkx==3.5
 neo4j==5.14.1
 python-louvain==0.16
 uvicorn==0.34.0
+prometheus_fastapi_instrumentator>=6.1.0

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/__init__.py
@@ -143,8 +143,6 @@ def __getattr__(name: str):
         from yosai_intel_dashboard.src.services.resilience.metrics import (
             start_metrics_server,
         )
-
-<<<<<< codex/wrap-http/kafka-clients-with-breaker-library
         return start_metrics_server
 
     raise AttributeError(name)


### PR DESCRIPTION
## Summary
- remove stray merge marker from monitoring utilities
- ensure prometheus_fastapi_instrumentator dependency
- provide local docker compose override and makefile helpers

## Testing
- `docker compose up -d --build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `docker compose ps` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `curl -f http://localhost:8050/health` *(fails: Failed to connect to localhost port 8050 after 0 ms: Couldn't connect to server)*
- `curl -f http://localhost:8000/health` *(fails: Failed to connect to localhost port 8000 after 0 ms: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689d84675f588320b851a323566ed17e