### PR TITLE
Ensure dashboard and API start with DB config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_HOST=db
+DB_PORT=5432
+ANALYTICS_API_KEY=dev
+ANALYTICS_API_URL=http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - ANALYTICS_API_URL
       - DB_USER
       - DB_PASSWORD
+      - DB_HOST
+      - DB_PORT
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "true"]
@@ -40,9 +42,25 @@ services:
       - ANALYTICS_API_URL
       - DB_USER
       - DB_PASSWORD
+      - DB_HOST
+      - DB_PORT
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "true"]
       interval: 30s
       timeout: 10s
+      retries: 5
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: yosai_intel
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL","pg_isready -U ${DB_USER}"]
+      interval: 10s
+      timeout: 5s
       retries: 5

--- a/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
+++ b/yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict
+
+import yaml
 
 from .app_config import UploadConfig
 from .base_loader import BaseConfigLoader
@@ -25,6 +28,12 @@ from yosai_intel_dashboard.src.infrastructure.config.configuration_mixin import 
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    with Path(__file__).with_name("monitoring.yaml").open(encoding="utf-8") as f:
+        monitoring_config = yaml.safe_load(f) or {}
+except FileNotFoundError:
+    monitoring_config = {}
 
 
 class DynamicConfigManager(ConfigurationMixin, BaseConfigLoader):


### PR DESCRIPTION
## Summary
- add `.env` with DB connection and analytics variables
- expose DB_HOST/DB_PORT to dashboard and api and provide optional Postgres service
- load monitoring config safely when missing

## Testing
- `pre-commit run --files docker-compose.yml yosai_intel_dashboard/src/infrastructure/config/dynamic_config.py .env`
- `docker-compose down -v` *(fails: Error while fetching server API version: No such file or directory)*
- `docker-compose up -d --build` *(fails: Error while fetching server API version: No such file or directory)*
- `docker-compose ps` *(fails: Error while fetching server API version: No such file or directory)*
- `curl -fsS http://localhost:8000/health` *(fails: Failed to connect)*

------
https://chatgpt.com/codex/tasks/task_e_689e492af61c83208f91196923e3d889