### PR TITLE
feat: standardize error responses

### DIFF
--- a/go/framework/errors_test.go
+++ b/go/framework/errors_test.go
@@ -1,20 +1,14 @@
 package framework
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
+        "encoding/json"
+        "net/http"
+        "net/http/httptest"
+        "strings"
+        "testing"
 
         sharederrors "github.com/WSG23/errors"
 )
-
-type body struct {
-	Code    string      `json:"code"`
-	Message string      `json:"message"`
-	Details interface{} `json:"details,omitempty"`
-}
 
 func TestErrorHandler(t *testing.T) {
 	h := NewErrorHandler()
@@ -26,11 +20,14 @@ func TestErrorHandler(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected %d got %d", http.StatusUnauthorized, rr.Code)
 	}
-	var b body
-	if err := json.NewDecoder(strings.NewReader(rr.Body.String())).Decode(&b); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if b.Code != string(sharederrors.Unauthorized) || b.Message != "unauthorized" {
-		t.Fatalf("unexpected body: %+v", b)
-	}
+        var m map[string]interface{}
+        if err := json.NewDecoder(strings.NewReader(rr.Body.String())).Decode(&m); err != nil {
+                t.Fatalf("decode: %v", err)
+        }
+        if m["code"] != string(sharederrors.Unauthorized) || m["message"] != "unauthorized" {
+                t.Fatalf("unexpected body: %+v", m)
+        }
+        if _, ok := m["details"]; !ok {
+                t.Fatalf("missing details field")
+        }
 }

--- a/openapi/components.yaml
+++ b/openapi/components.yaml
@@ -1,0 +1,16 @@
+schemas:
+  ErrorResponse:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: string
+        description: Machine-readable error code
+      message:
+        type: string
+        description: Human readable error message
+      details:
+        description: Optional additional information
+        nullable: true

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -20,7 +20,7 @@ const (
 type Error struct {
     Code    Code        `json:"code"`
     Message string      `json:"message"`
-    Details interface{} `json:"details,omitempty"`
+    Details interface{} `json:"details"`
 }
 
 // WriteJSON writes the error as JSON to the http.ResponseWriter.

--- a/sdks/go/model_error.go
+++ b/sdks/go/model_error.go
@@ -21,10 +21,10 @@ var _ MappedNullable = &Error{}
 
 // Error struct for Error
 type Error struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	// Additional error details
-	Details interface{} `json:"details,omitempty"`
+        Code    string `json:"code"`
+        Message string `json:"message"`
+        // Additional error details
+        Details interface{} `json:"details"`
 }
 
 type _Error Error
