### PR TITLE
refactor: remove test shims

### DIFF
--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -87,7 +87,7 @@ Tests typically create a fresh container with fakes registered:
 
 ```python
 from yosai_intel_dashboard.src.simple_di import ServiceContainer
-from tests.fakes import FakeUploadStore, FakeDeviceLearningService
+from tests.unit.fakes import FakeUploadStore, FakeDeviceLearningService
 
 @pytest.fixture
 def container():

--- a/docs/testing_with_protocols.md
+++ b/docs/testing_with_protocols.md
@@ -7,7 +7,7 @@ injection patterns as the production code.
 
 ## TestContainerBuilder
 
-`TestContainerBuilder` lives in `tests/builders.py`. It constructs a
+`TestContainerBuilder` lives in `tests/unit/builders.py`. It constructs a
 `ServiceContainer` pre-populated with lightweight module stubs so importing heavy
 packages like Dash or SQL parsing libraries is not required. Environment
 variables commonly needed by the services can be initialised with
@@ -15,7 +15,7 @@ variables commonly needed by the services can be initialised with
 `with_all_services()`.
 
 ```python
-from tests.builders import TestContainerBuilder
+from tests.unit.builders import TestContainerBuilder
 
 container = (
     TestContainerBuilder()
@@ -43,7 +43,7 @@ container = (
 
 ## Available Test Doubles
 
-Several fake implementations reside in `tests/fakes.py`:
+Several fake implementations reside in `tests/unit/fakes.py`:
 
 - `FakeUploadStore` – in-memory `UploadStorageProtocol`
 - `FakeUploadDataService` – minimal `UploadDataServiceProtocol`
@@ -62,7 +62,7 @@ append entries and `build_dataframe()` to retrieve a `pandas.DataFrame`.
 `as_upload_dict()` returns a mapping suitable for upload-based tests.
 
 ```python
-from tests.builders import TestDataBuilder
+from tests.unit.builders import TestDataBuilder
 
 df = TestDataBuilder().add_row(person_id="u2").build_dataframe()
 ```
@@ -74,7 +74,8 @@ shows a simplified upload-processing test that uses the container builder and
 data builder together with the `async_runner` fixture:
 
 ```python
-from tests.builders import TestContainerBuilder, TestDataBuilder, UploadFileBuilder
+from tests.unit.builders import TestContainerBuilder, TestDataBuilder
+from tests.utils.builders import UploadFileBuilder
 
 
 def test_simple_upload_processing(async_runner):

--- a/tests/callbacks/test_upload_callbacks_split.py
+++ b/tests/callbacks/test_upload_callbacks_split.py
@@ -5,7 +5,7 @@ from dash import no_update
 
 from yosai_intel_dashboard.src.services.upload.processor import UploadProcessingService
 from yosai_intel_dashboard.src.services.upload.upload_core import UploadCore
-from tests.fakes import (
+from tests.unit.fakes import (
     FakeDeviceLearningService,
     FakeUploadDataService,
     FakeUploadStore,

--- a/tests/stubs/services/device_learning_service.py
+++ b/tests/stubs/services/device_learning_service.py
@@ -1,4 +1,4 @@
-from tests.fakes import FakeDeviceLearningService
+from tests.unit.fakes import FakeDeviceLearningService
 
 
 def get_device_learning_service():

--- a/tests/stubs/utils/upload_store.py
+++ b/tests/stubs/utils/upload_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tests.fakes import FakeUploadStore
+from tests.unit.fakes import FakeUploadStore
 
 _fake_store = FakeUploadStore()
 uploaded_data_store = _fake_store

--- a/tests/test_file_processor_component.py
+++ b/tests/test_file_processor_component.py
@@ -1,7 +1,11 @@
 import pandas as pd
 
 from yosai_intel_dashboard.src.services.upload.file_processor_service import FileProcessor
-from tests.fakes import FakeFileProcessor, FakeUploadDataService, FakeUploadStore
+from tests.unit.fakes import (
+    FakeFileProcessor,
+    FakeUploadDataService,
+    FakeUploadStore,
+)
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 
 

--- a/tests/test_learning_coordinator_component.py
+++ b/tests/test_learning_coordinator_component.py
@@ -1,5 +1,5 @@
 from yosai_intel_dashboard.src.services.upload.learning_coordinator import LearningCoordinator
-from tests.fakes import FakeDeviceLearningService
+from tests.unit.fakes import FakeDeviceLearningService
 from tests.utils.builders import DataFrameBuilder
 
 

--- a/tests/test_mappings_endpoint.py
+++ b/tests/test_mappings_endpoint.py
@@ -121,7 +121,7 @@ class DummyUploadProcessor:
         self.store = store
 
 
-from tests.fakes import FakeUploadStore
+from tests.unit.fakes import FakeUploadStore
 
 
 class StoreWithSave(FakeUploadStore):
@@ -129,7 +129,7 @@ class StoreWithSave(FakeUploadStore):
         self.add_file(filename, df)
 
 
-from tests.fakes import FakeDeviceLearningService
+from tests.unit.fakes import FakeDeviceLearningService
 
 
 class DummyColumnService:

--- a/tests/test_process_uploaded_files.py
+++ b/tests/test_process_uploaded_files.py
@@ -3,7 +3,7 @@ import asyncio
 from yosai_intel_dashboard.src.services.device_learning_service import DeviceLearningService
 from yosai_intel_dashboard.src.services.upload import UploadProcessingService
 from yosai_intel_dashboard.src.services.upload.upload_core import UploadCore
-from tests.fakes import FakeUploadDataService
+from tests.unit.fakes import FakeUploadDataService
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 from yosai_intel_dashboard.src.utils.upload_store import UploadedDataStore
 

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.builders import TestContainerBuilder
+from tests.unit.builders import TestContainerBuilder
 
 
 class TestServiceIntegration:

--- a/tests/test_uploaded_helpers.py
+++ b/tests/test_uploaded_helpers.py
@@ -10,7 +10,7 @@ try:
     from yosai_intel_dashboard.src.services import AnalyticsService
 except Exception:  # pragma: no cover - skip if dependencies missing
     pytest.skip("analytics dependencies missing", allow_module_level=True)
-from tests.fakes import FakeUploadDataService, FakeUploadStore
+from tests.unit.fakes import FakeUploadDataService, FakeUploadStore
 from tests.utils.builders import DataFrameBuilder, UploadFileBuilder
 import pandas as pd
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities for unit test helpers and fakes."""
+

--- a/tests/unit/builders.py
+++ b/tests/unit/builders.py
@@ -15,7 +15,7 @@ from yosai_intel_dashboard.src.services.upload.protocols import (
     UploadStorageProtocol,
 )
 from startup.service_registration import register_all_services
-from tests.fakes import (
+from tests.unit.fakes import (
     FakeConfigurationService,
     FakeFileProcessor,
     FakeUnicodeProcessor,

--- a/tests/unit/fakes.py
+++ b/tests/unit/fakes.py
@@ -186,13 +186,26 @@ class FakeDeviceLearningService(DeviceLearningServiceProtocol):
         self.saved[filename] = user_mappings
         return True
 
+try:
+    class FakeColumnVerifier(ColumnVerifierProtocol):
+        def create_column_verification_modal(self, file_info: Dict[str, Any]) -> Any:
+            return {"modal": file_info}
 
-class FakeColumnVerifier(ColumnVerifierProtocol):
-    def create_column_verification_modal(self, file_info: Dict[str, Any]) -> Any:
-        return {"modal": file_info}
+        def register_callbacks(
+            self, manager: Any, controller: Any | None = None
+        ) -> None:
+            pass
+except TypeError:  # ColumnVerifierProtocol is not a class
+    class FakeColumnVerifier:  # type: ignore[too-few-public-methods]
+        def create_column_verification_modal(
+            self, file_info: Dict[str, Any]
+        ) -> Any:
+            return {"modal": file_info}
 
-    def register_callbacks(self, manager: Any, controller: Any | None = None) -> None:
-        pass
+        def register_callbacks(
+            self, manager: Any, controller: Any | None = None
+        ) -> None:
+            pass
 
 
 class FakeConfigurationService(ConfigurationServiceProtocol):


### PR DESCRIPTION
## Summary
- replace legacy test imports with tests.unit.builders and tests.unit.fakes
- document new test utility locations and delete old shims
- add dedicated tests/unit package for builders and fakes

## Testing
- `pytest tests/test_learning_coordinator_component.py -q` *(fails: cannot import name 'UnicodeSecurityConfig')*


------
https://chatgpt.com/codex/tasks/task_e_689f66a3eb688320a934871b4335feb3