### PR TITLE
feat: standardize api error handling

### DIFF
--- a/shared/errors/types.py
+++ b/shared/errors/types.py
@@ -1,5 +1,8 @@
+"""Shared error contract used across services."""
+
 from enum import Enum
-from typing import Any
+from http import HTTPStatus
+from typing import Any, Dict
 
 from pydantic import BaseModel
 
@@ -20,3 +23,16 @@ class ErrorResponse(BaseModel):
     code: ErrorCode
     message: str
     details: Any | None = None
+
+
+# Mapping of :class:`ErrorCode` values to HTTP status codes.
+CODE_TO_STATUS: Dict[ErrorCode, int] = {
+    ErrorCode.INVALID_INPUT: HTTPStatus.BAD_REQUEST,
+    ErrorCode.UNAUTHORIZED: HTTPStatus.UNAUTHORIZED,
+    ErrorCode.NOT_FOUND: HTTPStatus.NOT_FOUND,
+    ErrorCode.INTERNAL: HTTPStatus.INTERNAL_SERVER_ERROR,
+    ErrorCode.UNAVAILABLE: HTTPStatus.SERVICE_UNAVAILABLE,
+}
+
+
+__all__ = ["ErrorCode", "ErrorResponse", "CODE_TO_STATUS"]

--- a/tests/test_api_error_response.py
+++ b/tests/test_api_error_response.py
@@ -1,7 +1,19 @@
 import pytest
 from flask import Flask
 
-from yosai_intel_dashboard.src.error_handling import ErrorCategory, api_error_response
+try:  # pragma: no cover - optional dependency for FastAPI tests
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    _FASTAPI_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    _FASTAPI_AVAILABLE = False
+
+from yosai_intel_dashboard.src.error_handling import (
+    ErrorCategory,
+    ErrorHandlingMiddleware,
+    api_error_response,
+    register_error_handlers,
+)
 
 
 def test_api_error_response_generates_json_and_status():
@@ -14,5 +26,44 @@ def test_api_error_response_generates_json_and_status():
         assert resp.get_json() == {
             "code": "invalid_input",
             "message": "bad",
+            "details": None,
+        }
+
+
+def test_flask_error_handler_returns_standard_schema():
+    app = Flask(__name__)
+    register_error_handlers(app)
+
+    @app.get("/boom")
+    def boom():  # pragma: no cover - execution happens via test client
+        raise ValueError("boom")
+
+    with app.test_client() as client:
+        resp = client.get("/boom")
+        assert resp.status_code == 500
+        assert resp.get_json() == {
+            "code": "internal",
+            "message": "boom",
+            "details": None,
+        }
+
+
+def test_fastapi_middleware_returns_standard_schema():
+    if not _FASTAPI_AVAILABLE:
+        pytest.skip("fastapi not available")
+
+    app = FastAPI()
+    app.add_middleware(ErrorHandlingMiddleware)
+
+    @app.get("/boom")
+    async def boom():  # pragma: no cover - executed by TestClient
+        raise ValueError("boom")
+
+    with TestClient(app) as client:
+        resp = client.get("/boom")
+        assert resp.status_code == 500
+        assert resp.json() == {
+            "code": "internal",
+            "message": "boom",
             "details": None,
         }

--- a/yosai_intel_dashboard/src/error_handling/__init__.py
+++ b/yosai_intel_dashboard/src/error_handling/__init__.py
@@ -5,6 +5,8 @@ from .api_errors import http_error
 from .core import ErrorContext, ErrorHandler
 from .decorators import handle_errors
 from .exceptions import ErrorCategory, YosaiException
+from .flask import register_error_handlers
+from .middleware import ErrorHandlingMiddleware
 
 __all__ = [
     "ErrorHandler",
@@ -14,4 +16,6 @@ __all__ = [
     "ErrorCategory",
     "api_error_response",
     "http_error",
+    "ErrorHandlingMiddleware",
+    "register_error_handlers",
 ]

--- a/yosai_intel_dashboard/src/error_handling/api_error_response.py
+++ b/yosai_intel_dashboard/src/error_handling/api_error_response.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 from flask import Response, jsonify
 
-from shared.errors.types import ErrorCode
-
-CODE_TO_STATUS: dict[ErrorCode, int] = {
-    ErrorCode.INVALID_INPUT: 400,
-    ErrorCode.UNAUTHORIZED: 401,
-    ErrorCode.NOT_FOUND: 404,
-    ErrorCode.INTERNAL: 500,
-    ErrorCode.UNAVAILABLE: 503,
-}
+from shared.errors.types import CODE_TO_STATUS, ErrorCode
 
 from .core import ErrorHandler
 from .exceptions import ErrorCategory

--- a/yosai_intel_dashboard/src/error_handling/core.py
+++ b/yosai_intel_dashboard/src/error_handling/core.py
@@ -4,9 +4,16 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
-from yosai_intel_dashboard.src.infrastructure.monitoring.error_budget import (
-    record_error,
-)
+# ``record_error`` depends on optional monitoring libraries. During tests those
+# dependencies may not be installed, so fall back to a no-op implementation.
+try:
+    from yosai_intel_dashboard.src.infrastructure.monitoring.error_budget import (
+        record_error,
+    )
+except Exception:  # pragma: no cover - best effort when monitoring is absent
+    def record_error(service: str) -> None:  # type: ignore[no-redef]
+        """Fallback no-op used when monitoring dependencies are missing."""
+        return None
 
 from .exceptions import ErrorCategory, YosaiException
 

--- a/yosai_intel_dashboard/src/error_handling/flask.py
+++ b/yosai_intel_dashboard/src/error_handling/flask.py
@@ -1,0 +1,27 @@
+"""Flask integration for the shared error handling contract."""
+
+from flask import Flask, jsonify
+
+from shared.errors.types import CODE_TO_STATUS, ErrorCode
+
+from .core import ErrorHandler
+from .exceptions import ErrorCategory, YosaiException
+
+
+def register_error_handlers(app: Flask, handler: ErrorHandler | None = None) -> None:
+    """Register a generic exception handler returning ``ErrorResponse`` payloads."""
+
+    err_handler = handler or ErrorHandler()
+
+    @app.errorhandler(Exception)
+    def _handle(exc: Exception):  # type: ignore[override]
+        if isinstance(exc, YosaiException):
+            err = exc
+        else:
+            err = err_handler.handle(exc, ErrorCategory.INTERNAL)
+        status = CODE_TO_STATUS.get(ErrorCode(err.category.value), 500)
+        return jsonify(err.to_dict()), status
+
+
+__all__ = ["register_error_handlers"]
+

--- a/yosai_intel_dashboard/src/error_handling/middleware.py
+++ b/yosai_intel_dashboard/src/error_handling/middleware.py
@@ -4,8 +4,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from shared.errors.types import ErrorCode
-from yosai_framework.errors import CODE_TO_STATUS
+from shared.errors.types import CODE_TO_STATUS, ErrorCode
 
 from .core import ErrorHandler
 from .exceptions import ErrorCategory


### PR DESCRIPTION
## Summary
- centralize error schema and HTTP status map in `shared.errors`
- add Flask and FastAPI error handlers returning the shared schema
- cover unified error responses with tests

## Testing
- `pytest tests/test_api_error_response.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689edb26e6048320b38da59a9d406c63