### PR TITLE
Add deployment environment toggles and rollback documentation

### DIFF
--- a/deployment/pipeline.yaml
+++ b/deployment/pipeline.yaml
@@ -1,6 +1,13 @@
+variables:
+  DEPLOY_ENV: "staging"
+  TRAFFIC_PERCENT: "10"
+  STATEFUL_SERVICE: "dashboard-db"
+
 stages:
   - build
   - canary
+  - traffic_shaping
+  - verify_stateful
   - blue_green
 
 build:
@@ -11,15 +18,31 @@ build:
 canary:
   stage: canary
   script:
-    - kubectl apply -f k8s/canary
+    - kubectl --context $DEPLOY_ENV apply -f k8s/canary
   when: manual
   needs:
     - build
 
-blue_green:
-  stage: blue_green
+traffic_shaping:
+  stage: traffic_shaping
   script:
-    - kubectl apply -f k8s/bluegreen
+    - deployment/scripts/traffic_shaping.sh
   when: manual
   needs:
     - canary
+
+verify_stateful:
+  stage: verify_stateful
+  script:
+    - deployment/scripts/verify_stateful.sh $STATEFUL_SERVICE
+  when: manual
+  needs:
+    - traffic_shaping
+
+blue_green:
+  stage: blue_green
+  script:
+    - kubectl --context $DEPLOY_ENV apply -f k8s/bluegreen
+  when: manual
+  needs:
+    - verify_stateful

--- a/deployment/scripts/traffic_shaping.sh
+++ b/deployment/scripts/traffic_shaping.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+ENV=${DEPLOY_ENV:-staging}
+PERCENT=${TRAFFIC_PERCENT:-10}
+
+cat <<YAML | kubectl --context "$ENV" apply -f -
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: yosai-dashboard
+spec:
+  hosts:
+    - yosai-dashboard
+  http:
+    - route:
+        - destination:
+            host: yosai-dashboard
+            subset: canary
+          weight: ${PERCENT}
+        - destination:
+            host: yosai-dashboard
+            subset: stable
+          weight: $((100 - PERCENT))
+YAML

--- a/deployment/scripts/verify_stateful.sh
+++ b/deployment/scripts/verify_stateful.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+ENV=${DEPLOY_ENV:-staging}
+SERVICE_LABEL=${1:-dashboard-db}
+
+VERSIONS=$(kubectl --context "$ENV" get pods -l app="$SERVICE_LABEL" -o jsonpath='{.items[*].metadata.labels.version}' | tr ' ' '\n' | sort -u | wc -l)
+if [ "$VERSIONS" -lt 2 ]; then
+  echo "Stateful service $SERVICE_LABEL does not handle simultaneous versions"
+  exit 1
+fi
+
+echo "Stateful service $SERVICE_LABEL handles simultaneous versions"

--- a/runbooks/deployment-cutover-rollback.md
+++ b/runbooks/deployment-cutover-rollback.md
@@ -1,0 +1,15 @@
+# Deployment Cutover and Rollback
+
+## Cutover
+
+1. Set `DEPLOY_ENV` and `TRAFFIC_PERCENT` in the pipeline variables.
+2. Run the `canary` stage to deploy the new version to the target environment.
+3. Invoke the `traffic_shaping` stage to direct a percentage of traffic using `deployment/scripts/traffic_shaping.sh`.
+4. Execute `verify_stateful` to ensure stateful services support simultaneous versions via `deployment/scripts/verify_stateful.sh`.
+5. Once checks pass, run the `blue_green` stage to route all traffic to the new release.
+
+## Rollback
+
+1. Run `deployment/scripts/rollback.sh` to revert the deployment.
+2. If traffic shaping was applied, set `TRAFFIC_PERCENT=0` and rerun `deployment/scripts/traffic_shaping.sh` to shift all traffic back.
+3. Confirm services recover before attempting another deployment.


### PR DESCRIPTION
## Summary
- add environment toggles and traffic shaping stages to CI deployment pipeline
- provide scripts for traffic shaping and stateful service verification
- document deployment cutover and rollback process

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'models/ml/model_registry.py')*


------
https://chatgpt.com/codex/tasks/task_e_689eb8abbd74832091b0641632749770