### PR TITLE
Log drift detection results

### DIFF
--- a/docs/ml.md
+++ b/docs/ml.md
@@ -1,0 +1,13 @@
+# Machine learning metrics
+
+The machine learning services expose several Prometheus metrics to assist with
+monitoring.
+
+### Drift detection
+
+`drift_detection_results_total{detected="<bool>"}`
+
+: Counts each invocation of the drift detector and whether drift was detected.
+  A label of `detected="true"` represents drift, while `false` indicates a
+  clean check.
+

--- a/intel_analysis_service/ml/models.py
+++ b/intel_analysis_service/ml/models.py
@@ -26,6 +26,7 @@ except Exception:  # pragma: no cover - fallback when OpenTelemetry missing
 
     tracer = _Tracer()
 import pandas as pd
+from .drift import log_drift_detection
 
 class DriftDetector(Protocol):
     """Protocol describing drift detection behaviour."""
@@ -120,6 +121,7 @@ class AnomalyDetector:
                 drift = self.drift_detector.detect(
                     result[value_col], result["threshold"]
                 )
+                log_drift_detection(drift)
                 result["drift_detected"] = drift
             return result
 


### PR DESCRIPTION
## Summary
- expose `drift_detection_results_total` counter and helper to log outcomes
- record drift detection results from `AnomalyDetector.predict`
- document new metric

## Testing
- `pytest tests/ml/test_model_logging_and_drift.py -q -o addopts=` *(fails: TypeError: 'module' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689f23f4d7d48320ad90ede8e7ce221d