### PR TITLE
feat: add versioned model serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ data/learned_mappings.json
 !docs/analytics_microservice_openapi.json
 !docs/event_ingestion_openapi.json
 !docs/postman_collection.json
+!models/registry.json
 !renovate.json
 !package.json
 !package-lock.json

--- a/models/registry.json
+++ b/models/registry.json
@@ -1,0 +1,10 @@
+{
+  "demo": {
+    "versions": {
+      "1": {"factor": 1.0},
+      "2": {"factor": 2.0}
+    },
+    "active": "1",
+    "rollout": {"1": 1.0}
+  }
+}

--- a/unit_tests/test_model_serving.py
+++ b/unit_tests/test_model_serving.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from yosai_intel_dashboard.src.adapters.api.model_router import create_model_router
+from yosai_intel_dashboard.src.services.model_service import ModelService
+
+
+def _setup_app(tmp_path: Path) -> TestClient:
+    registry = {
+        "demo": {
+            "versions": {
+                "1": {"factor": 1.0},
+                "2": {"factor": 2.0},
+            },
+            "active": "1",
+            "rollout": {"1": 1.0},
+        }
+    }
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(json.dumps(registry))
+    service = ModelService(registry_path=reg_path)
+    app = FastAPI()
+    app.include_router(create_model_router(service))
+    return TestClient(app)
+
+
+def test_versioned_prediction(tmp_path: Path) -> None:
+    client = _setup_app(tmp_path)
+    resp = client.post("/models/demo/v2/predict", json={"value": 3})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["version"] == "2"
+    assert data["result"] == 6
+
+
+def test_ab_rollout_switch(tmp_path: Path) -> None:
+    client = _setup_app(tmp_path)
+    resp = client.post("/models/demo/predict", json={"value": 4})
+    assert resp.json()["version"] == "1"
+    resp = client.post("/models/demo/rollout", json={"rollout": {"2": 1.0}})
+    assert resp.status_code == 200
+    resp = client.post("/models/demo/predict", json={"value": 4})
+    assert resp.json()["version"] == "2"
+    assert resp.json()["result"] == 8

