### PR TITLE
feat: document database schema and indexing

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,40 @@
+# Database Schema Overview
+
+This document summarises the lightweight in-memory schemas used by the dashboard and the indexing strategies applied for efficient queries.
+
+## Entity Relationship Diagram
+
+The diagram below reflects the structures defined in `yosai_intel_dashboard/src/database` and was generated from the dataclass definitions in `migrations.py`.
+
+```mermaid
+erDiagram
+    EventRecord {
+        string name
+        datetime start
+        string category
+    }
+    TrafficEvent {
+        string event_type
+        string location
+        int delay_minutes
+        string source
+        datetime timestamp
+    }
+    InfrastructureEvent {
+        string source
+        string description
+        datetime start_time
+        datetime end_time
+    }
+```
+
+## Normalization
+
+Each table contains atomic values and has a clear primary key candidate, meeting third normal form. The separation of event types avoids update anomalies and keeps the schema extensible.
+
+## Indexing Strategy
+
+- **Events**: events are indexed by `category` to support frequent category filtering.
+- **Transport Events**: transport events maintain an index by `location` for fast lookup and aggregation.
+
+These in-memory indexes provide near constant-time access without the overhead of scanning entire collections, aligning the implementation with common database indexing practices.

--- a/yosai_intel_dashboard/src/database/events.py
+++ b/yosai_intel_dashboard/src/database/events.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -17,16 +18,25 @@ class EventRecord:
 
 
 _store: List[EventRecord] = []
+# Index events by category for faster lookups
+_by_category: Dict[str, List[EventRecord]] = defaultdict(list)
 
 
 def add_events(events: List[EventRecord]) -> None:
     """Persist a batch of events in memory."""
     _store.extend(events)
+    for event in events:
+        _by_category[event.category].append(event)
 
 
 def list_events() -> List[EventRecord]:
     """Return all stored events."""
     return list(_store)
+
+
+def get_events_by_category(category: str) -> List[EventRecord]:
+    """Return events filtered by *category* using the category index."""
+    return list(_by_category.get(category, []))
 
 
 def clear_events() -> None:
@@ -36,3 +46,4 @@ def clear_events() -> None:
     state between runs without having to reach into module internals.
     """
     _store.clear()
+    _by_category.clear()


### PR DESCRIPTION
## Summary
- add in-memory indexes for events and transport events
- document event schemas and indexing strategy with ER diagram

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/database/events.py yosai_intel_dashboard/src/database/transport_events.py docs/database.md`
- `pytest yosai_intel_dashboard/src/database` *(fails: Required test coverage of 80% not reached. Total coverage: 0.02%)*

------
https://chatgpt.com/codex/tasks/task_e_689edc08d66c8320a30d1f03276be5a5