### PR TITLE
Add Docker fixtures and separate slow-test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,12 +119,42 @@ jobs:
       - name: Run pytest
         run: |
           set -o pipefail
-          pytest -W error --cov=. --cov-report=xml --cov-report=term | tee pytest-report.txt
+          pytest -W error -m "not slow" --cov=. --cov-report=xml --cov-report=term | tee pytest-report.txt
       - name: Upload coverage
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: backend-coverage
+          path: |
+            coverage.xml
+            pytest-report.txt
+
+  slow-tests:
+    name: Slow Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run slow tests
+        run: |
+          set -o pipefail
+          pytest -W error -m slow --cov=. --cov-report=xml --cov-report=term | tee pytest-report.txt
+      - name: Upload coverage
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: slow-coverage
           path: |
             coverage.xml
             pytest-report.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,15 +35,22 @@ have not already run the setup script:
 ## Running Tests
 
 After installing the dependencies (including those from
-`requirements-dev.txt`) you can run the tests and code quality checks:
+`requirements-dev.txt`) you can run the quick test suite and code quality checks:
 
 ```bash
-pytest
+pytest -m "not slow"
 mypy --strict .
 flake8 .
 isort --check .
 black --check .
 bandit -r .
+```
+
+To execute the slower tests that start Docker containers for Postgres, Kafka,
+and Redis use:
+
+```bash
+pytest -m slow
 ```
 
 Run `isort .` to automatically sort imports before committing changes.
@@ -109,8 +116,8 @@ Please ensure tests and linters pass before opening a pull request.
 
 | Type | Description | Approx. runtime | Command |
 | ---- | ----------- | --------------- | ------- |
-| Unit tests | No external services, network and file I/O are mocked. | < 5 minutes | `pytest -m "not integration"` |
-| Integration tests | Spin up ephemeral services (Kafka, Postgres, Redis) via Docker. Skipped when Docker is unavailable. | ~10 minutes | `pytest -m integration` |
+| Unit tests | No external services, network and file I/O are mocked. | < 5 minutes | `pytest -m "not slow"` |
+| Slow tests | Spin up ephemeral services (Kafka, Postgres, Redis) via Docker. Skipped when Docker is unavailable. | ~10 minutes | `pytest -m slow` |
 
 ## Dependency Updates
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,25 +1,9 @@
 from __future__ import annotations
 
-import shutil
-from typing import Generator
-
 import pytest
 
-try:  # pragma: no cover - optional dependency in CI
-    from testcontainers.kafka import KafkaContainer
-except Exception:  # pragma: no cover - import error handled at runtime
-    KafkaContainer = None
+from tests.conftest import kafka_service, postgres_service  # re-export fixtures
 
+pytestmark = pytest.mark.slow
 
-def _docker_available() -> bool:
-    return shutil.which("docker") is not None
-
-
-@pytest.fixture(scope="session")
-def kafka_service() -> Generator[str, None, None]:
-    """Provide an ephemeral Kafka broker for integration tests."""
-    if KafkaContainer is None or not _docker_available():
-        pytest.skip("docker or testcontainers not available")
-    with KafkaContainer() as kafka:
-        bootstrap = kafka.get_bootstrap_server().split("//", 1)[-1]
-        yield bootstrap
+__all__ = ["kafka_service", "postgres_service"]


### PR DESCRIPTION
## Summary
- provide Postgres and Kafka Docker fixtures along with in-memory mocks for DB and queues
- mark integration tests as `slow` and exclude them from the main test job
- add dedicated CI job for slow tests and document local test commands

## Testing
- `pre-commit run --files tests/conftest.py tests/integration/conftest.py .github/workflows/ci.yml CONTRIBUTING.md`
- `pytest -m "not slow" tests/test_kafka_integration.py --override-ini="addopts="`
- `pytest -m slow tests/test_kafka_integration.py --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_689f110c78588320972b70a42bb0fb85