### PR TITLE
refactor: load gateway runtime config and ping database

### DIFF
--- a/gateway/internal/config/circuitbreakers.go
+++ b/gateway/internal/config/circuitbreakers.go
@@ -30,9 +30,9 @@ type Config struct {
 //go:embed circuitbreakers_schema.json
 var cbSchema []byte
 
-// Load reads YAML configuration from path. If path is empty, the default
+// LoadCircuitBreakers reads YAML configuration from path. If path is empty, the default
 // "config/circuit-breakers.yaml" is used.
-func Load(path string) (*Config, error) {
+func LoadCircuitBreakers(path string) (*Config, error) {
 	if path == "" {
 		path = "config/circuit-breakers.yaml"
 	}

--- a/gateway/internal/config/circuitbreakers_test.go
+++ b/gateway/internal/config/circuitbreakers_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLoadValidConfig(t *testing.T) {
-	cfg, err := Load("../../../config/circuit-breakers.yaml")
+	cfg, err := LoadCircuitBreakers("../../../config/circuit-breakers.yaml")
 	if err != nil {
 		t.Fatalf("load valid: %v", err)
 	}
@@ -24,7 +24,7 @@ func TestLoadInvalidConfig(t *testing.T) {
 	tmp.WriteString("database:\n  failure_threshold: 'x'\n")
 	tmp.Close()
 
-	if _, err := Load(tmp.Name()); err == nil {
+	if _, err := LoadCircuitBreakers(tmp.Name()); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/gateway/internal/config/runtime.go
+++ b/gateway/internal/config/runtime.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	xerrors "github.com/WSG23/errors"
+	vault "github.com/hashicorp/vault/api"
+)
+
+// Runtime holds configuration values loaded at startup.
+type Runtime struct {
+	DBHost       string
+	DBPort       string
+	DBUser       string
+	DBName       string
+	DBSSLMode    string
+	DBPassword   string
+	KafkaBrokers string
+	JWTSecret    string
+}
+
+// Load reads environment variables and Vault secrets once and validates them.
+func Load() (*Runtime, error) {
+	required := []string{"DB_HOST", "DB_PORT", "DB_USER", "DB_GATEWAY_NAME"}
+	var missing []string
+	for _, v := range required {
+		if os.Getenv(v) == "" {
+			missing = append(missing, v)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, xerrors.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	vclient, err := newVaultClient()
+	if err != nil {
+		return nil, err
+	}
+
+	dbPassword, err := readVaultField(vclient, "secret/data/db#password")
+	if err != nil {
+		return nil, err
+	}
+
+	jwtSecret, err := readVaultField(vclient, "secret/data/jwt#secret")
+	if err != nil {
+		return nil, err
+	}
+
+	brokers := os.Getenv("KAFKA_BROKERS")
+	if brokers == "" {
+		brokers = "localhost:9092"
+	}
+
+	sslMode := os.Getenv("DB_SSLMODE")
+	if sslMode == "" {
+		sslMode = "require"
+	}
+
+	cfg := &Runtime{
+		DBHost:       os.Getenv("DB_HOST"),
+		DBPort:       os.Getenv("DB_PORT"),
+		DBUser:       os.Getenv("DB_USER"),
+		DBName:       os.Getenv("DB_GATEWAY_NAME"),
+		DBSSLMode:    sslMode,
+		DBPassword:   dbPassword,
+		KafkaBrokers: brokers,
+		JWTSecret:    jwtSecret,
+	}
+	return cfg, nil
+}
+
+func newVaultClient() (*vault.Client, error) {
+	cfg := vault.DefaultConfig()
+	if err := cfg.ReadEnvironment(); err != nil {
+		return nil, err
+	}
+	c, err := vault.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	token := os.Getenv("VAULT_TOKEN")
+	if token == "" {
+		return nil, xerrors.Errorf("VAULT_TOKEN not set")
+	}
+	c.SetToken(token)
+	return c, nil
+}
+
+func readVaultField(c *vault.Client, path string) (string, error) {
+	parts := strings.SplitN(path, "#", 2)
+	if len(parts) != 2 {
+		return "", xerrors.Errorf("invalid vault path %q", path)
+	}
+	p, field := parts[0], parts[1]
+	secretPath := strings.TrimPrefix(p, "secret/data/")
+	s, err := c.KVv2("secret").Get(context.Background(), secretPath)
+	if err != nil {
+		return "", err
+	}
+	val, ok := s.Data[field].(string)
+	if !ok {
+		return "", xerrors.Errorf("field %s not found at %s", field, p)
+	}
+	return val, nil
+}


### PR DESCRIPTION
## Summary
- add runtime configuration loader reading env and Vault secrets
- refactor gateway main to use runtime config and ping database
- rename circuit breaker loader to `LoadCircuitBreakers`

## Testing
- `go test ./...` *(fails: ambiguous import in google.golang.org/genproto)*


------
https://chatgpt.com/codex/tasks/task_e_689ebe52fa64832095085c4c4b7a88e1