### PR TITLE
feat(database): add transaction context manager

### DIFF
--- a/yosai_intel_dashboard/src/database/__init__.py
+++ b/yosai_intel_dashboard/src/database/__init__.py
@@ -3,6 +3,7 @@
 from .mock_database import MockDatabase
 from .protocols import ConnectionProtocol
 from .shard_resolver import ShardResolver
+from .transaction import with_transaction
 
 __all__ = [
     "DatabaseManager",
@@ -10,6 +11,7 @@ __all__ = [
     "MockDatabase",
     "ConnectionProtocol",
     "ShardResolver",
+    "with_transaction",
 ]
 
 

--- a/yosai_intel_dashboard/src/database/retry_strategy.py
+++ b/yosai_intel_dashboard/src/database/retry_strategy.py
@@ -3,9 +3,21 @@ from __future__ import annotations
 """Simple retry helper used by pooled connections.
 
 The :class:`RetryStrategy` encapsulates retry logic with exponential
-backoff.  It exposes a :meth:`run` method that executes a callable and
-will retry on failure.  Individual calls may override the configured
-``attempts`` and ``backoff`` values.
+backoff suitable for dealing with transient failures such as temporary
+network issues or database lock timeouts.  The delay doubles after each
+failed attempt which gives the remote service time to recover.  The
+strategy is intentionally lightweight – callers can override the
+default number of ``attempts`` and initial ``backoff`` delay per call to
+match the characteristics of the operation being performed.
+
+Example
+-------
+
+>>> retry = RetryStrategy(attempts=5, backoff=0.2)
+>>> retry.run(unreliable_operation)
+
+The above will attempt ``unreliable_operation`` up to five times,
+sleeping for ``0.2``, ``0.4``, ``0.8`` ... seconds between retries.
 """
 
 from dataclasses import dataclass

--- a/yosai_intel_dashboard/src/database/transaction.py
+++ b/yosai_intel_dashboard/src/database/transaction.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Context manager utilities for database transactions.
+
+The :func:`with_transaction` helper wraps a SQLAlchemy session in a
+transactional scope.  It commits on success, rolls back on error and
+always closes the session ensuring that connections are returned to the
+pool.  The function works with both synchronous :class:`~sqlalchemy.orm.Session`
+and asynchronous :class:`~sqlalchemy.ext.asyncio.AsyncSession` objects.
+"""
+
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncIterator, Iterator
+
+try:  # Optional import so tests without SQLAlchemy still run
+    from sqlalchemy.ext.asyncio import AsyncSession  # type: ignore
+    from sqlalchemy.orm import Session  # type: ignore
+except Exception:  # pragma: no cover - SQLAlchemy not installed
+    AsyncSession = object  # type: ignore
+    Session = object  # type: ignore
+
+
+@contextmanager
+def _transaction_sync(session: Session) -> Iterator[Session]:
+    """Transactional scope for synchronous sessions."""
+    try:
+        yield session
+        session.commit()
+    except Exception:  # pragma: no cover - passthrough to caller
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+@asynccontextmanager
+async def _transaction_async(session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    """Transactional scope for asynchronous sessions."""
+    try:
+        yield session
+        await session.commit()
+    except Exception:  # pragma: no cover - passthrough to caller
+        await session.rollback()
+        raise
+    finally:
+        await session.close()
+
+
+def with_transaction(session):
+    """Return a context manager wrapping *session* in a transaction.
+
+    The returned object can be used with ``with`` for synchronous sessions or
+    ``async with`` for :class:`~sqlalchemy.ext.asyncio.AsyncSession` instances.
+    """
+
+    if isinstance(session, AsyncSession):
+        return _transaction_async(session)
+    return _transaction_sync(session)
+
+
+__all__ = ["with_transaction"]


### PR DESCRIPTION
## Summary
- add `with_transaction` helper for safe session commit/rollback
- document retry strategy and timescale connect backoff
- ensure timescale manager cleans up failed pool connections

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/database/transaction.py yosai_intel_dashboard/src/database/__init__.py yosai_intel_dashboard/src/database/retry_strategy.py yosai_intel_dashboard/src/services/timescale/manager.py`
- `python -m pytest tests/integration/test_db_transactions.py tests/analytics/test_async_repository.py -q` *(fails: _RegistryEntry() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689f1109794c8320bbc8bf2e37bfdf0a