### PR TITLE
Generate ER diagram and document index strategy

### DIFF
--- a/docs/database/er_diagram.md
+++ b/docs/database/er_diagram.md
@@ -1,0 +1,11 @@
+# Entity Relationship Diagram
+
+Generated automatically from migrations.
+
+```mermaid
+erDiagram
+    access_events ||--o{ anomaly_detections : ""
+    permissions ||--o{ role_permissions : ""
+    roles ||--o{ role_permissions : ""
+    roles ||--o{ user_roles : ""
+```

--- a/migrations/007_add_composite_indexes.sql
+++ b/migrations/007_add_composite_indexes.sql
@@ -1,0 +1,5 @@
+-- Composite indexes to optimize range queries by person and door
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_person_timestamp
+    ON access_events(person_id, timestamp);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_access_events_door_timestamp
+    ON access_events(door_id, timestamp);

--- a/migrations/versions/0007_add_composite_indexes.py
+++ b/migrations/versions/0007_add_composite_indexes.py
@@ -1,0 +1,24 @@
+"""Add composite indexes for common access_event lookups"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa  # noqa:F401
+from alembic import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[1] / "007_add_composite_indexes.sql"
+    with op.get_context().autocommit_block():
+        op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_access_events_door_timestamp")
+    op.execute("DROP INDEX IF EXISTS idx_access_events_person_timestamp")

--- a/scripts/generate_er_diagram.py
+++ b/scripts/generate_er_diagram.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Generate a Mermaid ER diagram from SQL migration files.
+
+The script scans SQL files in the ``migrations`` directory for ``CREATE TABLE``
+statements and ``REFERENCES`` clauses. It then emits a Mermaid ``erDiagram``
+representation listing the foreign key relationships discovered.
+
+Usage::
+
+    python scripts/generate_er_diagram.py
+
+The resulting diagram is written to ``docs/database/er_diagram.md``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS = ROOT / "migrations"
+OUTPUT = ROOT / "docs" / "database" / "er_diagram.md"
+
+create_re = re.compile(r"^CREATE TABLE IF NOT EXISTS\s+(\w+)", re.IGNORECASE)
+ref_re = re.compile(r"REFERENCES\s+(\w+)", re.IGNORECASE)
+
+def main() -> None:
+    tables: set[str] = set()
+    relations: set[tuple[str, str]] = set()
+
+    for sql_file in sorted(MIGRATIONS.glob("*.sql")):
+        lines = sql_file.read_text().splitlines()
+        current: str | None = None
+        for raw in lines:
+            line = raw.strip()
+            m = create_re.match(line)
+            if m:
+                current = m.group(1)
+                tables.add(current)
+                continue
+            if current:
+                if line.startswith(")"):
+                    current = None
+                    continue
+                ref = ref_re.search(line)
+                if ref:
+                    parent = ref.group(1)
+                    relations.add((parent, current))
+
+    mermaid_lines = ["# Entity Relationship Diagram", "", "Generated automatically from migrations.", "", "```mermaid", "erDiagram"]
+    for parent, child in sorted(relations):
+        mermaid_lines.append(f"    {parent} ||--o{{ {child} : \"\"")
+    mermaid_lines.append("```")
+    OUTPUT.write_text("\n".join(mermaid_lines) + "\n")
+    print(f"Wrote {OUTPUT.relative_to(ROOT)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to build mermaid ER diagram from SQL migrations
- document index strategy and link generated diagram
- add composite indexes for common access_event range queries

## Testing
- `pre-commit run --files scripts/generate_er_diagram.py docs/database.md docs/database/er_diagram.md migrations/007_add_composite_indexes.sql migrations/versions/0007_add_composite_indexes.py`
- `pytest -q` *(fails: 235 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689f110827348320a8a48a3f95dca8d9