### PR TITLE
feat: add health endpoint for local docker

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,6 @@ services:
       interval: 30s
       timeout: 3s
       retries: 1
-
   api:
     healthcheck:
       test: ["CMD-SHELL","true"]

--- a/yosai_intel_dashboard/src/app.py
+++ b/yosai_intel_dashboard/src/app.py
@@ -6,6 +6,7 @@ from yosai_intel_dashboard.src.adapters.ui.pages import greetings
 from yosai_intel_dashboard.src.callbacks import register_callbacks
 
 from yosai_intel_dashboard.src.simple_di import ServiceContainer
+from flask import Response
 
 try:  # pragma: no cover - allow running without full services package
     from yosai_intel_dashboard.src.services.greeting import GreetingService
@@ -32,5 +33,13 @@ def create_app() -> Dash:
     return app
 
 
+app = create_app()
+
+
+@app.server.get("/health")
+def _health() -> Response:  # pragma: no cover - simple health endpoint
+    return Response("ok", 200)
+
+
 if __name__ == "__main__":
-    create_app().run(debug=True)
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- expose global Dash app with /health endpoint
- add docker-compose override with commands and healthchecks

## Testing
- `python -m py_compile yosai_intel_dashboard/src/app.py`
- `docker-compose down -v` *(fails: ConnectionRefusedError)*
- `curl -fsS http://localhost:8050/health` *(fails: Couldn't connect to server)*
- `curl -fsS http://localhost:8000/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c77a98083209a512b1d6b1231b6