### PR TITLE
Add Kafka consumer and RBAC store tests with coverage enforcement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,13 @@ jobs:
       - name: Run unit tests
         run: |
           pytest tests/unit tests/integration --cov=repositories --cov=yosai_intel_dashboard/src/services/kafka_consumer.py --cov-fail-under=80
-      - name: Go handler tests
+      - name: Go tests
         run: |
-          cd gateway && go test ./internal/handlers -coverprofile=coverage.out
+          cd gateway && go test ./internal/handlers ./internal/rbac -coverprofile=coverage.out
           cov=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3,1,length($3)-1)}')
-          echo "Go coverage: $cov%"
+          echo "Gateway coverage: $cov%"
+          awk -v cov="$cov" 'BEGIN { if (cov+0 < 80) exit 1 }'
+          cd ../yosai_intel_dashboard/src/services/event_processing && go test ./internal/kafka -coverprofile=coverage.out
+          cov=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3,1,length($3)-1)}')
+          echo "Kafka coverage: $cov%"
           awk -v cov="$cov" 'BEGIN { if (cov+0 < 80) exit 1 }'

--- a/tests/unit/rbac/store_test.go
+++ b/tests/unit/rbac/store_test.go
@@ -1,0 +1,76 @@
+package rbac_test
+
+import (
+    "context"
+    "errors"
+    "os"
+    "testing"
+
+    sqlmock "github.com/DATA-DOG/go-sqlmock"
+    "github.com/alicebob/miniredis/v2"
+    "github.com/redis/go-redis/v9"
+
+    rbac "github.com/WSG23/yosai-gateway/internal/rbac"
+)
+
+func TestEnvStore(t *testing.T) {
+    os.Setenv("PERMISSIONS_ALICE", "read, write ,")
+    defer os.Unsetenv("PERMISSIONS_ALICE")
+    perms, err := (rbac.EnvStore{}).Permissions(context.Background(), "alice")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if len(perms) != 2 || perms[0] != "read" || perms[1] != "write" {
+        t.Fatalf("unexpected perms: %v", perms)
+    }
+}
+
+func TestRedisStore(t *testing.T) {
+    srv := miniredis.RunT(t)
+    client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+    if err := client.Set(context.Background(), "permissions:alice", "read", 0).Err(); err != nil {
+        t.Fatalf("set: %v", err)
+    }
+    store := rbac.NewRedisStore(client, "")
+    perms, err := store.Permissions(context.Background(), "Alice")
+    if err != nil || len(perms) != 1 || perms[0] != "read" {
+        t.Fatalf("unexpected perms %v err %v", perms, err)
+    }
+}
+
+func TestRedisStoreError(t *testing.T) {
+    client := redis.NewClient(&redis.Options{Addr: "bad:1234"})
+    store := rbac.NewRedisStore(client, "p")
+    if _, err := store.Permissions(context.Background(), "u"); err == nil {
+        t.Fatal("expected error")
+    }
+}
+
+func TestSQLStore(t *testing.T) {
+    db, mock, err := sqlmock.New()
+    if err != nil {
+        t.Fatalf("sqlmock: %v", err)
+    }
+    defer db.Close()
+    rows := sqlmock.NewRows([]string{"name"}).AddRow("read").AddRow("write")
+    mock.ExpectQuery("SELECT p.name").WithArgs("u").WillReturnRows(rows)
+    store := rbac.NewSQLStore(db)
+    perms, err := store.Permissions(context.Background(), "u")
+    if err != nil || len(perms) != 2 {
+        t.Fatalf("unexpected %v err %v", perms, err)
+    }
+}
+
+func TestSQLStoreQueryError(t *testing.T) {
+    db, mock, err := sqlmock.New()
+    if err != nil {
+        t.Fatalf("sqlmock: %v", err)
+    }
+    defer db.Close()
+    mock.ExpectQuery("SELECT p.name").WithArgs("u").WillReturnError(errors.New("boom"))
+    store := rbac.NewSQLStore(db)
+    if _, err := store.Permissions(context.Background(), "u"); err == nil {
+        t.Fatal("expected error")
+    }
+}
+

--- a/yosai_intel_dashboard/src/services/event_processing/internal/kafka/consumer_test.go
+++ b/yosai_intel_dashboard/src/services/event_processing/internal/kafka/consumer_test.go
@@ -1,0 +1,73 @@
+package kafka
+
+import (
+    "context"
+    "errors"
+    "sync/atomic"
+    "testing"
+
+    ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+type mockClient struct {
+    subscribeErr error
+    messages     []*ckafka.Message
+    commitCount  int32
+}
+
+func (m *mockClient) SubscribeTopics([]string, ckafka.RebalanceCb) error { return m.subscribeErr }
+func (m *mockClient) ReadMessage(int) (*ckafka.Message, error) {
+    if len(m.messages) == 0 {
+        return nil, ckafka.NewError(ckafka.ErrTimedOut, "timeout", false)
+    }
+    msg := m.messages[0]
+    m.messages = m.messages[1:]
+    return msg, nil
+}
+func (m *mockClient) CommitMessage(*ckafka.Message) ([]ckafka.TopicPartition, error) {
+    atomic.AddInt32(&m.commitCount, 1)
+    return nil, nil
+}
+func (m *mockClient) Close() {}
+
+func TestNewConsumerError(t *testing.T) {
+    old := newClient
+    newClient = func(cfg *ckafka.ConfigMap) (kafkaClient, error) { return nil, errors.New("boom") }
+    defer func() { newClient = old }()
+    if _, err := NewConsumer("b", "g"); err == nil {
+        t.Fatal("expected error")
+    }
+}
+
+func TestConsumeSubscribeError(t *testing.T) {
+    mc := &mockClient{subscribeErr: errors.New("bad")}
+    c := &Consumer{c: mc}
+    if err := c.Consume(context.Background(), []string{"t"}, func(context.Context, *ckafka.Message) error { return nil }); err == nil {
+        t.Fatal("expected error")
+    }
+}
+
+func TestConsumeProcesses(t *testing.T) {
+    mc := &mockClient{messages: []*ckafka.Message{{Key: []byte("k1")}, {Key: []byte("k1")}}}
+    c := &Consumer{c: mc}
+    ctx, cancel := context.WithCancel(context.Background())
+    var processed int32
+    errCh := make(chan error, 1)
+    go func() {
+        errCh <- c.Consume(ctx, []string{"t"}, func(ctx context.Context, m *ckafka.Message) error {
+            atomic.AddInt32(&processed, 1)
+            cancel()
+            return nil
+        })
+    }()
+    if err := <-errCh; err != context.Canceled {
+        t.Fatalf("expected context canceled, got %v", err)
+    }
+    if processed != 1 {
+        t.Fatalf("expected 1 processed, got %d", processed)
+    }
+    if mc.commitCount != 1 {
+        t.Fatalf("expected commit, got %d", mc.commitCount)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for RBAC permission stores
- make Kafka consumer testable and cover error paths
- enforce Go package coverage in CI workflow

## Testing
- `go test ./... -cover` *(fails: cmd/app/main.go:15:9: package yourmodule/pkg/shutdown is not in std)*
- `go test ./unit/rbac -run TestEnvStore` *(fails: go: updates to go.mod needed; to update it: go mod tidy)*
- `go test ./internal/kafka -run TestConsumeProcesses` *(hangs and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689ea8d1ee1c8320993c69de5db5134c