### PR TITLE
chore: remove legacy API routes

### DIFF
--- a/docs/analytics_sequence.md
+++ b/docs/analytics_sequence.md
@@ -11,7 +11,7 @@ sequenceDiagram
     participant AS as AnalyticsService
 
     U->>B: Drag or select file, click Upload
-    B->>S: POST /upload
+    B->>S: POST /api/v1/upload
     S->>V: Validate file
     V-->>S: Clean data
     S->>AS: analyze(data)

--- a/docs/architecture_diagrams.md
+++ b/docs/architecture_diagrams.md
@@ -24,7 +24,7 @@ sequenceDiagram
     participant DB as Database
 
     U->>FE: Drag or select file
-    FE->>BE: POST /upload
+    FE->>BE: POST /api/v1/upload
     BE->>S: Validate and parse
     S->>DB: Store records
     S-->>BE: Processed analytics

--- a/docs/developer_setup_checklist.md
+++ b/docs/developer_setup_checklist.md
@@ -49,11 +49,11 @@ After starting the development servers you can manually confirm that the upload 
    ```
 2. Confirm the Flask API is serving requests (default port **5001**):
    ```bash
-   curl -I http://localhost:5001/v1/health
+   curl -I http://localhost:5001/api/v1/health
    ```
 3. Verify CORS is enabled on the upload endpoint:
    ```bash
