### PR TITLE
Add model registry metadata and version logging

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,49 @@
+"""Utilities for loading deployed models.
+
+This module exposes a :func:`load_model` helper used by deployment
+code to fetch a model implementation for a given version.  The metadata
+for available models is stored in ``registry.json`` within this package.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+_REGISTRY_PATH = Path(__file__).with_name("registry.json")
+
+
+def _read_registry() -> Dict[str, Any]:
+    if _REGISTRY_PATH.exists():
+        with _REGISTRY_PATH.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {}
+
+
+def load_model(version: str, name: str = "demo") -> Callable[[float], float]:
+    """Load and return a callable model implementation for ``version``.
+
+    Parameters
+    ----------
+    version:
+        The version identifier of the model to load.
+    name:
+        Optional model name.  Defaults to ``"demo"`` which is used in tests.
+
+    Returns
+    -------
+    Callable[[float], float]
+        A simple callable representing the model.  For demonstration
+        purposes models are represented as ``lambda`` functions that scale
+        the input by a factor defined in :mod:`registry.json`.
+    """
+
+    registry = _read_registry()
+    info = registry.get(name, {}).get("versions", {}).get(version)
+    if info is None:
+        raise ValueError(f"Unknown model {name} version {version}")
+    factor = float(info.get("factor", 1.0))
+    return lambda x, factor=factor: x * factor
+
+__all__ = ["load_model"]

--- a/models/registry.json
+++ b/models/registry.json
@@ -1,8 +1,8 @@
 {
   "demo": {
     "versions": {
-      "1": {"factor": 1.0},
-      "2": {"factor": 2.0}
+      "1": {"factor": 1.0, "timestamp": "2024-01-01T00:00:00Z"},
+      "2": {"factor": 2.0, "timestamp": "2024-01-02T00:00:00Z"}
     },
     "active": "1",
     "rollout": {"1": 1.0}

--- a/tests/test_model_performance_monitor.py
+++ b/tests/test_model_performance_monitor.py
@@ -18,7 +18,9 @@ cfg_mod.dynamic_config = SimpleNamespace(
     performance=SimpleNamespace(memory_usage_threshold_mb=1024)
 )
 safe_import("config", cfg_mod)
+safe_import("yosai_intel_dashboard.src.config", cfg_mod)
 safe_import("config.dynamic_config", cfg_mod)
+safe_import("yosai_intel_dashboard.src.config.dynamic_config", cfg_mod)
 
 # minimal performance monitor stub
 perf_mod = ModuleType("core.performance")
@@ -33,12 +35,14 @@ perf_mod.get_performance_monitor = lambda: SimpleNamespace(
     record_metric=lambda *a, **k: None, aggregated_metrics={}
 )
 safe_import("core.performance", perf_mod)
+safe_import("yosai_intel_dashboard.src.core.performance", perf_mod)
 
 # extend prometheus metrics stub
 prom_mod = ModuleType("monitoring.prometheus.model_metrics")
 prom_mod.update_model_metrics = lambda *a, **k: None
 prom_mod.start_model_metrics_server = lambda *a, **k: None
 safe_import("monitoring.prometheus.model_metrics", prom_mod)
+safe_import("yosai_intel_dashboard.src.infrastructure.monitoring.prometheus.model_metrics", prom_mod)
 
 # stub services.resilience.metrics to avoid heavy deps
 metrics_mod = ModuleType("services.resilience.metrics")
@@ -48,8 +52,11 @@ metrics_mod.circuit_breaker_state = SimpleNamespace(
 resilience_pkg = ModuleType("services.resilience")
 resilience_pkg.metrics = metrics_mod
 safe_import("services", ModuleType("services"))
+safe_import("yosai_intel_dashboard.src.services", ModuleType("services"))
 safe_import("services.resilience", resilience_pkg)
+safe_import("yosai_intel_dashboard.src.services.resilience", resilience_pkg)
 safe_import("services.resilience.metrics", metrics_mod)
+safe_import("yosai_intel_dashboard.src.services.resilience.metrics", metrics_mod)
 
 from yosai_intel_dashboard.src.infrastructure.monitoring import (
     model_performance_monitor as mpm,
@@ -83,12 +90,13 @@ def test_log_prediction():
     logger = SimpleNamespace(info=lambda msg, extra=None: records.append(extra))
     monitor = mpm.ModelPerformanceMonitor(logger=logger)
     ts = datetime(2024, 1, 1)
-    monitor.log_prediction("h", {"x": 1}, timestamp=ts)
+    monitor.log_prediction("h", {"x": 1}, "1", timestamp=ts)
 
     event = records[0]
     assert event["input_hash"] == "h"
     assert event["prediction"] == {"x": 1}
     assert event["timestamp"] == ts.isoformat()
+    assert event["model_version"] == "1"
 
 
 def test_detect_drift():

--- a/tests/unit/test_prediction_logging.py
+++ b/tests/unit/test_prediction_logging.py
@@ -4,7 +4,7 @@ from types import ModuleType, SimpleNamespace
 
 from yosai_intel_dashboard.src.core.imports.resolver import safe_import
 
-# Stub resilience metrics to avoid optional dependency errors
+# Stubs to avoid heavy dependency imports
 metrics_mod = ModuleType("services.resilience.metrics")
 metrics_mod.circuit_breaker_state = SimpleNamespace(
     labels=lambda *a, **k: SimpleNamespace(inc=lambda: None)
@@ -12,9 +12,46 @@ metrics_mod.circuit_breaker_state = SimpleNamespace(
 resilience_pkg = ModuleType("services.resilience")
 resilience_pkg.metrics = metrics_mod
 services_pkg = ModuleType("services")
+
+perf_mod = sys.modules.get("core.performance", ModuleType("core.performance"))
+perf_mod.MetricType = SimpleNamespace(FILE_PROCESSING="file", EXECUTION_TIME="exec")
+perf_mod.get_performance_monitor = lambda: SimpleNamespace(record_metric=lambda *a, **k: None)
+sys.modules["core.performance"] = perf_mod
+sys.modules["yosai_intel_dashboard.src.core.performance"] = perf_mod
+
+prom_mod = ModuleType("monitoring.prometheus.model_metrics")
+prom_mod.update_model_metrics = lambda *a, **k: None
+prom_mod.start_model_metrics_server = lambda *a, **k: None
+
+model_registry_stub = ModuleType("model_registry")
+model_registry_stub.ModelRecord = object
+model_registry_stub.ModelRegistry = object
+pipeline_stub = ModuleType("pipeline_contract")
+pipeline_stub.preprocess_events = lambda *a, **k: None
+security_stub = ModuleType("security_models")
+security_stub.TrainResult = object
+security_stub.train_access_anomaly_iforest = lambda *a, **k: None
+security_stub.train_online_threat_detector = lambda *a, **k: None
+security_stub.train_predictive_maintenance_lstm = lambda *a, **k: None
+security_stub.train_risk_scoring_xgboost = lambda *a, **k: None
+security_stub.train_user_clustering_dbscan = lambda *a, **k: None
+
+safe_import("monitoring.prometheus.model_metrics", prom_mod)
+safe_import("yosai_intel_dashboard.src.infrastructure.monitoring.prometheus.model_metrics", prom_mod)
+
 safe_import("services", services_pkg)
+safe_import("yosai_intel_dashboard.src.services", services_pkg)
 safe_import("services.resilience", resilience_pkg)
+safe_import("yosai_intel_dashboard.src.services.resilience", resilience_pkg)
 safe_import("services.resilience.metrics", metrics_mod)
+safe_import("yosai_intel_dashboard.src.services.resilience.metrics", metrics_mod)
+
+safe_import("yosai_intel_dashboard.models.ml.model_registry", model_registry_stub)
+safe_import("yosai_intel_dashboard.src.models.ml.model_registry", model_registry_stub)
+safe_import("yosai_intel_dashboard.models.ml.pipeline_contract", pipeline_stub)
+safe_import("yosai_intel_dashboard.src.models.ml.pipeline_contract", pipeline_stub)
+safe_import("yosai_intel_dashboard.models.ml.security_models", security_stub)
+safe_import("yosai_intel_dashboard.src.models.ml.security_models", security_stub)
 
 from yosai_intel_dashboard.models.ml.base_model import BaseModel, ModelMetadata
 from yosai_intel_dashboard.src.infrastructure.monitoring import (
@@ -44,6 +81,7 @@ def test_prediction_logged(monkeypatch):
     assert event["prediction"] == {"out": "foo"}
     assert "input_hash" in event
     assert "timestamp" in event
+    assert event["model_version"] == model.metadata.version
 
 
 def test_env_toggle(monkeypatch):

--- a/unit_tests/test_model_loader.py
+++ b/unit_tests/test_model_loader.py
@@ -1,0 +1,9 @@
+from models import load_model
+
+
+def test_load_model_versions():
+    model_v1 = load_model("1")
+    model_v2 = load_model("2")
+
+    assert model_v1(3) == 3  # factor 1.0
+    assert model_v2(3) == 6  # factor 2.0

--- a/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_monitor.py
+++ b/yosai_intel_dashboard/src/infrastructure/monitoring/model_performance_monitor.py
@@ -56,6 +56,7 @@ class ModelPerformanceMonitor:
         self,
         input_hash: str,
         prediction: Any,
+        model_version: str,
         timestamp: Optional[datetime] = None,
     ) -> None:
         """Emit a prediction event via the configured logger."""
@@ -66,6 +67,7 @@ class ModelPerformanceMonitor:
                 "input_hash": input_hash,
                 "prediction": prediction,
                 "timestamp": ts.isoformat(),
+                "model_version": model_version,
             },
         )
 

--- a/yosai_intel_dashboard/src/models/ml/base_model.py
+++ b/yosai_intel_dashboard/src/models/ml/base_model.py
@@ -142,7 +142,7 @@ class BaseModel(ABC):
         if log_prediction:
             monitor = get_model_performance_monitor()
             input_hash = self._hash_input(prepared)
-            monitor.log_prediction(input_hash, result, datetime.utcnow())
+            monitor.log_prediction(input_hash, result, self.metadata.version, datetime.utcnow())
 
         return result
 

--- a/yosai_intel_dashboard/src/services/model_service.py
+++ b/yosai_intel_dashboard/src/services/model_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import random
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Tuple
 
@@ -30,8 +31,12 @@ class ModelService:
                 self._models[name][ver] = lambda x, factor=factor: x * factor
 
     def register_model(self, name: str, version: str, metadata: Dict[str, Any]) -> None:
-        meta = self._registry.setdefault(name, {"versions": {}, "active": version, "rollout": {}})
-        meta["versions"][version] = metadata
+        meta = self._registry.setdefault(
+            name, {"versions": {}, "active": version, "rollout": {}}
+        )
+        entry = dict(metadata)
+        entry.setdefault("timestamp", datetime.utcnow().isoformat())
+        meta["versions"][version] = entry
         meta["rollout"].setdefault(version, 1.0)
         self._save()
         self._load_registry()
@@ -75,4 +80,3 @@ class ModelService:
 
     def list_models(self) -> Dict[str, Any]:
         return self._registry
-


### PR DESCRIPTION
## Summary
- track model versions with timestamps via `models/registry.json`
- provide `load_model` helper for deployment
- log model version alongside predictions

## Testing
- `pytest tests/test_model_performance_monitor.py tests/unit/test_prediction_logging.py unit_tests/test_model_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1102f790832091ccec047369770a