### PR TITLE
Propagate tracing context through Kafka

### DIFF
--- a/tests/unit/test_kafka_client.py
+++ b/tests/unit/test_kafka_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+import importlib.util
+
+import opentelemetry.trace as trace
+
+# Stub confluent_kafka before loading KafkaClient
+kafka_module = types.ModuleType("confluent_kafka")
+kafka_module.Producer = MagicMock()
+sys.modules["confluent_kafka"] = kafka_module
+
+spec = importlib.util.spec_from_file_location(
+    "kafka_client_module",
+    Path(__file__).resolve().parents[2]
+    / "yosai_intel_dashboard/src/services/kafka_client.py",
+)
+kc_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kc_mod)
+KafkaClient = kc_mod.KafkaClient
+
+
+def test_publish_injects_traceparent_header() -> None:
+    import opentelemetry.trace as trace_mod
+
+    tracer = trace_mod.get_tracer(__name__)
+    with tracer.start_as_current_span("root"):
+        client = KafkaClient("brokers")
+        client.publish("topic", "task", {"foo": "bar"})
+        headers = kafka_module.Producer.return_value.produce.call_args[1]["headers"]
+        assert any(key == "traceparent" for key, _ in headers)

--- a/tests/unit/test_kafka_consumer.py
+++ b/tests/unit/test_kafka_consumer.py
@@ -1,17 +1,26 @@
-from __future__ import annotations
-
-import logging
 import sys
 import types
+import logging
+from pathlib import Path
 from unittest.mock import MagicMock
+import importlib.util
 
-# Stub confluent_kafka.avro before importing the module under test
+import opentelemetry.trace as trace
+
+# Stub confluent_kafka.avro before loading KafkaConsumer
 avro_module = types.ModuleType("confluent_kafka.avro")
 avro_module.AvroConsumer = MagicMock()
 sys.modules.setdefault("confluent_kafka", types.ModuleType("confluent_kafka"))
 sys.modules["confluent_kafka.avro"] = avro_module
 
-from yosai_intel_dashboard.src.services.kafka_consumer import KafkaConsumer
+spec = importlib.util.spec_from_file_location(
+    "kafka_consumer_module",
+    Path(__file__).resolve().parents[2]
+    / "yosai_intel_dashboard/src/services/kafka_consumer.py",
+)
+kc_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kc_mod)
+KafkaConsumer = kc_mod.KafkaConsumer
 
 
 def test_poll_returns_message() -> None:
@@ -42,3 +51,21 @@ def test_close_swallows_exceptions() -> None:
     consumer = KafkaConsumer(["topic"])
     consumer.close()  # should not raise
 
+
+def test_poll_extracts_trace_context() -> None:
+    import opentelemetry.trace as trace_mod
+
+    msg = MagicMock()
+    msg.error.return_value = None
+    trace_id = "0123456789abcdef0123456789abcdef"
+    span_id = "0123456789abcdef"
+    msg.headers.return_value = [("traceparent", f"00-{trace_id}-{span_id}-01")]
+    avro_module.AvroConsumer.return_value.poll.return_value = msg
+
+    consumer = KafkaConsumer(["topic"])
+    consumer.poll()
+
+    current = trace_mod.get_current_span()
+    assert f"{current.get_span_context().trace_id:032x}" == trace_id
+
+    consumer.close()


### PR DESCRIPTION
## Summary
- inject traceparent headers in KafkaClient publishes
- extract trace context in KafkaConsumer and attach it for downstream spans
- document Kafka trace propagation in monitoring guide
- add unit tests for Kafka trace propagation

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/services/kafka_client.py yosai_intel_dashboard/src/services/kafka_consumer.py docs/monitoring.md tests/unit/test_kafka_client.py tests/unit/test_kafka_consumer.py` *(fails: no files to check)*
- `pytest tests/unit/test_kafka_client.py tests/unit/test_kafka_consumer.py -o addopts=` *(fails: module 'propagate' has no attribute 'extract', module 'trace' has no attribute 'get_tracer')*

------
https://chatgpt.com/codex/tasks/task_e_689ebe5eb33883209495155d4d226292