### PR TITLE
feat: add streaming join fallback and benchmarks

### DIFF
--- a/intel_analysis_service/ml/benchmark_feature_pipeline.py
+++ b/intel_analysis_service/ml/benchmark_feature_pipeline.py
@@ -5,6 +5,7 @@ of :func:`build_context_features` on large datasets.  It compares the
 standard pandas merge implementation with the optional pyarrow-based
 implementation when pyarrow is available.
 """
+
 from __future__ import annotations
 
 import time
@@ -15,8 +16,12 @@ import numpy as np
 import pandas as pd
 
 import sys
-sys.path.append(str(Path(__file__).resolve().parent))
-from feature_pipeline import build_context_features, _HAVE_ARROW  # type: ignore
+
+try:
+    from .feature_pipeline import build_context_features, _HAVE_ARROW  # type: ignore
+except ImportError:  # pragma: no cover - script execution fallback
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from feature_pipeline import build_context_features, _HAVE_ARROW  # type: ignore
 
 
 def _make_stream(name: str, n: int) -> pd.DataFrame:
@@ -25,28 +30,58 @@ def _make_stream(name: str, n: int) -> pd.DataFrame:
     return pd.DataFrame({"timestamp": ts, name: data})
 
 
-def run_benchmark(n: int = 100_000) -> Dict[str, float]:
+def run_benchmark(n: int = 100_000, chunk_size: int = 100_000) -> Dict[str, float]:
     weather = _make_stream("weather", n)
     events = _make_stream("events", n)
     transport = _make_stream("transport", n)
     social = _make_stream("social", n)
     infra = _make_stream("infra", n)
 
+    # Legacy pandas merge
     start = time.perf_counter()
     build_context_features(
-        weather, events, transport, social, infra, use_pyarrow=False
+        weather,
+        events,
+        transport,
+        social,
+        infra,
+        use_pyarrow=False,
+        streaming=False,
     )
-    pandas_time = time.perf_counter() - start
+    pandas_legacy = time.perf_counter() - start
+
+    # Streaming pandas join
+    start = time.perf_counter()
+    build_context_features(
+        weather,
+        events,
+        transport,
+        social,
+        infra,
+        use_pyarrow=False,
+        streaming=True,
+        chunk_size=chunk_size,
+    )
+    pandas_stream = time.perf_counter() - start
 
     arrow_time = None
     if _HAVE_ARROW:
         start = time.perf_counter()
         build_context_features(
-            weather, events, transport, social, infra, use_pyarrow=True
+            weather,
+            events,
+            transport,
+            social,
+            infra,
+            use_pyarrow=True,
         )
         arrow_time = time.perf_counter() - start
 
-    return {"pandas": pandas_time, "pyarrow": arrow_time}
+    return {
+        "pandas_legacy": pandas_legacy,
+        "pandas_stream": pandas_stream,
+        "pyarrow": arrow_time,
+    }
 
 
 if __name__ == "__main__":
@@ -54,6 +89,6 @@ if __name__ == "__main__":
     print("Benchmark results (seconds):")
     for k, v in results.items():
         if v is not None:
-            print(f"  {k:7s}: {v:.3f}")
+            print(f"  {k:13s}: {v:.3f}")
         else:
-            print(f"  {k:7s}: not run")
+            print(f"  {k:13s}: not run")


### PR DESCRIPTION
## Summary
- profile build_context_features and introduce streaming pandas join as fallback
- add benchmarking harness comparing legacy merge, streaming join, and pyarrow

## Testing
- `pytest tests/ml/test_context_models.py::test_build_context_features_merges_sources -q --no-cov`
- `pre-commit run --files intel_analysis_service/ml/feature_pipeline.py intel_analysis_service/ml/benchmark_feature_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_689f23fae58c83208ea8d99395239a05