### PR TITLE
feat: add hyperloglog utils

### DIFF
--- a/analytics/core/utils.py
+++ b/analytics/core/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 # Dev shim for analytics.core.utils expected by the real API.
 # Provides a simple cardinality estimator compatible with the real import.
-# Replace with the project’s actual implementation when available.
+# TODO: replace with the production implementation when available.
 
 def hll_count(iterable) -> int:
     try:

--- a/yosai_intel_dashboard/src/services/analytics/core/utils.py
+++ b/yosai_intel_dashboard/src/services/analytics/core/utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Utility helpers for analytics services."""
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    from hyperloglog import HyperLogLog
+except Exception:  # pragma: no cover - the package may be missing
+    HyperLogLog = None
+
+
+def hll_count(series: pd.Series, error_rate: float = 0.01) -> int:
+    """Estimate the number of unique items in ``series``.
+
+    Uses the :mod:`hyperloglog` library when available. If the dependency is
+    missing, falls back to :meth:`pandas.Series.nunique` for an exact count.
+
+    Parameters
+    ----------
+    series:
+        Series containing values whose distinct count is desired.
+    error_rate:
+        Relative error rate for the HyperLogLog counter.
+
+    Returns
+    -------
+    int
+        Estimated cardinality of the series.
+    """
+
+    if HyperLogLog is None:
+        return int(series.nunique())
+
+    hll = HyperLogLog(error_rate)
+    for value in series.dropna():
+        hll.add(str(value).encode("utf-8"))
+    return int(len(hll))
+
+
+__all__ = ["hll_count"]

--- a/yosai_intel_dashboard/src/services/analytics/generator.py
+++ b/yosai_intel_dashboard/src/services/analytics/generator.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 
-from analytics.core.utils import hll_count
+from .core.utils import hll_count
 
 from yosai_intel_dashboard.src.infrastructure.config import get_cache_config
 

--- a/yosai_intel_dashboard/src/services/analytics/processor.py
+++ b/yosai_intel_dashboard/src/services/analytics/processor.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
-from analytics.core.utils import hll_count
+from .core.utils import hll_count
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add `hll_count` utility with HyperLogLog and nunique fallback
- update analytics generator and processor to use local utility
- note TODO in analytics shim for production replacement

## Testing
- `DB_HOST=localhost DB_PORT=5432 DB_USER=user DB_PASSWORD=pw DB_NAME=test SECRET_KEY=secret ANALYTICS_API_KEY=dummy pytest tests/test_hll_count.py -q` *(fails: _RegistryEntry() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c57ef8b88320a1e0499527192e4b