### PR TITLE
Validate secrets and enforce secret checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
+      - name: Detect hardcoded secrets
+        run: |
+          pip install detect-secrets
+          detect-secrets-hook --baseline .secrets.baseline
       - name: Run secret scan
         run: |
           export SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,8 @@ repos:
       - id: mypy
         files: ^(services/|intel_analysis_service/)
         args: [--ignore-missing-imports, --follow-imports=skip]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]


### PR DESCRIPTION
## Summary
- require SECRET_KEY and validate required secrets at app startup
- run detect-secrets in pre-commit and CI

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/app.py .pre-commit-config.yaml .github/workflows/ci.yml`
- `pytest tests/test_secret_manager.py tests/test_app_factory_health.py -q` *(fails: DID NOT RAISE <class 'KeyError'>; '_LazyModule' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689f110e15088320b088b346ffb3b085