### PR TITLE
Add baseline load tests and nightly CI workflow

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -1,0 +1,26 @@
+name: load-tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  locust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install locust psutil pyyaml
+      - name: Run load tests
+        run: load-tests/run_locust_ci.sh
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results
+          path: load-tests/results

--- a/load-tests/baseline.json
+++ b/load-tests/baseline.json
@@ -11,6 +11,12 @@
     "p95": 500,
     "p99": 800
   },
+  "/api/v1/analytics/threat_assessment": {
+    "throughput": 60,
+    "p50": 200,
+    "p95": 500,
+    "p99": 800
+  },
   "/health": {
     "throughput": 50,
     "p50": 50,

--- a/load-tests/k6/scenarios/analytics-baseline-test.js
+++ b/load-tests/k6/scenarios/analytics-baseline-test.js
@@ -1,0 +1,26 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    analytics: {
+      executor: 'constant-arrival-rate',
+      rate: 10,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 5,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+export default function () {
+  const baseUrl = 'http://localhost:8000';
+  check(http.get(`${baseUrl}/health`), { 'health ok': (r) => r.status === 200 });
+  check(http.get(`${baseUrl}/api/v1/analytics/dashboard-summary`), { 'dashboard ok': (r) => r.status === 200 });
+  check(http.get(`${baseUrl}/api/v1/analytics/access-patterns`), { 'access ok': (r) => r.status === 200 });
+  check(http.get(`${baseUrl}/api/v1/analytics/threat_assessment`), { 'threat ok': (r) => r.status === 200 });
+}

--- a/yosai_intel_dashboard/src/infrastructure/config/performance_budgets.yml
+++ b/yosai_intel_dashboard/src/infrastructure/config/performance_budgets.yml
@@ -9,6 +9,10 @@ endpoints:
     p50: 200
     p95: 500
     p99: 800
+  /api/v1/analytics/threat_assessment:
+    p50: 200
+    p95: 500
+    p99: 800
   /health:
     p50: 50
     p95: 100


### PR DESCRIPTION
## Summary
- add k6 scenario covering key analytics and health endpoints
- extend performance budgets with threat assessment baseline
- run locust-based load tests nightly and on releases to capture throughput/latency

## Testing
- `pre-commit run --files load-tests/k6/scenarios/analytics-baseline-test.js load-tests/baseline.json yosai_intel_dashboard/src/infrastructure/config/performance_budgets.yml .github/workflows/load-tests.yml`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/yosai_intel_dashboard_fresh/models/ml/model_registry.py')*

------
https://chatgpt.com/codex/tasks/task_e_689f111787008320be3fa77a787b94ec