### PR TITLE
refactor: centralize error helpers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,8 @@ max-line-length = 88
 extend-ignore = E203,W503
 exclude = .git,pycache,build,dist,.venv,.eggs,venv,.mypy_cache,.pytest_cache,config/generated
 
+[flake8:local-plugins]
+extension =
+    ERH = flake8_error_helpers:ErrorHelperChecker
+paths = ./tools
+

--- a/shared/errors/helpers.py
+++ b/shared/errors/helpers.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+from .types import CODE_TO_STATUS, ErrorCode
+
+
+@dataclass
+class ServiceError(Exception):
+    """Represents a standardized service error."""
+
+    code: ErrorCode | str
+    message: str
+    details: Optional[Any] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code.value if isinstance(self.code, ErrorCode) else self.code,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+def from_exception(exc: Exception) -> "ServiceError":
+    """Create a ``ServiceError`` from any exception."""
+    if isinstance(exc, ServiceError):
+        return exc
+    try:
+        from yosai_intel_dashboard.src.core.exceptions import (  # type: ignore
+            YosaiBaseException,
+        )
+    except Exception:  # pragma: no cover - imported lazily
+        YosaiBaseException = Exception  # type: ignore
+    if isinstance(exc, YosaiBaseException):
+        return ServiceError(
+            exc.error_code,
+            getattr(exc, "message", str(exc)),
+            getattr(exc, "details", None),
+        )
+    return ServiceError(ErrorCode.INTERNAL, str(exc))
+
+
+def error_response(
+    error: ServiceError, status_code: Optional[int] = None
+) -> Tuple[dict[str, Any], int]:
+    """Return a JSON serialisable body and status code for the error."""
+    status = status_code
+    if status is None:
+        code = error.code if isinstance(error.code, ErrorCode) else ErrorCode.INTERNAL
+        status = CODE_TO_STATUS.get(code, 500)
+    return error.to_dict(), status
+
+
+__all__ = ["ServiceError", "from_exception", "error_response"]

