### PR TITLE
Fix callback registration wrapper

### DIFF
--- a/tests/test_callback_registration_helpers.py
+++ b/tests/test_callback_registration_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import types
+from typing import Any
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
     DashCallbackRegistration,
@@ -27,10 +28,10 @@ def make_manager() -> TrulyUnifiedCallbacks:
     return TrulyUnifiedCallbacks(DummyDash(), security_validator=object())
 
 
-def test_validate_registration_normalizes_args():
+def test_validate_registration_normalizes_args_and_duplicate_id():
     manager = make_manager()
     outs, ins, states, ins_arg, states_arg = manager._validate_registration(
-        DummyIO("o", "children"), DummyIO("i", "value"), DummyIO("s", "data")
+        "cid", DummyIO("o", "children"), DummyIO("i", "value"), DummyIO("s", "data")
     )
     assert outs[0].component_id == "o"
     assert ins[0].component_id == "i"
@@ -38,9 +39,6 @@ def test_validate_registration_normalizes_args():
     assert ins_arg is not None
     assert states_arg is not None
 
-
-def test_resolve_conflicts_duplicate_id():
-    manager = make_manager()
     manager._dash_callbacks["cid"] = DashCallbackRegistration(
         callback_id="cid",
         component_name="comp",
@@ -49,44 +47,60 @@ def test_resolve_conflicts_duplicate_id():
         states=(),
     )
     with pytest.raises(ValueError):
-        manager._resolve_conflicts("cid", (DummyIO("o", "children"),), False)
+        manager._validate_registration("cid", DummyIO("o", "c"), None, None)
 
 
 def test_wrap_callback_invokes_dash(monkeypatch):
     manager = make_manager()
 
-    # Provide stub module to avoid importing heavy dependencies
-    dummy_module = types.SimpleNamespace(wrap_callback=lambda f, o, s: f)
+    captured = {}
+
+    # Provide stub module to capture wrap_callback usage
+    def fake_wrap(func, outputs, security):
+        captured["func"] = func
+        captured["outputs"] = outputs
+        captured["security"] = security
+        return func
+
+    dummy_module = types.SimpleNamespace(wrap_callback=fake_wrap)
     sys.modules[
         "yosai_intel_dashboard.src.core.dash_callback_middleware"
     ] = dummy_module
 
-    captured = {}
-
-    def fake_callback(outputs, inputs, states, **kwargs):
-        captured["args"] = (outputs, inputs, states, kwargs)
-
-        def inner(func):
-            captured["func"] = func
-            return func
-
-        return inner
-
-    manager.app.callback = fake_callback  # type: ignore[assignment]
-
     def handler():
         return "ok"
 
-    result = manager._wrap_callback(
-        handler,
-        DummyIO("o", "children"),
-        None,
-        tuple(),
-        None,
-        tuple(),
-        (DummyIO("o", "children"),),
-    )
+    result = manager._wrap_callback(handler, (DummyIO("o", "children"),))
 
     assert result is handler
     assert captured["func"] is handler
-    assert captured["args"][0].component_id == "o"
+    assert captured["outputs"][0].component_id == "o"
+
+
+def test_handle_register_registers_callback(monkeypatch):
+    manager = make_manager()
+
+    wrapped_calls: dict[str, Any] = {}
+
+    def fake_wrap(func, outputs_tuple):
+        wrapped_calls["func"] = func
+        wrapped_calls["outputs"] = outputs_tuple
+        return func
+
+    monkeypatch.setattr(manager, "_wrap_callback", fake_wrap)
+
+    outputs = DummyIO("o", "children")
+    decorator = manager.handle_register(
+        outputs, callback_id="cid", component_name="comp"
+    )
+
+    def handler() -> str:
+        return "ok"
+
+    result = decorator(handler)
+
+    assert wrapped_calls["func"] is handler
+    assert manager._dash_callbacks["cid"].outputs[0].component_id == "o"
+    assert manager._output_map["o.children"] == "cid"
+    assert manager._namespaces["comp"] == ["cid"]
+    assert result is handler

--- a/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
+++ b/yosai_intel_dashboard/src/infrastructure/callbacks/unified_callbacks.py
@@ -188,9 +188,13 @@ class TrulyUnifiedCallbacks(EventPublisher):
 
     # ------------------------------------------------------------------
     def _validate_registration(
-        self, outputs: Outputs, inputs: Inputs, states: States
+        self,
+        callback_id: str,
+        outputs: Outputs,
+        inputs: Inputs,
+        states: States,
     ) -> tuple[tuple[Output, ...], tuple[Input, ...], tuple[State, ...], Inputs, States]:
-        """Validate and normalize Dash callback arguments."""
+        """Validate and normalize Dash callback arguments and ensure ID uniqueness."""
 
         if self.app is None:
             raise RuntimeError("Dash app not configured for TrulyUnifiedCallbacks")
@@ -284,16 +288,22 @@ class TrulyUnifiedCallbacks(EventPublisher):
                     **kwargs,
                 )(wrapped_callback)
 
+                reg = DashCallbackRegistration(
+                    callback_id=callback_id,
+                    component_name=component_name,
+                    outputs=tuple(outputs_tuple),
+                    inputs=inputs_tuple,
+                    states=states_tuple,
+                )
+                self._dash_callbacks[callback_id] = reg
+                for o in outputs_tuple:
+                    key = f"{o.component_id}.{o.component_property}"
+                    self._output_map.setdefault(key, callback_id)
+                self._namespaces[component_name].append(callback_id)
 
-        from ...core.dash_callback_middleware import wrap_callback
+                return wrapped
 
-        wrapped_callback = wrap_callback(func, outputs_tuple, self.security)
-        return self.app.callback(
-            outputs,
-            inputs_arg if inputs_arg is not None else inputs_tuple,
-            states_arg if states_arg is not None else states_tuple,
-            **kwargs,
-        )(wrapped_callback)
+        return decorator
 
     # ------------------------------------------------------------------
     def register_callback(


### PR DESCRIPTION
## Summary
- ensure `handle_register` decorator registers callbacks and returns wrapped handler
- move callback wrapping inside `handle_register` decorator and track registrations
- add tests for callback registration

## Testing
- `pytest tests/test_callback_registration_helpers.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689f23ee190083209d57fd8a8e1af802