### PR TITLE
Lower P95 latency threshold for load-test gating

### DIFF
--- a/yosai_intel_dashboard/src/infrastructure/config/performance_budgets.yml
+++ b/yosai_intel_dashboard/src/infrastructure/config/performance_budgets.yml
@@ -1,5 +1,5 @@
 http_req_failed_rate: 0.01
-http_req_duration_p95: 500
+http_req_duration_p95: 100
 endpoints:
   /api/v1/analytics/dashboard-summary:
     p50: 200


### PR DESCRIPTION
## Summary
- enforce stricter 100ms P95 latency budget in performance_budgets.yml

## Testing
- `k6 run --summary-export load-tests/results/event-ingestion.json load-tests/k6/scenarios/event-ingestion-test.js` *(fails: interrupted, high p95)*
- `load-tests/check_thresholds.sh load-tests/results/event-ingestion.json` *(fails: p95 duration 226.82ms exceeds threshold 100ms)*


------
https://chatgpt.com/codex/tasks/task_e_689ebe5c07088320bdb3d868528b6056