### PR TITLE
Track bridge mount status and expose health endpoint

### DIFF
--- a/tests/test_bridge_status.py
+++ b/tests/test_bridge_status.py
@@ -1,0 +1,15 @@
+import os
+import importlib
+from fastapi import FastAPI
+
+os.environ["YOSAI_REALAPI_SPEC"] = "fastapi:FastAPI"
+import mvp_api_bridge
+
+
+def test_try_mount_real_api_updates_status():
+    importlib.reload(mvp_api_bridge)
+    app = FastAPI()
+    mvp_api_bridge.try_mount_real_api(app)
+    assert mvp_api_bridge._status["spec"] == "fastapi:FastAPI"
+    assert mvp_api_bridge._status["mounted"] is True
+    assert mvp_api_bridge._status["error"] is None


### PR DESCRIPTION
## Summary
- add logging-based bridge status tracking in `try_mount_real_api`
- expose `/bridge/status` endpoint on MVP API
- test bridge mounting status

## Testing
- `pytest --override-ini="addopts=" tests/test_bridge_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c57e3634832096452479d2af5d26