--- a/tools/flake8_error_helpers.py
+++ b/tools/flake8_error_helpers.py
@@ -1,0 +1,45 @@
+"""Flake8 plugin to disallow duplicate error helper definitions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator, Tuple
+
+
+class ErrorHelperChecker:
+    """Detect duplicate error helper definitions outside shared package."""
+
+    name = "error-helper-checker"
+    version = "0.1.0"
+
+    def __init__(self, tree: ast.AST, filename: str) -> None:
+        self.tree = tree
+        self.filename = filename
+
+    def run(self) -> Iterator[Tuple[int, int, str, type]]:
+        # pragma: no cover - flake8 hook
+        path = Path(self.filename)
+        if "tests" in path.parts or path.match("*.pyi"):
+            return
+        if "shared" in path.parts and "errors" in path.parts:
+            return
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "CODE_TO_STATUS":
+                        yield (
+                            node.lineno,
+                            node.col_offset,
+                            "ERH001 duplicate CODE_TO_STATUS mapping; "
+                            "use shared.errors.types",
+                            type(self),
+                        )
+            if isinstance(node, ast.ClassDef) and node.name == "ServiceError":
+                yield (
+                    node.lineno,
+                    node.col_offset,
+                    "ERH002 duplicate ServiceError definition; "
+                    "use shared.errors.helpers",
+                    type(self),
+                )

--- a/yosai_framework/errors.py
+++ b/yosai_framework/errors.py
@@ -1,57 +1,10 @@
-from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from shared.errors.types import CODE_TO_STATUS, ErrorCode
+from shared.errors.helpers import ServiceError, from_exception, error_response
 
-from shared.errors.types import ErrorCode
-
-# Mapping of error codes to HTTP status codes
-CODE_TO_STATUS: dict[ErrorCode, int] = {
-    ErrorCode.INVALID_INPUT: 400,
-    ErrorCode.UNAUTHORIZED: 401,
-    ErrorCode.NOT_FOUND: 404,
-    ErrorCode.INTERNAL: 500,
-    ErrorCode.UNAVAILABLE: 503,
-}
-
-
-@dataclass
-class ServiceError(Exception):
-    """Represents a standardized service error."""
-
-    code: ErrorCode | str
-    message: str
-    details: Optional[Any] = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "code": self.code.value if isinstance(self.code, ErrorCode) else self.code,
-            "message": self.message,
-            "details": self.details,
-        }
-
-
-def from_exception(exc: Exception) -> "ServiceError":
-    """Create a ``ServiceError`` from any exception."""
-    if isinstance(exc, ServiceError):
-        return exc
-    try:
-        from yosai_intel_dashboard.src.core.exceptions import YosaiBaseException
-    except Exception:
-        YosaiBaseException = Exception  # type: ignore
-    if isinstance(exc, YosaiBaseException):
-        return ServiceError(
-            exc.error_code,
-            getattr(exc, "message", str(exc)),
-            getattr(exc, "details", None),
-        )
-    return ServiceError(ErrorCode.INTERNAL, str(exc))
-
-
-def error_response(
-    error: ServiceError, status_code: Optional[int] = None
-) -> Tuple[dict[str, Any], int]:
-    """Return a JSON serialisable body and status code for the error."""
-    status = status_code
-    if status is None:
-        code = error.code if isinstance(error.code, ErrorCode) else ErrorCode.INTERNAL
-        status = CODE_TO_STATUS.get(code, 500)
-    return error.to_dict(), status
+__all__ = [
+    "ErrorCode",
+    "CODE_TO_STATUS",
+    "ServiceError",
+    "from_exception",
+    "error_response",
+]

--- a/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
+++ b/yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py
@@ -6,17 +6,9 @@ from flask import Flask, jsonify
 from werkzeug.exceptions import HTTPException
 
 from yosai_intel_dashboard.src.core.exceptions import YosaiBaseException
-from shared.errors.types import ErrorCode
+from shared.errors.types import CODE_TO_STATUS, ErrorCode
 
 from ...core.error_handling import ErrorCategory, ErrorSeverity, error_handler
-
-_CODE_TO_STATUS: dict[ErrorCode, int] = {
-    ErrorCode.INVALID_INPUT: 400,
-    ErrorCode.UNAUTHORIZED: 401,
-    ErrorCode.NOT_FOUND: 404,
-    ErrorCode.INTERNAL: 500,
-    ErrorCode.UNAVAILABLE: 503,
-}
 
 
 def _json_body(code: ErrorCode | str, message: str, details: Optional[Any] = None):
@@ -29,18 +21,22 @@ def register_error_handlers(app: Flask) -> None:
     """Register global JSON error handlers on *app*."""
 
     @app.errorhandler(YosaiBaseException)
-    def _handle_yosai_error(error: YosaiBaseException):  # type: ignore[missing-return-type]
+    def _handle_yosai_error(
+        error: YosaiBaseException,
+    ):  # type: ignore[missing-return-type]
         error_handler.handle_error(
             error,
             category=ErrorCategory.USER_INPUT,
             severity=ErrorSeverity.MEDIUM,
             context={"code": error.error_code.value, "message": error.message},
         )
-        status = _CODE_TO_STATUS.get(error.error_code, 500)
+        status = CODE_TO_STATUS.get(error.error_code, 500)
         return _json_body(error.error_code, error.message, error.details), status
 
     @app.errorhandler(HTTPException)
-    def _handle_http_exception(error: HTTPException):  # type: ignore[missing-return-type]
+    def _handle_http_exception(
+        error: HTTPException,
+    ):  # type: ignore[missing-return-type]
         code = error.code or 500
         mapping = {
             400: ErrorCode.INVALID_INPUT,


### PR DESCRIPTION
## Summary
- centralize ServiceError and helpers in shared package
- reuse shared error mappings throughout modules
- add flake8 plugin blocking duplicate error helpers

## Testing
- `flake8 shared/errors/helpers.py yosai_framework/errors.py yosai_intel_dashboard/src/infrastructure/error_handling/handlers.py tools/flake8_error_helpers.py`
- `pytest tests/test_framework_errors.py tests/test_fastapi_error_handler.py` *(fails: ImportError: cannot import name 'JaegerExporter' from 'thrift')*


------
https://chatgpt.com/codex/tasks/task_e_689f10fb2d608320ae343a48f3c52bcd