### PR TITLE
feat: enable mTLS for shared client and rotate certs

### DIFF
--- a/deploy/k8s/certs/rotation-cronjob.yaml
+++ b/deploy/k8s/certs/rotation-cronjob.yaml
@@ -14,9 +14,10 @@ data:
     fi
     for svc in gateway queue resilience httpx; do
       if [ ! -f "$DIR/${svc}.key" ]; then
-        openssl req -new -nodes -newkey rsa:2048 -keyout "$DIR/${svc}.key" -subj "/CN=${svc}" -out "$DIR/${svc}.csr"
-        openssl x509 -req -in "$DIR/${svc}.csr" -CA "$DIR/ca.crt" -CAkey "$DIR/ca.key" -CAcreateserial -out "$DIR/${svc}.crt" -days 365
-        rm "$DIR/${svc}.csr"
+        openssl req -new -nodes -newkey rsa:2048 -keyout "$DIR/${svc}.key" -subj "/CN=${svc}" -addext "subjectAltName=DNS:${svc},IP:127.0.0.1" -out "$DIR/${svc}.csr"
+        printf "[v3_req]\nsubjectAltName=DNS:${svc},IP:127.0.0.1" > "$DIR/${svc}.ext"
+        openssl x509 -req -in "$DIR/${svc}.csr" -CA "$DIR/ca.crt" -CAkey "$DIR/ca.key" -CAcreateserial -out "$DIR/${svc}.crt" -days 365 -extfile "$DIR/${svc}.ext" -extensions v3_req
+        rm "$DIR/${svc}.csr" "$DIR/${svc}.ext"
       fi
     done
 ---

--- a/shared/httpx/__init__.py
+++ b/shared/httpx/__init__.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import os
 import httpx
 
 from services.resilience.circuit_breaker import CircuitBreaker
 
 
 class BreakerClient:
-    """HTTPX client wrapped with a circuit breaker."""
+    """HTTPX client wrapped with a circuit breaker.
+
+    The client reads standard TLS environment variables (``TLS_CERT_FILE``,
+    ``TLS_KEY_FILE`` and ``TLS_CA_FILE``) and configures mutual TLS for
+    outbound requests when provided.
+    """
 
     def __init__(
         self,
@@ -16,7 +22,12 @@ class BreakerClient:
         recovery_timeout: int = 60,
         name: str = "httpx",
     ) -> None:
-        self._client = httpx.AsyncClient(timeout=timeout)
+        tls_cert = os.getenv("TLS_CERT_FILE")
+        tls_key = os.getenv("TLS_KEY_FILE")
+        tls_ca = os.getenv("TLS_CA_FILE")
+        verify = tls_ca or True
+        cert = (tls_cert, tls_key) if tls_cert and tls_key else None
+        self._client = httpx.AsyncClient(timeout=timeout, verify=verify, cert=cert)
         self.circuit_breaker = CircuitBreaker(
             failure_threshold, recovery_timeout, name=name
         )

--- a/tests/unit/test_tls_client.py
+++ b/tests/unit/test_tls_client.py
@@ -1,0 +1,64 @@
+import asyncio
+import json
+import os
+import ssl
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from shared.httpx import BreakerClient
+
+CERT_DIR = Path(__file__).resolve().parents[2] / "deploy" / "k8s" / "certs"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{\"ok\": true}")
+
+
+@pytest.fixture
+def tls_server():
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ctx.load_cert_chain(
+        certfile=str(CERT_DIR / "gateway.crt"),
+        keyfile=str(CERT_DIR / "gateway.key"),
+    )
+    ctx.load_verify_locations(cafile=str(CERT_DIR / "ca.crt"))
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    port = server.socket.getsockname()[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"https://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.mark.asyncio
+async def test_tls_connection_validates_certificate(tls_server):
+    os.environ["TLS_CERT_FILE"] = str(CERT_DIR / "httpx.crt")
+    os.environ["TLS_KEY_FILE"] = str(CERT_DIR / "httpx.key")
+    os.environ["TLS_CA_FILE"] = str(CERT_DIR / "ca.crt")
+    client = BreakerClient()
+    resp = await client.request("GET", tls_server)
+    assert resp.json() == {"ok": True}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tls_connection_fails_without_client_cert(tls_server):
+    os.environ.pop("TLS_CERT_FILE", None)
+    os.environ.pop("TLS_KEY_FILE", None)
+    os.environ["TLS_CA_FILE"] = str(CERT_DIR / "ca.crt")
+    client = BreakerClient()
+    with pytest.raises(Exception):
+        await client.request("GET", tls_server)
+    await client.aclose()


### PR DESCRIPTION
## Summary
- add environment-driven mTLS support to shared BreakerClient
- update cert rotation CronJob to issue SAN-aware service certs
- test TLS handshake for Python client

## Testing
- `GOFLAGS='-mod=mod' go test ./unit -run TLS -count=1` *(fails: ambiguous import from grpc-gateway)*
- `PYTHONPATH=/workspace/yosai_intel_dashboard_fresh python -m pytest test_tls_client.py -q --noconftest -c /dev/null` *(fails: ImportError register_fallback)*

------
https://chatgpt.com/codex/tasks/task_e_689ea8ca6e908320abf368e382236893