### PR TITLE
refactor: update enum imports to value_objects

### DIFF
--- a/docs/models_guide.md
+++ b/docs/models_guide.md
@@ -20,7 +20,7 @@ is organized and consistent.
 FILE-BY-FILE BREAKDOWN
 ======================
 
-### <span aria-hidden="true">📋</span> models/enums.py - "The Dropdown Lists"
+### <span aria-hidden="true">📋</span> core/domain/value_objects/enums.py - "The Dropdown Lists"
 WHAT IT DOES:
 This file defines all the fixed choices/options used throughout the system.
 Like dropdown menus in a form - you can only pick from specific options.
@@ -36,14 +36,14 @@ CONTAINS:
 HOW OTHER MODULES USE IT:
 ```python
 # In analytics page - checking access results
-from yosai_intel_dashboard.src.models.enums import AccessResult, AnomalyType
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import AccessResult, AnomalyType
 
 def analyze_failed_access(data):
     denied_events = data[data['access_result'] == AccessResult.DENIED.value]
     return f"Found {len(denied_events)} denied access attempts"
 
 # In dashboard components - showing severity colors
-from yosai_intel_dashboard.src.models.enums import SeverityLevel
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import SeverityLevel
 
 def get_alert_color(severity_text):
     if severity_text == SeverityLevel.CRITICAL.value:
@@ -53,7 +53,7 @@ def get_alert_color(severity_text):
     return "yellow"
 
 # In incident response - updating ticket status
-from yosai_intel_dashboard.src.models.enums import TicketStatus
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import TicketStatus
 
 def resolve_ticket(ticket_id, resolution_type):
     if resolution_type == "harmful":
@@ -92,7 +92,7 @@ def add_new_employee(emp_data):
 
 # In map panel - showing door information
 from yosai_intel_dashboard.src.models.entities import Door
-from yosai_intel_dashboard.src.models.enums import DoorType
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import DoorType
 
 def create_door_for_map(door_data):
     door = Door(
@@ -137,7 +137,7 @@ HOW OTHER MODULES USE IT:
 ```python
 # In file upload processing - converting CSV to structured events
 from yosai_intel_dashboard.src.models.events import AccessEvent
-from yosai_intel_dashboard.src.models.enums import AccessResult, BadgeStatus
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import AccessResult, BadgeStatus
 
 def process_access_log_csv(csv_data):
     events = []
@@ -155,7 +155,7 @@ def process_access_log_csv(csv_data):
 
 # In anomaly detection - creating anomaly records
 from yosai_intel_dashboard.src.models.events import AnomalyDetection
-from yosai_intel_dashboard.src.core.domain.entities.enums import AnomalyType, SeverityLevel
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import AnomalyType, SeverityLevel
 
 def flag_odd_time_access(access_event):
     anomaly = AnomalyDetection(
@@ -171,7 +171,7 @@ def flag_odd_time_access(access_event):
 
 # In incident management - creating tickets
 from yosai_intel_dashboard.src.core.domain.entities.events import IncidentTicket
-from yosai_intel_dashboard.src.core.domain.entities.enums import TicketStatus
+from yosai_intel_dashboard.src.core.domain.value_objects.enums import TicketStatus
 
 def create_security_ticket(anomaly, threat_level):
     ticket = IncidentTicket(

--- a/yosai_intel_dashboard/src/core/domain/entities/access_events.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/access_events.py
@@ -23,7 +23,7 @@ from yosai_intel_dashboard.src.infrastructure.config.constants import (
 )
 
 from .base import BaseModel
-from .enums import AccessResult, BadgeStatus
+from ..value_objects.enums import AccessResult, BadgeStatus
 
 _sql_validator = SecurityValidator()
 

--- a/yosai_intel_dashboard/src/core/domain/entities/entities.py
+++ b/yosai_intel_dashboard/src/core/domain/entities/entities.py
@@ -46,7 +46,7 @@ def failure(error: E) -> Failure[E]:
     return Failure(error)
 
 
-from .enums import DoorType
+from ..value_objects.enums import DoorType
 from .events import AccessEvent
 
 

--- a/yosai_intel_dashboard/src/models/__init__.py
+++ b/yosai_intel_dashboard/src/models/__init__.py
@@ -14,7 +14,7 @@ except Exception:  # noqa: BLE001 - best effort fallback
 
 # Import core enums if available, otherwise provide dummy placeholders.
 try:  # pragma: no cover - exercised indirectly
-    from .enums import (
+    from ..core.domain.value_objects.enums import (
         AccessResult,
         AccessType,
         AnomalyType,


### PR DESCRIPTION
## Summary
- switch AccessEventModel to use enums from value_objects
- update domain entities and models package to new value_objects enum path
- refresh documentation examples for updated enum imports

## Testing
- `pytest tests/repositories/test_sql_injection_repo.py tests/repositories/test_repositories.py` *(fails: ImportError: cannot import name 'register_fallback' from 'optional_dependencies')*


------
https://chatgpt.com/codex/tasks/task_e_689ea3b7ff6883208514aa1af2fa09ab