### PR TITLE
feat: add role-based protection

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from services.api.middleware.body_size_limit import BodySizeLimitMiddleware
 from services.api.middleware.security_headers import SecurityHeadersMiddleware
+from yosai_intel_dashboard.src.services.security import requires_role
 
 app = FastAPI()
 app.add_middleware(BodySizeLimitMiddleware, max_bytes=50 * 1024 * 1024)
 app.add_middleware(SecurityHeadersMiddleware)
+
 
 @app.route("/health")
 async def health(request: Request) -> JSONResponse:
@@ -25,5 +27,7 @@ class EchoResponse(BaseModel):
 
 
 @app.post("/api/v1/echo", response_model=EchoResponse)
-async def echo(body: EchoRequest) -> EchoResponse:
+async def echo(
+    body: EchoRequest, _: None = Depends(requires_role("admin"))
+) -> EchoResponse:
     return EchoResponse(message=body.message)

--- a/tests/integration/test_requires_role.py
+++ b/tests/integration/test_requires_role.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+import pytest
+from httpx import AsyncClient
+
+# Provide a stub secrets module to avoid Vault dependency during import
+secrets_stub = types.ModuleType("yosai_intel_dashboard.src.services.common.secrets")
+secrets_stub.get_secret = lambda key: "test"
+secrets_stub.invalidate_secret = lambda key=None: None
+sys.modules["yosai_intel_dashboard.src.services.common.secrets"] = secrets_stub
+sys.modules["graphene"] = None
+sys.modules["fastapi.graphql"] = None
+
+from services.api.main import app as api_app
+from yosai_intel_dashboard.src.services.intel_analysis_service.api.service import (
+    app as intel_app,
+)
+
+
+@pytest.mark.anyio
+async def test_api_echo_requires_admin_role():
+    async with AsyncClient(app=api_app, base_url="http://test") as client:
+        resp = await client.post("/api/v1/echo", json={"message": "hi"})
+        assert resp.status_code == 403
+        resp = await client.post(
+            "/api/v1/echo", json={"message": "hi"}, headers={"X-Roles": "admin"}
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_intel_service_requires_analyst_role():
+    async with AsyncClient(app=intel_app, base_url="http://test") as client:
+        resp = await client.get("/api/v1/status")
+        assert resp.status_code == 403
+        resp = await client.get("/api/v1/status", headers={"X-Roles": "analyst"})
+        assert resp.status_code == 200

--- a/yosai_intel_dashboard/src/services/analytics_microservice/app.py
+++ b/yosai_intel_dashboard/src/services/analytics_microservice/app.py
@@ -13,6 +13,7 @@ from typing import Dict
 import os
 
 from fastapi import Depends, FastAPI
+from yosai_intel_dashboard.src.services.security import requires_role
 
 from yosai_intel_dashboard.src.services.analytics_service import (
     create_analytics_service,
@@ -68,7 +69,10 @@ service = create_analytics_service()
 
 
 @app.get("/api/v1/analytics/dashboard-summary")
-async def dashboard_summary(_: dict = Depends(verify_token)) -> Dict[str, object]:
+async def dashboard_summary(
+    _: dict = Depends(verify_token),
+    __: None = Depends(requires_role("analyst")),
+) -> Dict[str, object]:
     """Return a summary of analytics data."""
     return service.get_dashboard_summary()
 
@@ -78,6 +82,7 @@ async def dashboard_summary(_: dict = Depends(verify_token)) -> Dict[str, object
 async def access_patterns(
     days: int = 7,
     _: dict = Depends(verify_token),
+    __: None = Depends(requires_role("analyst")),
 ) -> Dict[str, object]:
     """Return access pattern analytics.
 

--- a/yosai_intel_dashboard/src/services/intel_analysis_service/api/service.py
+++ b/yosai_intel_dashboard/src/services/intel_analysis_service/api/service.py
@@ -10,7 +10,8 @@ dependency.  If the package is not installed the endpoint will raise an
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from yosai_intel_dashboard.src.services.security import requires_role
 
 try:
     import graphene
@@ -24,7 +25,7 @@ app = FastAPI(title="Intel Analysis Service")
 
 
 @app.get("/api/v1/status")
-def status() -> dict[str, str]:
+def status(_: None = Depends(requires_role("analyst"))) -> dict[str, str]:
     """Basic health endpoint for REST clients."""
 
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add reusable `requires_role` decorator for FastAPI services
- secure service endpoints with role requirements
- cover authorized and unauthorized access in tests

## Testing
- `pytest tests/integration/test_requires_role.py` *(fails: File write outside tmp directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f11005aec83208aa7a9ba17d42d43