### PR TITLE
Improve test isolation around Kafka and I/O

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,13 @@ the testing protocols, container builder and available test doubles.
 
 Please ensure tests and linters pass before opening a pull request.
 
+### Test Types and Expected Runtime
+
+| Type | Description | Approx. runtime | Command |
+| ---- | ----------- | --------------- | ------- |
+| Unit tests | No external services, network and file I/O are mocked. | < 5 minutes | `pytest -m "not integration"` |
+| Integration tests | Spin up ephemeral services (Kafka, Postgres, Redis) via Docker. Skipped when Docker is unavailable. | ~10 minutes | `pytest -m integration` |
+
 ## Dependency Updates
 
 Automated pull requests labeled `deps` are created by Dependabot to keep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,16 +12,20 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Callable, Iterator, List
 from unittest import mock
+import builtins
+import requests
 
 # Make project package importable
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from yosai_intel_dashboard.src.core.imports import fallbacks as _fallbacks
+from yosai_intel_dashboard.src.core.imports import (
+    fallbacks as _fallbacks,
+)  # noqa: F401,E402
 
-import pytest
+import pytest  # noqa: E402
 
-from yosai_intel_dashboard.src.database.types import DatabaseConnection
+from yosai_intel_dashboard.src.database.types import DatabaseConnection  # noqa: E402
 
 try:
     from memory_profiler import memory_usage  # type: ignore
@@ -392,3 +396,32 @@ def postgres_connection_factory() -> Iterator[DatabaseConnectionFactory]:
                 pass
         _close_pool(pool)
         manager.close()
+
+
+@pytest.fixture(autouse=True)
+def mock_network_and_files(monkeypatch, tmp_path, request):
+    """Disable real network calls and restrict file writes in unit tests.
+
+    Integration tests opt-out by using the ``integration`` marker.
+    """
+    if "integration" in request.keywords:
+        return
+
+    def _blocked(*_a, **_k):
+        raise RuntimeError("Network access disabled during unit tests")
+
+    try:
+        monkeypatch.setattr(requests.sessions.Session, "request", _blocked)
+    except Exception:
+        pass
+
+    original_open = builtins.open
+
+    def _safe_open(file, mode="r", *args, **kwargs):
+        if any(m in mode for m in ("w", "a", "x")):
+            path = Path(file).resolve()
+            if not str(path).startswith(str(tmp_path)):
+                raise RuntimeError("File write outside tmp path disabled in unit tests")
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _safe_open)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import shutil
+from typing import Generator
+
+import pytest
+
+try:  # pragma: no cover - optional dependency in CI
+    from testcontainers.kafka import KafkaContainer
+except Exception:  # pragma: no cover - import error handled at runtime
+    KafkaContainer = None
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.fixture(scope="session")
+def kafka_service() -> Generator[str, None, None]:
+    """Provide an ephemeral Kafka broker for integration tests."""
+    if KafkaContainer is None or not _docker_available():
+        pytest.skip("docker or testcontainers not available")
+    with KafkaContainer() as kafka:
+        bootstrap = kafka.get_bootstrap_server().split("//", 1)[-1]
+        yield bootstrap

--- a/tests/integration/test_gateway_kafka_event.py
+++ b/tests/integration/test_gateway_kafka_event.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 import requests
 from kafka import KafkaConsumer
 from testcontainers.core.container import DockerContainer
@@ -21,48 +22,33 @@ def wait_for_service(url: str, timeout: int = 60) -> None:
     raise RuntimeError(f"service {url} not ready")
 
 
-def wait_for_kafka(brokers: str = "localhost:9092", timeout: int = 60) -> None:
-    start = time.time()
-    while time.time() - start < timeout:
-        try:
-            KafkaConsumer(bootstrap_servers=brokers).close()
-            return
-        except Exception:
-            time.sleep(1)
-    raise RuntimeError("Kafka not ready")
-
-
-def test_publish_event_via_gateway(tmp_path):
-    wait_for_kafka()
+@pytest.mark.integration
+def test_publish_event_via_gateway(tmp_path, kafka_service):
     service_script = Path(__file__).with_name("mock_event_service.py")
     event_service = (
         DockerContainer("python:3.11-slim")
-        .with_exposed_ports(5000)
-        .with_env("KAFKA_BROKERS", "host.docker.internal:9092")
+        .with_network_mode("host")
+        .with_env("KAFKA_BROKERS", kafka_service)
         .with_volume_mapping(str(service_script), "/app/service.py")
         .with_command(
-            "sh -c \"pip install fastapi uvicorn kafka-python >/tmp/pip.log && "
-            "uvicorn service:app --host 0.0.0.0 --port 5000\""
+            'sh -c "pip install fastapi uvicorn kafka-python >/tmp/pip.log && '
+            'uvicorn service:app --host 0.0.0.0 --port 5000"'
         )
     )
-    with event_service as svc:
-        s_host = svc.get_container_host_ip()
-        s_port = svc.get_exposed_port(5000)
-        wait_for_service(f"http://{s_host}:{s_port}/health")
+    with event_service:
+        wait_for_service("http://localhost:5000/health")
 
         gateway_image = DockerContainer.from_dockerfile(
             Path(".").resolve(), dockerfile="Dockerfile.gateway"
         ).build()
         gateway = (
             DockerContainer(gateway_image)
-            .with_exposed_ports(8080)
-            .with_env("APP_HOST", s_host)
-            .with_env("APP_PORT", s_port)
+            .with_network_mode("host")
+            .with_env("APP_HOST", "localhost")
+            .with_env("APP_PORT", "5000")
         )
-        with gateway as gw:
-            g_host = gw.get_container_host_ip()
-            g_port = gw.get_exposed_port(8080)
-            wait_for_service(f"http://{g_host}:{g_port}/health")
+        with gateway:
+            wait_for_service("http://localhost:8080/health")
 
             event = {
                 "event_id": "1",
@@ -72,13 +58,13 @@ def test_publish_event_via_gateway(tmp_path):
                 "access_result": "Granted",
             }
             resp = requests.post(
-                f"http://{g_host}:{g_port}/api/v1/events", json=event, timeout=30
+                "http://localhost:8080/api/v1/events", json=event, timeout=30
             )
             assert resp.status_code == 200
 
             consumer = KafkaConsumer(
                 "access-events",
-                bootstrap_servers="localhost:9092",
+                bootstrap_servers=kafka_service,
                 group_id=f"test-{time.time()}",
                 auto_offset_reset="earliest",
                 consumer_timeout_ms=5000,


### PR DESCRIPTION
## Summary
- add Kafka testcontainer fixture for integration tests
- block external network calls and file writes in unit tests
- document test categories and runtime expectations

## Testing
- `pre-commit run --files tests/conftest.py tests/integration/conftest.py tests/integration/test_gateway_kafka_event.py CONTRIBUTING.md` (fails: Function is missing a type annotation)
- `pytest --no-cov tests/test_contains_surrogates.py::test_contains_surrogates_detects_unpaired_high -q`
- `pytest --no-cov tests/integration/test_gateway_kafka_event.py::test_publish_event_via_gateway -q`

------
https://chatgpt.com/codex/tasks/task_e_689edc5af3cc8320a4f908d0f02a78d7