@@ -139,12 +139,10 @@ func (o Error) MarshalJSON() ([]byte, error) {
 
 func (o Error) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["code"] = o.Code
-	toSerialize["message"] = o.Message
-	if o.Details != nil {
-		toSerialize["details"] = o.Details
-	}
-	return toSerialize, nil
+        toSerialize["code"] = o.Code
+        toSerialize["message"] = o.Message
+        toSerialize["details"] = o.Details
+        return toSerialize, nil
 }
 
 func (o *Error) UnmarshalJSON(data []byte) (err error) {

--- a/shared/errors/types.go
+++ b/shared/errors/types.go
@@ -17,9 +17,9 @@ const (
 )
 
 type Error struct {
-	Code    Code        `json:"code"`
-	Message string      `json:"message"`
-	Details interface{} `json:"details,omitempty"`
+        Code    Code        `json:"code"`
+        Message string      `json:"message"`
+        Details interface{} `json:"details"`
 }
 
 // WriteJSON writes the error as JSON to the http.ResponseWriter.

--- a/shared/errors/types.py
+++ b/shared/errors/types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -16,5 +17,6 @@ class ErrorCode(str, Enum):
 class ErrorResponse(BaseModel):
     """Standard error response model."""
 
-    code: ErrorCode | None = None
-    detail: str
+    code: ErrorCode
+    message: str
+    details: Any | None = None

--- a/tests/adapters/api/test_error_handlers.py
+++ b/tests/adapters/api/test_error_handlers.py
@@ -37,6 +37,7 @@ def test_yosai_base_exception_handled():
     body = resp.get_json()
     assert body["code"] == "invalid_input"
     assert body["message"] == "bad"
+    assert body["details"] == {}
 
 
 def test_service_unavailable_error():
@@ -45,7 +46,11 @@ def test_service_unavailable_error():
 
     resp = client.get("/unavail")
     assert resp.status_code == 503
-    assert resp.get_json() == {"code": "unavailable", "message": "maintenance"}
+    assert resp.get_json() == {
+        "code": "unavailable",
+        "message": "maintenance",
+        "details": {},
+    }
 
 
 def test_generic_exception_handled():
@@ -57,3 +62,4 @@ def test_generic_exception_handled():
     body = resp.get_json()
     assert body["code"] == "internal"
     assert body["message"] == "boom"
+    assert body["details"] is None

--- a/tests/services/test_event_ingestion_app.py
+++ b/tests/services/test_event_ingestion_app.py
@@ -63,7 +63,12 @@ def load_module():
                 return await call_next(request)
             except Exception as exc:  # noqa: BLE001
                 return JSONResponse(
-                    {"code": "internal", "message": str(exc)}, status_code=500
+                    {
+                        "code": "internal",
+                        "message": str(exc),
+                        "details": None,
+                    },
+                    status_code=500,
                 )
 
     err_mw.ErrorHandlingMiddleware = DummyMW
@@ -173,7 +178,11 @@ def load_module():
             self.message = message
 
         def to_dict(self):
-            return {"code": self.code, "message": self.message}
+            return {
+                "code": self.code,
+                "message": self.message,
+                "details": None,
+            }
 
     errors_stub.ServiceError = ServiceError
     safe_import("yosai_framework.errors", errors_stub)
@@ -249,7 +258,7 @@ async def test_error_handling_middleware():
     ) as client:
         resp = await client.get("/boom")
     assert resp.status_code == 500
-    assert resp.json() == {"code": "internal", "message": "fail"}
+    assert resp.json() == {"code": "internal", "message": "fail", "details": None}
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_error_response.py
+++ b/tests/test_api_error_response.py
@@ -11,4 +11,8 @@ def test_api_error_response_generates_json_and_status():
             ValueError("bad"), ErrorCategory.INVALID_INPUT
         )
         assert status == 400
-        assert resp.get_json() == {"code": "invalid_input", "message": "bad"}
+        assert resp.get_json() == {
+            "code": "invalid_input",
+            "message": "bad",
+            "details": None,
+        }

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -5,4 +5,8 @@ from shared.errors.types import ErrorCode
 def test_http_error_returns_exception():
     exc = http_error(ErrorCode.INVALID_INPUT, "bad request", 400)
     assert exc.status_code == 400
-    assert exc.detail == {"code": "invalid_input", "message": "bad request"}
+    assert exc.detail == {
+        "code": "invalid_input",
+        "message": "bad request",
+        "details": None,
+    }

--- a/tests/test_fastapi_error_handler.py
+++ b/tests/test_fastapi_error_handler.py
@@ -20,4 +20,8 @@ client = TestClient(app)
 def test_fastapi_error_format():
     resp = client.get("/fail")
     assert resp.status_code == 400
-    assert resp.json() == {"code": "invalid_input", "message": "bad"}
+    assert resp.json() == {
+        "code": "invalid_input",
+        "message": "bad",
+        "details": None,
+    }

--- a/tests/test_framework_errors.py
+++ b/tests/test_framework_errors.py
@@ -8,11 +8,11 @@ def test_error_response_defaults():
     err = ServiceError(ErrorCode.NOT_FOUND, "missing")
     body, status = error_response(err)
     assert status == 404
-    assert body == {"code": "not_found", "message": "missing"}
+    assert body == {"code": "not_found", "message": "missing", "details": None}
 
 
 def test_error_response_custom_status():
     err = ServiceError(ErrorCode.UNAUTHORIZED, "nope")
     body, status = error_response(err, 418)
     assert status == 418
