### PR TITLE
Add cold data archival tooling and documentation

### DIFF
--- a/runbooks/data-archival.md
+++ b/runbooks/data-archival.md
@@ -1,0 +1,33 @@
+# Data Archival
+
+## Scheduling
+
+Use `scripts/archive_cold_data.py` to move cold data to object storage. Schedule
+the job via cron:
+
+```
+0 1 * * * /usr/bin/python3 /app/scripts/archive_cold_data.py
+```
+
+This runs the archival daily at 1 AM and removes local files once they are
+safely stored in the S3 bucket.
+
+## Retention and Retrieval
+
+Retention settings live in `config/data_archival.yaml`. Files older than the
+configured `retention_days` are archived. Archived data can be retrieved by
+copying it back from the object store:
+
+```
+aws s3 cp s3://intel-cold-data/<object-key> /var/lib/app/restored/
+```
+
+Items restored to the local `restore_directory` should be cleaned up after
+`default_expiry_days` to avoid unnecessary storage.
+
+## Monitoring
+
+Archival monitoring thresholds reside in `config/monitoring.yaml`. The archival
+script logs each archived file along with the total storage size and estimated
+monthly cost. Pipe these logs to your metrics system to alert on low success
+rates or rising storage costs.

--- a/scripts/archive_cold_data.py
+++ b/scripts/archive_cold_data.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Archive cold data to object storage.
+
+Moves files older than the configured retention period from a local
+filesystem path to object storage (e.g. AWS S3) and logs the current
+storage footprint to help estimate costs.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import pathlib
+
+import boto3
+import yaml
+
+CONFIG_PATH = pathlib.Path(__file__).resolve().parent.parent / "config" / "data_archival.yaml"
+
+
+def load_config() -> dict:
+    """Load archival configuration from YAML file."""
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)["archival"]
+
+
+def log_storage_cost(s3: boto3.client, bucket: str) -> None:
+    """Log total storage in the bucket and approximate monthly cost."""
+    total_bytes = 0
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        for obj in page.get("Contents", []):
+            total_bytes += obj["Size"]
+    gb = total_bytes / (1024 ** 3)
+    cost = gb * 0.023  # Standard S3 pricing per GB-month
+    logging.info("Current archival storage: %.2f GB (approx $%.2f/month)", gb, cost)
+
+
+def archive() -> None:
+    cfg = load_config()
+    base_path = pathlib.Path(cfg["cold_data_path"])
+    retention = dt.timedelta(days=cfg.get("retention_days", 30))
+    cutoff = dt.datetime.utcnow() - retention
+
+    storage_cfg = cfg["object_storage"]
+    s3 = boto3.client("s3", region_name=storage_cfg.get("region"))
+    bucket = storage_cfg["bucket"]
+
+    archived = 0
+    for file_path in base_path.rglob("*"):
+        if not file_path.is_file():
+            continue
+        mtime = dt.datetime.utcfromtimestamp(file_path.stat().st_mtime)
+        if mtime >= cutoff:
+            continue
+        key = file_path.relative_to(base_path).as_posix()
+        s3.upload_file(str(file_path), bucket, key)
+        file_path.unlink()
+        archived += 1
+        logging.info("Archived %s to s3://%s/%s", file_path, bucket, key)
+
+    logging.info("Archived %d files", archived)
+    log_storage_cost(s3, bucket)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    archive()

--- a/yosai_intel_dashboard/src/infrastructure/config/data_archival.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/data_archival.yaml
@@ -1,0 +1,10 @@
+archival:
+  cold_data_path: /var/lib/app/data
+  retention_days: 30
+  object_storage:
+    provider: s3
+    bucket: intel-cold-data
+    region: us-east-1
+  retrieval:
+    restore_directory: /var/lib/app/restored
+    default_expiry_days: 7

--- a/yosai_intel_dashboard/src/infrastructure/config/monitoring.yaml
+++ b/yosai_intel_dashboard/src/infrastructure/config/monitoring.yaml
@@ -17,3 +17,7 @@ data_quality:
 
 model_monitor:
   evaluation_interval_minutes: 60
+
+archival:
+  success_rate_threshold: 0.99
+  max_storage_cost_usd: 100


### PR DESCRIPTION
## Summary
- add script to move cold data to S3 and log storage use
- add archival and monitoring configuration
- document scheduling and retrieval process

## Testing
- `pre-commit run --files runbooks/data-archival.md scripts/archive_cold_data.py yosai_intel_dashboard/src/infrastructure/config/data_archival.yaml yosai_intel_dashboard/src/infrastructure/config/monitoring.yaml`
- `pytest scripts/archive_cold_data.py -q` *(fails: Required test coverage of 80% not reached. Total coverage: 0.05%)*

------
https://chatgpt.com/codex/tasks/task_e_689eae951f248320ac5823527257f02e