### PR TITLE
Guard navbar import and streamline config helper

### DIFF
--- a/yosai_intel_dashboard/src/core/app_factory/__init__.py
+++ b/yosai_intel_dashboard/src/core/app_factory/__init__.py
@@ -7,19 +7,18 @@ import dash
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 
-# Import Path for building robust file paths
 try:
-    from yosai_intel_dashboard.src.adapters.ui.components.ui.navbar import *  # type: ignore  # noqa: F403
+    from yosai_intel_dashboard.src.adapters.ui.components.ui.navbar import *  # type: ignore
 
     _NAVBAR_AVAILABLE = True
 except Exception:
     _NAVBAR_AVAILABLE = False
 
-from yosai_intel_dashboard.src.infrastructure.error_handling.handlers import (
-    register_error_handlers,
-)
 from yosai_intel_dashboard.src.core.app_factory.health import (
     register_health_endpoints,
+)
+from yosai_intel_dashboard.src.infrastructure.error_handling.handlers import (
+    register_error_handlers,
 )
 
 
@@ -38,12 +37,10 @@ def create_app(mode=None, **kwargs):
     register_error_handlers(app.server)
     register_health_endpoints(app.server)
 
-    # if navbar is optional, skip if missing
     if not _NAVBAR_AVAILABLE:
-        # proceed without navbar; layout should still be created elsewhere
-        navbar_layout = None
-    else:
-        navbar_layout = create_navbar_layout()  # noqa: F405
+        pass
+
+    navbar_layout = create_navbar_layout() if _NAVBAR_AVAILABLE else None
 
     # Simple working layout
     app.layout = html.Div(

--- a/yosai_intel_dashboard/src/core/config_helpers.py
+++ b/yosai_intel_dashboard/src/core/config_helpers.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional  # noqa: F401
+from typing import Optional
 
 
 def _int_env(name: str, default: int) -> int:
@@ -10,8 +10,4 @@ def _int_env(name: str, default: int) -> int:
 
 
 def get_max_display_rows(default: int = 200) -> int:
-    """
-    Lightweight helper that reads MAX_DISPLAY_ROWS from the environment.
-    It must not import any other project modules to avoid circular imports.
-    """
     return _int_env("MAX_DISPLAY_ROWS", default)


### PR DESCRIPTION
## Summary
- simplify environment helper for `MAX_DISPLAY_ROWS`
- guard dashboard navbar import and usage when component missing

## Testing
- `python -m black yosai_intel_dashboard/src/core/config_helpers.py yosai_intel_dashboard/src/core/app_factory/__init__.py`
- `python -m isort yosai_intel_dashboard/src/core/config_helpers.py yosai_intel_dashboard/src/core/app_factory/__init__.py`
- `pytest --no-cov unit_tests/test_threadsafe_database_manager_pool.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e454b6ef48320818c9b31193648d6