--- a/yosai_intel_dashboard/src/adapters/api/adapter.py
+++ b/yosai_intel_dashboard/src/adapters/api/adapter.py
@@ -41,6 +41,8 @@ from yosai_intel_dashboard.src.adapters.api.monitoring_router import (
 from yosai_intel_dashboard.src.adapters.api.routes.feature_flags import (
     router as feature_flags_router,
 )
+from yosai_intel_dashboard.src.adapters.api.model_router import create_model_router
+from yosai_intel_dashboard.src.services.model_service import ModelService
 from yosai_intel_dashboard.src.core.container import container
 from yosai_intel_dashboard.src.core.rbac import create_rbac_service
 from yosai_intel_dashboard.src.core.secrets_validator import validate_all_secrets
@@ -62,6 +64,8 @@ from yosai_intel_dashboard.src.core.logging import get_logger
 
 
 logger = get_logger(__name__)
+
+model_router = create_model_router(ModelService())
 
 def _configure_app(service: BaseService) -> Path:
     """Initialize the FastAPI app, base service and middleware."""
@@ -143,6 +147,7 @@ def _register_routes(
     api_v1.include_router(monitoring_router)
     api_v1.include_router(explanations_router)
     api_v1.include_router(feature_flags_router)
+    api_v1.include_router(model_router)
     service.app.include_router(api_v1, dependencies=[Depends(require_service_token)])
 
     legacy_router = APIRouter()
@@ -150,6 +155,7 @@ def _register_routes(
     legacy_router.include_router(monitoring_router)
     legacy_router.include_router(explanations_router)
     legacy_router.include_router(feature_flags_router)
+    legacy_router.include_router(model_router)
     service.app.include_router(
         legacy_router,
         dependencies=[Depends(require_service_token), Depends(add_deprecation_warning)],

--- a/yosai_intel_dashboard/src/adapters/api/model_router.py
+++ b/yosai_intel_dashboard/src/adapters/api/model_router.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from yosai_intel_dashboard.src.services.model_service import ModelService
+
+
+class PredictRequest(BaseModel):
+    value: float
+
+
+class RolloutRequest(BaseModel):
+    rollout: Dict[str, float]
+
+
+def create_model_router(service: ModelService) -> APIRouter:
+    router = APIRouter(prefix="/models", tags=["models"])
+
+    @router.post("/{model_name}/predict")
+    async def predict(model_name: str, req: PredictRequest) -> Dict[str, float | str]:
+        model, version = service.get_model(model_name)
+        result = model(req.value)
+        return {"version": version, "result": result}
+
+    @router.post("/{model_name}/v{version}/predict")
+    async def predict_version(
+        model_name: str, version: str, req: PredictRequest
+    ) -> Dict[str, float | str]:
+        model, _ = service.get_model(model_name, version)
+        result = model(req.value)
+        return {"version": version, "result": result}
+
+    @router.post("/{model_name}/rollout")
+    async def update_rollout(model_name: str, req: RolloutRequest) -> Dict[str, str]:
+        service.set_rollout(model_name, req.rollout)
+        meta = service.metadata(model_name)
+        return {"status": "ok", "active": meta.get("active", "")}
+
+    @router.get("/{model_name}/active")
+    async def get_active(model_name: str) -> Dict[str, str]:
+        meta = service.metadata(model_name)
+        return {"version": meta.get("active", "")}
+
+    return router
+

--- a/yosai_intel_dashboard/src/services/model_service.py
+++ b/yosai_intel_dashboard/src/services/model_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
+
+
+class ModelService:
+    """Serve models based on versioned metadata stored in ``registry.json``."""
+
+    def __init__(self, registry_path: Path | None = None) -> None:
+        self.registry_path = registry_path or Path("models/registry.json")
+        self._registry: Dict[str, Any] = {}
+        self._models: Dict[str, Dict[str, Callable[[float], float]]] = {}
+        self._load_registry()
+
+    def _load_registry(self) -> None:
+        if self.registry_path.exists():
+            with open(self.registry_path, "r", encoding="utf-8") as fh:
+                self._registry = json.load(fh)
+        else:
+            self._registry = {}
+        for name, meta in self._registry.items():
+            versions = meta.get("versions", {})
+            self._models.setdefault(name, {})
+            for ver, info in versions.items():
+                factor = float(info.get("factor", ver))
+                # Store simple lambda as placeholder model
+                self._models[name][ver] = lambda x, factor=factor: x * factor
+
+    def register_model(self, name: str, version: str, metadata: Dict[str, Any]) -> None:
+        meta = self._registry.setdefault(name, {"versions": {}, "active": version, "rollout": {}})
+        meta["versions"][version] = metadata
+        meta["rollout"].setdefault(version, 1.0)
+        self._save()
+        self._load_registry()
+
+    def _save(self) -> None:
+        self.registry_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.registry_path, "w", encoding="utf-8") as fh:
+            json.dump(self._registry, fh, indent=2)
+
+    def set_rollout(self, name: str, rollout: Dict[str, float]) -> None:
+        if name not in self._registry:
+            raise KeyError(f"Unknown model {name}")
+        total = sum(rollout.values()) or 1.0
+        normalized = {k: v / total for k, v in rollout.items()}
+        self._registry[name]["rollout"] = normalized
+        self._registry[name]["active"] = max(normalized, key=normalized.get)
+        self._save()
+
+    def _select_version(self, name: str) -> str:
+        meta = self._registry[name]
+        rollout = meta.get("rollout", {})
+        if not rollout:
+            return meta.get("active")
+        rand = random.random()
+        cumulative = 0.0
+        for ver, weight in rollout.items():
+            cumulative += weight
+            if rand < cumulative:
+                return ver
+        return meta.get("active")
+
+    def get_model(self, name: str, version: str | None = None) -> Tuple[Callable[[float], float], str]:
+        if name not in self._models:
+            raise KeyError(f"Unknown model {name}")
+        ver = version or self._select_version(name)
+        model = self._models[name][ver]
+        return model, ver
+
+    def metadata(self, name: str) -> Dict[str, Any]:
+        return self._registry.get(name, {})
+
+    def list_models(self) -> Dict[str, Any]:
+        return self._registry
+


### PR DESCRIPTION
## Summary
- serve models from registry.json via versioned endpoints
- add rollout policy with simple A/B switching
- track model metadata in models/registry.json

## Testing
- `pytest unit_tests/test_model_serving.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_689eae906ef88320a2efdcb814f0e9d2