### PR TITLE
Add env toggles, traffic shaping, and rollback docs

### DIFF
--- a/deployment/pipeline.yaml
+++ b/deployment/pipeline.yaml
@@ -1,7 +1,12 @@
 stages:
   - build
   - canary
+  - traffic_shift
   - blue_green
+
+variables:
+  TARGET_ENV: "staging"
+  TRAFFIC_PERCENT: "10"
 
 build:
   stage: build
@@ -11,10 +16,20 @@ build:
 canary:
   stage: canary
   script:
-    - kubectl apply -f k8s/canary
+    - TARGET_ENV=$TARGET_ENV TRAFFIC_PERCENT=$TRAFFIC_PERCENT \
+      deployment/scripts/traffic_shape.sh
   when: manual
   needs:
     - build
+
+traffic_shift:
+  stage: traffic_shift
+  script:
+    - TARGET_ENV=$TARGET_ENV TRAFFIC_PERCENT=50 \
+      deployment/scripts/traffic_shape.sh
+  when: manual
+  needs:
+    - canary
 
 blue_green:
   stage: blue_green
@@ -22,4 +37,4 @@ blue_green:
     - kubectl apply -f k8s/bluegreen
   when: manual
   needs:
-    - canary
+    - traffic_shift

--- a/deployment/scripts/rollback.sh
+++ b/deployment/scripts/rollback.sh
@@ -26,9 +26,10 @@ if [[ -z "$MIGRATION_STATE" || "$MIGRATION_STATE" == "null" ]]; then
   exit 1
 fi
 
-echo "Rolling back container image to $IMAGE_TAG"
+NAMESPACE="${TARGET_ENV:-default}"
+echo "Rolling back container image to $IMAGE_TAG in namespace $NAMESPACE"
 # Example rollback command for Kubernetes deployment
-kubectl set image deployment/dashboard dashboard="$IMAGE_TAG" --record || true
+kubectl -n "$NAMESPACE" set image deployment/dashboard dashboard="$IMAGE_TAG" --record || true
 
 ROLLBACK_SCRIPT="$(dirname "$0")/../../migrations/rollback.sh"
 if [[ ! -x "$ROLLBACK_SCRIPT" ]]; then

--- a/deployment/scripts/traffic_shape.sh
+++ b/deployment/scripts/traffic_shape.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Toggle target environment, defaulting to staging
+TARGET_ENV="${TARGET_ENV:-staging}"
+TRAFFIC_PERCENT="${TRAFFIC_PERCENT:-10}"
+DEPLOYMENT="${1:-dashboard}"
+
+# Apply manifests for the desired environment
+MANIFEST_DIR="k8s/canary"
+if [[ "$TARGET_ENV" == "production" ]]; then
+  MANIFEST_DIR="k8s/bluegreen"
+fi
+
+kubectl apply -f "$MANIFEST_DIR" >/dev/null
+
+# Annotate service to shape traffic for canary deployments
+kubectl -n "$TARGET_ENV" annotate service "$DEPLOYMENT" \
+  traffic.percent="$TRAFFIC_PERCENT" --overwrite >/dev/null
+
+echo "Applied $MANIFEST_DIR with $TRAFFIC_PERCENT% traffic to $DEPLOYMENT in $TARGET_ENV"

--- a/runbooks/deployment.md
+++ b/runbooks/deployment.md
@@ -2,14 +2,17 @@
 
 ## Rollout Procedure
 1. Build and push container images.
-2. Trigger the `canary` stage in `deployment/pipeline.yaml` or run `kubectl apply -f k8s/canary` to deploy the canary release.
+2. Trigger the `canary` stage in `deployment/pipeline.yaml` or run `deployment/scripts/traffic_shape.sh`.
+   The script honours `TARGET_ENV` (default `staging`) and `TRAFFIC_PERCENT` to control
+   the initial canary traffic share.
 3. Verify metrics and logs for the canary pods. Readiness and liveness probes should remain green before continuing.
 4. Start `scripts/rollback.sh` to watch unlock latency and error SLOs. The script queries
    Prometheus and will undo the rollout if P95 latency exceeds **100 ms** for 5 minutes or
    errors exceed **1%**.
 5. Confirm log entries appear in the staging ELK and Datadog dashboards and include correlation IDs from test requests.
-6. Execute the `blue_green` stage to shift traffic using `k8s/bluegreen` manifests.
-7. Remove the old color once the new version is healthy.
+6. Execute the `traffic_shift` stage to gradually raise `TRAFFIC_PERCENT` as confidence grows.
+7. Execute the `blue_green` stage to shift traffic using `k8s/bluegreen` manifests.
+8. Remove the old color once the new version is healthy.
 
 ## Rollback Procedure
 1. Re-route traffic back to the previous color or disable the canary.

--- a/runbooks/rollback.md
+++ b/runbooks/rollback.md
@@ -21,3 +21,5 @@ bash deployment/scripts/rollback.sh
 
 Before running the script manually, ensure that `deployment/rollback_state.json`
 contains the desired image tag and migration state.
+Set `TARGET_ENV` when rolling back non-default namespaces to route traffic away
+from the faulty version before restoring the database.

--- a/unit_tests/test_stateful_service_versions.py
+++ b/unit_tests/test_stateful_service_versions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+class StatefulServiceV1:
+    """First version of a simple stateful counter."""
+
+    def __init__(self, store: dict[str, int]):
+        self.store = store
+
+    def increment(self) -> int:
+        self.store["value"] = self.store.get("value", 0) + 1
+        return self.store["value"]
+
+
+class StatefulServiceV2(StatefulServiceV1):
+    """Second version sharing the same underlying store."""
+
+    # This version adds a no-op method representing a new feature
+    def ping(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+
+def test_simultaneous_versions_share_state():
+    store: dict[str, int] = {}
+    v1 = StatefulServiceV1(store)
+    v2 = StatefulServiceV2(store)
+
+    assert v1.increment() == 1
+    assert v2.increment() == 2
+    assert v1.increment() == 3
+    assert v2.increment() == 4


### PR DESCRIPTION
## Summary
- add traffic_shape script for environment toggles and canary traffic control
- wire traffic shaping into deployment pipeline and rollback script
- document cutover and rollback steps and add unit test for simultaneous versions

## Testing
- `pytest unit_tests/test_stateful_service_versions.py --override-ini=addopts= -q`
- `pre-commit run --files deployment/pipeline.yaml deployment/scripts/traffic_shape.sh deployment/scripts/rollback.sh runbooks/deployment.md runbooks/rollback.md unit_tests/test_stateful_service_versions.py`


------
https://chatgpt.com/codex/tasks/task_e_689eae90fedc8320868b73c99e2affad