### PR TITLE
Add coverage enforcement and critical path tests

### DIFF
--- a/scripts/run_tests_and_smoke.sh
+++ b/scripts/run_tests_and_smoke.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Running unit tests..."
-if ! pytest --maxfail=1 --disable-warnings -q --cov=./ --cov-fail-under=80; then
+echo "Running critical path tests..."
+pytest tests/services/test_token_endpoint.py tests/test_feature_pipeline.py -q
+
+echo "Running unit tests with coverage..."
+if ! pytest --maxfail=1 --disable-warnings -q --cov=./ --cov-report=term-missing --cov-report=xml --cov-fail-under=80; then
     echo "❌ Unit tests failed"
     exit 1
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,36 @@ for _mod, _stub in [
     ("opentelemetry.instrumentation.fastapi", None),
     ("structlog", None),
     ("sklearn", None),
+    (
+        "sklearn.linear_model",
+        SimpleNamespace(
+            LogisticRegression=type(
+                "LogisticRegression", (), {"fit": lambda self, X, y: self}
+            )
+        ),
+    ),
+    (
+        "sklearn.preprocessing",
+        SimpleNamespace(
+            StandardScaler=type(
+                "StandardScaler",
+                (),
+                {
+                    "fit": lambda self, X: self,
+                    "transform": lambda self, X: X,
+                    "fit_transform": lambda self, X: X,
+                },
+            )
+        ),
+    ),
+    (
+        "sklearn.inspection",
+        SimpleNamespace(
+            permutation_importance=lambda model, X, y, n_jobs=None: SimpleNamespace(
+                importances_mean=[0] * len(X.columns)
+            )
+        ),
+    ),
     ("sklearn.ensemble", SimpleNamespace(IsolationForest=object())),
     (
         "yosai_intel_dashboard.src.infrastructure.security.query_builder",
@@ -118,6 +148,7 @@ for _mod, _stub in [
         _stub.Counter = _Metric
         _stub.Gauge = _Metric
         _stub.Histogram = _Metric
+        _stub.CollectorRegistry = object
         _stub.REGISTRY = SimpleNamespace(_names_to_collectors={})
     _register_stub(_mod, _stub)
 

--- a/tests/services/test_token_endpoint.py
+++ b/tests/services/test_token_endpoint.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+import types
+from flask import Flask
+from shared.errors.types import ErrorCode
+
+# Stub security module to avoid external dependencies
+security_stub = types.ModuleType("yosai_intel_dashboard.src.services.security")
+security_stub.refresh_access_token = lambda token: "token"
+sys.modules.setdefault("yosai_intel_dashboard.src.services.security", security_stub)
+
+# Stub monitoring dependency to avoid importing prometheus_client
+sys.modules.setdefault(
+    "yosai_intel_dashboard.src.infrastructure.monitoring.error_budget",
+    types.SimpleNamespace(record_error=lambda *a, **k: None),
+)
+
+# Stub error mapping to avoid importing yosai_framework
+sys.modules.setdefault(
+    "yosai_framework.errors",
+    types.SimpleNamespace(
+        CODE_TO_STATUS={
+            ErrorCode.INVALID_INPUT: 400,
+            ErrorCode.UNAUTHORIZED: 401,
+            ErrorCode.INTERNAL: 500,
+        }
+    ),
+)
+
+from yosai_intel_dashboard.src.services import token_endpoint
+
+
+def _make_client(monkeypatch, token):
+    monkeypatch.setattr(token_endpoint, "refresh_access_token", lambda refresh: token)
+    app = Flask(__name__)
+    app.register_blueprint(token_endpoint.create_token_blueprint())
+    return app.test_client()
+
+
+def test_refresh_token_success(monkeypatch):
+    client = _make_client(monkeypatch, "new-token")
+    resp = client.post("/v1/token/refresh", json={"refresh_token": "old"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"access_token": "new-token"}
+
+
+def test_refresh_token_invalid(monkeypatch):
+    client = _make_client(monkeypatch, None)
+    resp = client.post("/v1/token/refresh", json={"refresh_token": "bad"})
+    assert resp.status_code == 401
+    data = resp.get_json()
+    assert data["code"] == "unauthorized"
+    assert data["message"] == "invalid refresh token"


### PR DESCRIPTION
## Summary
- Run token endpoint and feature pipeline tests up front and enforce 80% coverage with an XML report
- Stub optional ML and monitoring dependencies so feature pipeline tests can execute without heavy installs
- Add focused token refresh endpoint tests

## Testing
- `pre-commit run --files scripts/run_tests_and_smoke.sh tests/conftest.py tests/services/test_token_endpoint.py` (failed: Item "None" of "SimpleNamespace | Module | None" has no attribute "REGISTRY")
- `pytest tests/services/test_token_endpoint.py tests/test_feature_pipeline.py --cov=yosai_intel_dashboard.src.services.token_endpoint --cov=yosai_intel_dashboard.models.ml.feature_pipeline --cov-report=term-missing --cov-fail-under=80 -q` (failed: Required test coverage of 80% not reached. Total coverage: 8.41%)

------
https://chatgpt.com/codex/tasks/task_e_689edc457d1083208ef8f4811481774b