### PR TITLE
chore: remove workflow concurrency block

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,9 +10,10 @@ permissions:
   security-events: write
   actions: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+
+# Removed concurrency to prevent cancellation of in-progress runs.
+# If necessary, reintroduce with a more specific group key.
+
 
 jobs:
   build-test:


### PR DESCRIPTION
## Summary
- remove concurrency from CI pipeline workflow to avoid canceling in-progress runs

## Testing
- `npm test` *(fails: components/overlay/Hint.vitest.test.tsx logs view and click interactions)*

------
https://chatgpt.com/codex/tasks/task_e_689e49b969b083209ae85534f43bc471