### PR TITLE
test: verify kafka flow through gateway

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+      - name: Start Kafka
+        run: docker compose -f docker-compose.kafka.yml up -d
+      - name: Wait for Kafka
+        run: |
+          for i in {1..30}; do
+            if nc -z localhost 9092; then
+              break
+            fi
+            sleep 1
+          done
       - name: Run unit tests
         run: |
           pytest tests/unit tests/integration --cov=repositories --cov=yosai_intel_dashboard/src/services/kafka_consumer.py --cov-fail-under=80
@@ -40,3 +50,9 @@ jobs:
           cov=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3,1,length($3)-1)}')
           echo "Kafka coverage: $cov%"
           awk -v cov="$cov" 'BEGIN { if (cov+0 < 80) exit 1 }'
+      - name: Show Kafka logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.kafka.yml logs
+      - name: Stop Kafka
+        if: always()
+        run: docker compose -f docker-compose.kafka.yml down

--- a/tests/integration/mock_event_service.py
+++ b/tests/integration/mock_event_service.py
@@ -1,0 +1,22 @@
+import json
+import os
+from fastapi import FastAPI
+from kafka import KafkaProducer
+
+brokers = os.environ.get("KAFKA_BROKERS", "localhost:9092")
+producer = KafkaProducer(
+    bootstrap_servers=brokers,
+    value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+)
+
+app = FastAPI()
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+@app.post("/api/v1/events")
+async def ingest_event(event: dict) -> dict:
+    producer.send("access-events", event)
+    producer.flush()
+    return {"status": "ok"}

--- a/tests/integration/test_gateway_kafka_event.py
+++ b/tests/integration/test_gateway_kafka_event.py
@@ -1,0 +1,89 @@
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+import requests
+from kafka import KafkaConsumer
+from testcontainers.core.container import DockerContainer
+
+
+def wait_for_service(url: str, timeout: int = 60) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code < 500:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"service {url} not ready")
+
+
+def wait_for_kafka(brokers: str = "localhost:9092", timeout: int = 60) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            KafkaConsumer(bootstrap_servers=brokers).close()
+            return
+        except Exception:
+            time.sleep(1)
+    raise RuntimeError("Kafka not ready")
+
+
+def test_publish_event_via_gateway(tmp_path):
+    wait_for_kafka()
+    service_script = Path(__file__).with_name("mock_event_service.py")
+    event_service = (
+        DockerContainer("python:3.11-slim")
+        .with_exposed_ports(5000)
+        .with_env("KAFKA_BROKERS", "host.docker.internal:9092")
+        .with_volume_mapping(str(service_script), "/app/service.py")
+        .with_command(
+            "sh -c \"pip install fastapi uvicorn kafka-python >/tmp/pip.log && "
+            "uvicorn service:app --host 0.0.0.0 --port 5000\""
+        )
+    )
+    with event_service as svc:
+        s_host = svc.get_container_host_ip()
+        s_port = svc.get_exposed_port(5000)
+        wait_for_service(f"http://{s_host}:{s_port}/health")
+
+        gateway_image = DockerContainer.from_dockerfile(
+            Path(".").resolve(), dockerfile="Dockerfile.gateway"
+        ).build()
+        gateway = (
+            DockerContainer(gateway_image)
+            .with_exposed_ports(8080)
+            .with_env("APP_HOST", s_host)
+            .with_env("APP_PORT", s_port)
+        )
+        with gateway as gw:
+            g_host = gw.get_container_host_ip()
+            g_port = gw.get_exposed_port(8080)
+            wait_for_service(f"http://{g_host}:{g_port}/health")
+
+            event = {
+                "event_id": "1",
+                "timestamp": datetime.utcnow().isoformat(),
+                "person_id": "p1",
+                "door_id": "d1",
+                "access_result": "Granted",
+            }
+            resp = requests.post(
+                f"http://{g_host}:{g_port}/api/v1/events", json=event, timeout=30
+            )
+            assert resp.status_code == 200
+
+            consumer = KafkaConsumer(
+                "access-events",
+                bootstrap_servers="localhost:9092",
+                group_id=f"test-{time.time()}",
+                auto_offset_reset="earliest",
+                consumer_timeout_ms=5000,
+                value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+            )
+            msgs = [msg.value for msg in consumer]
+            assert any(m.get("event_id") == "1" for m in msgs)
+            consumer.close()


### PR DESCRIPTION
## Summary
- start Kafka in CI via docker-compose.kafka.yml
- add integration test that posts events through gateway and confirms Kafka consumption

## Testing
- `pytest -o addopts='' tests/integration/test_gateway_kafka_event.py::test_publish_event_via_gateway -q` *(fails: MemoryError)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe62b1448320a34cfa0ac1a1a0d7