### PR TITLE
feat: enable automatic secret rotation

### DIFF
--- a/deployment/reload-secrets.sh
+++ b/deployment/reload-secrets.sh
@@ -6,7 +6,7 @@ set -eu
 SECRET_DIR=${SECRET_DIR:-/etc/secrets}
 PID_FILE=${PID_FILE:-/var/run/service.pid}
 
-inotifywait -m "$SECRET_DIR" -e modify,create,delete |
+inotifywait -m "$SECRET_DIR" -e modify,create,delete,move |
 while read -r _ _ file; do
   if [ -f "$PID_FILE" ]; then
     kill -HUP "$(cat "$PID_FILE")"

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,9 +65,12 @@ Following these practices ensures that user input is passed separately from the 
 ## Secret Rotation
 
 Secrets are rotated automatically. The `k8s/cron/secret-rotate.yaml` CronJob
-invokes a Vault script to generate fresh credentials and update Kubernetes
-secrets. Services load credentials from mounted files and rely on the
-`pkg/config` `SecretWatcher` to reload values when the files change.
+invokes a Vault script to generate fresh credentials via the KMS policies in
+`vault/policies/` and then updates the Kubernetes secret objects. Running
+services read credentials from mounted files and either use the
+`deployment/reload-secrets.sh` helper (which sends `HUP` to the process) or the
+`pkg/config` `SecretWatcher` to pick up changes as Kubernetes replaces the
+files.
 
 To trigger a rotation manually, run:
 

--- a/k8s/cron/secret-rotate.yaml
+++ b/k8s/cron/secret-rotate.yaml
@@ -4,6 +4,9 @@ metadata:
   name: secret-rotate
 spec:
   schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -25,14 +26,17 @@ func NewSecretWatcher(path string) (*SecretWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := watcher.Add(path); err != nil {
+	dir := filepath.Dir(path)
+	if err := watcher.Add(dir); err != nil {
 		watcher.Close()
 		return nil, err
 	}
 
 	go func() {
-		for range watcher.Events {
-			w.reload()
+		for event := range watcher.Events {
+			if filepath.Clean(event.Name) == path {
+				w.reload()
+			}
 		}
 	}()
 

--- a/vault/policies/kms.hcl
+++ b/vault/policies/kms.hcl
@@ -1,0 +1,11 @@
+path "transit/keys/*" {
+  capabilities = ["read"]
+}
+
+path "transit/encrypt/*" {
+  capabilities = ["update"]
+}
+
+path "transit/decrypt/*" {
+  capabilities = ["update"]
+}


### PR DESCRIPTION
## Summary
- watch mounted secrets and reload on file replacement
- run daily secret rotation CronJob and restrict concurrency
- document rotation steps and add Vault KMS policy

## Testing
- `go test ./...` (pkg)
- `shellcheck deployment/reload-secrets.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ea8d462dc8320893f56e589f8974b