### PR TITLE
Add secret rotation checks

### DIFF
--- a/deployment/pipeline.yaml
+++ b/deployment/pipeline.yaml
@@ -4,11 +4,17 @@ variables:
   STATEFUL_SERVICE: "dashboard-db"
 
 stages:
+  - preflight
   - build
   - canary
   - traffic_shaping
   - verify_stateful
   - blue_green
+
+rotation_check:
+  stage: preflight
+  script:
+    - python deployment/scripts/check_secret_rotation.py
 
 build:
   stage: build

--- a/deployment/scripts/check_secret_rotation.py
+++ b/deployment/scripts/check_secret_rotation.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Check secrets for rotation requirements."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from yosai_intel_dashboard.src.core.secret_manager import SecretsManager
+
+# Mapping of secret names to their required rotation frequency (in days)
+ROTATION_POLICY = {
+    "SECRET_KEY": 90,
+    "DB_PASSWORD": 30,
+}
+
+
+def _last_rotated(name: str) -> datetime | None:
+    ts = os.getenv(f"{name}_LAST_ROTATED")
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    stale: list[str] = []
+    for name, days in ROTATION_POLICY.items():
+        last_rotated = _last_rotated(name)
+        if last_rotated is None or SecretsManager.needs_rotation(last_rotated, days):
+            stale.append(name)
+    if stale:
+        print("Secrets requiring rotation: " + ", ".join(stale))
+        return 1
+    print("All secrets satisfy rotation policy.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    raise SystemExit(main())

--- a/runbooks/secret-rotation.md
+++ b/runbooks/secret-rotation.md
@@ -1,0 +1,20 @@
+# Secret Rotation
+
+Secrets must be rotated regularly to reduce the risk of compromise. Each secret stores the timestamp of its last rotation in an environment variable named `<SECRET_NAME>_LAST_ROTATED` using ISO 8601 format.
+
+## Checking rotation status
+
+Run the helper script to verify that secrets meet rotation policy:
+
+```bash
+python deployment/scripts/check_secret_rotation.py
+```
+
+The deployment pipeline runs this check automatically during the `preflight` stage.
+
+## Rotating a secret
+
+1. Generate a new secret value and update the backing store (environment variable, secret store, etc.).
+2. Restart any services that consume the secret.
+3. Set `<SECRET_NAME>_LAST_ROTATED` to the current UTC timestamp.
+4. Re-run the rotation check to confirm the secret is compliant.

--- a/tests/security/test_secret_rotation.py
+++ b/tests/security/test_secret_rotation.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+
+from yosai_intel_dashboard.src.core.secret_manager import SecretsManager
+from yosai_intel_dashboard.src.core.secrets_validator import SecretsValidator
+
+
+class DummyManager(SecretsManager):
+    def get(self, key: str, default=None):  # type: ignore[override]
+        return "x" * 32
+
+
+def test_flags_stale_secret(monkeypatch):
+    validator = SecretsValidator(DummyManager())
+    old = (datetime.utcnow() - timedelta(days=91)).isoformat()
+    monkeypatch.setenv("SECRET_KEY_LAST_ROTATED", old)
+    invalid = validator.validate_production_secrets()
+    assert "SECRET_KEY" in invalid


### PR DESCRIPTION
## Summary
- flag stale secrets using `SecretsManager.needs_rotation`
- add secret rotation check script and preflight pipeline stage
- document rotation procedures for operators

## Testing
- `pytest tests/security/test_secret_rotation.py::test_flags_stale_secret -q --override-ini=addopts=""`
- `pytest tests/security/test_secrets_validator.py::test_production_failure -q --override-ini=addopts=""` *(fails: ImportError: cannot import name 'SecureQueryBuilder' from '<unknown module name>')*
- `SECRET_KEY_LAST_ROTATED=$(date -u -d '100 days ago' +%Y-%m-%dT%H:%M:%S) DB_PASSWORD_LAST_ROTATED=$(date -u -d '10 days ago' +%Y-%m-%dT%H:%M:%S) python deployment/scripts/check_secret_rotation.py`

------
https://chatgpt.com/codex/tasks/task_e_689f110f0cf8832084785aeac0fb559b