### PR TITLE
feat: add prometheus instrumentation and SLO dashboards

### DIFF
--- a/deploy/grafana/alerts.yml
+++ b/deploy/grafana/alerts.yml
@@ -17,3 +17,33 @@ groups:
         for: 5m
         annotations:
           summary: Decision latency p95 above SLO
+      - uid: gateway-latency-high
+        title: High gateway latency
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.95, sum(rate(gateway_http_request_duration_seconds_bucket[5m])) by (le))
+              interval: 1m
+        for: 5m
+        annotations:
+          summary: Gateway request latency p95 above SLO
+      - uid: queue-processing-errors
+        title: Queue processing errors
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(queue_processing_errors_total[5m]) > 0
+              interval: 1m
+        for: 5m
+        annotations:
+          summary: Queue processing errors detected

--- a/deploy/grafana/slo-dashboard.json
+++ b/deploy/grafana/slo-dashboard.json
@@ -1,0 +1,25 @@
+{
+  "title": "Service SLOs",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Gateway Request Latency p95",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(gateway_http_request_duration_seconds_bucket[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Queue Processing Errors",
+      "targets": [
+        {
+          "expr": "rate(queue_processing_errors_total[5m])",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,10 +31,14 @@ scrape the metrics endpoints automatically.
 
 ## Metrics
 
-The platform tracks key decision activity and latency:
+The platform tracks key decision activity, gateway traffic, and queue processing:
 
 - `service_decisions_total{service,decision}` – counter of important decisions made by each service.
-- `service_decision_latency_seconds{service,decision}` – histogram of decision latency in seconds. Target: 95% < 500ms.
+- `service_decision_latency_seconds{service,decision}` – histogram of decision latency in seconds.
+- `gateway_http_requests_total{path,method,status}` – number of HTTP requests handled by the gateway.
+- `gateway_http_request_duration_seconds{path,method}` – latency of HTTP requests in seconds.
+- `queue_processed_messages_total{queue}` – count of messages processed successfully.
+- `queue_processing_errors_total{queue}` – count of handler errors while processing messages.
 
 Both the `gateway` and `queue` services expose `/metrics` endpoints for Prometheus scraping.
 
@@ -43,6 +47,8 @@ Both the `gateway` and `queue` services expose `/metrics` endpoints for Promethe
 | Metric | Target |
 | --- | --- |
 | Decision latency p95 | < 0.5s |
+| Gateway request latency p95 | < 0.5s |
+| Queue processing error rate | < 1% |
 | Error budget remaining | ≥ 99.9% |
 
 Dashboards and alerting rules for these SLOs live in `deploy/grafana/`.

--- a/gateway/internal/gateway/gateway.go
+++ b/gateway/internal/gateway/gateway.go
@@ -34,6 +34,7 @@ func New() (*Gateway, error) {
 
 	r := mux.NewRouter()
 	r.Use(imw.TracePropagator())
+	r.Use(middleware.Metrics())
 	r.HandleFunc("/health", handlers.HealthCheck).Methods(http.MethodGet)
 	r.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 	r.Handle("/breaker", imw.RequireRole("admin")(http.HandlerFunc(handlers.BreakerMetrics))).Methods(http.MethodGet)

--- a/gateway/middleware/metrics.go
+++ b/gateway/middleware/metrics.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	httpRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_http_requests_total",
+			Help: "Total HTTP requests processed by the gateway",
+		},
+		[]string{"path", "method", "status"},
+	)
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "gateway_http_request_duration_seconds",
+			Help:    "Duration of HTTP requests in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"path", "method"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(httpRequests, httpRequestDuration)
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (sr *statusRecorder) WriteHeader(code int) {
+	sr.status = code
+	sr.ResponseWriter.WriteHeader(code)
+}
+
+// Metrics instruments HTTP handlers with Prometheus metrics.
+func Metrics() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(sr, r)
+			duration := time.Since(start).Seconds()
+			httpRequests.WithLabelValues(r.URL.Path, r.Method, strconv.Itoa(sr.status)).Inc()
+			httpRequestDuration.WithLabelValues(r.URL.Path, r.Method).Observe(duration)
+		})
+	}
+}

--- a/queue/consumer.go
+++ b/queue/consumer.go
@@ -19,8 +19,26 @@ var DLQMessages = prometheus.NewCounterVec(
 	[]string{"queue"},
 )
 
+// ProcessedMessages counts successfully handled tasks.
+var ProcessedMessages = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "queue_processed_messages_total",
+		Help: "Number of messages processed successfully",
+	},
+	[]string{"queue"},
+)
+
+// ProcessingErrors counts task handler failures.
+var ProcessingErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "queue_processing_errors_total",
+		Help: "Number of errors while processing messages",
+	},
+	[]string{"queue"},
+)
+
 func init() {
-	prometheus.MustRegister(DLQMessages)
+	prometheus.MustRegister(DLQMessages, ProcessedMessages, ProcessingErrors)
 }
 
 // DLQProducer publishes tasks to a dead-letter queue.
@@ -57,6 +75,7 @@ func (c *Consumer) Process(ctx context.Context, msg []byte, handler func(context
 	}
 	if err := handler(ctx, &t); err != nil {
 		t.RetryCount++
+		ProcessingErrors.WithLabelValues(c.queue).Inc()
 		if t.MaxRetries > 0 && t.RetryCount >= t.MaxRetries {
 			DLQMessages.WithLabelValues(c.queue).Inc()
 			if c.p != nil {
@@ -65,5 +84,6 @@ func (c *Consumer) Process(ctx context.Context, msg []byte, handler func(context
 		}
 		return err
 	}
+	ProcessedMessages.WithLabelValues(c.queue).Inc()
 	return nil
 }

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/queue_metrics.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/queue_metrics.py
@@ -1,0 +1,34 @@
+"""Prometheus metrics for queue processing."""
+
+from prometheus_client import REGISTRY, Counter
+from prometheus_client.core import CollectorRegistry
+
+if "queue_processed_messages_total" not in REGISTRY._names_to_collectors:
+    processed_messages = Counter(
+        "queue_processed_messages_total",
+        "Number of messages processed successfully",
+        ["queue"],
+    )
+else:  # pragma: no cover
+    processed_messages = Counter(
+        "queue_processed_messages_total",
+        "Number of messages processed successfully",
+        ["queue"],
+        registry=CollectorRegistry(),
+    )
+
+if "queue_processing_errors_total" not in REGISTRY._names_to_collectors:
+    processing_errors = Counter(
+        "queue_processing_errors_total",
+        "Number of errors while processing messages",
+        ["queue"],
+    )
+else:  # pragma: no cover
+    processing_errors = Counter(
+        "queue_processing_errors_total",
+        "Number of errors while processing messages",
+        ["queue"],
+        registry=CollectorRegistry(),
+    )
+
+__all__ = ["processed_messages", "processing_errors"]


### PR DESCRIPTION
## Summary
- instrument queue processing and gateway requests with Prometheus metrics
- expose metrics dashboards and alerts for gateway and queue
- document new metrics and SLO targets

## Testing
- `go test ./queue/...` (fails: [no test files])
- `go test ./gateway/...` (fails: missing dependencies)
- `pytest monitoring/queue_metrics.py -q` (fails: missing pytest plugins)
- `pre-commit run --files queue/consumer.go gateway/middleware/metrics.go gateway/internal/gateway/gateway.go monitoring/queue_metrics.py deploy/grafana/slo-dashboard.json deploy/grafana/alerts.yml docs/observability.md`

------
https://chatgpt.com/codex/tasks/task_e_689ea8d627d0832090d8952debb30735