### PR TITLE
chore: unify analytics services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,7 +1329,7 @@ async with factory.get_async_connection() as conn:
   Run the analytics microservice via the unified BaseService:
 
   ```bash
-  python -m uvicorn services.analytics_microservice.app:app --host 0.0.0.0 --port 8001
+  python -m uvicorn services.analytics.app:app --host 0.0.0.0 --port 8001
   ```
 
 - **Async analytics microservice**: FastAPI implementation using an async

--- a/docs/async_db_migration.md
+++ b/docs/async_db_migration.md
@@ -9,7 +9,7 @@ created on application startup.
 
 - New module `services/common/async_db.py` provides pool creation,
   teardown and a simple health check.
-- `services/analytics_microservice/async_queries.py` contains the
+ - `services/analytics/async_queries.py` contains the
   SQL helpers used by the FastAPI services.
 - Microservice endpoints call these async functions directly rather
   than executing blocking code in a thread executor.

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -15,7 +15,7 @@ repositories to simplify development and deployment.
   - Standalone upload interface written in React/TypeScript.
 - **plugins/** → `yosai-plugins`
   - Collection of first‑party plugins and plugin manager helpers.
-- **services/analytics_microservice/** → `analytics-service`
+  - **services/analytics/** → `analytics-service`
   - Independent analytics engine with TimescaleDB integration.
 - **services/security/** → `security-service`
   - Security and authentication logic for downstream services.

--- a/mypy-report/index.txt
+++ b/mypy-report/index.txt
@@ -9,7 +9,7 @@ Script: index
 | examples                            |   6.25% imprecise |  32 LOC |
 | examples.types                      |   0.00% imprecise |  11 LOC |
 | services                            |   0.00% imprecise |   6 LOC |
-| services.analytics_microservice.app |   3.12% imprecise |  32 LOC |
+| services.analytics.app |   3.12% imprecise |  32 LOC |
 | services.arrival_estimator          |   0.00% imprecise |  53 LOC |
 | services.common.healthcheck         |   0.00% imprecise |  38 LOC |
 | services.export                     |   0.00% imprecise |   5 LOC |

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 testpaths =
     tests
     tests/cli
-    services/analytics_microservice/tests
 python_files = test_*.py
 python_classes = Test
 python_functions = test_*

--- a/scripts/generate_fastapi_openapi.py
+++ b/scripts/generate_fastapi_openapi.py
@@ -95,10 +95,10 @@ def _stub_analytics_deps() -> None:
     sys.modules.setdefault("redis", redis_stub)
     sys.modules.setdefault("redis.asyncio", redis_async)
 
-    queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+    queries_stub = types.ModuleType("services.analytics.async_queries")
     queries_stub.fetch_dashboard_summary = lambda *a, **k: {}
     queries_stub.fetch_access_patterns = lambda *a, **k: {}
-    sys.modules["services.analytics_microservice.async_queries"] = queries_stub
+    sys.modules["services.analytics.async_queries"] = queries_stub
 
     yd_models = types.ModuleType("yosai_intel_dashboard.models")
     ml_stub = types.ModuleType("yosai_intel_dashboard.models.ml")

--- a/services/analytics/__init__.py
+++ b/services/analytics/__init__.py
@@ -1,0 +1,10 @@
+"""Unified analytics service package.
+
+This package consolidates the previous ``analytics`` and
+``analytics_microservice`` modules.  It re-exports the FastAPI
+application and helper utilities from the real implementation in
+``yosai_intel_dashboard``.  The package also exposes a small CLI entry
+point via :mod:`services.analytics.cli`.
+"""
+
+__all__ = ["app", "analytics_service", "async_queries", "model_loader"]

--- a/services/analytics/analytics_service.py
+++ b/services/analytics/analytics_service.py
@@ -1,0 +1,17 @@
+"""Re-export the analytics service used by the FastAPI app."""
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from yosai_intel_dashboard.src.services.analytics_microservice import analytics_service as _impl
+else:  # pragma: no cover - runtime import only
+    _impl = import_module("yosai_intel_dashboard.src.services.analytics_microservice.analytics_service")
+
+# Expose all public attributes from the implementation module
+for _name in dir(_impl):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_impl, _name)
+
+__all__ = [name for name in dir(_impl) if not name.startswith("_")]

--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -1,10 +1,10 @@
 """Compatibility wrapper for tests.
 
-The test-suite expects the analytics microservice to be importable from the
-``services`` package.  The actual implementation lives in
-``yosai_intel_dashboard.src.services.analytics_microservice``.  This module
-re-exports the FastAPI ``app`` object from the real implementation so that both
-import locations behave the same.
+This module exposes the FastAPI ``app`` object from the real analytics
+microservice implementation located in
+``yosai_intel_dashboard.src.services.analytics_microservice``.  It allows
+imports to use ``services.analytics.app`` uniformly for both service and
+CLI contexts.
 """
 
 from importlib import import_module

--- a/services/analytics/async_queries.py
+++ b/services/analytics/async_queries.py
@@ -1,0 +1,16 @@
+"""Re-export async query helpers for the analytics service."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from yosai_intel_dashboard.src.services.analytics_microservice import async_queries as _impl
+else:  # pragma: no cover - runtime import only
+    _impl = import_module("yosai_intel_dashboard.src.services.analytics_microservice.async_queries")
+
+# Re-export public names from implementation module
+for _name in dir(_impl):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_impl, _name)
+
+__all__ = [name for name in dir(_impl) if not name.startswith("_")]

--- a/services/analytics/cli.py
+++ b/services/analytics/cli.py
@@ -1,0 +1,33 @@
+"""Simple command line interface for analytics tasks."""
+
+from __future__ import annotations
+
+import argparse
+
+from yosai_intel_dashboard.src.services.analytics_service import create_analytics_service
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run basic analytics commands.
+
+    The current CLI supports a single ``--preload-models`` flag which
+    preloads any active models and then exits.  It acts primarily as a
+    lightweight example demonstrating how the analytics package can expose
+    a CLI entrypoint separate from the FastAPI service.
+    """
+
+    parser = argparse.ArgumentParser(description="Analytics CLI")
+    parser.add_argument(
+        "--preload-models",
+        action="store_true",
+        help="Preload active models into memory and exit",
+    )
+    args = parser.parse_args(argv)
+
+    service = create_analytics_service()
+    if args.preload_models:
+        service.preload_active_models()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/services/analytics/model_loader.py
+++ b/services/analytics/model_loader.py
@@ -1,0 +1,15 @@
+"""Provide access to model loading helpers used by analytics tests."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from yosai_intel_dashboard.src.services.analytics_microservice import model_loader as _impl
+else:  # pragma: no cover - runtime import only
+    _impl = import_module("yosai_intel_dashboard.src.services.analytics_microservice.model_loader")
+
+for _name in dir(_impl):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_impl, _name)
+
+__all__ = [name for name in dir(_impl) if not name.startswith("_")]

--- a/tests/integration/test_analytics_microservice_metrics.py
+++ b/tests/integration/test_analytics_microservice_metrics.py
@@ -72,7 +72,7 @@ analytics_stub = types.ModuleType("services.analytics_service")
 analytics_stub.create_analytics_service = lambda: DummyAnalytics()
 safe_import('services.analytics_service', analytics_stub)
 
-async_queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+async_queries_stub = types.ModuleType("services.analytics.async_queries")
 
 
 async def _fetch_summary(pool):
@@ -85,7 +85,7 @@ async def _fetch_patterns(pool, days):
 
 async_queries_stub.fetch_dashboard_summary = _fetch_summary
 async_queries_stub.fetch_access_patterns = _fetch_patterns
-safe_import('services.analytics_microservice.async_queries', async_queries_stub)
+safe_import('services.analytics.async_queries', async_queries_stub)
 
 dummy_tracing = types.ModuleType("tracing")
 called = {}
@@ -103,8 +103,8 @@ safe_import('tracing', dummy_tracing)
 def test_metrics_and_tracing():
 
     app_spec = importlib.util.spec_from_file_location(
-        "services.analytics_microservice.app",
-        SERVICES_PATH / "analytics_microservice" / "app.py",
+        "services.analytics.app",
+        SERVICES_PATH / "analytics" / "app.py",
     )
     app_module = importlib.util.module_from_spec(app_spec)
     app_spec.loader.exec_module(app_module)

--- a/tests/integration/test_analytics_microservice_startup.py
+++ b/tests/integration/test_analytics_microservice_startup.py
@@ -41,10 +41,10 @@ async_db_stub.close_pool = lambda: None
 safe_import('services.common.async_db', async_db_stub)
 
 # Stub analytics queries
-async_queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+async_queries_stub = types.ModuleType("services.analytics.async_queries")
 async_queries_stub.fetch_dashboard_summary = lambda *a, **k: {}
 async_queries_stub.fetch_access_patterns = lambda *a, **k: {}
-safe_import('services.analytics_microservice.async_queries', async_queries_stub)
+safe_import('services.analytics.async_queries', async_queries_stub)
 
 # Stub tracing
 tracing_stub = types.ModuleType("tracing")
@@ -74,8 +74,8 @@ async def test_startup_requires_jwt_secret(monkeypatch):
     monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
 
     app_spec = importlib.util.spec_from_file_location(
-        "services.analytics_microservice.app",
-        SERVICES_PATH / "analytics_microservice" / "app.py",
+        "services.analytics.app",
+        SERVICES_PATH / "analytics" / "app.py",
     )
     app_module = importlib.util.module_from_spec(app_spec)
     app_spec.loader.exec_module(app_module)

--- a/tests/integration/test_e2e_gateway.py
+++ b/tests/integration/test_e2e_gateway.py
@@ -49,7 +49,7 @@ def test_gateway_end_to_end(tmp_path):
             .with_env("REDIS_HOST", redis_host)
             .with_env("REDIS_PORT", redis_port)
             .with_command(
-                "python -m uvicorn services.analytics_microservice.app:app --host 0.0.0.0 --port 8001"
+                "python -m uvicorn services.analytics.app:app --host 0.0.0.0 --port 8001"
             )
         )
         analytics.start()

--- a/tests/integration/test_gateway_to_microservice.py
+++ b/tests/integration/test_gateway_to_microservice.py
@@ -101,7 +101,7 @@ analytics_stub.create_analytics_service = lambda: DummyAnalytics()
 safe_import('services.analytics_service', analytics_stub)
 
 # Stub async query functions used by the microservice
-async_queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+async_queries_stub = types.ModuleType("services.analytics.async_queries")
 
 
 async def _fetch_summary(pool):
@@ -114,7 +114,7 @@ async def _fetch_patterns(pool, days):
 
 async_queries_stub.fetch_dashboard_summary = _fetch_summary
 async_queries_stub.fetch_access_patterns = _fetch_patterns
-safe_import('services.analytics_microservice.async_queries', async_queries_stub)
+safe_import('services.analytics.async_queries', async_queries_stub)
 
 # Ensure base health check always succeeds during tests
 health_stub = types.ModuleType(
@@ -126,8 +126,8 @@ safe_import(
 )
 
 app_spec = importlib.util.spec_from_file_location(
-    "services.analytics_microservice.app",
-    SERVICES_PATH / "analytics_microservice" / "app.py",
+    "services.analytics.app",
+    SERVICES_PATH / "analytics" / "app.py",
 )
 app_module = importlib.util.module_from_spec(app_spec)
 app_spec.loader.exec_module(app_module)

--- a/tests/integration/test_microservice_adapters.py
+++ b/tests/integration/test_microservice_adapters.py
@@ -14,8 +14,8 @@ SERVICES_PATH = pathlib.Path(__file__).resolve().parents[2] / "services"
 
 # Load the FastAPI analytics microservice
 app_spec = importlib.util.spec_from_file_location(
-    "services.analytics_microservice.app",
-    SERVICES_PATH / "analytics_microservice" / "app.py",
+    "services.analytics.app",
+    SERVICES_PATH / "analytics" / "app.py",
 )
 app_module = importlib.util.module_from_spec(app_spec)
 app_spec.loader.exec_module(app_module)
@@ -46,7 +46,7 @@ def test_analytics_service_adapter_microservice(monkeypatch):
     """Adapter should return the same data as the microservice."""
     monkeypatch.setenv("USE_GO_ANALYTICS", "true")
     monkeypatch.setitem(
-        migration_adapter.feature_flags._flags, "use_analytics_microservice", True
+        migration_adapter.feature_flags._flags, "use_analytics_service", True
     )
 
     client = TestClient(app_module.app)

--- a/tests/services/analytics/test_queries_security.py
+++ b/tests/services/analytics/test_queries_security.py
@@ -1,5 +1,5 @@
 import asyncio
-from yosai_intel_dashboard.src.services.analytics_microservice import queries
+from yosai_intel_dashboard.src.services.analytics import queries
 
 
 class FakePool:

--- a/tests/services/test_analytics_microservice_app.py
+++ b/tests/services/test_analytics_microservice_app.py
@@ -58,8 +58,8 @@ def load_app():
     safe_import('tracing', tracing_stub)
 
     spec = importlib.util.spec_from_file_location(
-        "services.analytics_microservice.app",
-        SERVICES_PATH / "analytics_microservice" / "app.py",
+        "services.analytics.app",
+        SERVICES_PATH / "analytics" / "app.py",
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[arg-type]

--- a/yosai_intel_dashboard/src/services/analytics_microservice/model_loader.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/model_loader.py
@@ -9,7 +9,7 @@ from yosai_intel_dashboard.src.services.common.analytics_utils import (
 )
 
 warnings.warn(
-    "services.analytics_microservice.model_loader is deprecated; use"
+    "services.analytics.model_loader is deprecated; use"
     " services.common.analytics_utils.preload_active_models",
     DeprecationWarning,
     stacklevel=2,

--- a/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/tests/conftest.py
@@ -383,15 +383,15 @@ def env_setup(monkeypatch):
 
 @pytest.fixture
 def mock_services(monkeypatch):
-    queries_stub = types.ModuleType("services.analytics_microservice.async_queries")
+    queries_stub = types.ModuleType("services.analytics.async_queries")
     queries_stub.fetch_dashboard_summary = AsyncMock(return_value={"status": "ok"})
     queries_stub.fetch_access_patterns = AsyncMock(return_value={"days": 7})
     monkeypatch.setitem(
-        sys.modules, "services.analytics_microservice.async_queries", queries_stub
+        sys.modules, "services.analytics.async_queries", queries_stub
     )
     monkeypatch.setitem(
         sys.modules,
-        "yosai_intel_dashboard.src.services.analytics_microservice.async_queries",
+        "yosai_intel_dashboard.src.services.analytics.async_queries",
         queries_stub,
     )
 
@@ -409,16 +409,16 @@ def mock_services(monkeypatch):
 
     dummy_service = DummyAnalyticsService()
     analytics_stub = types.ModuleType(
-        "services.analytics_microservice.analytics_service"
+        "services.analytics.analytics_service"
     )
     analytics_stub.AnalyticsService = DummyAnalyticsService
     analytics_stub.get_analytics_service = lambda *a, **k: dummy_service
     monkeypatch.setitem(
-        sys.modules, "services.analytics_microservice.analytics_service", analytics_stub
+        sys.modules, "services.analytics.analytics_service", analytics_stub
     )
     monkeypatch.setitem(
         sys.modules,
-        "yosai_intel_dashboard.src.services.analytics_microservice.analytics_service",
+        "yosai_intel_dashboard.src.services.analytics.analytics_service",
         analytics_stub,
     )
 
@@ -432,7 +432,7 @@ def _load_app(dummy_service, secret: str | None):
         os.environ.pop("JWT_SECRET_KEY", None)
 
     spec = importlib.util.spec_from_file_location(
-        "services.analytics_microservice.app",
+        "services.analytics.app",
         SERVICES_PATH / "analytics_microservice" / "app.py",
     )
     module = importlib.util.module_from_spec(spec)

--- a/yosai_intel_dashboard/src/services/timescale/adapter.py
+++ b/yosai_intel_dashboard/src/services/timescale/adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from yosai_intel_dashboard.src.services.analytics_microservice import queries
+from yosai_intel_dashboard.src.services.analytics import queries
 
 from .manager import TimescaleDBManager
 


### PR DESCRIPTION
## Summary
- merge analytics microservice shim into new `services.analytics` package
- add CLI entrypoint and re-export analytics helpers from consolidated package
- remove deprecated `services.analytics_microservice` references and update tests/docs

## Testing
- `pytest tests/services/test_analytics_microservice_app.py -q` *(fails: TypeError: Cannot create a consistent method resolution order (MRO) for bases object, WebSocketDisconnect)*

------
https://chatgpt.com/codex/tasks/task_e_689ed84e00f083208367569a8a1a27a8