-   curl -I -X OPTIONS http://localhost:5001/v1/upload \
+   curl -I -X OPTIONS http://localhost:5001/api/v1/upload \
      -H "Origin: http://localhost:3000" \
      -H "Access-Control-Request-Method: POST"
    ```

--- a/docs/ui_flows.md
+++ b/docs/ui_flows.md
@@ -13,7 +13,7 @@ sequenceDiagram
     participant AS as AnalyticsService
 
     U->>B: Drag or select file
-    B->>S: POST /upload
+    B->>S: POST /api/v1/upload
     S->>AS: validate_and_store()
     AS-->>S: confirmation
     S-->>B: Show upload success

--- a/docs/upload_interface.md
+++ b/docs/upload_interface.md
@@ -15,7 +15,7 @@ File previews are rendered as thumbnails for images or with a generic file icon 
 
 Behind the scenes the upload is handled by a background worker. A task ID is
 returned immediately and progress events are streamed over Server‑Sent Events at
-`/upload/progress/<task_id>`. When processing completes the UI refreshes the
+`/api/v1/upload/progress/<task_id>`. When processing completes the UI refreshes the
 `file-info-store` so analytics pages can use the new data without reloading the
 entire app.
 

--- a/optional_dependencies.py
+++ b/optional_dependencies.py
@@ -1,10 +1,24 @@
 import importlib
 import logging
+import types
+import sys
+
 logger = logging.getLogger("optional_dependencies")
+
+_FALLBACKS: dict[str, types.ModuleType] = {}
+
+
+def register_fallback(name: str, module: types.ModuleType) -> None:
+    """Register a lightweight fallback for an optional dependency."""
+    try:
+        importlib.import_module(name)
+    except Exception:
+        _FALLBACKS[name] = module
+
 
 def import_optional(modpath: str):
     try:
         return importlib.import_module(modpath)
     except Exception as e:
         logger.error("Error importing optional dependency %r: %s", modpath, e)
-        return None
+        return _FALLBACKS.get(modpath)

--- a/tests/adapters/api/test_adapter_helpers.py
+++ b/tests/adapters/api/test_adapter_helpers.py
@@ -69,7 +69,7 @@ def test_setup_security_sets_secret(monkeypatch):
     service = DummyService()
     _configure_app(service)
     monkeypatch.setenv("SECRET_KEY", "test")
-    serializer, _ = _setup_security(service)
+    serializer = _setup_security(service)
     mws = _middleware_names(service.app)
     assert "SecurityHeadersMiddleware" in mws
     assert "CORSMiddleware" in mws
@@ -81,26 +81,21 @@ def test_register_routes_adds_versioned_paths(monkeypatch):
     service = DummyService()
     build_dir = _configure_app(service)
     monkeypatch.setenv("SECRET_KEY", "test")
-    serializer, add_dep = _setup_security(service)
+    serializer = _setup_security(service)
     monkeypatch.setattr(
         "yosai_intel_dashboard.src.services.auth.require_service_token",
         lambda: None,
     )
-    _register_routes(service, build_dir, add_dep)
+    _register_routes(service, build_dir)
     paths = {r.path for r in service.app.routes}
     assert "/api/v1/analytics/patterns" in paths
-    assert "/analytics/patterns" in paths
-
-    client = TestClient(service.app)
-    resp = client.get("/analytics/patterns")
-    assert resp.headers["Warning"].startswith("299")
 
 
 def test_register_upload_endpoints(monkeypatch):
     service = DummyService()
     _configure_app(service)
     monkeypatch.setenv("SECRET_KEY", "test")
-    serializer, add_dep = _setup_security(service)
+    serializer = _setup_security(service)
 
     class DummyValidator:
         def validate_file_upload(self, filename, content):
@@ -120,7 +115,7 @@ def test_register_upload_endpoints(monkeypatch):
     monkeypatch.setattr(container, "get", lambda name: DummyFileProcessor())
     monkeypatch.setattr(container, "has", lambda name: False)
 
-    _register_upload_endpoints(service, serializer, add_dep)
+    _register_upload_endpoints(service, serializer)
 
     paths = {r.path for r in service.app.routes}
     assert "/api/v1/upload" in paths
@@ -129,5 +124,3 @@ def test_register_upload_endpoints(monkeypatch):
     resp = client.get("/api/v1/csrf-token")
     assert resp.status_code == 200
     assert "csrf_token" in resp.json()
-    legacy = client.get("/csrf-token")
-    assert legacy.headers["Warning"].startswith("299")

--- a/tests/performance/locust/upload_load.py
+++ b/tests/performance/locust/upload_load.py
@@ -9,4 +9,4 @@ class UploadUser(HttpUser):
     @task
     def upload_file(self):
         data = {"file": ("data.csv", "a,b\n1,2\n")}
-        self.client.post("/upload", files=data)
+        self.client.post("/api/v1/upload", files=data)

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -124,16 +124,11 @@ def _setup_security(service: BaseService) -> tuple[URLSafeTimedSerializer, calla
     service.app.state.secret_key = secret_key
     serializer = URLSafeTimedSerializer(secret_key)
 
-    def add_deprecation_warning(response: Response) -> None:
-        response.headers["Warning"] = (
-            "299 - Deprecated API path; please use versioned '/api/v1' routes"
-        )
-
-    return serializer, add_deprecation_warning
+    return serializer
 
 
 def _register_routes(
-    service: BaseService, build_dir: Path, add_deprecation_warning: callable
+    service: BaseService, build_dir: Path
 ) -> None:
     """Register routers and static file handlers."""
     service.app.add_event_handler("startup", init_cache_manager)
@@ -144,17 +139,6 @@ def _register_routes(
     api_v1.include_router(explanations_router)
     api_v1.include_router(feature_flags_router)
     service.app.include_router(api_v1, dependencies=[Depends(require_service_token)])
-
-    legacy_router = APIRouter()
-    legacy_router.include_router(analytics_router)
-    legacy_router.include_router(monitoring_router)
-    legacy_router.include_router(explanations_router)
-    legacy_router.include_router(feature_flags_router)
-    service.app.include_router(
-        legacy_router,
-        dependencies=[Depends(require_service_token), Depends(add_deprecation_warning)],
-        deprecated=True,
-    )
 
     @service.app.get("/", include_in_schema=False)
     def root_index() -> FileResponse:
@@ -189,7 +173,7 @@ def _register_routes(
 
 
 def _register_upload_endpoints(
-    service: BaseService, serializer: URLSafeTimedSerializer, add_deprecation_warning: callable
+    service: BaseService, serializer: URLSafeTimedSerializer
 ) -> None:
     """Register upload, settings and token refresh endpoints."""
     file_handler = (
@@ -218,12 +202,6 @@ def _register_upload_endpoints(
         token = serializer.dumps("csrf")
         response.set_cookie("csrf_token", token, httponly=True)
         return {"csrf_token": token}
-
-    @service.app.get(
-        "/csrf-token", dependencies=[Depends(add_deprecation_warning)], deprecated=True
-    )
-    def get_csrf_token_legacy(response: Response) -> dict:
-        return get_csrf_token(response)
 
     def verify_csrf(request: Request) -> None:
         token = (
@@ -313,19 +291,6 @@ def _register_upload_endpoints(
 
         return {"results": results}
 
-    @service.app.post(
-        "/upload",
-        response_model=UploadResponse,
-        status_code=200,
-        dependencies=[Depends(verify_csrf), Depends(add_deprecation_warning)],
-        deprecated=True,
-    )
-    async def upload_files_legacy(
-        payload: UploadRequestSchema,
-        files: list[UploadFile] = File([]),
-    ) -> dict:
-        return await upload_files(payload, files)
-
     from yosai_intel_dashboard.src.adapters.api.settings_endpoint import (
         SettingsSchema,
         _load_settings,
@@ -347,27 +312,6 @@ def _register_upload_endpoints(
             raise HTTPException(status_code=500, detail=str(exc))
         return settings_data
 
-    @service.app.get(
-        "/settings", response_model=SettingsSchema, dependencies=[Depends(add_deprecation_warning)], deprecated=True
-    )
-    def get_settings_legacy() -> dict:
-        return get_settings()
-
-    @service.app.post(
-        "/settings",
-        response_model=SettingsSchema,
-        dependencies=[Depends(add_deprecation_warning)],
-        deprecated=True,
-    )
-    @service.app.put(
-        "/settings",
-        response_model=SettingsSchema,
-        dependencies=[Depends(add_deprecation_warning)],
-        deprecated=True,
-    )
-    def update_settings_legacy(payload: SettingsSchema) -> dict:
-        return update_settings(payload)
-
     from yosai_intel_dashboard.src.services.security import refresh_access_token
     from yosai_intel_dashboard.src.services.token_endpoint import (
         AccessTokenResponse,
@@ -383,15 +327,6 @@ def _register_upload_endpoints(
             raise HTTPException(status_code=401, detail="invalid refresh token")
         return {"access_token": new_token}
 
-    @service.app.post(
-        "/token/refresh",
-        response_model=AccessTokenResponse,
-        status_code=200,
-        dependencies=[Depends(add_deprecation_warning)],
-        deprecated=True,
-    )
-    def refresh_token_legacy(payload: RefreshRequest) -> dict:
-        return refresh_token(payload)
 
 
 def create_api_app() -> "FastAPI":
@@ -399,9 +334,9 @@ def create_api_app() -> "FastAPI":
     validate_all_secrets()
     service = BaseService("api", "")
     build_dir = _configure_app(service)
-    serializer, add_deprecation_warning = _setup_security(service)
-    _register_routes(service, build_dir, add_deprecation_warning)
-    _register_upload_endpoints(service, serializer, add_deprecation_warning)
+    serializer = _setup_security(service)
+    _register_routes(service, build_dir)
+    _register_upload_endpoints(service, serializer)
     return service.app
 
 

--- a/yosai_intel_dashboard/src/adapters/api/openapi/yosai-api-v2.yaml
+++ b/yosai_intel_dashboard/src/adapters/api/openapi/yosai-api-v2.yaml
@@ -5,17 +5,17 @@ info:
   description: |
     Physical security intelligence and access control API.
 servers:
-  - url: https://api.yosai.com/v1
+  - url: https://api.yosai.com
     description: Production
-  - url: https://staging-api.yosai.com/v1
+  - url: https://staging-api.yosai.com
     description: Staging
-  - url: http://localhost:8080/v1
+  - url: http://localhost:8080
     description: Development
 security:
   - jwtAuth: []
   - csrfToken: []
 paths:
-  /csrf-token:
+  /api/v1/csrf-token:
     get:
       summary: Get CSRF token
       operationId: getCsrfToken
@@ -29,14 +29,14 @@ paths:
                 properties:
                   csrf_token:
                     type: string
-  /upload:
+  /api/v1/upload:
     post:
       summary: Upload a file
       operationId: uploadFile
       responses:
         '200':
           description: Upload result
-  /settings:
+  /api/v1/settings:
     get:
       summary: Get user settings
       operationId: getSettings
@@ -49,35 +49,35 @@ paths:
       responses:
         '200':
           description: Successful response
-  /token/refresh:
+  /api/v1/token/refresh:
     post:
       summary: Refresh access token
       operationId: refreshToken
       responses:
         '200':
           description: New access token
-  /analytics/patterns:
+  /api/v1/analytics/patterns:
     get:
       summary: Summarize access patterns
       operationId: getPatterns
       responses:
         '200':
           description: Analytics summary
-  /analytics/sources:
+  /api/v1/analytics/sources:
     get:
       summary: List data sources
       operationId: getSources
       responses:
         '200':
           description: Data sources
-  /analytics/health:
+  /api/v1/analytics/health:
     get:
       summary: Analytics service health
       operationId: analyticsHealth
       responses:
         '200':
           description: Health status
-  /analytics/chart/{chart_type}:
+  /api/v1/analytics/chart/{chart_type}:
     get:
       summary: Retrieve chart data
       operationId: getChartData
@@ -90,7 +90,7 @@ paths:
       responses:
         '200':
           description: Chart data
-  /model-monitoring/{model_name}:
+  /api/v1/model-monitoring/{model_name}:
     get:
       summary: Get model monitoring events
       operationId: getModelMonitoringEvents
@@ -113,7 +113,7 @@ paths:
       responses:
         '200':
           description: Monitoring events
-  /explanations/{prediction_id}:
+  /api/v1/explanations/{prediction_id}:
     get:
       summary: Get prediction explanation
       operationId: getExplanation
@@ -126,7 +126,7 @@ paths:
       responses:
         '200':
           description: Explanation payload
-  /feature-flags:
+  /api/v1/feature-flags:
     get:
       summary: List feature flags
       operationId: listFeatureFlags
@@ -139,7 +139,7 @@ paths:
       responses:
         '201':
           description: Created
-  /feature-flags/{name}:
+  /api/v1/feature-flags/{name}:
     get:
       summary: Get feature flag
       operationId: getFeatureFlag
@@ -176,7 +176,7 @@ paths:
       responses:
         '204':
           description: Deleted
-  /feature-flags/{name}/audit:
+  /api/v1/feature-flags/{name}/audit:
     get:
       summary: Get feature flag audit history
       operationId: getFeatureFlagAudit

--- a/yosai_intel_dashboard/src/adapters/api/types.ts
+++ b/yosai_intel_dashboard/src/adapters/api/types.ts
@@ -292,7 +292,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/token/refresh": {
+  "/api/v1/token/refresh": {
     parameters: {
       query?: never;
       header?: never;
@@ -327,7 +327,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/upload": {
+  "/api/v1/upload": {
     parameters: {
       query?: never;
       header?: never;
@@ -357,7 +357,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/upload/status/{job_id}': {
+  '/api/v1/upload/status/{job_id}': {
     parameters: {
       query?: never;
       header?: never;


### PR DESCRIPTION
## Summary
- drop unversioned legacy routes from API adapter
- update OpenAPI spec, docs, and tests to use `/api/v1` endpoints
- add lightweight `register_fallback` helper for optional dependencies

## Testing
- `pytest tests/adapters/api/test_adapter_helpers.py tests/integration/test_e2e.py` *(fails: TypeError: Cannot create a consistent method resolution order)*

------
https://chatgpt.com/codex/tasks/task_e_689eae95cc30832094f06df58189956e