### PR TITLE
feat(readers): centralize callbacks in base class

### DIFF
--- a/tests/file_processing/test_readers.py
+++ b/tests/file_processing/test_readers.py
@@ -4,9 +4,13 @@ import pandas as pd
 import pytest
 
 from yosai_intel_dashboard.src.file_processing.readers import (
+    BaseReader,
     CSVReader,
     ExcelReader,
     JSONReader,
+)
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
 )
 
 
@@ -31,3 +35,10 @@ def test_cannot_parse(tmp_path: Path):
     path.write_text("")
     with pytest.raises(CSVReader.CannotParse):
         CSVReader().read(str(path))
+
+
+def test_readers_provide_unified_callbacks():
+    for cls in (CSVReader, JSONReader, ExcelReader):
+        reader = cls()
+        assert isinstance(reader, BaseReader)
+        assert isinstance(reader.unified_callbacks, TrulyUnifiedCallbacks)

--- a/yosai_intel_dashboard/src/file_processing/readers/archive_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/archive_reader.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-import io
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 
-from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
 from ..format_detector import FormatDetector
 
 from .base import BaseReader
@@ -24,12 +19,6 @@ class ArchiveReader(BaseReader):
     """Read archives containing a single supported file."""
 
     format_name = "archive"
-
-    def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
-    ) -> None:
-        super().__init__(unicode_processor=unicode_processor)
-        self.callback_controller = TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
         path = Path(file_path)

--- a/yosai_intel_dashboard/src/file_processing/readers/base.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/base.py
@@ -6,6 +6,9 @@ import pandas as pd
 
 from yosai_intel_dashboard.src.core.container import get_unicode_processor
 from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
+from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import (
+    TrulyUnifiedCallbacks,
+)
 
 
 class BaseReader:
@@ -17,9 +20,13 @@ class BaseReader:
         """Raised when a reader cannot parse a file."""
 
     def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
+        self,
+        *,
+        unicode_processor: UnicodeProcessorProtocol | None = None,
+        callbacks: TrulyUnifiedCallbacks | None = None,
     ) -> None:
         self.unicode_processor = unicode_processor or get_unicode_processor()
+        self.unified_callbacks = callbacks or TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: Optional[Dict] = None) -> pd.DataFrame:
         raise NotImplementedError

--- a/yosai_intel_dashboard/src/file_processing/readers/csv_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/csv_reader.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_csv
 
 from .base import BaseReader
@@ -15,12 +12,6 @@ class CSVReader(BaseReader):
     """Read comma separated value files."""
 
     format_name = "csv"
-
-    def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
-    ) -> None:
-        super().__init__(unicode_processor=unicode_processor)
-        self.unified_callbacks = TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
         hint = hint or {}

--- a/yosai_intel_dashboard/src/file_processing/readers/excel_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/excel_reader.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_excel
 
 from .base import BaseReader
@@ -15,12 +12,6 @@ class ExcelReader(BaseReader):
     """Read Excel files (xls/xlsx)."""
 
     format_name = "excel"
-
-    def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
-    ) -> None:
-        super().__init__(unicode_processor=unicode_processor)
-        self.unified_callbacks = TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
         if not str(file_path).lower().endswith((".xls", ".xlsx")):

--- a/yosai_intel_dashboard/src/file_processing/readers/fwf_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/fwf_reader.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_fwf
 
 from .base import BaseReader
@@ -15,12 +12,6 @@ class FWFReader(BaseReader):
     """Read fixed-width formatted files."""
 
     format_name = "fwf"
-
-    def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
-    ) -> None:
-        super().__init__(unicode_processor=unicode_processor)
-        self.unified_callbacks = TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
         hint = hint or {}

--- a/yosai_intel_dashboard/src/file_processing/readers/json_reader.py
+++ b/yosai_intel_dashboard/src/file_processing/readers/json_reader.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import pandas as pd
 
 from yosai_intel_dashboard.src.infrastructure.callbacks.events import CallbackEvent
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
-from yosai_intel_dashboard.src.core.protocols import UnicodeProcessorProtocol
-from yosai_intel_dashboard.src.infrastructure.callbacks.unified_callbacks import TrulyUnifiedCallbacks
 from yosai_intel_dashboard.src.utils.pandas_readers import read_json as util_read_json
 
 from .base import BaseReader
@@ -15,12 +12,6 @@ class JSONReader(BaseReader):
     """Read JSON or JSON lines files."""
 
     format_name = "json"
-
-    def __init__(
-        self, *, unicode_processor: UnicodeProcessorProtocol | None = None
-    ) -> None:
-        super().__init__(unicode_processor=unicode_processor)
-        self.unified_callbacks = TrulyUnifiedCallbacks()
 
     def read(self, file_path: str, hint: dict | None = None) -> pd.DataFrame:
         hint = hint or {}


### PR DESCRIPTION
## Summary
- have `BaseReader` own a `TrulyUnifiedCallbacks` instance
- rely on `BaseReader` in csv/excel/json/fwf/archive readers
- add test ensuring readers expose unified callbacks

## Testing
- `pytest tests/file_processing/test_readers.py -q` *(fails: cannot import name 'UnicodeSecurityConfig')*

------
https://chatgpt.com/codex/tasks/task_e_689f23ef545c8320b8046005a9588627