### PR TITLE
Add schema registry client and document versioned migrations

### DIFF
--- a/docs/events/schema-evolution.md
+++ b/docs/events/schema-evolution.md
@@ -12,5 +12,15 @@ Existing schema files **must not** be modified in place. Instead:
 - Register the new version with the schema registry.
 - Update producers and consumers to handle the new version.
 
+Developers can use `tools/schema_registry_client.py` to register and
+inspect schemas without pulling in the full Confluent tooling. For
+example, to register `schemas/avro/access_event_v1.avsc` under the
+`access-events-value` subject:
+
+```bash
+python tools/schema_registry_client.py http://localhost:8081 \
+  register access-events-value schemas/avro/access_event_v1.avsc
+```
+
 The `scripts/check_schema_versions.py` helper runs in CI and fails if any schema
 is modified without adding a new versioned file.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -29,3 +29,21 @@ python scripts/verify_timescale_migration.py
 ```
 
 The script checks hypertables, migrated event counts, and basic query performance. It exits with a non-zero status if the migration is incomplete.
+
+## Versioned migrations for service databases
+
+Each microservice maintains its own Alembic environment under
+`migrations/versions`. Migrations are named with a service prefix so
+they can evolve independently (for example, `analytics_0001_initial.py`).
+
+When altering a service's database schema:
+
+1. Generate a new migration using Alembic with an incremented version
+   number for that service.
+2. Commit the migration file alongside any corresponding SQL in
+   `migrations`.
+3. Run `alembic upgrade head` within the service container or via the
+   deployment pipeline to apply the change.
+
+This approach ensures each service database can be upgraded in a
+controlled, versioned manner without affecting other services.

--- a/docs/upgrade_guides/dependent-services.md
+++ b/docs/upgrade_guides/dependent-services.md
@@ -1,0 +1,19 @@
+# Upgrading Dependent Services
+
+When the dashboard introduces breaking changes to event schemas or
+service databases, downstream services may require updates. Follow these
+steps to keep dependents compatible:
+
+1. Review the changelog for new schema versions and database migrations.
+2. Update any generated client code or ORM models that rely on the
+   changed schema.
+3. If consuming events, fetch the latest schema from the registry using
+   `tools/schema_registry_client.py` and adjust deserializers
+   accordingly.
+4. Run the service's Alembic migrations to upgrade its database schema
+   before deploying new code.
+5. Perform end-to-end tests in a staging environment to validate the
+   upgrade.
+
+Adhering to this guide helps ensure upgrades remain coordinated across
+services and prevents runtime incompatibilities.

--- a/tools/schema_registry_client.py
+++ b/tools/schema_registry_client.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Lightweight client for interacting with a Confluent Schema Registry.
+
+This utility registers Avro schemas and fetches registered schemas
+without requiring the full Confluent Python client. It is intended for
+use in CI and local development where only basic HTTP access to the
+registry is needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+def register_schema(registry: str, subject: str, schema_path: str) -> dict[str, Any]:
+    """Register a schema file under the given subject."""
+    schema = Path(schema_path).read_text()
+    payload = {"schema": schema}
+    response = requests.post(
+        f"{registry.rstrip('/')}/subjects/{subject}/versions",
+        headers={"Content-Type": "application/vnd.schemaregistry.v1+json"},
+        data=json.dumps(payload),
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_latest_schema(registry: str, subject: str) -> dict[str, Any]:
+    """Fetch the latest schema registered under *subject*."""
+    response = requests.get(
+        f"{registry.rstrip('/')}/subjects/{subject}/versions/latest",
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with schema registry")
+    parser.add_argument("registry", help="Schema registry URL, e.g. http://localhost:8081")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    reg = subparsers.add_parser("register", help="Register a new schema version")
+    reg.add_argument("subject", help="Schema subject name")
+    reg.add_argument("file", help="Path to Avro schema file")
+
+    fetch = subparsers.add_parser("get", help="Fetch latest schema")
+    fetch.add_argument("subject", help="Schema subject name")
+
+    args = parser.parse_args()
+    if args.command == "register":
+        info = register_schema(args.registry, args.subject, args.file)
+        print(json.dumps(info, indent=2))
+    else:
+        info = get_latest_schema(args.registry, args.subject)
+        print(json.dumps(info, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add lightweight Python client to register and fetch schemas from a Confluent Schema Registry
- document using the client in schema evolution docs
- outline per-service versioned migration process and provide upgrade guide for dependent services

## Testing
- `python -m py_compile tools/schema_registry_client.py`
- `pytest -q tools` *(fails: unrecognized arguments from pytest.ini addopts)*

------
https://chatgpt.com/codex/tasks/task_e_689eae976b388320803008a498d13278