### PR TITLE
Add Chaos Mesh experiments for staging

### DIFF
--- a/deploy/chaos-mesh/network-delay.yaml
+++ b/deploy/chaos-mesh/network-delay.yaml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: dashboard-network-delay
+  namespace: chaos-testing
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces:
+      - dashboard
+    labelSelectors:
+      app: dashboard
+  delay:
+    latency: '200ms'
+  duration: '1m'

--- a/deploy/chaos-mesh/network-loss.yaml
+++ b/deploy/chaos-mesh/network-loss.yaml
@@ -1,0 +1,17 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: dashboard-network-loss
+  namespace: chaos-testing
+spec:
+  action: loss
+  mode: all
+  selector:
+    namespaces:
+      - dashboard
+    labelSelectors:
+      app: dashboard
+  loss:
+    loss: '100'
+    correlation: '0'
+  duration: '1m'

--- a/deploy/chaos-mesh/pod-kill.yaml
+++ b/deploy/chaos-mesh/pod-kill.yaml
@@ -1,0 +1,14 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: dashboard-pod-kill
+  namespace: chaos-testing
+spec:
+  action: pod-kill
+  mode: one
+  selector:
+    namespaces:
+      - dashboard
+    labelSelectors:
+      app: dashboard
+  duration: '30s'

--- a/docs/chaos/README.md
+++ b/docs/chaos/README.md
@@ -41,3 +41,43 @@ echo '{"name":"service-kill","duration":60,"succeeded":true}' | \
 ```
 
 These metrics populate the resilience panels in the existing SLO dashboards.
+
+## Chaos Mesh
+
+Chaos Mesh provides an alternative framework for fault injection in the staging cluster.
+
+### Installation
+
+Install the operator:
+
+```bash
+helm repo add chaos-mesh https://charts.chaos-mesh.org
+helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --create-namespace \
+  --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/run/containerd/containerd.sock
+```
+
+### Experiments
+
+- **Pod Kill** – `deploy/chaos-mesh/pod-kill.yaml` randomly kills a dashboard pod for 30s.
+- **Network Delay** – `deploy/chaos-mesh/network-delay.yaml` injects 200ms latency for 1 minute.
+- **Network Loss** – `deploy/chaos-mesh/network-loss.yaml` drops all packets for 1 minute.
+
+Apply an experiment with:
+
+```bash
+kubectl apply -f deploy/chaos-mesh/<experiment>.yaml
+```
+
+Remove with `kubectl delete -f` to stop the fault injection.
+
+### Monitoring and Documentation
+
+While experiments run, watch SLO dashboards to confirm services recover automatically.
+Record time-to-recovery and notable alerts in the runbook, then publish metrics:
+
+```bash
+echo '{"name":"pod-kill","duration":30,"succeeded":true}' | \\
+  python scripts/publish_chaos_metrics.py
+```
+
+These steps document resilience and feed recovery data back into the system.


### PR DESCRIPTION
## Summary
- document how to install and run Chaos Mesh experiments in staging
- add Chaos Mesh manifests for pod kill, network delay, and network loss scenarios

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'register_fallback' from 'optional_dependencies')*

------
https://chatgpt.com/codex/tasks/task_e_689eae9339888320a391c17cdf4df619