### PR TITLE
Harden model registry unpickling with checksum verification

### DIFF
--- a/docs/security/model_registry.md
+++ b/docs/security/model_registry.md
@@ -1,0 +1,17 @@
+# Model Registry Security
+
+The model registry stores serialized models on disk. Serialized Python objects
+can execute arbitrary code when unpickled, so the registry applies two layers of
+defense:
+
+1. **Checksum verification** – The registry computes a SHA256 hash for each
+   stored model. When loading, the hash of the stored file must match the
+   checksum recorded in the metadata. Any modification of the file results in a
+   checksum mismatch and the load is aborted.
+2. **Restricted unpickling** – After verifying integrity, models are loaded with
+   a custom `pickle.Unpickler` that only allows explicitly whitelisted classes
+   (`AnomalyDetector` and `RiskScorer`). Attempts to deserialize other objects
+   raise `pickle.UnpicklingError`.
+
+These measures prevent tampering and block malicious payloads that might try to
+execute code during deserialization.

--- a/intel_analysis_service/ml/__init__.py
+++ b/intel_analysis_service/ml/__init__.py
@@ -1,8 +1,15 @@
 """Machine learning utilities for the intel analysis service."""
 
 from .feature_pipeline import build_context_features
-from .models import AnomalyDetector, DriftDetector, RiskScorer
 from .drift import ThresholdDriftDetector
+from .model_registry import ModelRegistry, ModelMetadata
+from .models import (
+    AnomalyDetector,
+    DriftDetector,
+    RiskScorer,
+    load_anomaly_model,
+    load_risk_model,
+)
 
 __all__ = [
     "build_context_features",
@@ -10,4 +17,8 @@ __all__ = [
     "DriftDetector",
     "RiskScorer",
     "ThresholdDriftDetector",
+    "ModelRegistry",
+    "ModelMetadata",
+    "load_anomaly_model",
+    "load_risk_model",
 ]

--- a/intel_analysis_service/ml/model_registry.py
+++ b/intel_analysis_service/ml/model_registry.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import io
 import json
 import pickle
+import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from hashlib import sha256
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 
 @dataclass
@@ -15,6 +18,23 @@ class ModelMetadata:
     version: str
     timestamp: str
     parameters: Dict[str, Any]
+    checksum: str
+
+
+ALLOWED_CLASSES: Iterable[Tuple[str, str]] = (
+    ("intel_analysis_service.ml.models", "AnomalyDetector"),
+    ("intel_analysis_service.ml.models", "RiskScorer"),
+)
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that only allows a predefined set of classes."""
+
+    def find_class(self, module: str, name: str) -> Any:  # pragma: no cover - small wrapper
+        if (module, name) in ALLOWED_CLASSES:
+            __import__(module)
+            return getattr(sys.modules[module], name)
+        raise pickle.UnpicklingError(f"Global '{module}.{name}' is forbidden")
 
 
 class ModelRegistry:
@@ -37,15 +57,18 @@ class ModelRegistry:
         """Persist *model* under *name* and return its metadata."""
 
         version = version or datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        data = pickle.dumps(model)
+        checksum = sha256(data).hexdigest()
         metadata = ModelMetadata(
             version=version,
             timestamp=datetime.utcnow().isoformat(),
             parameters=parameters,
+            checksum=checksum,
         )
         model_dir = self._model_dir(name, version)
         model_dir.mkdir(parents=True, exist_ok=True)
         with open(model_dir / "model.pkl", "wb") as fh:
-            pickle.dump(model, fh)
+            fh.write(data)
         with open(model_dir / "metadata.json", "w") as fh:
             json.dump(asdict(metadata), fh)
         return metadata
@@ -54,10 +77,13 @@ class ModelRegistry:
         """Load *name* model for *version* returning model and metadata."""
 
         model_dir = self._model_dir(name, version)
-        with open(model_dir / "model.pkl", "rb") as fh:
-            model = pickle.load(fh)
         with open(model_dir / "metadata.json") as fh:
             metadata = ModelMetadata(**json.load(fh))
+        with open(model_dir / "model.pkl", "rb") as fh:
+            data = fh.read()
+        if sha256(data).hexdigest() != metadata.checksum:
+            raise ValueError("Model checksum mismatch")
+        model = _RestrictedUnpickler(io.BytesIO(data)).load()
         return model, metadata
 
 

--- a/tests/ml/test_model_registry_security.py
+++ b/tests/ml/test_model_registry_security.py
@@ -1,0 +1,36 @@
+import json
+import pickle
+from datetime import datetime
+from hashlib import sha256
+
+import pytest
+
+from intel_analysis_service.ml.model_registry import ModelRegistry
+
+
+class Malicious:
+    def __reduce__(self):
+        import os
+        return (os.system, ("echo hacked",))
+
+
+def test_malicious_pickle_rejected(tmp_path):
+    registry = ModelRegistry(tmp_path)
+    model_dir = registry._model_dir("bad", "v1")
+    model_dir.mkdir(parents=True)
+
+    payload = pickle.dumps(Malicious())
+    checksum = sha256(payload).hexdigest()
+    with open(model_dir / "model.pkl", "wb") as fh:
+        fh.write(payload)
+    metadata = {
+        "version": "v1",
+        "timestamp": datetime.utcnow().isoformat(),
+        "parameters": {},
+        "checksum": checksum,
+    }
+    with open(model_dir / "metadata.json", "w") as fh:
+        json.dump(metadata, fh)
+
+    with pytest.raises(pickle.UnpicklingError):
+        registry.load_model("bad", "v1")


### PR DESCRIPTION
## Summary
- compute and store SHA256 checksum for persisted models
- restrict `pickle` loading to known classes via custom `Unpickler`
- document model registry security considerations
- add test ensuring malicious pickle payloads are rejected

## Testing
- `pytest --override-ini="addopts=" tests/ml/test_model_registry_security.py -q`
- `pytest --override-ini="addopts=" tests/ml/test_model_persistence.py tests/ml/test_model_registry_security.py -q` *(fails: module 'pandas' has no attribute 'date_range')*

------
https://chatgpt.com/codex/tasks/task_e_689f23f9fd108320a8f2e94e6cf5ee0c