### PR TITLE
Add circuit breaker wrappers for HTTP and queue clients

### DIFF
--- a/pkg/httpx/config.go
+++ b/pkg/httpx/config.go
@@ -12,8 +12,8 @@ type Config struct {
 // DefaultConfig provides sane defaults for HTTP clients.
 func DefaultConfig() Config {
 	return Config{
-		Timeout: 10 * time.Second,
-		Backoff: 50 * time.Millisecond,
+		Timeout: 5 * time.Second,
+		Backoff: 100 * time.Millisecond,
 		Retries: 3,
 	}
 }

--- a/shared/httpx/__init__.py
+++ b/shared/httpx/__init__.py
@@ -1,8 +1,12 @@
+"""HTTPX client instrumented with a circuit breaker."""
+
 from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional
 
 import httpx
 
-from services.resilience.circuit_breaker import CircuitBreaker
+from services.resilience.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
 
 
 class BreakerClient:
@@ -21,14 +25,37 @@ class BreakerClient:
             failure_threshold, recovery_timeout, name=name
         )
 
-    async def request(self, method: str, url: str, **kwargs):
-        async with self.circuit_breaker:
-            response = await self._client.request(method, url, **kwargs)
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        fallback: Optional[Callable[[], Awaitable[httpx.Response]]] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Perform an HTTP request guarded by the circuit breaker.
+
+        Parameters
+        ----------
+        method, url, **kwargs:
+            Passed directly to ``httpx.AsyncClient.request``.
+        fallback:
+            Optional coroutine invoked when the circuit is open. If provided,
+            the HTTP request is skipped and the fallback response returned.
+        """
+        try:
+            async with self.circuit_breaker:
+                response = await self._client.request(method, url, **kwargs)
+        except CircuitBreakerOpen:
+            if fallback is not None:
+                return await fallback()
+            raise
         response.raise_for_status()
         return response
 
     async def aclose(self) -> None:
         await self._client.aclose()
+
 
 __all__ = ["BreakerClient"]
 

--- a/tests/resilience/test_breaker_client.py
+++ b/tests/resilience/test_breaker_client.py
@@ -1,0 +1,39 @@
+import httpx
+import pytest
+
+from shared.httpx import BreakerClient
+from services.resilience.circuit_breaker import CircuitBreakerOpen
+
+
+@pytest.mark.asyncio
+async def test_breaker_client_uses_fallback(monkeypatch):
+    client = BreakerClient()
+
+    async def deny() -> bool:
+        return False
+
+    monkeypatch.setattr(client.circuit_breaker, "allows_request", deny)
+
+    called = False
+
+    async def fallback() -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, text="fallback")
+
+    result = await client.request("GET", "http://example.com", fallback=fallback)
+    assert called is True
+    assert result.text == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_breaker_client_raises_without_fallback(monkeypatch):
+    client = BreakerClient()
+
+    async def deny() -> bool:
+        return False
+
+    monkeypatch.setattr(client.circuit_breaker, "allows_request", deny)
+
+    with pytest.raises(CircuitBreakerOpen):
+        await client.request("GET", "http://example.com")

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/__init__.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/__init__.py
@@ -3,3 +3,7 @@
 Import from this package to register counters and gauges that expose
 application health and performance data.
 """
+
+from .breaker import circuit_breaker_state
+
+__all__ = ["circuit_breaker_state"]


### PR DESCRIPTION
## Summary
- wrap httpx requests with circuit breaker and optional fallback
- apply circuit breaker to RabbitMQ publisher
- standardize HTTP timeout/backoff and expose breaker metrics
- add tests for breaker fallback behavior

## Testing
- `go test ./tests/resilience/...`
- `PYTHONPATH=/tmp/stub pytest tests/resilience/test_breaker_client.py tests/resilience/test_circuit_breaker.py tests/resilience/test_service_client.py` *(fails: AttributeError: module 'tornado.gen' has no attribute 'sleep')*

------
https://chatgpt.com/codex/tasks/task_e_689ea8cd8cd0832083895e71fa8c59f6