-    assert body == {"code": "unauthorized", "message": "nope"}
+    assert body == {"code": "unauthorized", "message": "nope", "details": None}

--- a/yosai_framework/errors.py
+++ b/yosai_framework/errors.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
 from shared.errors.types import ErrorCode
@@ -22,13 +22,11 @@ class ServiceError(Exception):
     details: Optional[Any] = None
 
     def to_dict(self) -> dict[str, Any]:
-        data = {
+        return {
             "code": self.code.value if isinstance(self.code, ErrorCode) else self.code,
             "message": self.message,
+            "details": self.details,
         }
-        if self.details is not None:
-            data["details"] = self.details
-        return data
 
 
 def from_exception(exc: Exception) -> "ServiceError":

--- a/yosai_intel_dashboard/src/error_handling/api_errors.py
+++ b/yosai_intel_dashboard/src/error_handling/api_errors.py
@@ -3,11 +3,13 @@ from fastapi import HTTPException
 from shared.errors.types import ErrorCode
 
 
-def http_error(code: ErrorCode, message: str, status: int) -> HTTPException:
+def http_error(
+    code: ErrorCode, message: str, status: int, details: object | None = None
+) -> HTTPException:
     """Return an ``HTTPException`` with a standardized error body."""
     return HTTPException(
         status_code=status,
-        detail={"code": code.value, "message": message},
+        detail={"code": code.value, "message": message, "details": details},
     )
 
 

--- a/yosai_intel_dashboard/src/error_handling/exceptions.py
+++ b/yosai_intel_dashboard/src/error_handling/exceptions.py
@@ -31,10 +31,11 @@ class YosaiException(Exception):
         super().__init__(message)
 
     def to_dict(self) -> dict[str, Any]:
-        body = {"code": self.category.value, "message": self.message}
-        if self.details is not None:
-            body["details"] = self.details
-        return body
+        return {
+            "code": self.category.value,
+            "message": self.message,
+            "details": self.details,
+        }
 
 
 __all__ = ["ErrorCategory", "YosaiException"]

--- a/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
+++ b/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
@@ -22,10 +22,7 @@ _CODE_TO_STATUS: dict[ErrorCode, int] = {
 def _json_body(code: ErrorCode | str, message: str, details: Optional[Any] = None):
     if isinstance(code, ErrorCode):
         code = code.value
-    body = {"code": code, "message": message}
-    if details is not None:
-        body["details"] = details
-    return jsonify(body)
+    return jsonify({"code": code, "message": message, "details": details})
 
 
 def register_error_handlers(app: Flask) -> None:


### PR DESCRIPTION
## Summary
- add ErrorResponse schema to OpenAPI components
- ensure Go and Python handlers return {code, message, details}
- expand contract tests for unified error format

## Testing
- `pre-commit run --files go/framework/errors_test.go pkg/errors/http.go sdks/go/model_error.go shared/errors/types.go shared/errors/types.py tests/adapters/api/test_error_handlers.py tests/services/test_event_ingestion_app.py tests/test_api_error_response.py tests/test_api_errors.py tests/test_fastapi_error_handler.py tests/test_framework_errors.py yosai_framework/errors.py yosai_intel_dashboard/src/error_handling/api_errors.py yosai_intel_dashboard/src/error_handling/exceptions.py openapi/components.yaml`
- `pre-commit run --files tests/adapters/api/test_error_handlers.py yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py`
- `pytest --no-cov tests/test_api_error_response.py tests/test_api_errors.py tests/adapters/api/test_error_handlers.py`
- `pytest --no-cov tests/services/test_event_ingestion_app.py -k error_handling_middleware` *(fails: 'asyncio' not found in markers configuration option)*
- `go test ./pkg/errors` *(no test files)*
- `go test ./go/framework` *(fails: missing go.sum entry for github.com/WSG23/resilience)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe61350c83208776d3da6cbaa21a