### PR TITLE
Add probes, pipeline steps, and online migrations

### DIFF
--- a/deployment/pipeline.yaml
+++ b/deployment/pipeline.yaml
@@ -1,7 +1,7 @@
 stages:
   - build
   - canary
-  - promote
+  - blue_green
 
 build:
   stage: build
@@ -16,8 +16,8 @@ canary:
   needs:
     - build
 
-promote_blue_green:
-  stage: promote
+blue_green:
+  stage: blue_green
   script:
     - kubectl apply -f k8s/bluegreen
   when: manual

--- a/k8s/jaeger.yaml
+++ b/k8s/jaeger.yaml
@@ -20,6 +20,19 @@ spec:
           ports:
             - containerPort: 16686
             - containerPort: 14268
+            - containerPort: 14269
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 14269
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/migrations/006_create_outbox_table.sql
+++ b/migrations/006_create_outbox_table.sql
@@ -7,4 +7,4 @@ CREATE TABLE IF NOT EXISTS outbox (
     published_at TIMESTAMPTZ
 );
 
-CREATE INDEX IF NOT EXISTS idx_outbox_published_at ON outbox(published_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_outbox_published_at ON outbox(published_at);

--- a/migrations/versions/0006_create_outbox_table.py
+++ b/migrations/versions/0006_create_outbox_table.py
@@ -1,0 +1,26 @@
+"""Create outbox table for event sourcing"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[1] / "006_create_outbox_table.sql"
+    with op.get_context().autocommit_block():
+        op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_outbox_published_at")
+    op.execute("DROP TABLE IF EXISTS outbox")
+

--- a/runbooks/deployment.md
+++ b/runbooks/deployment.md
@@ -2,17 +2,16 @@
 
 ## Rollout Procedure
 1. Build and push container images.
-2. Deploy the canary release using `k8s/canary` manifests.
-3. Verify metrics and logs for the canary pods.
+2. Trigger the `canary` stage in `deployment/pipeline.yaml` or run `kubectl apply -f k8s/canary` to deploy the canary release.
+3. Verify metrics and logs for the canary pods. Readiness and liveness probes should remain green before continuing.
 4. Start `scripts/rollback.sh` to watch unlock latency and error SLOs. The script queries
    Prometheus and will undo the rollout if P95 latency exceeds **100 ms** for 5 minutes or
    errors exceed **1%**.
 5. Confirm log entries appear in the staging ELK and Datadog dashboards and include correlation IDs from test requests.
-6. Promote traffic with the blue/green deployment in `k8s/bluegreen`.
+6. Execute the `blue_green` stage to shift traffic using `k8s/bluegreen` manifests.
 7. Remove the old color once the new version is healthy.
 
 ## Rollback Procedure
 1. Re-route traffic back to the previous color or disable the canary.
-2. Redeploy the last known good image or run `scripts/rollback.sh <deployment> <namespace>`
-   to trigger `kubectl rollout undo` when SLOs are violated.
+2. Run `scripts/rollback.sh <deployment> <namespace>` or `kubectl rollout undo` to revert to the last known good image when SLOs are violated.
 3. Monitor until service health is restored.


### PR DESCRIPTION
## Summary
- add readiness and liveness probes for jaeger deployment
- introduce explicit canary and blue/green stages in CI pipeline
- use concurrent index and new Alembic migration for outbox table
- document rollout and rollback procedures

## Testing
- `pre-commit run --files k8s/jaeger.yaml deployment/pipeline.yaml migrations/006_create_outbox_table.sql migrations/versions/0006_create_outbox_table.py runbooks/deployment.md`
- `pytest -q` *(fails: ImportError: cannot import name 'register_fallback')*


------
https://chatgpt.com/codex/tasks/task_e_689ea8d089348320a87d8d64c6584768