### PR TITLE
Expose resource metrics and add graceful shutdown helpers

### DIFF
--- a/go/framework/metrics/metrics.go
+++ b/go/framework/metrics/metrics.go
@@ -49,11 +49,14 @@ func NewPrometheusCollector(addr string, hm healthHandlers, lg logging.Logger) *
 }
 
 func (p *PrometheusCollector) init() error {
-	p.registry = prometheus.NewRegistry()
-	p.reqCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "yosai_request_total",
-		Help: "Total HTTP requests",
-	}, []string{"method", "endpoint", "status"})
+        p.registry = prometheus.NewRegistry()
+        // Expose Go runtime and process metrics including CPU and memory usage.
+        p.registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+        p.registry.MustRegister(prometheus.NewGoCollector())
+        p.reqCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+                Name: "yosai_request_total",
+                Help: "Total HTTP requests",
+        }, []string{"method", "endpoint", "status"})
 	p.reqDur = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "yosai_request_duration_seconds",
 		Help:    "HTTP request duration in seconds",

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,11 +1,11 @@
 package shutdown
 
 import (
-	"context"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
+        "context"
+        "os"
+        "os/signal"
+        "syscall"
+        "time"
 )
 
 // WithTimeout returns a context that is cancelled when the timeout expires or
@@ -26,5 +26,26 @@ func WithTimeout(parent context.Context, timeout time.Duration) (context.Context
 		close(sigCh)
 	}()
 
-	return ctx, cancel
+        return ctx, cancel
+}
+
+// Notify returns a context cancelled when an interrupt or termination signal
+// is received. The returned cancel function should be called to release
+// resources once the application is shutting down.
+func Notify(parent context.Context) (context.Context, context.CancelFunc) {
+        ctx, cancel := context.WithCancel(parent)
+        sigCh := make(chan os.Signal, 1)
+        signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+        go func() {
+                select {
+                case <-sigCh:
+                        cancel()
+                case <-ctx.Done():
+                }
+                signal.Stop(sigCh)
+                close(sigCh)
+        }()
+
+        return ctx, cancel
 }

--- a/yosai_framework/service.py
+++ b/yosai_framework/service.py
@@ -17,6 +17,7 @@ from prometheus_client import (
     CollectorRegistry,
     Counter,
     Histogram,
+    ProcessCollector,
     start_http_server,
 )
 
@@ -91,6 +92,8 @@ class BaseService:
 
     def _setup_metrics(self) -> None:
         """Register Prometheus metrics and expose HTTP endpoint."""
+        if "process_cpu_seconds_total" not in REGISTRY._names_to_collectors:
+            ProcessCollector(registry=REGISTRY)
         if "yosai_request_total" not in REGISTRY._names_to_collectors:
             self.request_total = Counter(
                 "yosai_request_total", "Total requests handled"

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/app_alerts.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/app_alerts.yml
@@ -26,6 +26,14 @@ groups:
       severity: critical
     annotations:
       summary: High database query error rate
+  - alert: ConnectionLeak
+    expr: db_pool_active_connections > db_pool_current_size * 0.9
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: Potential connection leak
+      description: Database connection pool usage above 90% for 10m
 - name: error_budget
   rules:
   - alert: ErrorBudgetExhausted

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/system_threshold_rules.yml
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/prometheus/rules/system_threshold_rules.yml
@@ -17,6 +17,14 @@ groups:
         annotations:
           summary: Memory usage above 90%
           description: High memory consumption detected
+      - alert: ProcessHighMemory
+        expr: process_resident_memory_bytes > 500 * 1024 * 1024
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Process RSS above 500MB
+          description: Individual service memory usage exceeds 500MB
       - alert: HighErrorRate
         expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
         for: 5m
@@ -25,4 +33,3 @@ groups:
         annotations:
           summary: Error rate above 5%
           description: High HTTP error rate detected
-


### PR DESCRIPTION
## Summary
- expose Go runtime and process CPU/memory metrics via Prometheus
- register process metrics in Python services
- add shutdown.Notify helper for signal-triggered cancellation
- alert on connection leaks and high memory usage

## Testing
- `pre-commit run --files pkg/shutdown/shutdown.go pkg/shutdown/shutdown_test.go go/framework/metrics/metrics.go yosai_framework/service.py monitoring/prometheus/rules/app_alerts.yml monitoring/prometheus/rules/system_threshold_rules.yml`
- `go test ./shutdown -run . -v` (from pkg)
- `pytest yosai_framework -q` *(fails: Required test coverage of 80% not reached)*


------
https://chatgpt.com/codex/tasks/task_e_689f11121f248320a63b1e22c45b6243