### PR TITLE
Document TimescaleDB CDC and monitor replication lag

### DIFF
--- a/deploy/cdc/debezium-connector.json
+++ b/deploy/cdc/debezium-connector.json
@@ -1,0 +1,16 @@
+{
+  "name": "timescale-cdc",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "cdc_replication",
+    "database.password": "CHANGE_ME",
+    "database.dbname": "app",
+    "plugin.name": "pgoutput",
+    "slot.name": "cdc_slot",
+    "slot.drop.on.stop": "false",
+    "publication.autocreate.mode": "filtered",
+    "schema.include.list": "public"
+  }
+}

--- a/deploy/cdc/logical_replication.sql
+++ b/deploy/cdc/logical_replication.sql
@@ -1,0 +1,5 @@
+-- Create a role with replication privileges
+CREATE ROLE cdc_replication WITH REPLICATION LOGIN PASSWORD 'CHANGE_ME';
+
+-- Create a logical replication slot for Debezium
+SELECT pg_create_logical_replication_slot('cdc_slot', 'pgoutput');

--- a/deploy/monitoring/prometheus-rules.yaml
+++ b/deploy/monitoring/prometheus-rules.yaml
@@ -22,3 +22,10 @@ groups:
       severity: page
     annotations:
       summary: Kafka consumer lag > 1000 messages
+  - alert: ReplicationSlotLag
+    expr: replication_lag_bytes > 10000000
+    for: 10m
+    labels:
+      severity: page
+    annotations:
+      summary: Logical replication lag exceeds 10MB

--- a/docs/cdc_timescaledb.md
+++ b/docs/cdc_timescaledb.md
@@ -1,0 +1,53 @@
+# Logical Replication Slots for TimescaleDB
+
+Logical replication slots allow applications to consume a stream of database changes.
+They are commonly used with change data capture frameworks such as Debezium.
+The slot retains WAL records until they are consumed, ensuring no updates are lost.
+
+## Creating a Slot
+
+The following SQL creates a dedicated replication role and slot for the dashboard:
+
+```sql
+-- Create a role with replication privileges
+CREATE ROLE cdc_replication WITH REPLICATION LOGIN PASSWORD 'CHANGE_ME';
+
+-- Create a logical replication slot using the pgoutput plugin
+SELECT pg_create_logical_replication_slot('cdc_slot', 'pgoutput');
+```
+
+## Debezium Connector
+
+A Debezium connector can stream the slot to Kafka. Example configuration:
+
+```json
+{
+  "name": "timescale-cdc",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "cdc_replication",
+    "database.password": "CHANGE_ME",
+    "database.dbname": "app",
+    "plugin.name": "pgoutput",
+    "slot.name": "cdc_slot",
+    "slot.drop.on.stop": "false",
+    "publication.autocreate.mode": "filtered",
+    "schema.include.list": "public"
+  }
+}
+```
+
+The configuration is available in `deploy/cdc/debezium-connector.json` and the SQL
+in `deploy/cdc/logical_replication.sql` for production use.
+
+## Monitoring
+
+`monitoring/replication_lag.py` exposes a Prometheus gauge
+`replication_lag_bytes` which queries `pg_replication_slots` and records
+how many bytes of WAL are pending for a slot. The included Prometheus rule
+raises an alert when the lag grows beyond a threshold.
+
+Regularly check the metric and consider pruning or restarting consumers if
+lag continues to increase.

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/replication_lag.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/replication_lag.py
@@ -1,0 +1,43 @@
+"""Prometheus metrics for logical replication lag."""
+
+from prometheus_client import REGISTRY, Gauge
+from prometheus_client.core import CollectorRegistry
+import psycopg2
+
+if "replication_lag_bytes" not in REGISTRY._names_to_collectors:
+    replication_lag_bytes = Gauge(
+        "replication_lag_bytes",
+        "Bytes of WAL pending for a logical replication slot",
+        ["slot"],
+    )
+else:  # pragma: no cover - defensive in tests
+    replication_lag_bytes = Gauge(
+        "replication_lag_bytes",
+        "Bytes of WAL pending for a logical replication slot",
+        ["slot"],
+        registry=CollectorRegistry(),
+    )
+
+def record_replication_lag(dsn: str, slot_name: str) -> None:
+    """Update the replication_lag_bytes gauge for *slot_name*.
+
+    Parameters
+    ----------
+    dsn:
+        Connection string for the source database.
+    slot_name:
+        Name of the logical replication slot to inspect.
+    """
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) "
+            "FROM pg_replication_slots WHERE slot_name = %s",
+            (slot_name,),
+        )
+        lag = cur.fetchone()
+        if lag and lag[0] is not None:
+            replication_lag_bytes.labels(slot=slot_name).set(float(lag[0]))
+        else:
+            replication_lag_bytes.labels(slot=slot_name).set(0)
+
+__all__ = ["record_replication_lag", "replication_lag_bytes"]


### PR DESCRIPTION
## Summary
- document TimescaleDB logical replication slots and Debezium connector configuration
- add SQL script and Debezium connector example under `deploy/cdc`
- expose `replication_lag_bytes` metric and Prometheus alert for replication lag

## Testing
- `python -m py_compile monitoring/replication_lag.py`
- `pytest monitoring -q` *(fails: KeyboardInterrupt after coverage scan)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe60098c8320a4777b8786356cd0