### PR TITLE
docs: document cross-service data flow

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,1 +1,5 @@
-"""API package for Yosai Intel Dashboard."""
+"""API package for Yosai Intel Dashboard.
+
+Ingress: handles REST requests from external clients.
+Egress: delegates to the service layer and returns HTTP responses.
+"""

--- a/docs/adr/0007-cross-module-dependencies.md
+++ b/docs/adr/0007-cross-module-dependencies.md
@@ -1,0 +1,20 @@
+# 0007: Cross-Module Dependency Documentation
+
+## Status
+Accepted
+
+## Context
+Cross-service data flow between the API, services and callback modules was
+undocumented. Adding dependencies across these boundaries without review makes
+the architecture difficult to reason about.
+
+## Decision
+All new dependencies between the `api`, `services` and `callbacks` packages
+must include an Architecture Decision Record. A lightweight check script
+(`scripts/architecture_review_check.py`) scans the repository for cross-module
+imports and fails if such dependencies exist without a corresponding ADR.
+
+## Consequences
+Developers must document cross-module links and keep diagrams in
+`docs/architecture` up to date. The check script runs in CI to guard against
+undocumented architectural drift.

--- a/docs/architecture/cross_service_data_flow.md
+++ b/docs/architecture/cross_service_data_flow.md
@@ -1,0 +1,13 @@
+# Cross-Service Data Flow
+
+This diagram outlines how the API, service layer and callback module exchange
+data through REST and Kafka streams.
+
+```mermaid
+flowchart LR
+    Client -->|REST| API
+    API -->|Service calls| Services
+    Services -->|Kafka events| Kafka[(Kafka Stream)]
+    Kafka -->|Triggers| Callbacks
+    Callbacks -->|UI updates| Client
+```

--- a/scripts/architecture_review_check.py
+++ b/scripts/architecture_review_check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Ensure cross-module dependencies are documented.
+
+The check scans the ``api``, ``callbacks`` and ``services`` packages for
+imports of one another. If such dependencies are found and no ADR documenting
+cross-module dependencies exists, the script exits with an error.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+MODULES = {
+    "api": pathlib.Path("api"),
+    "callbacks": pathlib.Path("yosai_intel_dashboard/src/callbacks"),
+    "services": pathlib.Path("yosai_intel_dashboard/src/services"),
+}
+
+ADR_TOKEN = "cross-module-dependencies"
+
+
+def _module_for_import(name: str) -> str | None:
+    if name.startswith("api"):
+        return "api"
+    if "callbacks" in name:
+        return "callbacks"
+    if "services" in name:
+        return "services"
+    return None
+
+
+def _collect_violations() -> list[str]:
+    violations: list[str] = []
+    for module_name, root in MODULES.items():
+        for py in root.rglob("*.py"):
+            try:
+                tree = ast.parse(py.read_text())
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        other = _module_for_import(alias.name)
+                        if other and other != module_name:
+                            violations.append(f"{py} imports {alias.name}")
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    other = _module_for_import(node.module)
+                    if other and other != module_name:
+                        violations.append(f"{py} imports {node.module}")
+    return violations
+
+
+def main() -> int:
+    violations = _collect_violations()
+    adr_exists = any(ADR_TOKEN in p.name for p in pathlib.Path("docs/adr").glob("*.md"))
+    if violations and not adr_exists:
+        print("Cross-module dependencies found without ADR:")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/yosai_intel_dashboard/src/callbacks/__init__.py
+++ b/yosai_intel_dashboard/src/callbacks/__init__.py
@@ -1,4 +1,8 @@
-"""Central callback registration for dashboard pages."""
+"""Central callback registration for dashboard pages.
+
+Ingress: consumes user interactions and service events.
+Egress: emits UI updates and invokes service-layer calls via callbacks.
+"""
 
 from .controller import (
     register_callbacks,

--- a/yosai_intel_dashboard/src/services/__init__.py
+++ b/yosai_intel_dashboard/src/services/__init__.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Simplified Services Package"""
+"""Service layer coordinating analytics and data processing.
+
+Ingress: invoked by API endpoints and callbacks.
+Egress: publishes Kafka events and feeds callback responses.
+"""
 import logging
 import os
 import sys


### PR DESCRIPTION
## Summary
- document API, services, and callbacks interactions with a new architecture diagram
- add ingress/egress docstrings to API, callback, and service modules
- add architecture review check script and ADR for cross-module dependencies

## Testing
- `python scripts/architecture_review_check.py`
- `pytest tests/callbacks api/tests services/tests` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_689ed813211c8320a580a47af4cff436