### PR TITLE
feat: add unified FastAPI error middleware

### DIFF
--- a/openapi/components.yaml
+++ b/openapi/components.yaml
@@ -1,5 +1,6 @@
 schemas:
   ErrorResponse:
+    description: Standard error response returned by services
     type: object
     required:
       - code

--- a/yosai_intel_dashboard/src/error_handling/api_error_response.py
+++ b/yosai_intel_dashboard/src/error_handling/api_error_response.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import Response, jsonify
+from flask import Response, jsonify, has_app_context
 
 from shared.errors.types import CODE_TO_STATUS, ErrorCode
 
@@ -16,9 +16,21 @@ def api_error_response(
     *,
     handler: ErrorHandler | None = None,
     details: Any | None = None,
-) -> tuple[Response, int]:
-    """Return a JSON error response for *exc* using ``ErrorHandler``."""
+) -> tuple[Response | dict[str, Any], int]:
+    """Return a JSON error response for *exc* using ``ErrorHandler``.
+
+    When called within a Flask application context the first element of the
+    returned tuple is a :class:`flask.Response` generated via ``jsonify``.  If
+    no Flask context is active (e.g. when used by FastAPI middleware) a plain
+    ``dict`` payload is returned instead.  This allows the same helper to be
+    used by both Flask and FastAPI services while preserving the response
+    format.
+    """
+
     h = handler or ErrorHandler()
     err = h.handle(exc, category, details)
     status = CODE_TO_STATUS.get(ErrorCode(err.category.value), 500)
-    return jsonify(err.to_dict()), status
+    payload: dict[str, Any] = err.to_dict()
+    if has_app_context():
+        return jsonify(payload), status
+    return payload, status

--- a/yosai_intel_dashboard/src/error_handling/middleware.py
+++ b/yosai_intel_dashboard/src/error_handling/middleware.py
@@ -1,11 +1,12 @@
 """FastAPI middleware for unified error responses."""
 
-from fastapi import Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from shared.errors.types import CODE_TO_STATUS, ErrorCode
+from shared.errors.types import ErrorResponse
 
+from .api_error_response import api_error_response
 from .core import ErrorHandler
 from .exceptions import ErrorCategory
 
@@ -13,7 +14,7 @@ from .exceptions import ErrorCategory
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):
     """Transform uncaught exceptions into standard error responses."""
 
-    def __init__(self, app, handler: ErrorHandler | None = None) -> None:
+    def __init__(self, app: FastAPI, handler: ErrorHandler | None = None) -> None:
         super().__init__(app)
         self.handler = handler or ErrorHandler()
 
@@ -21,9 +22,41 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
         try:
             return await call_next(request)
         except Exception as exc:  # noqa: BLE001
-            err = self.handler.handle(exc, ErrorCategory.INTERNAL)
-            status = CODE_TO_STATUS.get(ErrorCode(err.category.value), 500)
-            return JSONResponse(content=err.to_dict(), status_code=status)
+            payload, status = api_error_response(
+                exc, ErrorCategory.INTERNAL, handler=self.handler
+            )
+            body = payload.get_json() if hasattr(payload, "get_json") else payload
+            return JSONResponse(content=body, status_code=status)
+
+    @classmethod
+    def setup(cls, app: FastAPI, handler: ErrorHandler | None = None) -> None:
+        """Add the middleware to *app* and document the error schema."""
+        app.add_middleware(cls, handler=handler)
+        _ensure_error_schema(app)
+
+
+def _ensure_error_schema(app: FastAPI) -> None:
+    """Ensure the ``ErrorResponse`` schema is present in the OpenAPI spec."""
+
+    if hasattr(app, "_error_schema_registered"):
+        return
+
+    original_openapi = app.openapi
+
+    def custom_openapi() -> dict:  # pragma: no cover - executed when generating docs
+        if app.openapi_schema is not None:
+            return app.openapi_schema
+        schema = original_openapi()
+        components = schema.setdefault("components", {}).setdefault("schemas", {})
+        components.setdefault(
+            "ErrorResponse",
+            ErrorResponse.model_json_schema(ref_template="#/components/schemas/{model}"),
+        )
+        app.openapi_schema = schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi  # type: ignore[assignment]
+    setattr(app, "_error_schema_registered", True)
 
 
 __all__ = ["ErrorHandlingMiddleware"]


### PR DESCRIPTION
## Summary
- allow `api_error_response` to return plain dicts when Flask context missing
- map FastAPI exceptions through `api_error_response` and document error schema
- describe `ErrorResponse` in shared OpenAPI components and add tests

## Testing
- `pre-commit run --files yosai_intel_dashboard/src/error_handling/api_error_response.py yosai_intel_dashboard/src/error_handling/middleware.py openapi/components.yaml tests/test_api_error_response.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_api_error_response.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689f11029cf883209711d92556bca0e1