### PR TITLE
test: add accessibility and responsive layout checks

### DIFF
--- a/cypress.a11y.config.ts
+++ b/cypress.a11y.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   e2e: {
+    baseUrl: 'http://localhost:3000',
     supportFile: 'cypress/support/e2e.ts',
     specPattern: 'cypress/e2e/**/*.cy.{js,ts}'
   }

--- a/cypress/e2e/core-pages-a11y.cy.ts
+++ b/cypress/e2e/core-pages-a11y.cy.ts
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+
+describe('Core page accessibility', () => {
+  const pages = ['/', '/upload', '/progressive-section'];
+
+  pages.forEach((page) => {
+    it(`has no detectable accessibility violations on ${page}`, () => {
+      cy.visit(page);
+      cy.injectAxeAndCheck();
+    });
+  });
+});

--- a/cypress/e2e/responsive-layout.cy.ts
+++ b/cypress/e2e/responsive-layout.cy.ts
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+
+describe('Responsive layout screenshots', () => {
+  const devices: Cypress.ViewportPreset[] = ['iphone-5', 'iphone-xr'];
+  const pages = ['/', '/upload'];
+
+  devices.forEach((device) => {
+    pages.forEach((page) => {
+      it(`captures ${page} on ${device}`, () => {
+        const screenshotName = `${page.replace(/\//g, '')}-${device}`;
+        cy.viewport(device);
+        cy.visit(page);
+        cy.get('body').should('be.visible');
+        cy.screenshot(screenshotName);
+        cy.readFile(
+          `cypress/screenshots/responsive-layout.cy.ts/${screenshotName}.png`,
+          'binary'
+        ).should('exist');
+      });
+    });
+  });
+});

--- a/yosai_intel_dashboard/src/adapters/ui/components/ResponsiveImage.tsx
+++ b/yosai_intel_dashboard/src/adapters/ui/components/ResponsiveImage.tsx
@@ -16,6 +16,7 @@ interface ResponsiveImageProps
 const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
   sources,
   src,
+  alt = '',
   ...imgProps
 }) => {
   const { saveData } = usePreferencesStore();
@@ -26,7 +27,7 @@ const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
 
   if (shouldReduce) {
     const lowSrc = src ?? sources[0]?.srcSet;
-    return <img {...imgProps} src={lowSrc} />;
+    return <img alt={alt} {...imgProps} src={lowSrc} />;
   }
 
   return (
@@ -34,7 +35,7 @@ const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
       {sources.map((source, index) => (
         <source key={index} {...source} />
       ))}
-      <img {...imgProps} src={src} />
+      <img alt={alt} {...imgProps} src={src} />
     </picture>
   );
 };


### PR DESCRIPTION
## Summary
- extend Cypress a11y config with base URL
- add aXe tests covering core pages
- capture screenshots on mobile viewports
- ensure ResponsiveImage always provides alt text

## Testing
- `npx cypress run --config-file cypress.a11y.config.ts --spec "cypress/e2e/core-pages-a11y.cy.ts,cypress/e2e/responsive-layout.cy.ts"` *(fails: requires cypress installation)*


------
https://chatgpt.com/codex/tasks/task_e_689ee5604a348320a4c41558bec4ac60